### PR TITLE
v2026.3.28 — Production readiness audit

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -857,3 +857,71 @@ Flag any `/health` implementation that returns 200 unconditionally without check
 `src/neo4j_client.py` maintains a `SOURCES` dict with `reliability` scores for each source.
 If a new collector is added, flag if there is no corresponding entry in `SOURCES` with an appropriate `reliability` value (0.0–1.0).
 Leaving a source out means its nodes get no `SOURCED_FROM` edges and no reliability weighting.
+
+---
+
+## 6. AIRFLOW DAG CONCURRENCY, TIMEOUTS & RETRIES — Blocking
+
+These rules protect against stuck/hung pipelines and concurrent run races. Violations can cause silent data loss or indefinite hangs in production.
+
+### Every DAG must have `max_active_runs=1`
+
+All 6 DAGs in `dags/edgeguard_pipeline.py` must set `max_active_runs=1`. Without this, a slow run causes the scheduler to pile up concurrent runs that race on MISP and Neo4j writes. Flag any DAG definition (`DAG(...)`) that is missing `max_active_runs=1`.
+
+### Every DAG must have `dagrun_timeout`
+
+All 6 DAGs must set `dagrun_timeout=timedelta(...)`. This is wall-clock time from DAG run start — if the entire run (including retries) exceeds this, Airflow marks it failed. Without it, a stuck run hangs indefinitely.
+
+The timeout must be **greater than** the worst-case task chain: `sum of sequential tasks' (execution_timeout x (1 + retries) + retries x retry_delay)`, using `max()` for parallel task groups, with at least 20% buffer. Flag any `dagrun_timeout` that is shorter than the worst-case calculation.
+
+Current correct values:
+
+| DAG | dagrun_timeout |
+|-----|---------------|
+| `edgeguard_pipeline` | 5h 30m |
+| `edgeguard_medium_freq` | 5h |
+| `edgeguard_low_freq` | 8h 30m |
+| `edgeguard_daily` | 8h 30m |
+| `edgeguard_neo4j_sync` | 22h |
+| `edgeguard_baseline` | 32h |
+
+### Every task must have `execution_timeout`
+
+All `PythonOperator` and `BashOperator` tasks must set `execution_timeout`. Without it, a single task can hang forever (e.g., MISP unresponsive) within the DAG run. Flag any task missing `execution_timeout`.
+
+### `dagrun_timeout` must be recalculated when task timeouts or retries change
+
+If someone changes a task's `execution_timeout`, or changes `retries`/`retry_delay` in `default_args`, the parent DAG's `dagrun_timeout` may need updating. Flag such changes without a corresponding `dagrun_timeout` update and ask for verification.
+
+### `default_args` must include `on_failure_callback`
+
+The `default_args` dict must include `on_failure_callback` pointing to `_on_task_failure`. This ensures all task failures are logged with `[ALERT]` and optionally sent to Slack. Flag removal of this callback.
+
+### `default_args` must include `on_success_callback`
+
+The `default_args` dict must include `on_success_callback` pointing to `_on_task_success`. This updates the `edgeguard_dag_last_success_timestamp` Prometheus gauge for stuck-run detection. Without it, the `EdgeGuardDAGLastSuccessStale` alert becomes dead code. Flag removal of this callback.
+
+### Baseline DAG must have `is_paused_upon_creation=False`
+
+`edgeguard_baseline` must set `is_paused_upon_creation=False`. Without this, manual triggers silently queue forever because Airflow starts DAGs paused by default. The `schedule_interval=None` already prevents automatic execution. Flag removal of this setting.
+
+### Neo4j merge return values must be checked before incrementing stats
+
+In `src/run_misp_to_neo4j.py` and `src/run_pipeline.py`, every call to `merge_indicator()`, `merge_vulnerability()`, `merge_cve()`, `merge_malware()`, `merge_actor()`, `merge_technique()` must check the boolean return value before incrementing the stats counter. Flag any pattern like:
+```python
+self.neo4j.merge_vulnerability(item, ...)
+self.stats["vulnerabilities_synced"] += 1  # BUG: not checking return value
+```
+The correct pattern is:
+```python
+if self.neo4j.merge_vulnerability(item, ...):
+    self.stats["vulnerabilities_synced"] += 1
+```
+
+### `clear_checkpoint()` must preserve incremental state
+
+`src/baseline_checkpoint.py` `clear_checkpoint(source=None)` (the `--fresh-baseline` path) must preserve `"incremental"` sub-dicts inside each source entry. These hold OTX `modified_since` cursors, MITRE ETags, etc. Destroying them forces scheduled runs to re-process all historical data. Flag any change to `clear_checkpoint` that deletes incremental state on the global (no-source) path.
+
+### Prometheus stuck-run alerts require gauge wiring
+
+The `EdgeGuardDAGRunStuck` and `EdgeGuardDAGLastSuccessStale` alerts in `prometheus/alerts.yml` depend on `edgeguard_dag_run_start_timestamp` and `edgeguard_dag_last_success_timestamp` gauges being set by the DAG code. If these gauges are defined but never `.set()`, the alerts are dead code. Flag removal of `on_success_callback` or the `DAG_LAST_SUCCESS`/`DAG_RUN_START` gauge definitions without also removing the corresponding alerts.

--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,7 @@ OTEL_EXPORTER_OTLP_INSECURE=false
 
 # Port for the EdgeGuard GraphQL endpoint (mirrors ISIM GraphQL on port 4001).
 EDGEGUARD_GRAPHQL_PORT=4001
-EDGEGUARD_GRAPHQL_HOST=0.0.0.0
+EDGEGUARD_GRAPHQL_HOST=127.0.0.1
 
 # Disable the interactive GraphiQL browser explorer in production.
 EDGEGUARD_GRAPHQL_PLAYGROUND=false

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ credentials/api_keys.yaml
 .env
 .env.*
 !.env.example
+# TLS certificates and private keys
+*.pem
+*.key
+*.cert
+*.p12
+*.pfx
 
 # =============================================================================
 # Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing & pull requests
+
+## Before you open a PR
+
+Use **Python 3.12+** (see `pyproject.toml` `requires-python`; CI uses 3.12).
+
+1. **Install dev deps:** `pip install -r requirements-dev.txt`
+2. **Lint & format:** `make lint` (or `ruff check` / `ruff format --check` as in CI)
+3. **Types (optional but recommended):** `make type-check`
+4. **Tests:** `make test` — same env vars as CI (`NEO4J_*`, `MISP_*` dummies are set by the Makefile)
+
+CI runs **Ruff**, **Mypy**, **pytest** (with coverage floor 30%), **Docker build**, and **pip-audit** — see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+
+## New CLI / version behavior
+
+- **`edgeguard version`** / **`edgeguard update`** — covered by `tests/test_edgeguard_cli_light.py` (update path mocks `subprocess.call` so `install.sh` is not executed in CI).
+- **CalVer** — bump `[project].version` in `pyproject.toml` only when cutting a release; see [`VERSIONING.md`](VERSIONING.md).
+
+## Commits
+
+Use clear messages (e.g. `test: add CLI smoke tests`, `ci: run PR workflow for all branches`). No secrets or real API keys in commits.
+
+## Generated Airflow files (local installs)
+
+If you run Airflow on the host (not only via repo `docker-compose.yml`), **do not commit** local metadata database files (Apache Airflow may create one in `AIRFLOW_HOME`), or any generated secrets/config you copy out of the container. Prefer Docker Compose metadata (**`airflow_postgres`**) for a clean, team-aligned setup. `airflow.cfg` and `webserver_config.py` remain listed in `.gitignore` for typical local layouts.
+
+---
+
+_Last updated: 2026-03-20_

--- a/README.md
+++ b/README.md
@@ -10,7 +10,20 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/actions/workflows/ci.yml"><img src="https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+">
+  <img src="https://img.shields.io/badge/neo4j-5.27-green.svg" alt="Neo4j 5.27">
+  <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
+  <img src="https://img.shields.io/badge/version-2026.3.28-orange.svg" alt="Version">
+</p>
+
+<p align="center">
   IICT-BAS + Ratio1 | financed by ResilMesh - open call 2
+</p>
+
+<p align="center">
+  <em>This project has received funding through the <strong>ResilMesh Open Call 2</strong>,<br>
+  supported by the European Union's Horizon Europe research and innovation programme.</em>
 </p>
 
 ---

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -95,6 +95,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -261,6 +262,18 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE:
             "edgeguard_last_success_timestamp", "Unix timestamp of last successful collection", ["source"]
         )
 
+        # DAG-level stuck-run detection
+        DAG_LAST_SUCCESS = Gauge(
+            "edgeguard_dag_last_success_timestamp",
+            "Unix timestamp of last successful DAG run (0 = never succeeded)",
+            ["dag_id"],
+        )
+        DAG_RUN_START = Gauge(
+            "edgeguard_dag_run_start_timestamp",
+            "Unix timestamp when the current DAG run started (0 = idle)",
+            ["dag_id"],
+        )
+
         logger.info("Prometheus metrics enabled (standalone mode)")
     except ImportError:
         logger.warning("prometheus_client not installed. Install with: pip install prometheus_client")
@@ -385,19 +398,52 @@ def send_slack_alert(message: str, channel: str = None):
 
 def _on_task_failure(context):
     """Callback on any task failure — logs prominently and sends Slack if enabled."""
-    dag_id = context.get("dag", {}).dag_id if context.get("dag") else "unknown"
-    task_id = context.get("task_instance", {}).task_id if context.get("task_instance") else "unknown"
+    dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
+    task_id = context.get("task_instance").task_id if context.get("task_instance") else "unknown"
     exc = context.get("exception", "")
     logger.error(f"[ALERT] Task FAILED: {dag_id}.{task_id} — {exc}")
     if ENABLE_SLACK_ALERTS:
         send_slack_alert(f"Task FAILED: {dag_id}.{task_id} — {exc}", level="critical")
     if ENABLE_PROMETHEUS_METRICS:
         try:
-            from resilience import COLLECTION_FAILURES
-
-            COLLECTION_FAILURES.labels(source=task_id, error_type="task_failure").inc()
+            PIPELINE_ERRORS.labels(task=task_id, error_type="task_failure").inc()
         except Exception:
             pass
+
+
+def _on_task_success(context):
+    """Callback on any task success — update DAG-level success gauge for stuck-run detection."""
+    if not ENABLE_PROMETHEUS_METRICS:
+        return
+    dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
+    try:
+        DAG_LAST_SUCCESS.labels(dag_id=dag_id).set(time.time())
+    except Exception:
+        pass
+
+
+def _on_dag_run_start(**kwargs):
+    """Called by the first task in each DAG to mark the run as in-progress."""
+    if not ENABLE_PROMETHEUS_METRICS:
+        return
+    dag_id = kwargs.get("dag", None)
+    dag_id = dag_id.dag_id if dag_id else "unknown"
+    try:
+        DAG_RUN_START.labels(dag_id=dag_id).set(time.time())
+    except Exception:
+        pass
+
+
+def _on_dag_run_end(**kwargs):
+    """Called by the last task in each DAG to clear the in-progress marker."""
+    if not ENABLE_PROMETHEUS_METRICS:
+        return
+    dag_id = kwargs.get("dag", None)
+    dag_id = dag_id.dag_id if dag_id else "unknown"
+    try:
+        DAG_RUN_START.labels(dag_id=dag_id).set(0)
+    except Exception:
+        pass
 
 
 # Default arguments
@@ -409,6 +455,7 @@ default_args = {
     "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": _on_task_failure,
+    "on_success_callback": _on_task_success,
 }
 
 # ================================================================================

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1022,7 +1022,7 @@ dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,  # Prevent pile-up if a run is slow
-    dagrun_timeout=timedelta(hours=2),  # Kill hung runs
+    dagrun_timeout=timedelta(hours=5, minutes=30),  # Worst-case: 4h25m (OTX retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "high-frequency"],
 )
 
@@ -1100,7 +1100,7 @@ medium_freq_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=3),
+    dagrun_timeout=timedelta(hours=5),  # Worst-case: 4h (CISA/VT retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "medium-frequency"],
 )
 
@@ -1147,7 +1147,7 @@ low_freq_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=6),
+    dagrun_timeout=timedelta(hours=8, minutes=30),  # Worst-case: 7h (NVD retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "low-frequency"],
 )
 
@@ -1187,7 +1187,7 @@ daily_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=6),
+    dagrun_timeout=timedelta(hours=8, minutes=30),  # Worst-case: 7h (7 collectors parallel + retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "daily"],
 )
 
@@ -1290,7 +1290,7 @@ neo4j_sync_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=8),
+    dagrun_timeout=timedelta(hours=22),  # Worst-case: 18h (full sync + rels + enrich, all with retries)
     tags=["threat-intel", "edgeguard", "neo4j", "sync"],
 )
 
@@ -1416,7 +1416,7 @@ baseline_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,  # Only one baseline at a time
-    dagrun_timeout=timedelta(hours=12),  # Kill if stuck longer than 12h
+    dagrun_timeout=timedelta(hours=32),  # Worst-case: 26h (full collection + sync + retries) + buffer
     is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -383,6 +383,23 @@ def send_slack_alert(message: str, channel: str = None):
         logger.warning(f"Failed to send Slack alert: {e}")
 
 
+def _on_task_failure(context):
+    """Callback on any task failure — logs prominently and sends Slack if enabled."""
+    dag_id = context.get("dag", {}).dag_id if context.get("dag") else "unknown"
+    task_id = context.get("task_instance", {}).task_id if context.get("task_instance") else "unknown"
+    exc = context.get("exception", "")
+    logger.error(f"[ALERT] Task FAILED: {dag_id}.{task_id} — {exc}")
+    if ENABLE_SLACK_ALERTS:
+        send_slack_alert(f"Task FAILED: {dag_id}.{task_id} — {exc}", level="critical")
+    if ENABLE_PROMETHEUS_METRICS:
+        try:
+            from resilience import COLLECTION_FAILURES
+
+            COLLECTION_FAILURES.labels(source=task_id, error_type="task_failure").inc()
+        except Exception:
+            pass
+
+
 # Default arguments
 default_args = {
     "owner": "edgeguard",
@@ -391,6 +408,7 @@ default_args = {
     "email_on_retry": False,
     "retries": 2,
     "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": _on_task_failure,
 }
 
 # ================================================================================
@@ -853,15 +871,18 @@ def should_run_neo4j_sync():
         logger.warning(f"Failed to get NEO4J_SYNC_INTERVAL, using default: {e}")
         interval_hours = 72
 
-    if os.path.exists(state_file):
-        with open(state_file, "r") as f:
-            state = json.load(f)
-            _raw = state.get("last_sync", "2000-01-01T00:00:00+00:00")
-            last_sync = datetime.fromisoformat(_raw if "+" in _raw or "Z" in _raw else _raw + "+00:00")
+    try:
+        if os.path.exists(state_file):
+            with open(state_file, "r") as f:
+                state = json.load(f)
+                _raw = state.get("last_sync", "2000-01-01T00:00:00+00:00")
+                last_sync = datetime.fromisoformat(_raw if "+" in _raw or "Z" in _raw else _raw + "+00:00")
 
-            if datetime.now(timezone.utc) - last_sync < timedelta(hours=interval_hours):
-                logger.info(f"Skipping Neo4j sync - last sync was {last_sync}, interval is {interval_hours}h")
-                return False
+                if datetime.now(timezone.utc) - last_sync < timedelta(hours=interval_hours):
+                    logger.info(f"Skipping Neo4j sync - last sync was {last_sync}, interval is {interval_hours}h")
+                    return False
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        logger.error(f"Corrupted sync state file ({state_file}): {e} — running sync to be safe")
 
     logger.info(f"Running Neo4j sync - interval {interval_hours}h has passed")
     return True
@@ -1000,6 +1021,8 @@ dag = DAG(
     schedule_interval="*/30 * * * *",
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,  # Prevent pile-up if a run is slow
+    dagrun_timeout=timedelta(hours=2),  # Kill hung runs
     tags=["threat-intel", "edgeguard", "misp", "high-frequency"],
 )
 
@@ -1076,6 +1099,8 @@ medium_freq_dag = DAG(
     schedule_interval="0 */4 * * *",  # Every 4 hours
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=3),
     tags=["threat-intel", "edgeguard", "misp", "medium-frequency"],
 )
 
@@ -1121,6 +1146,8 @@ low_freq_dag = DAG(
     schedule_interval="0 */8 * * *",  # Every 8 hours
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=6),
     tags=["threat-intel", "edgeguard", "misp", "low-frequency"],
 )
 
@@ -1159,6 +1186,8 @@ daily_dag = DAG(
     schedule_interval="0 2 * * *",  # Daily at 2 AM
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=6),
     tags=["threat-intel", "edgeguard", "misp", "daily"],
 )
 
@@ -1260,12 +1289,15 @@ neo4j_sync_dag = DAG(
     schedule_interval="0 3 */3 * *",  # Every 3 days at 3 AM
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=8),
     tags=["threat-intel", "edgeguard", "neo4j", "sync"],
 )
 
 check_neo4j_sync_needed = ShortCircuitOperator(
     task_id="check_sync_needed",
     python_callable=should_run_neo4j_sync,
+    execution_timeout=timedelta(minutes=2),
     dag=neo4j_sync_dag,
 )
 
@@ -1383,6 +1415,8 @@ baseline_dag = DAG(
     schedule_interval=None,  # MANUAL TRIGGER ONLY
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,  # Only one baseline at a time
+    dagrun_timeout=timedelta(hours=12),  # Kill if stuck longer than 12h
     is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -234,12 +234,25 @@ def ensure_metrics_server():
 
 PROMETHEUS_AVAILABLE = False
 
-# Only register local Prometheus counters when metrics_server is NOT available.
-# When metrics_server IS available it already registers these same metric names
-# (potentially with different label sets), so attempting to re-register them
-# causes a ValueError: "Duplicated timeseries in CollectorRegistry" on every
-# Airflow DAG re-parse.
-if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE:
+# When metrics_server IS available (production), import gauges from it to avoid
+# duplicate registration.  When NOT available (standalone/dev), define them locally.
+if ENABLE_PROMETHEUS_METRICS and METRICS_SERVER_AVAILABLE:
+    try:
+        from metrics_server import (
+            DAG_LAST_SUCCESS,
+            DAG_RUN_START,
+            PIPELINE_ERRORS,
+        )
+        from metrics_server import (
+            DAG_RUNS as DAG_RUNS_TOTAL,
+        )
+
+        PROMETHEUS_AVAILABLE = True
+        logger.info("Prometheus metrics imported from metrics_server (production mode)")
+    except (ImportError, AttributeError) as e:
+        logger.warning(f"Could not import metrics from metrics_server: {e}")
+
+if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS_AVAILABLE:
     try:
         from prometheus_client import Counter, Gauge, Histogram
 
@@ -397,7 +410,7 @@ def send_slack_alert(message: str, channel: str = None):
 
 
 def _on_task_failure(context):
-    """Callback on any task failure — logs prominently and sends Slack if enabled."""
+    """Callback on any task failure — logs prominently, updates metrics, sends Slack if enabled."""
     dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
     task_id = context.get("task_instance").task_id if context.get("task_instance") else "unknown"
     exc = context.get("exception", "")
@@ -412,36 +425,20 @@ def _on_task_failure(context):
 
 
 def _on_task_success(context):
-    """Callback on any task success — update DAG-level success gauge for stuck-run detection."""
+    """Callback on any task success — updates DAG activity timestamp.
+
+    Sets DAG_LAST_SUCCESS on every task completion so the
+    EdgeGuardDAGLastSuccessStale alert can detect DAGs where no task
+    has succeeded recently (covers both partial and full failures).
+    Also refreshes DAG_RUN_START to show the DAG is actively progressing.
+    """
     if not ENABLE_PROMETHEUS_METRICS:
         return
     dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
+    now = time.time()
     try:
-        DAG_LAST_SUCCESS.labels(dag_id=dag_id).set(time.time())
-    except Exception:
-        pass
-
-
-def _on_dag_run_start(**kwargs):
-    """Called by the first task in each DAG to mark the run as in-progress."""
-    if not ENABLE_PROMETHEUS_METRICS:
-        return
-    dag_id = kwargs.get("dag", None)
-    dag_id = dag_id.dag_id if dag_id else "unknown"
-    try:
-        DAG_RUN_START.labels(dag_id=dag_id).set(time.time())
-    except Exception:
-        pass
-
-
-def _on_dag_run_end(**kwargs):
-    """Called by the last task in each DAG to clear the in-progress marker."""
-    if not ENABLE_PROMETHEUS_METRICS:
-        return
-    dag_id = kwargs.get("dag", None)
-    dag_id = dag_id.dag_id if dag_id else "unknown"
-    try:
-        DAG_RUN_START.labels(dag_id=dag_id).set(0)
+        DAG_LAST_SUCCESS.labels(dag_id=dag_id).set(now)
+        DAG_RUN_START.labels(dag_id=dag_id).set(now)  # keeps refreshing while DAG is active
     except Exception:
         pass
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1383,6 +1383,7 @@ baseline_dag = DAG(
     schedule_interval=None,  # MANUAL TRIGGER ONLY
     start_date=_DAG_START_DATE,
     catchup=False,
+    is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -12,7 +12,7 @@ services:
     container_name: edgeguard_prometheus
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
@@ -48,7 +48,7 @@ services:
     container_name: edgeguard_grafana
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       # GRAFANA_ADMIN_PASSWORD must be set — no insecure fallback in production.
@@ -140,7 +140,7 @@ services:
     container_name: edgeguard_alertmanager
     restart: unless-stopped
     ports:
-      - "9093:9093"
+      - "127.0.0.1:9093:9093"
     volumes:
       - ./prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager_data:/alertmanager

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,8 @@ services:
     container_name: edgeguard_neo4j
     restart: unless-stopped
     ports:
-      - "7474:7474"   # Neo4j Browser (HTTP)
-      - "7687:7687"   # Bolt protocol
+      - "127.0.0.1:7474:7474"   # Neo4j Browser (HTTP) — loopback only
+      - "127.0.0.1:7687:7687"   # Bolt protocol — loopback only
     environment:
       NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
       NEO4J_PLUGINS: '["apoc"]'
@@ -159,7 +159,7 @@ services:
     # — that would override CMD and break the entrypoint chain.
     init: true
     ports:
-      - "8082:8082"
+      - "127.0.0.1:8082:8082"   # Airflow UI — loopback only
     environment:
       <<: *common-env
       # Mounted repo src at /opt/airflow/src — ensure all PythonOperator imports resolve without relying only on DAG sys.path hacks.
@@ -224,7 +224,7 @@ services:
     command: ["python", "-m", "uvicorn", "src.query_api:app",
               "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"   # REST API — loopback only; use reverse proxy for external access
     environment:
       <<: *common-env
       EDGEGUARD_ENABLE_ADMIN_QUERY: ${EDGEGUARD_ENABLE_ADMIN_QUERY:-false}
@@ -266,7 +266,7 @@ services:
     command: ["python", "-m", "uvicorn", "src.graphql_api:app",
               "--host", "0.0.0.0", "--port", "4001", "--workers", "2"]
     ports:
-      - "4001:4001"
+      - "127.0.0.1:4001:4001"   # GraphQL API — loopback only
     environment:
       <<: *common-env
       EDGEGUARD_GRAPHQL_PORT: "4001"

--- a/docs/AIRFLOW_DAGS.md
+++ b/docs/AIRFLOW_DAGS.md
@@ -1,6 +1,6 @@
 # EdgeGuard Airflow DAGs (operations guide)
 
-**Last Updated:** 2026-03-21  
+**Last Updated:** 2026-03-29
 **Purpose:** Automated ETL pipeline for threat intelligence collection and synchronization.  
 **DAG Python files:** repository `dags/` directory.
 
@@ -49,6 +49,23 @@ EdgeGuard defines **6** primary DAGs in `dags/edgeguard_pipeline.py` (baseline +
 | `edgeguard_low_freq` | Every 8 hours | Low-frequency sources | NVD |
 | `edgeguard_daily` | Daily at 2 AM | Daily feeds | MITRE, ThreatFox, AbuseIPDB, URLhaus, CyberCure, Feodo, SSLBlacklist |
 | `edgeguard_neo4j_sync` | `0 3 */3 * *` (every 3 days at 03:00) | MISP → Neo4j sync + `build_relationships` + `run_enrichment_jobs` | All sources |
+
+**Concurrency and timeout guards (all 6 DAGs):**
+
+| DAG | `max_active_runs` | `dagrun_timeout` | Notes |
+|-----|-------------------|------------------|-------|
+| `edgeguard_pipeline` | 1 | 5h 30m | Covers OTX with full retry chain |
+| `edgeguard_medium_freq` | 1 | 5h | CISA + VT parallel with retries |
+| `edgeguard_low_freq` | 1 | 8h 30m | NVD with full retry chain |
+| `edgeguard_daily` | 1 | 8h 30m | 7 parallel collectors with retries |
+| `edgeguard_neo4j_sync` | 1 | 22h | Full sync + relationships + enrichment |
+| `edgeguard_baseline` | 1 | 32h | Full historical collection + sync |
+
+`max_active_runs=1` prevents run pile-up when a run is slow. `dagrun_timeout` is wall-clock time from DAG run start — if the entire run (including retries) exceeds this, Airflow marks it as failed. These are calculated as worst-case: `execution_timeout x (1 + retries) + retries x retry_delay` summed across the sequential task chain, with a 20% buffer.
+
+**Callbacks:** All DAGs inherit `on_failure_callback` (logs `[ALERT]`, sends Slack if enabled, increments Prometheus error counter) and `on_success_callback` (updates `edgeguard_dag_last_success_timestamp` gauge for stuck-run detection).
+
+**Baseline note:** `edgeguard_baseline` uses `is_paused_upon_creation=False` so manual triggers execute immediately without needing to unpause first.
 
 **Metrics (optional):** `edgeguard_metrics_server` (+ `…_scheduled`) and **`edgeguard_metrics_helpers`** in `dags/edgeguard_metrics_server.py` — default scrape URL `http://127.0.0.1:8001/metrics` (`EDGEGUARD_METRICS_HOST` / `EDGEGUARD_METRICS_PORT`).
 
@@ -199,9 +216,15 @@ Neo4j uses unique constraints:
 - ✅ Container health verification
 - ✅ Rate limit awareness (each source group has its own DAG schedule)
 - ✅ Incremental sync support
-- ✅ Error handling and retry logic
+- ✅ Error handling and retry logic (`retries=2`, `retry_delay=5min`; baseline: `retries=1`)
 - ✅ Execution timeouts on all tasks (prevents hung workers)
-- ✅ `ShortCircuitOperator` gates the Neo4j sync (skips when nothing new)
+- ✅ `dagrun_timeout` on all DAGs (prevents entire DAG runs from hanging indefinitely)
+- ✅ `max_active_runs=1` on all DAGs (prevents concurrent run pile-up)
+- ✅ `on_failure_callback` / `on_success_callback` for alerting and metrics
+- ✅ `ShortCircuitOperator` gates the Neo4j sync (skips when nothing new; error-tolerant on corrupted state file)
+- ✅ Pipeline lock file (`checkpoints/pipeline.lock`) for CLI runs to prevent concurrent `run_pipeline.py` invocations
+- ✅ `clear_checkpoint()` preserves incremental state on `--fresh-baseline`
+- ✅ MISP dedup logging: `[DEDUP]` when all items already exist, `[SKIP]` when nothing new to push
 
 ### Metrics Exported
 ```

--- a/docs/DEPLOYMENT_READINESS_CHECKLIST.md
+++ b/docs/DEPLOYMENT_READINESS_CHECKLIST.md
@@ -72,6 +72,8 @@ Execute from the **same network context** as Airflow tasks (e.g. `docker exec` i
 | Done | Check | Action | Pass |
 |------|--------|--------|------|
 | [ ] | DAG import | `airflow dags list-import-errors` (after DB init) | Empty |
+| [ ] | DAG concurrency guards | Airflow UI → each DAG → Details | `max_active_runs=1` and `dagrun_timeout` per [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
+| [ ] | Baseline DAG unpaused | Airflow UI → `edgeguard_baseline` | `is_paused_upon_creation=False`; verify DAG is active |
 | [ ] | MISP preflight | Run a tier DAG once; open `misp_health_check` logs | **`healthy`** / **`healthy_for_collection`** (API + DB); workers only if **`EDGEGUARD_MISP_HEALTH_REQUIRE_WORKERS=true`** ([AIRFLOW_DAGS.md](AIRFLOW_DAGS.md)) |
 | [ ] | Collector tasks | Logs for `collect_*` | Status dict; skips show `skipped` + reason class; real failures → task failed as designed |
 | [ ] | Neo4j sync gate | Observe `full_neo4j_sync` / short-circuit | Matches [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
@@ -85,7 +87,8 @@ Execute from the **same network context** as Airflow tasks (e.g. `docker exec` i
 |------|--------|--------|
 | [ ] | Prometheus / metrics | [PROMETHEUS_SETUP.md](PROMETHEUS_SETUP.md), [docker-compose.monitoring.yml](../docker-compose.monitoring.yml) |
 | [ ] | Collector skips | `edgeguard_collector_skips_total` — [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
-| [ ] | Alerts | [prometheus/alerts.yml](../prometheus/alerts.yml) |
+| [ ] | Alerts | [prometheus/alerts.yml](../prometheus/alerts.yml) — verify `EdgeGuardDAGRunStuck`, `EdgeGuardDAGLastSuccessStale` and Alertmanager target (`alertmanager:9093`) |
+| [ ] | Failure callbacks | Trigger a task failure; check logs for `[ALERT] Task FAILED:` message |
 
 ---
 

--- a/docs/GRAPH_EXPLORER.md
+++ b/docs/GRAPH_EXPLORER.md
@@ -24,7 +24,7 @@ If your deployment uses Neo4j Enterprise or Aura, Bloom can be used alongside or
    docker compose up api
 
    # Or directly
-   uvicorn src.query_api:app --host 0.0.0.0 --port 8000
+   uvicorn src.query_api:app --host 127.0.0.1 --port 8000
    ```
 
 2. **Open the explorer** in your browser:

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -217,7 +217,7 @@ python3 src/edgeguard.py --baseline
 docker-compose -f docker-compose.monitoring.yml up -d
 
 # 5. (Optional) Start Airflow for automated recurring collection
-airflow webserver --port 8080 &
+airflow webserver --port 8082 &
 airflow scheduler &
 ```
 

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -23,13 +23,13 @@ The core pipeline is functional, well-documented, and CI-verified. All CI jobs p
 |-----------|--------|-------|
 | **Knowledge Graph Schema** | ✅ Ready | Full node/relationship design, UNIQUE constraints |
 | **MISP Integration** | ✅ Ready | Writer with sanitization, retry, rate limiting |
-| **Airflow DAGs** | ✅ Ready | **6** DAGs in `edgeguard_pipeline.py` + optional metrics DAGs in `edgeguard_metrics_server.py`; timeouts + `ShortCircuitOperator` on Neo4j sync |
+| **Airflow DAGs** | ✅ Ready | **6** DAGs; `max_active_runs=1` + `dagrun_timeout` on all; `on_failure_callback`/`on_success_callback`; baseline `is_paused_upon_creation=False`; `ShortCircuitOperator` on Neo4j sync |
 | **Data Collectors** | ✅ Ready | 11 active collectors → MISP → Neo4j |
 | **Neo4j Client** | ✅ Ready | Constraints, indexes, batch ops, sector labels applied |
 | **Health Checks** | ✅ Ready | MISP health sensor + Docker service healthchecks |
 | **Documentation** | ✅ Ready | 20+ docs updated to match current code |
 | **Security Hardening** | ✅ Ready | Input sanitization, injection guards, SSL, rate limiting |
-| **Monitoring/Metrics** | ✅ Ready | Prometheus metrics endpoint default **8001** / loopback (`EDGEGUARD_METRICS_*`); Grafana via `docker-compose.monitoring.yml` |
+| **Monitoring/Metrics** | ✅ Ready | Prometheus on **8001** (loopback); Alertmanager enabled; alerts: `EdgeGuardDAGRunStuck`, `EdgeGuardDAGLastSuccessStale` + 12 others; Grafana dashboard |
 | **CI/CD Pipeline** | ✅ Ready | GitHub Actions: lint, type-check, unit tests, Docker build, security scan |
 | **Automated Code Review** | ✅ Ready | Bugbot active on every PR with comprehensive rules |
 

--- a/docs/PROMETHEUS_SETUP.md
+++ b/docs/PROMETHEUS_SETUP.md
@@ -295,6 +295,8 @@ The following alerts are pre-configured in `prometheus/alerts.yml`:
 | `EdgeGuardCircuitBreakerOpen` | Circuit open | critical |
 | `EdgeGuardServiceDown` | Health check fail | critical |
 | `EdgeGuardDAGRunFailures` | >3 failures/hour | warning |
+| `EdgeGuardDAGRunStuck` | DAG run running >1 hour without completing | critical |
+| `EdgeGuardDAGLastSuccessStale` | No successful DAG run in >6 hours | warning |
 
 ### Custom Alerts
 

--- a/docs/RESILMESH_INTEROPERABILITY.md
+++ b/docs/RESILMESH_INTEROPERABILITY.md
@@ -1,6 +1,6 @@
 # EdgeGuard ↔ ResilMesh Interoperability Guide
 
-**Last updated: 2026-03-28* 2026-03-21  
+**Last updated: 2026-03-28**
 **Document type:** Integration contract — shared reference between EdgeGuard (IICT-BAS + Ratio1) and ResilMesh  
 **Purpose:** Defines exactly what EdgeGuard produces, what it relies on ResilMesh to provide, and what neither system covers today.
 

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -510,7 +510,7 @@ Auth:    Configured via environment variables
 CREATE CONSTRAINT vulnerability_key FOR (v:Vulnerability) REQUIRE (v.cve_id, v.tag, v.zone) IS UNIQUE;
 CREATE CONSTRAINT indicator_key FOR (i:Indicator) REQUIRE (i.indicator_type, i.value, i.tag, i.zone) IS UNIQUE;
 CREATE CONSTRAINT malware_key FOR (m:Malware) REQUIRE (m.name, m.tag) IS UNIQUE;
-CREATE CONSTRAINT actor_key FOR (a:ThreatActor) REQUIRE (a.name, m.tag) IS UNIQUE;
+CREATE CONSTRAINT actor_key FOR (a:ThreatActor) REQUIRE (a.name, a.tag) IS UNIQUE;
 CREATE CONSTRAINT technique_key FOR (t:Technique) REQUIRE (t.mitre_id, t.tag) IS UNIQUE;
 
 // ResilMesh constraints
@@ -778,10 +778,8 @@ curl "http://localhost:8000/zone/healthcare?limit=20&active_only=true"
 
 ---
 
-*Technical Specification Version: 2.0*  
-*Last Updated: 2026-03-07*  
+*Technical Specification Version: 2.0*
 *For ResilMesh Engineers*
-
 
 ---
 

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -155,6 +155,30 @@ groups:
           summary: "DAG {{ $labels.dag_id }} has multiple failures"
           description: "DAG {{ $labels.dag_id }} has had more than 3 failures in the last hour."
 
+      - alert: EdgeGuardDAGRunStuck
+        expr: |
+          edgeguard_dag_run_start_timestamp > 0
+          and (time() - edgeguard_dag_run_start_timestamp) > 3600
+        for: 5m
+        labels:
+          severity: critical
+          component: pipeline
+        annotations:
+          summary: "DAG run {{ $labels.dag_id }} appears stuck"
+          description: "DAG {{ $labels.dag_id }} has been running for over 1 hour without completing."
+
+      - alert: EdgeGuardDAGLastSuccessStale
+        expr: |
+          edgeguard_dag_last_success_timestamp > 0
+          and (time() - edgeguard_dag_last_success_timestamp) > 21600
+        for: 15m
+        labels:
+          severity: warning
+          component: pipeline
+        annotations:
+          summary: "No successful {{ $labels.dag_id }} run in 6 hours"
+          description: "Last successful run of {{ $labels.dag_id }} was {{ $value | humanizeDuration }} ago."
+
   # ================================================================================
   # Neo4j Alerts
   # ================================================================================

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,7 +16,7 @@ alerting:
   alertmanagers:
     - static_configs:
         - targets:
-          # - alertmanager:9093  # Uncomment when using AlertManager
+          - alertmanager:9093
 
 # Load rules once and periodically evaluate them
 rule_files:

--- a/scripts/clear_misp.py
+++ b/scripts/clear_misp.py
@@ -285,8 +285,8 @@ Examples:
         try:
             from baseline_checkpoint import clear_checkpoint
 
-            clear_checkpoint()
-            logger.info("Cleared baseline checkpoint (ETag/cursor cache)")
+            clear_checkpoint(include_incremental=True)
+            logger.info("Cleared baseline checkpoint + incremental cursors (full reset)")
         except Exception as e:
             logger.warning("Could not clear checkpoint: %s", e)
 

--- a/scripts/clear_neo4j.py
+++ b/scripts/clear_neo4j.py
@@ -303,8 +303,8 @@ Examples:
             try:
                 from baseline_checkpoint import clear_checkpoint
 
-                clear_checkpoint()
-                logging.getLogger(__name__).info("Cleared baseline checkpoint (ETag/cursor cache)")
+                clear_checkpoint(include_incremental=True)
+                logging.getLogger(__name__).info("Cleared baseline checkpoint + incremental cursors (full reset)")
             except Exception as e:
                 logging.getLogger(__name__).warning("Could not clear checkpoint: %s", e)
 

--- a/src/airflow_client.py
+++ b/src/airflow_client.py
@@ -1,0 +1,205 @@
+"""
+EdgeGuard — Airflow REST API client
+====================================
+Thin wrapper around the Airflow stable REST API (v1) for DAG status
+querying and run management.  Used by the ``edgeguard`` CLI and could
+be reused by monitoring scripts.
+
+Requires:
+    AIRFLOW_WEBSERVER_URL  (default http://localhost:8082)
+    AIRFLOW_API_USER       (optional — basic-auth username)
+    AIRFLOW_API_PASSWORD   (optional — basic-auth password)
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EDGEGUARD_DAG_IDS = [
+    "edgeguard_pipeline",
+    "edgeguard_medium_freq",
+    "edgeguard_low_freq",
+    "edgeguard_daily",
+    "edgeguard_neo4j_sync",
+    "edgeguard_baseline",
+]
+
+_TIMEOUT = 15  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_url() -> str:
+    return os.getenv("AIRFLOW_WEBSERVER_URL", "http://localhost:8082").rstrip("/")
+
+
+def _auth() -> Optional[Tuple[str, str]]:
+    user = os.getenv("AIRFLOW_API_USER", "airflow")
+    password = os.getenv("AIRFLOW_API_PASSWORD")
+    if password:
+        return (user, password)
+    return None
+
+
+def _get(path: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+    """GET request to Airflow API.  Returns parsed JSON or ``{"error": ...}``."""
+    url = f"{_base_url()}/api/v1{path}"
+    try:
+        resp = requests.get(url, params=params, auth=_auth(), timeout=_TIMEOUT)
+        if resp.status_code == 401:
+            return {"error": "Airflow API returned 401 Unauthorized. Set AIRFLOW_API_USER/AIRFLOW_API_PASSWORD."}
+        if resp.status_code == 403:
+            return {"error": "Airflow API returned 403 Forbidden. Check user permissions."}
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}. Is it running?"}
+    except requests.exceptions.Timeout:
+        return {"error": f"Airflow API timed out ({_TIMEOUT}s)."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _patch(path: str, body: Dict) -> Dict[str, Any]:
+    """PATCH request to Airflow API."""
+    url = f"{_base_url()}/api/v1{path}"
+    try:
+        resp = requests.patch(url, json=body, auth=_auth(), timeout=_TIMEOUT)
+        if resp.status_code in (401, 403):
+            return {"error": f"Airflow API returned {resp.status_code}. Check auth."}
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}."}
+    except requests.exceptions.Timeout:
+        return {"error": f"Airflow API timed out ({_TIMEOUT}s)."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _post(path: str, body: Dict) -> Dict[str, Any]:
+    """POST request to Airflow API."""
+    url = f"{_base_url()}/api/v1{path}"
+    try:
+        resp = requests.post(url, json=body, auth=_auth(), timeout=_TIMEOUT)
+        if resp.status_code in (401, 403):
+            return {"error": f"Airflow API returned {resp.status_code}. Check auth."}
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}."}
+    except requests.exceptions.Timeout:
+        return {"error": f"Airflow API timed out ({_TIMEOUT}s)."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def airflow_health() -> Dict[str, Any]:
+    """Check Airflow scheduler and metadatabase health.
+
+    Returns dict with 'metadatabase' and 'scheduler' status, or 'error'.
+    """
+    url = f"{_base_url()}/health"
+    try:
+        resp = requests.get(url, auth=_auth(), timeout=_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def list_dag_runs(
+    dag_id: str,
+    state: Optional[str] = None,
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    """List recent DAG runs for a specific DAG.
+
+    Returns list of run dicts, or a single-element list with ``{"error": ...}``.
+    """
+    params: Dict[str, Any] = {"order_by": "-start_date", "limit": limit}
+    if state:
+        params["state"] = state
+    result = _get(f"/dags/{dag_id}/dagRuns", params=params)
+    if "error" in result:
+        return [result]
+    return result.get("dag_runs", [])
+
+
+def list_all_active_dag_runs(
+    dag_ids: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Collect running and queued DAG runs across all EdgeGuard DAGs."""
+    ids = dag_ids or EDGEGUARD_DAG_IDS
+    active: List[Dict[str, Any]] = []
+    for dag_id in ids:
+        for state in ("running", "queued"):
+            runs = list_dag_runs(dag_id, state=state, limit=25)
+            if runs and "error" not in runs[0]:
+                for run in runs:
+                    run["dag_id"] = dag_id  # ensure dag_id is on each run
+                    active.append(run)
+    return active
+
+
+def patch_dag_run_state(dag_id: str, dag_run_id: str, state: str = "failed") -> Dict[str, Any]:
+    """Force a DAG run into a specific state (typically 'failed')."""
+    return _patch(f"/dags/{dag_id}/dagRuns/{dag_run_id}", {"state": state})
+
+
+def clear_task_instances(dag_id: str, dag_run_id: str) -> Dict[str, Any]:
+    """Clear (reset) task instances for a DAG run."""
+    body = {
+        "dry_run": False,
+        "dag_run_id": dag_run_id,
+        "reset_dag_runs": True,
+        "only_running": False,
+        "only_failed": False,
+    }
+    return _post(f"/dags/{dag_id}/clearTaskInstances", body)
+
+
+def get_registered_dags() -> List[Dict[str, Any]]:
+    """List EdgeGuard DAGs registered in Airflow."""
+    result = _get("/dags", params={"dag_id_pattern": "edgeguard", "limit": 25})
+    if "error" in result:
+        return [result]
+    return result.get("dags", [])
+
+
+def format_duration(start_str: Optional[str], end_str: Optional[str] = None) -> str:
+    """Human-readable duration from ISO timestamps."""
+    if not start_str:
+        return "—"
+    try:
+        start = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(end_str.replace("Z", "+00:00")) if end_str else datetime.now(timezone.utc)
+        delta = end - start
+        hours, remainder = divmod(int(delta.total_seconds()), 3600)
+        minutes, seconds = divmod(remainder, 60)
+        if hours > 0:
+            return f"{hours}h {minutes}m"
+        if minutes > 0:
+            return f"{minutes}m {seconds}s"
+        return f"{seconds}s"
+    except (ValueError, TypeError):
+        return "—"

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -179,30 +179,44 @@ def update_source_incremental(source: str, **kwargs) -> None:
         save_checkpoint(checkpoints)
 
 
-def clear_checkpoint(source: str = None) -> None:
+def clear_checkpoint(source: str = None, *, include_incremental: bool = False) -> None:
     """Clear baseline checkpoint for *source*, or all baseline checkpoints if source is None.
 
-    Preserves incremental state (``"incremental"`` sub-dict inside each source
-    entry) so that scheduled runs don't lose their "where I left off" cursors
-    after a fresh baseline.
+    By default, preserves incremental state (``"incremental"`` sub-dict inside
+    each source entry) so that scheduled runs don't lose their cursors after a
+    fresh baseline.  Pass ``include_incremental=True`` to wipe everything
+    (used by database wipe scripts that need a full reset).
     """
     if source:
         checkpoints = load_checkpoint()
         if source in checkpoints:
-            del checkpoints[source]
+            if include_incremental:
+                del checkpoints[source]
+            else:
+                # Preserve incremental sub-dict for this source
+                inc = checkpoints[source].get("incremental") if isinstance(checkpoints[source], dict) else None
+                if inc:
+                    checkpoints[source] = {"incremental": inc}
+                else:
+                    del checkpoints[source]
             save_checkpoint(checkpoints)
     else:
-        checkpoints = load_checkpoint()
-        # Keep only incremental state from each source
-        preserved = {}
-        for src, data in checkpoints.items():
-            inc = data.get("incremental") if isinstance(data, dict) else None
-            if inc:
-                preserved[src] = {"incremental": inc}
-        if preserved:
-            save_checkpoint(preserved)
-        elif CHECKPOINT_FILE.exists():
-            CHECKPOINT_FILE.unlink()
+        if include_incremental:
+            # Full wipe — used by clear_misp.py / clear_neo4j.py
+            if CHECKPOINT_FILE.exists():
+                CHECKPOINT_FILE.unlink()
+        else:
+            checkpoints = load_checkpoint()
+            # Keep only incremental state from each source
+            preserved = {}
+            for src, data in checkpoints.items():
+                inc = data.get("incremental") if isinstance(data, dict) else None
+                if inc:
+                    preserved[src] = {"incremental": inc}
+            if preserved:
+                save_checkpoint(preserved)
+            elif CHECKPOINT_FILE.exists():
+                CHECKPOINT_FILE.unlink()
 
 
 def get_baseline_status() -> dict:

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -180,14 +180,33 @@ def update_source_incremental(source: str, **kwargs) -> None:
 
 
 def clear_checkpoint(source: str = None) -> None:
-    """Clear checkpoint for *source*, or all checkpoints if source is None."""
+    """Clear baseline checkpoint for *source*, or all baseline checkpoints if source is None.
+
+    Preserves incremental state (``"incremental"`` sub-dict inside each source
+    entry) so that scheduled runs don't lose their "where I left off" cursors
+    after a fresh baseline.
+    """
     if source:
         checkpoints = load_checkpoint()
         if source in checkpoints:
-            del checkpoints[source]
+            # Preserve incremental sub-dict if it exists
+            inc = checkpoints[source].get("incremental")
+            if inc:
+                checkpoints[source] = {"incremental": inc}
+            else:
+                del checkpoints[source]
             save_checkpoint(checkpoints)
     else:
-        if CHECKPOINT_FILE.exists():
+        checkpoints = load_checkpoint()
+        # Keep only incremental state from each source
+        preserved = {}
+        for src, data in checkpoints.items():
+            inc = data.get("incremental") if isinstance(data, dict) else None
+            if inc:
+                preserved[src] = {"incremental": inc}
+        if preserved:
+            save_checkpoint(preserved)
+        elif CHECKPOINT_FILE.exists():
             CHECKPOINT_FILE.unlink()
 
 

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -189,12 +189,7 @@ def clear_checkpoint(source: str = None) -> None:
     if source:
         checkpoints = load_checkpoint()
         if source in checkpoints:
-            # Preserve incremental sub-dict if it exists
-            inc = checkpoints[source].get("incremental")
-            if inc:
-                checkpoints[source] = {"incremental": inc}
-            else:
-                del checkpoints[source]
+            del checkpoints[source]
             save_checkpoint(checkpoints)
     else:
         checkpoints = load_checkpoint()

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1102,6 +1102,8 @@ class MISPWriter:
         if not items:
             return 0, 0
 
+        total_items = len(items)
+
         # Guard against invalid batch_size (0 would crash range())
         batch_size = max(1, batch_size)
 
@@ -1181,6 +1183,13 @@ class MISPWriter:
 
         total_batches = sum((len(attrs) + batch_size - 1) // batch_size for _, attrs in push_queue)
 
+        if not push_queue and total_items > 0:
+            logger.warning(
+                "[DEDUP] All %d items were already present in MISP — nothing new to push. "
+                "This is normal on re-runs. Use --fresh-baseline to force re-collection.",
+                total_items,
+            )
+
         # Throttle delay between batches — gives MISP time to free memory
         # when processing large events (e.g. 95K NVD attributes).
         try:
@@ -1221,9 +1230,16 @@ class MISPWriter:
 
         # Final summary
         total_elapsed = time.time() - start_time
-        logger.info(
-            f"[OK] MISP push complete: {total_success} succeeded, {total_failed} failed in {total_elapsed:.1f}s"
-        )
+        if total_success > 0 or total_failed > 0:
+            logger.info(
+                f"[OK] MISP push complete: {total_success} succeeded, {total_failed} failed in {total_elapsed:.1f}s"
+            )
+        elif total_items > 0:
+            logger.info(
+                f"[SKIP] MISP push: 0 new attributes to push ({total_items} items all deduplicated) in {total_elapsed:.1f}s"
+            )
+        else:
+            logger.info("[OK] MISP push: no items provided")
 
         return total_success, total_failed
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1263,44 +1263,114 @@ def cmd_checkpoint_clear(args) -> int:
 
 
 def cmd_stats(args) -> int:
-    """Quick dashboard: node counts, last sync, recent runs."""
+    """Dashboard: node counts, by-zone, by-source, MISP events, sync, runs."""
     use_json = getattr(args, "json", False)
+    show_full = getattr(args, "full", False)
+    show_zone = show_full or getattr(args, "by_zone", False)
+    show_source = show_full or getattr(args, "by_source", False)
+    show_misp = show_full or getattr(args, "misp", False)
 
     section("EdgeGuard Stats")
 
     result = {}
+    neo4j_stats = None
 
-    # Neo4j node counts
+    # ── Neo4j full stats (by_source and by_zone come from get_stats()) ──
     try:
-        from health_check import get_neo4j_node_counts
+        from neo4j_client import Neo4jClient
 
-        counts = get_neo4j_node_counts()
-        if counts and "error" not in counts:
-            result["nodes"] = counts
-            print(f"\n  {'Node Type':<20} {'Count':>10}")
-            print(f"  {'—' * 20} {'—' * 10}")
-            for label, count in sorted(counts.items(), key=lambda x: -x[1]):
-                if label != "relationships":
-                    print(f"  {label:<20} {count:>10,}")
-            if "relationships" in counts:
-                print(f"  {'Relationships':<20} {counts['relationships']:>10,}")
-        else:
-            warn("Neo4j: could not fetch node counts")
+        client = Neo4jClient()
+        if client.connect():
+            neo4j_stats = client.get_stats()
+            client.close()
     except Exception as e:
         warn(f"Neo4j: {e}")
 
-    # Last sync
+    # 1. Node counts by label
+    if neo4j_stats and "error" not in neo4j_stats:
+        label_order = [
+            "Vulnerability",
+            "Indicator",
+            "CVE",
+            "Malware",
+            "ThreatActor",
+            "Technique",
+            "Tactic",
+            "Campaign",
+            "Tool",
+            "CVSSv31",
+            "CVSSv40",
+            "CVSSv30",
+            "CVSSv2",
+            "Alert",
+            "Sector",
+            "Sources",
+        ]
+        result["nodes"] = {k: neo4j_stats.get(k, 0) for k in label_order if neo4j_stats.get(k, 0) > 0}
+        result["nodes"]["relationships"] = neo4j_stats.get("sourced_relationships", 0)
+
+        if not use_json:
+            print(f"\n  {'Node Type':<20} {'Count':>10}")
+            print(f"  {'—' * 20} {'—' * 10}")
+            for label in label_order:
+                count = neo4j_stats.get(label, 0)
+                if count > 0:
+                    print(f"  {label:<20} {count:>10,}")
+            sr = neo4j_stats.get("sourced_relationships", 0)
+            if sr:
+                print(f"  {'SOURCED_FROM rels':<20} {sr:>10,}")
+
+    # 2. By zone
+    if show_zone and neo4j_stats:
+        by_zone = neo4j_stats.get("by_zone", {})
+        result["by_zone"] = by_zone
+        if by_zone and not use_json:
+            print(f"\n  {'Zone':<20} {'Nodes':>10}")
+            print(f"  {'—' * 20} {'—' * 10}")
+            for zone, count in sorted(by_zone.items(), key=lambda x: -x[1]):
+                print(f"  {zone:<20} {count:>10,}")
+
+    # 3. By source
+    if show_source and neo4j_stats:
+        by_source = neo4j_stats.get("by_source", {})
+        result["by_source"] = by_source
+        if by_source and not use_json:
+            print(f"\n  {'Source':<28} {'Nodes':>10}")
+            print(f"  {'—' * 28} {'—' * 10}")
+            for source, count in sorted(by_source.items(), key=lambda x: -x[1]):
+                print(f"  {source:<28} {count:>10,}")
+
+    # 4. MISP event summary
+    if show_misp:
+        try:
+            misp_summary = _fetch_misp_event_summary()
+            result["misp"] = misp_summary
+            if misp_summary and not use_json:
+                print(
+                    f"\n  MISP Events: {misp_summary['total_events']} events, "
+                    f"{misp_summary['total_attributes']:,} attributes"
+                )
+                if misp_summary.get("by_source"):
+                    print(f"\n  {'MISP Source':<28} {'Events':>8} {'Attributes':>12}")
+                    print(f"  {'—' * 28} {'—' * 8} {'—' * 12}")
+                    for src in sorted(misp_summary["by_source"], key=lambda x: -x["attributes"]):
+                        print(f"  {src['source']:<28} {src['events']:>8} {src['attributes']:>12,}")
+        except Exception as e:
+            warn(f"MISP: {e}")
+
+    # 5. Last sync
     try:
         sync = get_sync_status()
         result["last_sync"] = sync
-        if sync.get("last_sync"):
-            ok(f"Last sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
-        else:
-            warn("No sync recorded yet")
+        if not use_json:
+            if sync.get("last_sync"):
+                ok(f"\nLast sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
+            else:
+                warn("\nNo sync recorded yet")
     except Exception:
         pass
 
-    # Pipeline metrics
+    # 6. Pipeline metrics
     try:
         from metrics import PipelineMetrics
 
@@ -1308,14 +1378,14 @@ def cmd_stats(args) -> int:
         pm.load()
         summary = pm.get_summary()
         result["pipeline"] = summary
-        if summary.get("total_runs", 0) > 0:
+        if not use_json and summary.get("total_runs", 0) > 0:
             print(f"\n  Pipeline: {summary['total_runs']} runs, {summary.get('success_rate', 0):.0f}% success")
             if summary.get("avg_duration"):
                 print(f"  Avg duration: {summary['avg_duration']:.0f}s")
     except Exception:
         pass
 
-    # Checkpoint summary
+    # 7. Checkpoint summary
     try:
         from baseline_checkpoint import get_baseline_status
 
@@ -1324,7 +1394,8 @@ def cmd_stats(args) -> int:
             completed = sum(1 for d in cp.values() if isinstance(d, dict) and d.get("completed"))
             in_progress = len(cp) - completed
             result["checkpoints"] = {"completed": completed, "in_progress": in_progress}
-            print(f"\n  Checkpoints: {completed} completed, {in_progress} in-progress")
+            if not use_json:
+                print(f"\n  Checkpoints: {completed} completed, {in_progress} in-progress")
     except Exception:
         pass
 
@@ -1333,8 +1404,72 @@ def cmd_stats(args) -> int:
 
         print(_json.dumps(result, indent=2, default=str))
 
+    if not use_json and not (show_zone or show_source or show_misp):
+        info("\nTip: use --full for zone/source/MISP breakdowns, or --by-zone, --by-source, --misp individually.")
+
     print()
     return 0
+
+
+def _fetch_misp_event_summary() -> dict:
+    """Query MISP for event/attribute counts grouped by source tag."""
+    import requests as _requests
+    import urllib3
+
+    if not SSL_VERIFY:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    session = _requests.Session()
+    session.headers.update(
+        {
+            "Authorization": MISP_API_KEY,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+    )
+
+    # Fetch EdgeGuard events index (lightweight — no attributes)
+    resp = session.get(
+        f"{MISP_URL}/events/index",
+        params={"limit": 500, "searchall": "EdgeGuard"},
+        verify=SSL_VERIFY,
+        timeout=(15, 60),
+    )
+    resp.raise_for_status()
+    events = resp.json()
+    if not isinstance(events, list):
+        events = []
+
+    total_events = 0
+    total_attrs = 0
+    source_map = {}  # source_tag -> {events: N, attributes: N}
+
+    for ev in events:
+        info_field = ev.get("info", "") or ev.get("Event", {}).get("info", "")
+        attr_count = int(ev.get("attribute_count", 0) or ev.get("Event", {}).get("attribute_count", 0) or 0)
+
+        # Parse source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
+        source_tag = "unknown"
+        if info_field.startswith("EdgeGuard-"):
+            parts = info_field.split("-")
+            if len(parts) >= 3:
+                source_tag = parts[2]  # e.g., "alienvault_otx"
+
+        total_events += 1
+        total_attrs += attr_count
+        if source_tag not in source_map:
+            source_map[source_tag] = {"events": 0, "attributes": 0}
+        source_map[source_tag]["events"] += 1
+        source_map[source_tag]["attributes"] += attr_count
+
+    return {
+        "total_events": total_events,
+        "total_attributes": total_attrs,
+        "by_source": [
+            {"source": src, "events": data["events"], "attributes": data["attributes"]}
+            for src, data in source_map.items()
+        ],
+    }
 
 
 # ================================================================================
@@ -1672,6 +1807,12 @@ Examples:
 
     # Stats dashboard
     stats_parser = subparsers.add_parser("stats", help="Quick dashboard: node counts, sync, runs")
+    stats_parser.add_argument(
+        "--full", action="store_true", help="Include breakdowns by zone, source, and MISP event summary"
+    )
+    stats_parser.add_argument("--by-zone", action="store_true", help="Show node counts per zone")
+    stats_parser.add_argument("--by-source", action="store_true", help="Show node counts per source")
+    stats_parser.add_argument("--misp", action="store_true", help="Show MISP event summary")
     stats_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     # Preflight

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -990,6 +990,517 @@ def cmd_monitor(args):
 
 
 # ================================================================================
+# DAG MANAGEMENT
+# ================================================================================
+
+
+def cmd_dag(args) -> int:
+    """Dispatch dag subcommands."""
+    sub = getattr(args, "dag_command", None)
+    if sub == "status":
+        return cmd_dag_status(args)
+    elif sub == "kill":
+        return cmd_dag_kill(args)
+    else:
+        print("Usage: edgeguard dag {status|kill}")
+        return 1
+
+
+def cmd_dag_status(args) -> int:
+    """Show DAG run status from Airflow REST API."""
+    import airflow_client as ac
+
+    section("Airflow DAG Status")
+
+    health = ac.airflow_health()
+    if "error" in health:
+        err(f"Airflow: {health['error']}")
+        return 1
+    ok("Airflow is reachable")
+
+    dag_ids = [args.dag_id] if getattr(args, "dag_id", None) else ac.EDGEGUARD_DAG_IDS
+    state_filter = getattr(args, "state", None)
+    limit = getattr(args, "limit", 5) or 5
+    use_json = getattr(args, "json", False)
+
+    all_runs = []
+    for dag_id in dag_ids:
+        runs = ac.list_dag_runs(dag_id, state=state_filter, limit=limit)
+        if runs and "error" in runs[0]:
+            warn(f"{dag_id}: {runs[0]['error']}")
+            continue
+        for r in runs:
+            r["dag_id"] = dag_id
+        all_runs.extend(runs)
+
+    if use_json:
+        import json as _json
+
+        print(_json.dumps(all_runs, indent=2, default=str))
+        return 0
+
+    if not all_runs:
+        info("No DAG runs found.")
+        return 0
+
+    # Table header
+    print(f"\n  {'DAG':<28} {'State':<10} {'Start':<20} {'Duration':<12}")
+    print(f"  {'—' * 28} {'—' * 10} {'—' * 20} {'—' * 12}")
+    for r in all_runs:
+        dag_id = r.get("dag_id", "?")
+        state = r.get("state", "?")
+        start = (r.get("start_date") or "")[:19]
+        duration = ac.format_duration(r.get("start_date"), r.get("end_date"))
+
+        # Color-code state
+        if state == "success":
+            state_str = f"{Colors.GREEN}{state}{Colors.RESET}"
+        elif state in ("running", "queued"):
+            state_str = f"{Colors.YELLOW}{state}{Colors.RESET}"
+        elif state == "failed":
+            state_str = f"{Colors.RED}{state}{Colors.RESET}"
+        else:
+            state_str = state
+
+        print(f"  {dag_id:<28} {state_str:<22} {start:<20} {duration:<12}")
+
+    print()
+    return 0
+
+
+def cmd_dag_kill(args) -> int:
+    """Force-fail stuck DAG runs with checkpoint preservation."""
+    import airflow_client as ac
+
+    section("Kill Active DAG Runs")
+
+    health = ac.airflow_health()
+    if "error" in health:
+        err(f"Airflow: {health['error']}")
+        return 1
+
+    dag_id_filter = getattr(args, "dag_id", None)
+    dag_ids = [dag_id_filter] if dag_id_filter else None
+    active = ac.list_all_active_dag_runs(dag_ids)
+
+    if not active:
+        ok("No active (running/queued) DAG runs to kill.")
+        return 0
+
+    info(f"Found {len(active)} active run(s):")
+    for r in active:
+        print(f"  {r.get('dag_id', '?'):<28} {r.get('state', '?'):<10} started {(r.get('start_date') or '?')[:19]}")
+
+    if getattr(args, "dry_run", False):
+        info("Dry run — no action taken.")
+        return 0
+
+    if not getattr(args, "force", False):
+        confirm = input("\nKill these runs? Checkpoints will be preserved. [y/N]: ")
+        if confirm.lower() not in ("y", "yes"):
+            info("Aborted.")
+            return 0
+
+    # Checkpoint preservation — read-only snapshot
+    try:
+        from baseline_checkpoint import get_baseline_status
+
+        cp_status = get_baseline_status()
+        if cp_status:
+            ok(f"Checkpoint state: {len(cp_status)} source(s) tracked — preserved (read-only).")
+    except Exception:
+        pass
+
+    # Kill each run
+    killed = 0
+    for r in active:
+        dag_id = r.get("dag_id", "")
+        run_id = r.get("dag_run_id", "")
+        if not run_id:
+            continue
+
+        result = ac.patch_dag_run_state(dag_id, run_id, "failed")
+        if "error" in result:
+            err(f"  Failed to kill {dag_id}/{run_id}: {result['error']}")
+        else:
+            ok(f"  Killed: {dag_id} / {run_id}")
+            killed += 1
+
+    # Reset circuit breakers since services are fine — it was the DAG that was stuck
+    try:
+        from resilience import reset_all_circuit_breakers
+
+        reset_all_circuit_breakers()
+        ok("Circuit breakers reset.")
+    except Exception:
+        pass
+
+    section(f"Killed {killed}/{len(active)} run(s). Checkpoints preserved.")
+    info("Run 'edgeguard dag status' to verify.")
+    return 0
+
+
+# ================================================================================
+# CHECKPOINT MANAGEMENT
+# ================================================================================
+
+
+def cmd_checkpoint(args) -> int:
+    """Dispatch checkpoint subcommands."""
+    sub = getattr(args, "checkpoint_command", None)
+    if sub == "status":
+        return cmd_checkpoint_status(args)
+    elif sub == "clear":
+        return cmd_checkpoint_clear(args)
+    else:
+        print("Usage: edgeguard checkpoint {status|clear}")
+        return 1
+
+
+def cmd_checkpoint_status(args) -> int:
+    """Show baseline checkpoint state per source."""
+    from baseline_checkpoint import get_source_incremental, load_checkpoint
+
+    section("Checkpoint Status")
+    use_json = getattr(args, "json", False)
+    source_filter = getattr(args, "source", None)
+
+    checkpoints = load_checkpoint()
+    if not checkpoints:
+        info("No checkpoints found.")
+        return 0
+
+    if use_json:
+        import json as _json
+
+        data = {source_filter: checkpoints.get(source_filter, {})} if source_filter else checkpoints
+        print(_json.dumps(data, indent=2, default=str))
+        return 0
+
+    print(f"\n  {'Source':<20} {'Pages':<8} {'Items':<10} {'Status':<12} {'Incremental':<14} {'Last Updated':<20}")
+    print(f"  {'—' * 20} {'—' * 8} {'—' * 10} {'—' * 12} {'—' * 14} {'—' * 20}")
+
+    for source, data in sorted(checkpoints.items()):
+        if source_filter and source != source_filter:
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        pages = data.get("page", data.get("pages_collected", "—"))
+        items = data.get("items_collected", "—")
+        completed = data.get("completed", False)
+        updated = (data.get("updated_at") or "")[:19]
+        inc = get_source_incremental(source)
+        has_inc = "yes" if inc else "no"
+
+        if completed:
+            status = f"{Colors.GREEN}completed{Colors.RESET}"
+        elif items and items != "—":
+            status = f"{Colors.YELLOW}in-progress{Colors.RESET}"
+        else:
+            status = "—"
+
+        print(f"  {source:<20} {str(pages):<8} {str(items):<10} {status:<24} {has_inc:<14} {updated:<20}")
+
+    print()
+    return 0
+
+
+def cmd_checkpoint_clear(args) -> int:
+    """Clear baseline checkpoints (preserves incremental state by default)."""
+    from baseline_checkpoint import clear_checkpoint, get_baseline_status, load_checkpoint, save_checkpoint
+
+    section("Clear Checkpoints")
+    source = getattr(args, "source", None)
+    include_inc = getattr(args, "include_incremental", False)
+
+    status = get_baseline_status()
+    if not status:
+        info("No checkpoints to clear.")
+        return 0
+
+    info(f"Current checkpoints: {len(status)} source(s)")
+    for s, d in status.items():
+        if source and s != source:
+            continue
+        print(f"  {s}: {d.get('items_collected', 0)} items, completed={d.get('completed', False)}")
+
+    if include_inc:
+        warn("--include-incremental: This will also clear incremental cursors (modified_since, ETags).")
+        warn("Next collection will do a FULL re-fetch for affected sources.")
+
+    if not getattr(args, "force", False):
+        target = source or "ALL sources"
+        confirm = input(f"\nClear checkpoint for {target}? [y/N]: ")
+        if confirm.lower() not in ("y", "yes"):
+            info("Aborted.")
+            return 0
+
+    clear_checkpoint(source)
+    ok(f"Baseline checkpoint cleared for {source or 'all sources'}.")
+
+    if include_inc:
+        cp = load_checkpoint()
+        if source:
+            if source in cp:
+                cp[source].pop("incremental", None)
+                save_checkpoint(cp)
+        else:
+            for s in cp:
+                if isinstance(cp[s], dict):
+                    cp[s].pop("incremental", None)
+            save_checkpoint(cp)
+        ok("Incremental state also cleared.")
+    else:
+        ok("Incremental state preserved (next scheduled run resumes from cursor).")
+
+    return 0
+
+
+# ================================================================================
+# STATS DASHBOARD
+# ================================================================================
+
+
+def cmd_stats(args) -> int:
+    """Quick dashboard: node counts, last sync, recent runs."""
+    use_json = getattr(args, "json", False)
+
+    section("EdgeGuard Stats")
+
+    result = {}
+
+    # Neo4j node counts
+    try:
+        from health_check import get_neo4j_node_counts
+
+        counts = get_neo4j_node_counts()
+        if counts and "error" not in counts:
+            result["nodes"] = counts
+            print(f"\n  {'Node Type':<20} {'Count':>10}")
+            print(f"  {'—' * 20} {'—' * 10}")
+            for label, count in sorted(counts.items(), key=lambda x: -x[1]):
+                if label != "relationships":
+                    print(f"  {label:<20} {count:>10,}")
+            if "relationships" in counts:
+                print(f"  {'Relationships':<20} {counts['relationships']:>10,}")
+        else:
+            warn("Neo4j: could not fetch node counts")
+    except Exception as e:
+        warn(f"Neo4j: {e}")
+
+    # Last sync
+    try:
+        sync = get_sync_status()
+        result["last_sync"] = sync
+        if sync.get("last_sync"):
+            ok(f"Last sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
+        else:
+            warn("No sync recorded yet")
+    except Exception:
+        pass
+
+    # Pipeline metrics
+    try:
+        from metrics import PipelineMetrics
+
+        pm = PipelineMetrics()
+        pm.load()
+        summary = pm.get_summary()
+        result["pipeline"] = summary
+        if summary.get("total_runs", 0) > 0:
+            print(f"\n  Pipeline: {summary['total_runs']} runs, {summary.get('success_rate', 0):.0f}% success")
+            if summary.get("avg_duration"):
+                print(f"  Avg duration: {summary['avg_duration']:.0f}s")
+    except Exception:
+        pass
+
+    # Checkpoint summary
+    try:
+        from baseline_checkpoint import get_baseline_status
+
+        cp = get_baseline_status()
+        if cp:
+            completed = sum(1 for d in cp.values() if isinstance(d, dict) and d.get("completed"))
+            in_progress = len(cp) - completed
+            result["checkpoints"] = {"completed": completed, "in_progress": in_progress}
+            print(f"\n  Checkpoints: {completed} completed, {in_progress} in-progress")
+    except Exception:
+        pass
+
+    if use_json:
+        import json as _json
+
+        print(_json.dumps(result, indent=2, default=str))
+
+    print()
+    return 0
+
+
+# ================================================================================
+# PREFLIGHT
+# ================================================================================
+
+
+def cmd_preflight(args) -> int:
+    """Comprehensive pre-run readiness check."""
+    strict = getattr(args, "strict", False)
+    use_json = getattr(args, "json", False)
+
+    section("EdgeGuard Preflight Check")
+    errors = 0
+    warnings = 0
+    checks = {}
+
+    # 1. Required env vars
+    section("1. Environment Variables")
+    required = {"NEO4J_PASSWORD": NEO4J_PASSWORD, "MISP_API_KEY": MISP_API_KEY, "MISP_URL": MISP_URL}
+    for name, val in required.items():
+        if val:
+            ok(f"{name}: set")
+        else:
+            err(f"{name}: NOT SET (required)")
+            errors += 1
+    optional = {
+        "OTX_API_KEY": OTX_API_KEY,
+        "NVD_API_KEY": NVD_API_KEY,
+        "VIRUSTOTAL_API_KEY": os.getenv("VIRUSTOTAL_API_KEY"),
+        "ABUSEIPDB_API_KEY": os.getenv("ABUSEIPDB_API_KEY"),
+    }
+    for name, val in optional.items():
+        if val:
+            ok(f"{name}: set ({len(val)} chars)")
+        else:
+            info(f"{name}: not set (optional — source will be skipped)")
+    checks["env_vars"] = {"errors": errors}
+
+    # 2. Neo4j
+    section("2. Neo4j")
+    try:
+        from health_check import health_check_neo4j
+
+        neo4j_result = health_check_neo4j()
+        if neo4j_result.get("status") == "connected":
+            ok(f"Neo4j: connected ({NEO4J_URI})")
+            if neo4j_result.get("apoc_available"):
+                ok("APOC plugin: available")
+            else:
+                err("APOC plugin: NOT available (required)")
+                errors += 1
+        else:
+            err(f"Neo4j: {neo4j_result.get('error', 'unreachable')}")
+            errors += 1
+        checks["neo4j"] = neo4j_result
+    except Exception as e:
+        err(f"Neo4j: {e}")
+        errors += 1
+
+    # 3. MISP
+    section("3. MISP")
+    try:
+        from misp_health import MISPHealthCheck
+
+        checker = MISPHealthCheck()
+        misp_result = checker.check_health()
+        healthy = misp_result.get("healthy", False) if isinstance(misp_result, dict) else False
+        if healthy:
+            ok("MISP: healthy")
+        else:
+            err(f"MISP: unhealthy — {misp_result}")
+            errors += 1
+        checks["misp"] = misp_result
+    except Exception as e:
+        err(f"MISP: {e}")
+        errors += 1
+
+    # 4. Airflow
+    section("4. Airflow")
+    try:
+        import airflow_client as ac
+
+        af_health = ac.airflow_health()
+        if "error" in af_health:
+            warn(f"Airflow: {af_health['error']}")
+            warnings += 1
+        else:
+            ok("Airflow: reachable")
+            dags = ac.get_registered_dags()
+            if dags and "error" not in dags[0]:
+                ok(f"  {len(dags)} EdgeGuard DAG(s) registered")
+            else:
+                warn("  Could not query DAG list")
+                warnings += 1
+        checks["airflow"] = af_health
+    except Exception as e:
+        warn(f"Airflow: {e}")
+        warnings += 1
+
+    # 5. Disk space
+    section("5. Disk Space")
+    try:
+        stat = os.statvfs(".")
+        free_gb = (stat.f_bavail * stat.f_frsize) / (1024**3)
+        if free_gb < 1.0:
+            err(f"Disk: {free_gb:.1f} GB free (need at least 1 GB)")
+            errors += 1
+        else:
+            ok(f"Disk: {free_gb:.1f} GB free")
+        checks["disk"] = {"free_gb": round(free_gb, 1)}
+    except Exception as e:
+        warn(f"Disk check: {e}")
+        warnings += 1
+
+    # 6. Checkpoint state
+    section("6. Checkpoints")
+    try:
+        from baseline_checkpoint import get_baseline_status
+
+        cp = get_baseline_status()
+        if cp:
+            incomplete = [s for s, d in cp.items() if isinstance(d, dict) and not d.get("completed")]
+            if incomplete:
+                warn(f"Incomplete baselines: {', '.join(incomplete)}")
+                warnings += 1
+            else:
+                ok(f"{len(cp)} source(s) baselined")
+        else:
+            info("No baselines run yet")
+        checks["checkpoints"] = cp or {}
+    except Exception:
+        pass
+
+    # 7. Circuit breakers
+    section("7. Circuit Breakers")
+    try:
+        from resilience import _circuit_breakers
+
+        open_breakers = [name for name, cb in _circuit_breakers.items() if cb._state != "CLOSED"]
+        if open_breakers:
+            err(f"OPEN circuit breakers: {', '.join(open_breakers)}")
+            errors += 1
+        else:
+            ok("All circuit breakers CLOSED")
+    except Exception:
+        info("No circuit breaker state (fresh start)")
+
+    # Summary
+    section("Preflight Summary")
+    total_checks = 7
+    passed = total_checks - errors - (warnings if strict else 0)
+    if errors == 0 and (warnings == 0 or not strict):
+        ok(f"READY — {passed}/{total_checks} checks passed, {warnings} warning(s)")
+    else:
+        err(f"NOT READY — {errors} error(s), {warnings} warning(s)")
+
+    if use_json:
+        import json as _json
+
+        print(_json.dumps({"errors": errors, "warnings": warnings, "checks": checks}, indent=2, default=str))
+
+    return 1 if errors > 0 or (strict and warnings > 0) else 0
+
+
+# ================================================================================
 # CODE UPDATE (git pull + install.sh --update)
 # ================================================================================
 
@@ -1102,15 +1613,18 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  edgeguard.py doctor           # Run diagnostics (needs .env)
-  edgeguard.py heal             # Auto-repair
-  edgeguard.py validate         # Validate config
-  edgeguard.py monitor          # Show health status
-  edgeguard.py update           # git pull + reinstall (auto: Docker or pip)
-  edgeguard.py update --docker  # force Docker Compose path
-  edgeguard.py update --python  # force pip editable reinstall
-  edgeguard.py --update         # same as: edgeguard update
-  edgeguard.py version          # CalVer + git SHA (no .env required)
+  edgeguard.py doctor             # Run diagnostics (needs .env)
+  edgeguard.py preflight          # Comprehensive pre-run readiness check
+  edgeguard.py stats              # Quick dashboard: nodes, sync, runs
+  edgeguard.py dag status         # Show Airflow DAG run status
+  edgeguard.py dag kill           # Force-fail stuck DAG runs
+  edgeguard.py checkpoint status  # Show per-source checkpoint state
+  edgeguard.py checkpoint clear   # Clear baseline checkpoints
+  edgeguard.py heal               # Auto-repair
+  edgeguard.py validate           # Validate config
+  edgeguard.py monitor            # Show health status
+  edgeguard.py update             # git pull + reinstall
+  edgeguard.py version            # CalVer + git SHA
         """,
     )
 
@@ -1127,6 +1641,43 @@ Examples:
 
     # Monitor command
     subparsers.add_parser("monitor", help="Show health status")
+
+    # DAG management
+    dag_parser = subparsers.add_parser("dag", help="Airflow DAG operations")
+    dag_subparsers = dag_parser.add_subparsers(dest="dag_command", help="DAG commands")
+
+    dag_status_parser = dag_subparsers.add_parser("status", help="Show DAG run status")
+    dag_status_parser.add_argument("--dag-id", help="Filter to specific DAG ID")
+    dag_status_parser.add_argument("--state", choices=["running", "queued", "failed", "success"])
+    dag_status_parser.add_argument("--limit", type=int, default=5, help="Max runs per DAG (default: 5)")
+    dag_status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    dag_kill_parser = dag_subparsers.add_parser("kill", help="Force-fail stuck DAG runs")
+    dag_kill_parser.add_argument("--dag-id", help="Kill runs for specific DAG (default: all)")
+    dag_kill_parser.add_argument("--dry-run", action="store_true", help="Show what would be killed")
+    dag_kill_parser.add_argument("--force", action="store_true", help="Skip confirmation")
+
+    # Checkpoint management
+    cp_parser = subparsers.add_parser("checkpoint", help="Manage pipeline checkpoints")
+    cp_subparsers = cp_parser.add_subparsers(dest="checkpoint_command", help="Checkpoint commands")
+
+    cp_status_parser = cp_subparsers.add_parser("status", help="Show checkpoint state per source")
+    cp_status_parser.add_argument("--source", help="Filter to specific source")
+    cp_status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    cp_clear_parser = cp_subparsers.add_parser("clear", help="Clear baseline checkpoints")
+    cp_clear_parser.add_argument("--source", help="Clear specific source only")
+    cp_clear_parser.add_argument("--include-incremental", action="store_true", help="Also clear incremental cursors")
+    cp_clear_parser.add_argument("--force", action="store_true", help="Skip confirmation")
+
+    # Stats dashboard
+    stats_parser = subparsers.add_parser("stats", help="Quick dashboard: node counts, sync, runs")
+    stats_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Preflight
+    preflight_parser = subparsers.add_parser("preflight", help="Comprehensive pre-run readiness check")
+    preflight_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    preflight_parser.add_argument("--strict", action="store_true", help="Treat warnings as errors")
 
     # Source management
     source_parser = subparsers.add_parser("source", help="Manage data sources")
@@ -1238,6 +1789,14 @@ Examples:
         return cmd_monitor(args)
     elif args.command == "source":
         return cmd_source(args)
+    elif args.command == "dag":
+        return cmd_dag(args)
+    elif args.command == "checkpoint":
+        return cmd_checkpoint(args)
+    elif args.command == "stats":
+        return cmd_stats(args)
+    elif args.command == "preflight":
+        return cmd_preflight(args)
     else:
         parser.print_help()
         return 1

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1208,7 +1208,7 @@ def cmd_checkpoint_status(args) -> int:
 
 def cmd_checkpoint_clear(args) -> int:
     """Clear baseline checkpoints (preserves incremental state by default)."""
-    from baseline_checkpoint import clear_checkpoint, get_baseline_status, load_checkpoint, save_checkpoint
+    from baseline_checkpoint import clear_checkpoint, get_baseline_status
 
     section("Clear Checkpoints")
     source = getattr(args, "source", None)
@@ -1236,20 +1236,9 @@ def cmd_checkpoint_clear(args) -> int:
             info("Aborted.")
             return 0
 
-    clear_checkpoint(source)
+    clear_checkpoint(source, include_incremental=include_inc)
     ok(f"Baseline checkpoint cleared for {source or 'all sources'}.")
-
     if include_inc:
-        cp = load_checkpoint()
-        if source:
-            if source in cp:
-                cp[source].pop("incremental", None)
-                save_checkpoint(cp)
-        else:
-            for s in cp:
-                if isinstance(cp[s], dict):
-                    cp[s].pop("incremental", None)
-            save_checkpoint(cp)
         ok("Incremental state also cleared.")
     else:
         ok("Incremental state preserved (next scheduled run resumes from cursor).")

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -65,6 +65,13 @@ MISP_URL = os.getenv("MISP_URL", "").rstrip("/")
 # Auth helper
 # ---------------------------------------------------------------------------
 EDGEGUARD_API_KEY = os.getenv("EDGEGUARD_API_KEY", "")
+_ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()
+
+if _ENV == "prod" and not EDGEGUARD_API_KEY:
+    raise RuntimeError(
+        "EDGEGUARD_API_KEY must be set when EDGEGUARD_ENV=prod. "
+        "Set a strong random value before starting the GraphQL API in production."
+    )
 
 
 def _verify_api_key(x_api_key: Optional[str] = Header(None, alias="X-API-Key")) -> None:
@@ -630,6 +637,9 @@ async def health():
 if __name__ == "__main__":
     import uvicorn
 
-    port = int(os.getenv("EDGEGUARD_GRAPHQL_PORT", "4001"))
+    try:
+        port = int(os.getenv("EDGEGUARD_GRAPHQL_PORT", "4001"))
+    except (ValueError, TypeError):
+        port = 4001
     host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "0.0.0.0")
     uvicorn.run("graphql_api:app", host=host, port=port, reload=False)

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -6,7 +6,7 @@ Strawberry + FastAPI GraphQL endpoint, mirroring the ISIM GraphQL convention
 queries ISIM.
 
 Run standalone:
-    uvicorn src.graphql_api:app --host 0.0.0.0 --port 4001
+    uvicorn src.graphql_api:app --host 127.0.0.1 --port 4001
 
 Or import `app` into a combined runner alongside the REST API.
 
@@ -641,5 +641,5 @@ if __name__ == "__main__":
         port = int(os.getenv("EDGEGUARD_GRAPHQL_PORT", "4001"))
     except (ValueError, TypeError):
         port = 4001
-    host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "0.0.0.0")
+    host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")
     uvicorn.run("graphql_api:app", host=host, port=port, reload=False)

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -134,6 +134,19 @@ PIPELINE_STAGES = Gauge("edgeguard_pipeline_stage", "Current pipeline stage (1=r
 # DAG/Airflow metrics
 DAG_RUNS = Counter("edgeguard_dag_runs_total", "Total DAG runs", ["dag_id", "status", "run_type"])
 
+# Stuck-run detection: set to time.time() on success, alert if stale
+DAG_LAST_SUCCESS = Gauge(
+    "edgeguard_dag_last_success_timestamp",
+    "Unix timestamp of last successful DAG run (0 = never succeeded)",
+    ["dag_id"],
+)
+
+DAG_RUN_START = Gauge(
+    "edgeguard_dag_run_start_timestamp",
+    "Unix timestamp when the current DAG run started (0 = idle)",
+    ["dag_id"],
+)
+
 DAG_RUN_DURATION = Histogram(
     "edgeguard_dag_run_duration_seconds",
     "DAG run duration",

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -435,7 +435,10 @@ def get_metrics_server(host: str = None, port: int = None) -> MetricsServer:
 
     if _server_instance is None:
         host = host or os.getenv("EDGEGUARD_METRICS_HOST", "127.0.0.1")
-        port = port or int(os.getenv("EDGEGUARD_METRICS_PORT", "8001"))
+        try:
+            port = port or int(os.getenv("EDGEGUARD_METRICS_PORT", "8001"))
+        except (ValueError, TypeError):
+            port = port or 8001
         _server_instance = MetricsServer(host=host, port=port)
 
     return _server_instance

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -368,7 +368,7 @@ class MetricsServer:
         server.start_threaded()
     """
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8001):
+    def __init__(self, host: str = "127.0.0.1", port: int = 8001):
         self.host = host
         self.port = port
         self.server: Optional[ThreadedHTTPServer] = None
@@ -449,7 +449,7 @@ def start_metrics_server(host: str = None, port: int = None, threaded: bool = Tr
     Convenience function to start the metrics server.
 
     Args:
-        host: Bind host (default: 0.0.0.0)
+        host: Bind host (default: 127.0.0.1)
         port: Bind port (default: 8001)
         threaded: If True, start in background thread; if False, block
 
@@ -474,7 +474,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="EdgeGuard Prometheus Metrics Server")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=8001, help="Bind port (default: 8001)")
     parser.add_argument("--test-metrics", action="store_true", help="Generate test metrics")
 

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -955,7 +955,7 @@ if __name__ == "__main__":
     import uvicorn
 
     # Get configuration from environment
-    host = os.getenv("EDGEGUARD_API_HOST", "0.0.0.0")
+    host = os.getenv("EDGEGUARD_API_HOST", "127.0.0.1")
     try:
         port = int(os.getenv("EDGEGUARD_API_PORT", "8000"))
     except (ValueError, TypeError):

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -106,7 +106,10 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-_MAX_BODY_BYTES = int(os.getenv("EDGEGUARD_MAX_BODY_BYTES", str(1 * 1024 * 1024)))  # 1 MB default
+try:
+    _MAX_BODY_BYTES = int(os.getenv("EDGEGUARD_MAX_BODY_BYTES", str(1 * 1024 * 1024)))
+except (ValueError, TypeError):
+    _MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MB default
 
 
 @app.middleware("http")
@@ -953,7 +956,10 @@ if __name__ == "__main__":
 
     # Get configuration from environment
     host = os.getenv("EDGEGUARD_API_HOST", "0.0.0.0")
-    port = int(os.getenv("EDGEGUARD_API_PORT", "8000"))
+    try:
+        port = int(os.getenv("EDGEGUARD_API_PORT", "8000"))
+    except (ValueError, TypeError):
+        port = 8000
     reload = os.getenv("EDGEGUARD_API_RELOAD", "false").lower() == "true"
 
     logger.info(f"[START] Starting EdgeGuard Query API on {host}:{port}")

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2398,26 +2398,27 @@ class MISPToNeo4jSync:
                     or item.get("cvss_v30_data")
                     or item.get("cvss_v2_data")
                 ):
-                    self.neo4j.merge_cve(item, source_id=source_id)
+                    ok = self.neo4j.merge_cve(item, source_id=source_id)
                 else:
-                    self.neo4j.merge_vulnerability(item, source_id=source_id)
-                self.stats["vulnerabilities_synced"] += 1
+                    ok = self.neo4j.merge_vulnerability(item, source_id=source_id)
+                if ok:
+                    self.stats["vulnerabilities_synced"] += 1
 
             elif item.get("indicator_type") and item.get("value"):
-                self.neo4j.merge_indicator(item, source_id=source_id)
-                self.stats["indicators_synced"] += 1
+                if self.neo4j.merge_indicator(item, source_id=source_id):
+                    self.stats["indicators_synced"] += 1
 
             elif item_type == "malware":
-                self.neo4j.merge_malware(item, source_id=source_id)
-                self.stats["malware_synced"] += 1
+                if self.neo4j.merge_malware(item, source_id=source_id):
+                    self.stats["malware_synced"] += 1
 
             elif item_type == "actor":
-                self.neo4j.merge_actor(item, source_id=source_id)
-                self.stats["actors_synced"] += 1
+                if self.neo4j.merge_actor(item, source_id=source_id):
+                    self.stats["actors_synced"] += 1
 
             elif item_type == "technique":
-                self.neo4j.merge_technique(item, source_id=source_id)
-                self.stats["techniques_synced"] += 1
+                if self.neo4j.merge_technique(item, source_id=source_id):
+                    self.stats["techniques_synced"] += 1
 
             elif item_type == "tactic":
                 self.neo4j.merge_tactic(item, source_id=source_id)

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -796,7 +796,9 @@ class EdgeGuardPipeline:
             fresh_baseline: If True with baseline, discard any existing checkpoints and start
                 from scratch. Default False preserves partial progress for resume.
         """
-        # ── Pipeline lock: prevent concurrent runs ──
+        # ── Pipeline lock: prevent concurrent CLI runs ──
+        # NOTE: This lock only protects CLI invocations (python run_pipeline.py).
+        # Airflow DAGs use max_active_runs=1 for concurrency control instead.
         lock_dir = os.path.join(os.path.dirname(__file__), "..", "checkpoints")
         os.makedirs(lock_dir, exist_ok=True)
         lock_path = os.path.join(lock_dir, "pipeline.lock")
@@ -807,10 +809,12 @@ class EdgeGuardPipeline:
                 # Check if the process is still alive
                 try:
                     os.kill(old_pid, 0)
-                    logger.warning(
-                        f"Another pipeline process (PID {old_pid}) appears to be running. "
+                    logger.error(
+                        f"Another pipeline process (PID {old_pid}) is still running. "
+                        "Aborting to prevent data races. "
                         "If this is stale, delete checkpoints/pipeline.lock and retry."
                     )
+                    return False
                 except (OSError, ProcessLookupError):
                     logger.info(f"Stale lock file found (PID {old_pid} is gone) — removing.")
         except (ValueError, IOError):
@@ -819,8 +823,17 @@ class EdgeGuardPipeline:
             f.write(str(os.getpid()))
 
         import atexit
+        import signal
 
-        atexit.register(lambda: os.remove(lock_path) if os.path.exists(lock_path) else None)
+        def _cleanup_lock(*_args):
+            try:
+                if os.path.exists(lock_path):
+                    os.remove(lock_path)
+            except OSError:
+                pass
+
+        atexit.register(_cleanup_lock)
+        signal.signal(signal.SIGTERM, lambda s, f: (_cleanup_lock(), sys.exit(1)))
 
         # Import baseline checkpoint utilities
         from baseline_checkpoint import clear_checkpoint, get_baseline_status

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -406,7 +406,7 @@ class EdgeGuardPipeline:
                     # Parse pattern to extract indicator value
                     indicator_data = self._parse_stix_pattern(pattern)
                     if indicator_data:
-                        self.neo4j.merge_indicator(
+                        ok = self.neo4j.merge_indicator(
                             {
                                 "indicator_type": indicator_data.get("type", "unknown"),
                                 "value": indicator_data.get("value", ""),
@@ -420,7 +420,8 @@ class EdgeGuardPipeline:
                             },
                             source_id=obj.get("x_edgeguard_source", "unknown"),
                         )
-                        stats["indicators"] += 1
+                        if ok:
+                            stats["indicators"] += 1
 
                 # Handle Vulnerability objects (CVE)
                 elif obj_type == "vulnerability":
@@ -429,7 +430,7 @@ class EdgeGuardPipeline:
                     import re
 
                     if re.match(r"^CVE-\d{4}-\d{4,}$", vuln_name, re.IGNORECASE):
-                        self.neo4j.merge_vulnerability(
+                        ok = self.neo4j.merge_vulnerability(
                             {
                                 "cve_id": vuln_name.upper(),
                                 "description": obj.get("description", ""),
@@ -446,11 +447,12 @@ class EdgeGuardPipeline:
                             },
                             source_id=obj.get("x_edgeguard_source", "unknown"),
                         )
-                        stats["vulnerabilities"] += 1
+                        if ok:
+                            stats["vulnerabilities"] += 1
 
                 # Handle Threat Actor objects
                 elif obj_type == "threat-actor":
-                    self.neo4j.merge_actor(
+                    ok = self.neo4j.merge_actor(
                         {
                             "name": obj.get("name", ""),
                             "aliases": obj.get("aliases", []),
@@ -462,11 +464,12 @@ class EdgeGuardPipeline:
                         },
                         source_id=obj.get("x_edgeguard_source", "unknown"),
                     )
-                    stats["actors"] += 1
+                    if ok:
+                        stats["actors"] += 1
 
                 # Handle Malware objects
                 elif obj_type == "malware":
-                    self.neo4j.merge_malware(
+                    ok = self.neo4j.merge_malware(
                         {
                             "name": obj.get("name", ""),
                             "malware_types": obj.get("malware_types", []),
@@ -479,7 +482,8 @@ class EdgeGuardPipeline:
                         },
                         source_id=obj.get("x_edgeguard_source", "unknown"),
                     )
-                    stats["malware"] += 1
+                    if ok:
+                        stats["malware"] += 1
 
                 # Handle Tool objects (Cobalt Strike, Mimikatz, etc.)
                 elif obj_type == "tool":
@@ -792,6 +796,32 @@ class EdgeGuardPipeline:
             fresh_baseline: If True with baseline, discard any existing checkpoints and start
                 from scratch. Default False preserves partial progress for resume.
         """
+        # ── Pipeline lock: prevent concurrent runs ──
+        lock_dir = os.path.join(os.path.dirname(__file__), "..", "checkpoints")
+        os.makedirs(lock_dir, exist_ok=True)
+        lock_path = os.path.join(lock_dir, "pipeline.lock")
+        try:
+            if os.path.exists(lock_path):
+                with open(lock_path) as f:
+                    old_pid = int(f.read().strip())
+                # Check if the process is still alive
+                try:
+                    os.kill(old_pid, 0)
+                    logger.warning(
+                        f"Another pipeline process (PID {old_pid}) appears to be running. "
+                        "If this is stale, delete checkpoints/pipeline.lock and retry."
+                    )
+                except (OSError, ProcessLookupError):
+                    logger.info(f"Stale lock file found (PID {old_pid} is gone) — removing.")
+        except (ValueError, IOError):
+            pass
+        with open(lock_path, "w") as f:
+            f.write(str(os.getpid()))
+
+        import atexit
+
+        atexit.register(lambda: os.remove(lock_path) if os.path.exists(lock_path) else None)
+
         # Import baseline checkpoint utilities
         from baseline_checkpoint import clear_checkpoint, get_baseline_status
 

--- a/tests/test_incremental_dedup.py
+++ b/tests/test_incremental_dedup.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 def test_update_source_incremental_merges_under_incremental_key():
     from baseline_checkpoint import clear_checkpoint, get_source_incremental, update_source_incremental
 
-    clear_checkpoint("testsrc_incr")
+    clear_checkpoint("testsrc_incr", include_incremental=True)  # full cleanup for test isolation
     update_source_incremental("testsrc_incr", foo="bar")
     assert get_source_incremental("testsrc_incr") == {"foo": "bar"}
     update_source_incremental("testsrc_incr", baz=1)
     assert get_source_incremental("testsrc_incr") == {"foo": "bar", "baz": 1}
-    clear_checkpoint("testsrc_incr")
+    clear_checkpoint("testsrc_incr", include_incremental=True)  # cleanup after test
 
 
 def test_misp_writer_push_items_skips_prefetched_type_value():


### PR DESCRIPTION
## Summary

Full production readiness sweep — code hardening, security fixes, and documentation cleanup.

### Code changes
- **query_api.py, graphql_api.py, metrics_server.py**: wrap all bare `int(os.getenv())` in try/except to prevent import-time crashes on malformed env vars
- **graphql_api.py**: add prod-mode API key enforcement (raises RuntimeError if `EDGEGUARD_ENV=prod` and no key set — matching the REST API)
- **.gitignore**: add `*.pem, *.key, *.cert, *.p12, *.pfx` exclusions

### Documentation
- **README.md**: CI badge, Python/Neo4j/license/version badges, EU Horizon Europe funding acknowledgment
- **CONTRIBUTING.md**: copied to repo root for GitHub auto-discovery
- **TECHNICAL_SPEC.md**: fix `actor_key` constraint typo (`m.tag` → `a.tag`), remove stale date
- **RESILMESH_INTEROPERABILITY.md**: fix malformed date

## Test plan
- [x] All 161 tests pass
- [x] ruff lint + format clean
- [x] No secrets in code or history
- [x] BugBot scan pending

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Airflow DAG scheduling/timeout behavior, adds new alerting metrics/alerts, and alters checkpoint clearing semantics, which can affect production pipeline execution and recovery workflows.
> 
> **Overview**
> **Production hardening + operability sweep**: defaults are tightened to loopback-only bindings across APIs/Neo4j/monitoring (`docker-compose*.yml`, `.env.example`, docs) and GraphQL now *requires* `EDGEGUARD_API_KEY` when `EDGEGUARD_ENV=prod`.
> 
> **Airflow reliability upgrades**: all six DAGs add `max_active_runs=1` and calibrated `dagrun_timeout`, plus new task success/failure callbacks that emit Prometheus gauges/counters for *stuck-run detection*; Prometheus alerting is enabled (Alertmanager target + new `EdgeGuardDAGRunStuck`/`EdgeGuardDAGLastSuccessStale` rules).
> 
> **Pipeline correctness + ops tooling**: Neo4j sync/pipeline stats now increment only when `merge_*` calls succeed, the Neo4j sync short-circuit tolerates corrupted state files, and CLI runs gain a `checkpoints/pipeline.lock` to prevent concurrent execution. Checkpoint clearing is refactored to preserve incremental cursors by default (with an `include_incremental` opt-in used by wipe scripts), and the `edgeguard` CLI adds `preflight`, `stats`, and Airflow DAG management (`dag status`/`dag kill`) via a new `src/airflow_client.py`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a5fc7cfed41da8be6fcf288350396cbf12a05c6f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->