### PR TITLE
v2026.3.29 — Production readiness + CLI improvements

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -857,3 +857,71 @@ Flag any `/health` implementation that returns 200 unconditionally without check
 `src/neo4j_client.py` maintains a `SOURCES` dict with `reliability` scores for each source.
 If a new collector is added, flag if there is no corresponding entry in `SOURCES` with an appropriate `reliability` value (0.0–1.0).
 Leaving a source out means its nodes get no `SOURCED_FROM` edges and no reliability weighting.
+
+---
+
+## 6. AIRFLOW DAG CONCURRENCY, TIMEOUTS & RETRIES — Blocking
+
+These rules protect against stuck/hung pipelines and concurrent run races. Violations can cause silent data loss or indefinite hangs in production.
+
+### Every DAG must have `max_active_runs=1`
+
+All 6 DAGs in `dags/edgeguard_pipeline.py` must set `max_active_runs=1`. Without this, a slow run causes the scheduler to pile up concurrent runs that race on MISP and Neo4j writes. Flag any DAG definition (`DAG(...)`) that is missing `max_active_runs=1`.
+
+### Every DAG must have `dagrun_timeout`
+
+All 6 DAGs must set `dagrun_timeout=timedelta(...)`. This is wall-clock time from DAG run start — if the entire run (including retries) exceeds this, Airflow marks it failed. Without it, a stuck run hangs indefinitely.
+
+The timeout must be **greater than** the worst-case task chain: `sum of sequential tasks' (execution_timeout x (1 + retries) + retries x retry_delay)`, using `max()` for parallel task groups, with at least 20% buffer. Flag any `dagrun_timeout` that is shorter than the worst-case calculation.
+
+Current correct values:
+
+| DAG | dagrun_timeout |
+|-----|---------------|
+| `edgeguard_pipeline` | 5h 30m |
+| `edgeguard_medium_freq` | 5h |
+| `edgeguard_low_freq` | 8h 30m |
+| `edgeguard_daily` | 8h 30m |
+| `edgeguard_neo4j_sync` | 22h |
+| `edgeguard_baseline` | 32h |
+
+### Every task must have `execution_timeout`
+
+All `PythonOperator` and `BashOperator` tasks must set `execution_timeout`. Without it, a single task can hang forever (e.g., MISP unresponsive) within the DAG run. Flag any task missing `execution_timeout`.
+
+### `dagrun_timeout` must be recalculated when task timeouts or retries change
+
+If someone changes a task's `execution_timeout`, or changes `retries`/`retry_delay` in `default_args`, the parent DAG's `dagrun_timeout` may need updating. Flag such changes without a corresponding `dagrun_timeout` update and ask for verification.
+
+### `default_args` must include `on_failure_callback`
+
+The `default_args` dict must include `on_failure_callback` pointing to `_on_task_failure`. This ensures all task failures are logged with `[ALERT]` and optionally sent to Slack. Flag removal of this callback.
+
+### `default_args` must include `on_success_callback`
+
+The `default_args` dict must include `on_success_callback` pointing to `_on_task_success`. This updates the `edgeguard_dag_last_success_timestamp` Prometheus gauge for stuck-run detection. Without it, the `EdgeGuardDAGLastSuccessStale` alert becomes dead code. Flag removal of this callback.
+
+### Baseline DAG must have `is_paused_upon_creation=False`
+
+`edgeguard_baseline` must set `is_paused_upon_creation=False`. Without this, manual triggers silently queue forever because Airflow starts DAGs paused by default. The `schedule_interval=None` already prevents automatic execution. Flag removal of this setting.
+
+### Neo4j merge return values must be checked before incrementing stats
+
+In `src/run_misp_to_neo4j.py` and `src/run_pipeline.py`, every call to `merge_indicator()`, `merge_vulnerability()`, `merge_cve()`, `merge_malware()`, `merge_actor()`, `merge_technique()` must check the boolean return value before incrementing the stats counter. Flag any pattern like:
+```python
+self.neo4j.merge_vulnerability(item, ...)
+self.stats["vulnerabilities_synced"] += 1  # BUG: not checking return value
+```
+The correct pattern is:
+```python
+if self.neo4j.merge_vulnerability(item, ...):
+    self.stats["vulnerabilities_synced"] += 1
+```
+
+### `clear_checkpoint()` must preserve incremental state
+
+`src/baseline_checkpoint.py` `clear_checkpoint(source=None)` (the `--fresh-baseline` path) must preserve `"incremental"` sub-dicts inside each source entry. These hold OTX `modified_since` cursors, MITRE ETags, etc. Destroying them forces scheduled runs to re-process all historical data. Flag any change to `clear_checkpoint` that deletes incremental state on the global (no-source) path.
+
+### Prometheus stuck-run alerts require gauge wiring
+
+The `EdgeGuardDAGRunStuck` and `EdgeGuardDAGLastSuccessStale` alerts in `prometheus/alerts.yml` depend on `edgeguard_dag_run_start_timestamp` and `edgeguard_dag_last_success_timestamp` gauges being set by the DAG code. If these gauges are defined but never `.set()`, the alerts are dead code. Flag removal of `on_success_callback` or the `DAG_LAST_SUCCESS`/`DAG_RUN_START` gauge definitions without also removing the corresponding alerts.

--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -925,3 +925,50 @@ if self.neo4j.merge_vulnerability(item, ...):
 ### Prometheus stuck-run alerts require gauge wiring
 
 The `EdgeGuardDAGRunStuck` and `EdgeGuardDAGLastSuccessStale` alerts in `prometheus/alerts.yml` depend on `edgeguard_dag_run_start_timestamp` and `edgeguard_dag_last_success_timestamp` gauges being set by the DAG code. If these gauges are defined but never `.set()`, the alerts are dead code. Flag removal of `on_success_callback` or the `DAG_LAST_SUCCESS`/`DAG_RUN_START` gauge definitions without also removing the corresponding alerts.
+
+---
+
+## 7. CROSS-FILE CONTRACTS — Blocking
+
+These rules catch inconsistencies between Python files that interact through shared data, metrics, or conventions.
+
+### All `datetime.now()` must use `timezone.utc`
+
+Every call to `datetime.now()` across `src/`, `dags/`, `tests/`, and `scripts/` must pass `timezone.utc`. Bare `datetime.now()` produces naive timestamps that crash when compared to timezone-aware values (common in MISP/Airflow/Neo4j data). Flag any bare `datetime.now()` without `timezone.utc`.
+
+### Neo4j timestamps must use Cypher `datetime()`, not Python ISO strings
+
+All Cypher SET clauses for `first_seen`, `last_updated`, `first_imported_at` must use the Neo4j server-side `datetime()` function, not Python-side `$parameter` strings. Storing ISO strings as `last_updated` breaks `duration.between()` in enrichment decay queries. Flag any Cypher that writes `$first_seen` or `$last_updated` as string parameters instead of `datetime()`.
+
+### Prometheus metric labels must match between `metrics_server.py` and `dags/edgeguard_pipeline.py`
+
+Both files define the same Prometheus metrics (standalone and production paths). The label sets MUST be identical:
+- `PIPELINE_ERRORS`: `["task", "error_type", "source"]`
+- `DAG_RUNS_TOTAL`: `["dag_id", "status", "run_type"]`
+- `INDICATORS_COLLECTED`: `["source", "zone", "status"]`
+- `NEO4J_NODES`: `["label", "zone"]`
+- `SOURCE_HEALTH`: `["source", "zone"]` (metric name: `edgeguard_source_health`)
+- `DAG_LAST_SUCCESS`: `["dag_id"]`
+- `DAG_RUN_START`: `["dag_id"]`
+
+Flag any change to metric labels in one file without updating the other. Also flag any `.labels()` call that does not pass ALL required labels.
+
+### Production metrics import must cover all metrics used by DAG functions
+
+When `METRICS_SERVER_AVAILABLE` is True, the DAG imports metrics from `metrics_server.py`. ALL metrics used by unconditionally-defined functions (`record_indicators`, `record_neo4j_nodes`, `record_error`, `set_source_health`, etc.) must be imported. Flag any new metric usage in a DAG function without a corresponding import in the `METRICS_SERVER_AVAILABLE` block.
+
+### `retry_with_backoff` semantics must be consistent
+
+Three implementations exist: `collector_utils.py`, `neo4j_client.py`, `run_misp_to_neo4j.py`. All must use `range(max_retries + 1)` (first attempt + max_retries retries). The final error log must say `max_retries + 1` attempts. Flag any `range(max_retries)` without the `+ 1`.
+
+### Sync state file path must be checked in both `state/` and `dags/` directories
+
+`dags/edgeguard_pipeline.py` writes to `state/edgeguard_last_neo4j_sync.json`. `src/edgeguard.py` reads from multiple paths. Both `get_sync_status()` and `check_last_sync()` must include `state/` as a search path. Flag removal of the `state/` directory from the alt_paths list.
+
+### `source` field contract: singular key, list value, `n.source` Neo4j property
+
+All collector dicts must use `"source": [tag]` (singular key, list value). Neo4j node property is `n.source` (singular). Relationship properties may use `r.sources` (plural, different namespace). Flag any `"sources":` dict key in collector output, any `n.sources` in Cypher matching nodes, or any `.get("sources")` reading from Neo4j node results.
+
+### Changes must be reflected in documentation
+
+When code changes affect user-visible behavior (CLI commands, env vars, DAG settings, API responses), the corresponding documentation must be updated. Check: `README.md` (CLI table, env vars), `docs/AIRFLOW_DAGS.md` (DAG settings, CLI section), `docs/DEPLOYMENT_READINESS_CHECKLIST.md` (preflight steps), `docs/PRODUCTION_READINESS.md` (component status). Flag code changes without matching doc updates.

--- a/.env.example
+++ b/.env.example
@@ -81,7 +81,7 @@ OTEL_EXPORTER_OTLP_INSECURE=false
 
 # Port for the EdgeGuard GraphQL endpoint (mirrors ISIM GraphQL on port 4001).
 EDGEGUARD_GRAPHQL_PORT=4001
-EDGEGUARD_GRAPHQL_HOST=0.0.0.0
+EDGEGUARD_GRAPHQL_HOST=127.0.0.1
 
 # Disable the interactive GraphiQL browser explorer in production.
 EDGEGUARD_GRAPHQL_PLAYGROUND=false

--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,12 @@ credentials/api_keys.yaml
 .env
 .env.*
 !.env.example
+# TLS certificates and private keys
+*.pem
+*.key
+*.cert
+*.p12
+*.pfx
 
 # =============================================================================
 # Python

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing & pull requests
+
+## Before you open a PR
+
+Use **Python 3.12+** (see `pyproject.toml` `requires-python`; CI uses 3.12).
+
+1. **Install dev deps:** `pip install -r requirements-dev.txt`
+2. **Lint & format:** `make lint` (or `ruff check` / `ruff format --check` as in CI)
+3. **Types (optional but recommended):** `make type-check`
+4. **Tests:** `make test` — same env vars as CI (`NEO4J_*`, `MISP_*` dummies are set by the Makefile)
+
+CI runs **Ruff**, **Mypy**, **pytest** (with coverage floor 30%), **Docker build**, and **pip-audit** — see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
+
+## New CLI / version behavior
+
+- **`edgeguard version`** / **`edgeguard update`** — covered by `tests/test_edgeguard_cli_light.py` (update path mocks `subprocess.call` so `install.sh` is not executed in CI).
+- **CalVer** — bump `[project].version` in `pyproject.toml` only when cutting a release; see [`VERSIONING.md`](VERSIONING.md).
+
+## Commits
+
+Use clear messages (e.g. `test: add CLI smoke tests`, `ci: run PR workflow for all branches`). No secrets or real API keys in commits.
+
+## Generated Airflow files (local installs)
+
+If you run Airflow on the host (not only via repo `docker-compose.yml`), **do not commit** local metadata database files (Apache Airflow may create one in `AIRFLOW_HOME`), or any generated secrets/config you copy out of the container. Prefer Docker Compose metadata (**`airflow_postgres`**) for a clean, team-aligned setup. `airflow.cfg` and `webserver_config.py` remain listed in `.gitignore` for typical local layouts.
+
+---
+
+_Last updated: 2026-03-20_

--- a/README.md
+++ b/README.md
@@ -10,7 +10,20 @@
 </p>
 
 <p align="center">
+  <a href="https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/actions/workflows/ci.yml"><img src="https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
+  <img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+">
+  <img src="https://img.shields.io/badge/neo4j-5.27-green.svg" alt="Neo4j 5.27">
+  <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
+  <img src="https://img.shields.io/badge/version-2026.3.28-orange.svg" alt="Version">
+</p>
+
+<p align="center">
   IICT-BAS + Ratio1 | financed by ResilMesh - open call 2
+</p>
+
+<p align="center">
+  <em>This project has received funding through the <strong>ResilMesh Open Call 2</strong>,<br>
+  supported by the European Union's Horizon Europe research and innovation programme.</em>
 </p>
 
 ---

--- a/README.md
+++ b/README.md
@@ -139,9 +139,13 @@ python src/edgeguard.py stats      # quick dashboard: node counts, last sync, pi
 | Command | Purpose |
 |---------|---------|
 | `edgeguard preflight` | Pre-run readiness check (7 categories, `--strict` for CI) |
-| `edgeguard stats --full` | Node counts by type/zone/source + MISP event breakdown |
-| `edgeguard dag status` | Airflow DAG run states (running/queued/failed/success) |
-| `edgeguard dag kill` | Force-fail stuck DAG runs (preserves checkpoints) |
+| `edgeguard stats` | Quick dashboard: node counts, last sync, pipeline runs |
+| `edgeguard stats --full` | + breakdown by zone, source, and MISP events/zones |
+| `edgeguard stats --by-zone` | Node counts per zone (shows multi-zone overlap) |
+| `edgeguard stats --by-source` | Node counts per source (nvd, otx, cisa, etc.) |
+| `edgeguard stats --misp` | MISP event/attribute counts by source and by zone |
+| `edgeguard dag status` | Airflow DAG run states (color-coded, `--state running` filter) |
+| `edgeguard dag kill` | Force-fail stuck DAG runs (preserves checkpoints, `--dry-run`) |
 | `edgeguard checkpoint status` | Per-source baseline progress + incremental cursors |
 | `edgeguard checkpoint clear` | Clear baseline state (preserves incremental by default) |
 | `edgeguard doctor` | Diagnose connectivity (MISP, Neo4j, Airflow, NATS, schema) |

--- a/README.md
+++ b/README.md
@@ -127,11 +127,30 @@ cd EdgeGuard-Knowledge-Graph
 
 **Post-install validation (run this after any install method):**
 ```bash
+python src/edgeguard.py preflight  # comprehensive readiness check (env vars, APIs, Neo4j, MISP, Airflow, disk)
 python src/edgeguard.py doctor     # checks MISP, Neo4j, Airflow, NATS, schema, API keys, version compatibility
-python src/edgeguard.py validate   # checks config, rate limits, Neo4j labels/constraints, production readiness
+python src/edgeguard.py stats      # quick dashboard: node counts, last sync, pipeline runs
 ```
 
-`doctor` will detect hidden issues like MISP/PyMISP version mismatches that can silently hang the Airflow scheduler, missing Neo4j constraints, unreachable services, and misconfigured API keys. **Always run `doctor` after setup** — it takes 5 seconds and can save hours of debugging.
+`preflight` runs 7 check categories (env vars, API connectivity, Neo4j schema, MISP health, Airflow, disk, circuit breakers) and exits 0 = ready or 1 = issues found. `stats` shows what data is in the system right now.
+
+**EdgeGuard CLI quick reference:**
+
+| Command | Purpose |
+|---------|---------|
+| `edgeguard preflight` | Pre-run readiness check (7 categories, `--strict` for CI) |
+| `edgeguard stats --full` | Node counts by type/zone/source + MISP event breakdown |
+| `edgeguard dag status` | Airflow DAG run states (running/queued/failed/success) |
+| `edgeguard dag kill` | Force-fail stuck DAG runs (preserves checkpoints) |
+| `edgeguard checkpoint status` | Per-source baseline progress + incremental cursors |
+| `edgeguard checkpoint clear` | Clear baseline state (preserves incremental by default) |
+| `edgeguard doctor` | Diagnose connectivity (MISP, Neo4j, Airflow, NATS, schema) |
+| `edgeguard heal` | Auto-repair (reset circuit breakers, clear locks, retry) |
+| `edgeguard validate` | Config validation (rate limits, passwords, Neo4j schema) |
+| `edgeguard monitor` | Real-time health display |
+| `edgeguard version` | CalVer + git SHA |
+
+All commands support `--help`. Data commands support `--json` for automation.
 
 **Then (recommended order):** [docs/SETUP_GUIDE.md](docs/SETUP_GUIDE.md) (finish wiring) → [docs/AIRFLOW_DAGS.md](docs/AIRFLOW_DAGS.md) (run DAGs) → [docs/BASELINE_SMOKE_TEST.md](docs/BASELINE_SMOKE_TEST.md) (first baseline). See **§ Recommended reading order** below.
 
@@ -437,7 +456,8 @@ EdgeGuard/
 │   ├── graphql_schema.py       # Strawberry type definitions (CVE, Indicator, Actor …)
 │   ├── health_check.py         # MISP + Neo4j connectivity checks
 │   ├── resilience.py           # Circuit breakers and retry logic
-│   ├── edgeguard.py            # CLI: doctor / heal / validate / monitor / update / version
+│   ├── edgeguard.py            # CLI: preflight / stats / dag / checkpoint / doctor / heal / validate / monitor
+│   ├── airflow_client.py       # Airflow REST API wrapper (used by CLI dag commands)
 │   └── collectors/             # One module per data source
 │       ├── otx_collector.py
 │       ├── nvd_collector.py    # Extracts CVSSv2, CVSSv31, CVSSv40
@@ -820,7 +840,7 @@ EdgeGuard v2026.3.28 is **production-test ready**. Full pipeline validated on Do
 - **Full-stack Docker Compose**: Neo4j + Airflow + REST API + GraphQL in one `docker compose up -d`; also supports conda/venv/bare-metal with external MISP+Neo4j
 - **CI/CD**: Lint (ruff), type-check (mypy), pytest (161 tests, 30% coverage gate), Docker build, pip-audit, BugBot — all green
 - **Health Checks + Metrics**: MISP (with PyMISP version compatibility detection), Neo4j (with 30s timeout), Airflow, NATS; Prometheus/Grafana monitoring stack
-- **Production CLI**: `edgeguard doctor` (checks MISP/Neo4j/Airflow/NATS/schema/version compatibility), `heal` (real circuit breaker reset + DAG trigger), `validate` (Neo4j labels + constraints)
+- **Production CLI** (16 commands): `preflight` (8-category readiness check), `stats --full` (node counts by zone/source + MISP breakdown), `dag status/kill` (Airflow run monitoring + stuck-run recovery), `checkpoint status/clear` (baseline progress + incremental cursors), `doctor`, `heal`, `validate`, `monitor`, `version`
 - **Circuit Breakers + Retry**: Fixed HALF_OPEN deadlock, monotonic time, resilience patterns for all external service calls
 - **UTC-aware timestamps**: All 70+ datetime instances across 24 files use `timezone.utc` (Python 3.12 compatible)
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -95,6 +95,7 @@ import logging
 import os
 import sys
 import threading
+import time
 from datetime import datetime, timedelta, timezone
 from typing import Optional
 
@@ -261,6 +262,18 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE:
             "edgeguard_last_success_timestamp", "Unix timestamp of last successful collection", ["source"]
         )
 
+        # DAG-level stuck-run detection
+        DAG_LAST_SUCCESS = Gauge(
+            "edgeguard_dag_last_success_timestamp",
+            "Unix timestamp of last successful DAG run (0 = never succeeded)",
+            ["dag_id"],
+        )
+        DAG_RUN_START = Gauge(
+            "edgeguard_dag_run_start_timestamp",
+            "Unix timestamp when the current DAG run started (0 = idle)",
+            ["dag_id"],
+        )
+
         logger.info("Prometheus metrics enabled (standalone mode)")
     except ImportError:
         logger.warning("prometheus_client not installed. Install with: pip install prometheus_client")
@@ -385,19 +398,52 @@ def send_slack_alert(message: str, channel: str = None):
 
 def _on_task_failure(context):
     """Callback on any task failure — logs prominently and sends Slack if enabled."""
-    dag_id = context.get("dag", {}).dag_id if context.get("dag") else "unknown"
-    task_id = context.get("task_instance", {}).task_id if context.get("task_instance") else "unknown"
+    dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
+    task_id = context.get("task_instance").task_id if context.get("task_instance") else "unknown"
     exc = context.get("exception", "")
     logger.error(f"[ALERT] Task FAILED: {dag_id}.{task_id} — {exc}")
     if ENABLE_SLACK_ALERTS:
         send_slack_alert(f"Task FAILED: {dag_id}.{task_id} — {exc}", level="critical")
     if ENABLE_PROMETHEUS_METRICS:
         try:
-            from resilience import COLLECTION_FAILURES
-
-            COLLECTION_FAILURES.labels(source=task_id, error_type="task_failure").inc()
+            PIPELINE_ERRORS.labels(task=task_id, error_type="task_failure").inc()
         except Exception:
             pass
+
+
+def _on_task_success(context):
+    """Callback on any task success — update DAG-level success gauge for stuck-run detection."""
+    if not ENABLE_PROMETHEUS_METRICS:
+        return
+    dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
+    try:
+        DAG_LAST_SUCCESS.labels(dag_id=dag_id).set(time.time())
+    except Exception:
+        pass
+
+
+def _on_dag_run_start(**kwargs):
+    """Called by the first task in each DAG to mark the run as in-progress."""
+    if not ENABLE_PROMETHEUS_METRICS:
+        return
+    dag_id = kwargs.get("dag", None)
+    dag_id = dag_id.dag_id if dag_id else "unknown"
+    try:
+        DAG_RUN_START.labels(dag_id=dag_id).set(time.time())
+    except Exception:
+        pass
+
+
+def _on_dag_run_end(**kwargs):
+    """Called by the last task in each DAG to clear the in-progress marker."""
+    if not ENABLE_PROMETHEUS_METRICS:
+        return
+    dag_id = kwargs.get("dag", None)
+    dag_id = dag_id.dag_id if dag_id else "unknown"
+    try:
+        DAG_RUN_START.labels(dag_id=dag_id).set(0)
+    except Exception:
+        pass
 
 
 # Default arguments
@@ -409,6 +455,7 @@ default_args = {
     "retries": 2,
     "retry_delay": timedelta(minutes=5),
     "on_failure_callback": _on_task_failure,
+    "on_success_callback": _on_task_success,
 }
 
 # ================================================================================

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -266,7 +266,9 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS
         MISP_PUSH_DURATION = Histogram("edgeguard_misp_push_duration_seconds", "Time spent pushing to MISP", ["source"])
         NEO4J_SYNC_DURATION = Histogram("edgeguard_neo4j_sync_duration_seconds", "Time spent syncing to Neo4j")
         NEO4J_NODES = Gauge("edgeguard_neo4j_nodes", "Number of nodes in Neo4j", ["type"])
-        PIPELINE_ERRORS = Counter("edgeguard_pipeline_errors_total", "Total pipeline errors", ["task", "error_type", "source"])
+        PIPELINE_ERRORS = Counter(
+            "edgeguard_pipeline_errors_total", "Total pipeline errors", ["task", "error_type", "source"]
+        )
         SOURCE_HEALTH = Gauge("edgeguard_source_healthy", "Health status of data sources", ["source"])
 
         # Circuit breaker state metrics

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1022,7 +1022,7 @@ dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,  # Prevent pile-up if a run is slow
-    dagrun_timeout=timedelta(hours=2),  # Kill hung runs
+    dagrun_timeout=timedelta(hours=5, minutes=30),  # Worst-case: 4h25m (OTX retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "high-frequency"],
 )
 
@@ -1100,7 +1100,7 @@ medium_freq_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=3),
+    dagrun_timeout=timedelta(hours=5),  # Worst-case: 4h (CISA/VT retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "medium-frequency"],
 )
 
@@ -1147,7 +1147,7 @@ low_freq_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=6),
+    dagrun_timeout=timedelta(hours=8, minutes=30),  # Worst-case: 7h (NVD retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "low-frequency"],
 )
 
@@ -1187,7 +1187,7 @@ daily_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=6),
+    dagrun_timeout=timedelta(hours=8, minutes=30),  # Worst-case: 7h (7 collectors parallel + retries) + buffer
     tags=["threat-intel", "edgeguard", "misp", "daily"],
 )
 
@@ -1290,7 +1290,7 @@ neo4j_sync_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,
-    dagrun_timeout=timedelta(hours=8),
+    dagrun_timeout=timedelta(hours=22),  # Worst-case: 18h (full sync + rels + enrich, all with retries)
     tags=["threat-intel", "edgeguard", "neo4j", "sync"],
 )
 
@@ -1416,7 +1416,7 @@ baseline_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,  # Only one baseline at a time
-    dagrun_timeout=timedelta(hours=12),  # Kill if stuck longer than 12h
+    dagrun_timeout=timedelta(hours=32),  # Worst-case: 26h (full collection + sync + retries) + buffer
     is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -263,21 +263,20 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS
             "edgeguard_dag_runs_total", "Total number of DAG runs", ["dag_id", "status", "run_type"]
         )
         INDICATORS_COLLECTED = Counter(
-            "edgeguard_indicators_collected_total", "Total indicators collected", ["source", "zone"]
+            "edgeguard_indicators_collected_total", "Total indicators collected", ["source", "zone", "status"]
         )
         MISP_PUSH_DURATION = Histogram("edgeguard_misp_push_duration_seconds", "Time spent pushing to MISP", ["source"])
         NEO4J_SYNC_DURATION = Histogram("edgeguard_neo4j_sync_duration_seconds", "Time spent syncing to Neo4j")
-        NEO4J_NODES = Gauge("edgeguard_neo4j_nodes", "Number of nodes in Neo4j", ["type"])
+        NEO4J_NODES = Gauge("edgeguard_neo4j_nodes", "Number of nodes in Neo4j by label", ["label", "zone"])
         PIPELINE_ERRORS = Counter(
             "edgeguard_pipeline_errors_total", "Total pipeline errors", ["task", "error_type", "source"]
         )
-        SOURCE_HEALTH = Gauge("edgeguard_source_healthy", "Health status of data sources", ["source"])
+        SOURCE_HEALTH = Gauge("edgeguard_source_health", "Data source health status", ["source", "zone"])
 
         # Circuit breaker state metrics
         CIRCUIT_OPEN = Gauge("edgeguard_circuit_open", "Circuit breaker state (1=open, 0=closed)", ["service"])
-        LAST_SUCCESS_TIMESTAMP = Gauge(
-            "edgeguard_last_success_timestamp", "Unix timestamp of last successful collection", ["source"]
-        )
+        # Note: edgeguard_last_success_timestamp is already registered by resilience.py
+        # (imported above). Do NOT re-register here to avoid duplicate timeseries error.
 
         # DAG-level stuck-run detection
         DAG_LAST_SUCCESS = Gauge(
@@ -307,10 +306,10 @@ if not METRICS_SERVER_AVAILABLE:
             DAG_RUNS_TOTAL.labels(dag_id=dag_id, status=status, run_type=run_type).inc()
 
 
-def record_indicators(source: str, zone: str, count: int):
+def record_indicators(source: str, zone: str, count: int, status: str = "success"):
     """Record collected indicators."""
     if PROMETHEUS_AVAILABLE:
-        INDICATORS_COLLECTED.labels(source=source, zone=zone).inc(count)
+        INDICATORS_COLLECTED.labels(source=source, zone=zone, status=status).inc(count)
 
 
 def record_misp_push_duration(source: str, duration: float):
@@ -325,10 +324,10 @@ def record_neo4j_sync_duration(duration: float):
         NEO4J_SYNC_DURATION.observe(duration)
 
 
-def record_neo4j_nodes(node_type: str, count: int):
+def record_neo4j_nodes(node_type: str, count: int, zone: str = "all"):
     """Record Neo4j node counts."""
     if PROMETHEUS_AVAILABLE:
-        NEO4J_NODES.labels(type=node_type).set(count)
+        NEO4J_NODES.labels(label=node_type, zone=zone).set(count)
 
 
 def record_error(task: str, error_type: str, source: str = ""):
@@ -340,9 +339,9 @@ def record_error(task: str, error_type: str, source: str = ""):
 if not METRICS_SERVER_AVAILABLE:
 
     def set_source_health(source: str, zone: str, healthy: bool):
-        """Set source health (standalone mode: gauge has source label only; zone ignored)."""
+        """Set source health status."""
         if PROMETHEUS_AVAILABLE:
-            SOURCE_HEALTH.labels(source=source).set(1 if healthy else 0)
+            SOURCE_HEALTH.labels(source=source, zone=zone).set(1 if healthy else 0)
 
 
 def set_circuit_state(service: str, is_open: bool):
@@ -353,10 +352,8 @@ def set_circuit_state(service: str, is_open: bool):
 
 def set_last_success_timestamp(source: str):
     """Set last successful collection timestamp."""
-    if PROMETHEUS_AVAILABLE:
-        import time
-
-        LAST_SUCCESS_TIMESTAMP.labels(source=source).set(time.time())
+    if RESILIENCE_METRICS_AVAILABLE:
+        LAST_SUCCESS.labels(source=source).set(time.time())
 
 
 def log_circuit_breaker_status():

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -383,6 +383,23 @@ def send_slack_alert(message: str, channel: str = None):
         logger.warning(f"Failed to send Slack alert: {e}")
 
 
+def _on_task_failure(context):
+    """Callback on any task failure — logs prominently and sends Slack if enabled."""
+    dag_id = context.get("dag", {}).dag_id if context.get("dag") else "unknown"
+    task_id = context.get("task_instance", {}).task_id if context.get("task_instance") else "unknown"
+    exc = context.get("exception", "")
+    logger.error(f"[ALERT] Task FAILED: {dag_id}.{task_id} — {exc}")
+    if ENABLE_SLACK_ALERTS:
+        send_slack_alert(f"Task FAILED: {dag_id}.{task_id} — {exc}", level="critical")
+    if ENABLE_PROMETHEUS_METRICS:
+        try:
+            from resilience import COLLECTION_FAILURES
+
+            COLLECTION_FAILURES.labels(source=task_id, error_type="task_failure").inc()
+        except Exception:
+            pass
+
+
 # Default arguments
 default_args = {
     "owner": "edgeguard",
@@ -391,6 +408,7 @@ default_args = {
     "email_on_retry": False,
     "retries": 2,
     "retry_delay": timedelta(minutes=5),
+    "on_failure_callback": _on_task_failure,
 }
 
 # ================================================================================
@@ -853,15 +871,18 @@ def should_run_neo4j_sync():
         logger.warning(f"Failed to get NEO4J_SYNC_INTERVAL, using default: {e}")
         interval_hours = 72
 
-    if os.path.exists(state_file):
-        with open(state_file, "r") as f:
-            state = json.load(f)
-            _raw = state.get("last_sync", "2000-01-01T00:00:00+00:00")
-            last_sync = datetime.fromisoformat(_raw if "+" in _raw or "Z" in _raw else _raw + "+00:00")
+    try:
+        if os.path.exists(state_file):
+            with open(state_file, "r") as f:
+                state = json.load(f)
+                _raw = state.get("last_sync", "2000-01-01T00:00:00+00:00")
+                last_sync = datetime.fromisoformat(_raw if "+" in _raw or "Z" in _raw else _raw + "+00:00")
 
-            if datetime.now(timezone.utc) - last_sync < timedelta(hours=interval_hours):
-                logger.info(f"Skipping Neo4j sync - last sync was {last_sync}, interval is {interval_hours}h")
-                return False
+                if datetime.now(timezone.utc) - last_sync < timedelta(hours=interval_hours):
+                    logger.info(f"Skipping Neo4j sync - last sync was {last_sync}, interval is {interval_hours}h")
+                    return False
+    except (json.JSONDecodeError, OSError, ValueError) as e:
+        logger.error(f"Corrupted sync state file ({state_file}): {e} — running sync to be safe")
 
     logger.info(f"Running Neo4j sync - interval {interval_hours}h has passed")
     return True
@@ -1000,6 +1021,8 @@ dag = DAG(
     schedule_interval="*/30 * * * *",
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,  # Prevent pile-up if a run is slow
+    dagrun_timeout=timedelta(hours=2),  # Kill hung runs
     tags=["threat-intel", "edgeguard", "misp", "high-frequency"],
 )
 
@@ -1076,6 +1099,8 @@ medium_freq_dag = DAG(
     schedule_interval="0 */4 * * *",  # Every 4 hours
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=3),
     tags=["threat-intel", "edgeguard", "misp", "medium-frequency"],
 )
 
@@ -1121,6 +1146,8 @@ low_freq_dag = DAG(
     schedule_interval="0 */8 * * *",  # Every 8 hours
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=6),
     tags=["threat-intel", "edgeguard", "misp", "low-frequency"],
 )
 
@@ -1159,6 +1186,8 @@ daily_dag = DAG(
     schedule_interval="0 2 * * *",  # Daily at 2 AM
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=6),
     tags=["threat-intel", "edgeguard", "misp", "daily"],
 )
 
@@ -1260,12 +1289,15 @@ neo4j_sync_dag = DAG(
     schedule_interval="0 3 */3 * *",  # Every 3 days at 3 AM
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,
+    dagrun_timeout=timedelta(hours=8),
     tags=["threat-intel", "edgeguard", "neo4j", "sync"],
 )
 
 check_neo4j_sync_needed = ShortCircuitOperator(
     task_id="check_sync_needed",
     python_callable=should_run_neo4j_sync,
+    execution_timeout=timedelta(minutes=2),
     dag=neo4j_sync_dag,
 )
 
@@ -1383,6 +1415,8 @@ baseline_dag = DAG(
     schedule_interval=None,  # MANUAL TRIGGER ONLY
     start_date=_DAG_START_DATE,
     catchup=False,
+    max_active_runs=1,  # Only one baseline at a time
+    dagrun_timeout=timedelta(hours=12),  # Kill if stuck longer than 12h
     is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -266,7 +266,7 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS
         MISP_PUSH_DURATION = Histogram("edgeguard_misp_push_duration_seconds", "Time spent pushing to MISP", ["source"])
         NEO4J_SYNC_DURATION = Histogram("edgeguard_neo4j_sync_duration_seconds", "Time spent syncing to Neo4j")
         NEO4J_NODES = Gauge("edgeguard_neo4j_nodes", "Number of nodes in Neo4j", ["type"])
-        PIPELINE_ERRORS = Counter("edgeguard_pipeline_errors_total", "Total pipeline errors", ["task", "error_type"])
+        PIPELINE_ERRORS = Counter("edgeguard_pipeline_errors_total", "Total pipeline errors", ["task", "error_type", "source"])
         SOURCE_HEALTH = Gauge("edgeguard_source_healthy", "Health status of data sources", ["source"])
 
         # Circuit breaker state metrics
@@ -419,7 +419,7 @@ def _on_task_failure(context):
         send_slack_alert(f"Task FAILED: {dag_id}.{task_id} — {exc}", level="critical")
     if ENABLE_PROMETHEUS_METRICS:
         try:
-            PIPELINE_ERRORS.labels(task=task_id, error_type="task_failure").inc()
+            PIPELINE_ERRORS.labels(task=task_id, error_type="task_failure", source=dag_id).inc()
         except Exception:
             pass
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -241,11 +241,24 @@ if ENABLE_PROMETHEUS_METRICS and METRICS_SERVER_AVAILABLE:
         from metrics_server import (
             DAG_LAST_SUCCESS,
             DAG_RUN_START,
+            INDICATORS_COLLECTED,
+            MISP_PUSH_DURATION,
+            NEO4J_NODES,
+            NEO4J_SYNC_DURATION,
             PIPELINE_ERRORS,
+            SOURCE_HEALTH,
         )
         from metrics_server import (
             DAG_RUNS as DAG_RUNS_TOTAL,
         )
+
+        # CIRCUIT_OPEN is not in metrics_server; define locally if needed
+        try:
+            from prometheus_client import Gauge as _Gauge
+
+            CIRCUIT_OPEN = _Gauge("edgeguard_circuit_open", "Circuit breaker state (1=open, 0=closed)", ["service"])
+        except Exception:
+            pass
 
         PROMETHEUS_AVAILABLE = True
         logger.info("Prometheus metrics imported from metrics_server (production mode)")

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -252,13 +252,14 @@ if ENABLE_PROMETHEUS_METRICS and METRICS_SERVER_AVAILABLE:
             DAG_RUNS as DAG_RUNS_TOTAL,
         )
 
-        # CIRCUIT_OPEN is not in metrics_server; define locally if needed
+        # CIRCUIT_OPEN is not in metrics_server; define locally
         try:
             from prometheus_client import Gauge as _Gauge
 
             CIRCUIT_OPEN = _Gauge("edgeguard_circuit_open", "Circuit breaker state (1=open, 0=closed)", ["service"])
-        except Exception:
-            pass
+        except Exception as e:
+            CIRCUIT_OPEN = None
+            logger.warning(f"Could not create CIRCUIT_OPEN gauge: {e}")
 
         PROMETHEUS_AVAILABLE = True
         logger.info("Prometheus metrics imported from metrics_server (production mode)")
@@ -359,7 +360,7 @@ if not METRICS_SERVER_AVAILABLE:
 
 def set_circuit_state(service: str, is_open: bool):
     """Set circuit breaker state."""
-    if PROMETHEUS_AVAILABLE:
+    if PROMETHEUS_AVAILABLE and CIRCUIT_OPEN is not None:
         CIRCUIT_OPEN.labels(service=service).set(1 if is_open else 0)
 
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -234,12 +234,25 @@ def ensure_metrics_server():
 
 PROMETHEUS_AVAILABLE = False
 
-# Only register local Prometheus counters when metrics_server is NOT available.
-# When metrics_server IS available it already registers these same metric names
-# (potentially with different label sets), so attempting to re-register them
-# causes a ValueError: "Duplicated timeseries in CollectorRegistry" on every
-# Airflow DAG re-parse.
-if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE:
+# When metrics_server IS available (production), import gauges from it to avoid
+# duplicate registration.  When NOT available (standalone/dev), define them locally.
+if ENABLE_PROMETHEUS_METRICS and METRICS_SERVER_AVAILABLE:
+    try:
+        from metrics_server import (
+            DAG_LAST_SUCCESS,
+            DAG_RUN_START,
+            PIPELINE_ERRORS,
+        )
+        from metrics_server import (
+            DAG_RUNS as DAG_RUNS_TOTAL,
+        )
+
+        PROMETHEUS_AVAILABLE = True
+        logger.info("Prometheus metrics imported from metrics_server (production mode)")
+    except (ImportError, AttributeError) as e:
+        logger.warning(f"Could not import metrics from metrics_server: {e}")
+
+if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS_AVAILABLE:
     try:
         from prometheus_client import Counter, Gauge, Histogram
 
@@ -397,7 +410,7 @@ def send_slack_alert(message: str, channel: str = None):
 
 
 def _on_task_failure(context):
-    """Callback on any task failure — logs prominently and sends Slack if enabled."""
+    """Callback on any task failure — logs prominently, updates metrics, sends Slack if enabled."""
     dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
     task_id = context.get("task_instance").task_id if context.get("task_instance") else "unknown"
     exc = context.get("exception", "")
@@ -412,36 +425,20 @@ def _on_task_failure(context):
 
 
 def _on_task_success(context):
-    """Callback on any task success — update DAG-level success gauge for stuck-run detection."""
+    """Callback on any task success — updates DAG activity timestamp.
+
+    Sets DAG_LAST_SUCCESS on every task completion so the
+    EdgeGuardDAGLastSuccessStale alert can detect DAGs where no task
+    has succeeded recently (covers both partial and full failures).
+    Also refreshes DAG_RUN_START to show the DAG is actively progressing.
+    """
     if not ENABLE_PROMETHEUS_METRICS:
         return
     dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
+    now = time.time()
     try:
-        DAG_LAST_SUCCESS.labels(dag_id=dag_id).set(time.time())
-    except Exception:
-        pass
-
-
-def _on_dag_run_start(**kwargs):
-    """Called by the first task in each DAG to mark the run as in-progress."""
-    if not ENABLE_PROMETHEUS_METRICS:
-        return
-    dag_id = kwargs.get("dag", None)
-    dag_id = dag_id.dag_id if dag_id else "unknown"
-    try:
-        DAG_RUN_START.labels(dag_id=dag_id).set(time.time())
-    except Exception:
-        pass
-
-
-def _on_dag_run_end(**kwargs):
-    """Called by the last task in each DAG to clear the in-progress marker."""
-    if not ENABLE_PROMETHEUS_METRICS:
-        return
-    dag_id = kwargs.get("dag", None)
-    dag_id = dag_id.dag_id if dag_id else "unknown"
-    try:
-        DAG_RUN_START.labels(dag_id=dag_id).set(0)
+        DAG_LAST_SUCCESS.labels(dag_id=dag_id).set(now)
+        DAG_RUN_START.labels(dag_id=dag_id).set(now)  # keeps refreshing while DAG is active
     except Exception:
         pass
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -301,10 +301,10 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS
 # is unavailable; otherwise the imported versions from metrics_server remain active.
 if not METRICS_SERVER_AVAILABLE:
 
-    def record_dag_run(dag_id: str, status: str = "success"):
+    def record_dag_run(dag_id: str, status: str = "success", run_type: str = "scheduled"):
         """Record a DAG run in metrics."""
         if PROMETHEUS_AVAILABLE:
-            DAG_RUNS_TOTAL.labels(status=status, dag_id=dag_id).inc()
+            DAG_RUNS_TOTAL.labels(dag_id=dag_id, status=status, run_type=run_type).inc()
 
 
 def record_indicators(source: str, zone: str, count: int):
@@ -331,10 +331,10 @@ def record_neo4j_nodes(node_type: str, count: int):
         NEO4J_NODES.labels(type=node_type).set(count)
 
 
-def record_error(task: str, error_type: str):
+def record_error(task: str, error_type: str, source: str = ""):
     """Record a pipeline error."""
     if PROMETHEUS_AVAILABLE:
-        PIPELINE_ERRORS.labels(task=task, error_type=error_type).inc()
+        PIPELINE_ERRORS.labels(task=task, error_type=error_type, source=source).inc()
 
 
 if not METRICS_SERVER_AVAILABLE:
@@ -421,7 +421,7 @@ def _on_task_failure(context):
     logger.error(f"[ALERT] Task FAILED: {dag_id}.{task_id} — {exc}")
     if ENABLE_SLACK_ALERTS:
         send_slack_alert(f"Task FAILED: {dag_id}.{task_id} — {exc}", level="critical")
-    if ENABLE_PROMETHEUS_METRICS:
+    if ENABLE_PROMETHEUS_METRICS and PROMETHEUS_AVAILABLE:
         try:
             PIPELINE_ERRORS.labels(task=task_id, error_type="task_failure", source=dag_id).inc()
         except Exception:
@@ -436,7 +436,7 @@ def _on_task_success(context):
     has succeeded recently (covers both partial and full failures).
     Also refreshes DAG_RUN_START to show the DAG is actively progressing.
     """
-    if not ENABLE_PROMETHEUS_METRICS:
+    if not (ENABLE_PROMETHEUS_METRICS and PROMETHEUS_AVAILABLE):
         return
     dag_id = context.get("dag").dag_id if context.get("dag") else "unknown"
     now = time.time()

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -259,7 +259,9 @@ if ENABLE_PROMETHEUS_METRICS and not METRICS_SERVER_AVAILABLE and not PROMETHEUS
         PROMETHEUS_AVAILABLE = True
 
         # Define metrics
-        DAG_RUNS_TOTAL = Counter("edgeguard_dag_runs_total", "Total number of DAG runs", ["status", "dag_id"])
+        DAG_RUNS_TOTAL = Counter(
+            "edgeguard_dag_runs_total", "Total number of DAG runs", ["dag_id", "status", "run_type"]
+        )
         INDICATORS_COLLECTED = Counter(
             "edgeguard_indicators_collected_total", "Total indicators collected", ["source", "zone"]
         )

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1383,6 +1383,7 @@ baseline_dag = DAG(
     schedule_interval=None,  # MANUAL TRIGGER ONLY
     start_date=_DAG_START_DATE,
     catchup=False,
+    is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )
 

--- a/docker-compose.monitoring.yml
+++ b/docker-compose.monitoring.yml
@@ -12,7 +12,7 @@ services:
     container_name: edgeguard_prometheus
     restart: unless-stopped
     ports:
-      - "9090:9090"
+      - "127.0.0.1:9090:9090"
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
       - ./prometheus/alerts.yml:/etc/prometheus/alerts.yml:ro
@@ -48,7 +48,7 @@ services:
     container_name: edgeguard_grafana
     restart: unless-stopped
     ports:
-      - "3000:3000"
+      - "127.0.0.1:3000:3000"
     environment:
       - GF_SECURITY_ADMIN_USER=${GRAFANA_ADMIN_USER:-admin}
       # GRAFANA_ADMIN_PASSWORD must be set — no insecure fallback in production.
@@ -140,7 +140,7 @@ services:
     container_name: edgeguard_alertmanager
     restart: unless-stopped
     ports:
-      - "9093:9093"
+      - "127.0.0.1:9093:9093"
     volumes:
       - ./prometheus/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager_data:/alertmanager

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,8 +77,8 @@ services:
     container_name: edgeguard_neo4j
     restart: unless-stopped
     ports:
-      - "7474:7474"   # Neo4j Browser (HTTP)
-      - "7687:7687"   # Bolt protocol
+      - "127.0.0.1:7474:7474"   # Neo4j Browser (HTTP) — loopback only
+      - "127.0.0.1:7687:7687"   # Bolt protocol — loopback only
     environment:
       NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
       NEO4J_PLUGINS: '["apoc"]'
@@ -159,7 +159,7 @@ services:
     # — that would override CMD and break the entrypoint chain.
     init: true
     ports:
-      - "8082:8082"
+      - "127.0.0.1:8082:8082"   # Airflow UI — loopback only
     environment:
       <<: *common-env
       # Mounted repo src at /opt/airflow/src — ensure all PythonOperator imports resolve without relying only on DAG sys.path hacks.
@@ -224,7 +224,7 @@ services:
     command: ["python", "-m", "uvicorn", "src.query_api:app",
               "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
     ports:
-      - "8000:8000"
+      - "127.0.0.1:8000:8000"   # REST API — loopback only; use reverse proxy for external access
     environment:
       <<: *common-env
       EDGEGUARD_ENABLE_ADMIN_QUERY: ${EDGEGUARD_ENABLE_ADMIN_QUERY:-false}
@@ -266,7 +266,7 @@ services:
     command: ["python", "-m", "uvicorn", "src.graphql_api:app",
               "--host", "0.0.0.0", "--port", "4001", "--workers", "2"]
     ports:
-      - "4001:4001"
+      - "127.0.0.1:4001:4001"   # GraphQL API — loopback only
     environment:
       <<: *common-env
       EDGEGUARD_GRAPHQL_PORT: "4001"

--- a/docs/AIRFLOW_DAGS.md
+++ b/docs/AIRFLOW_DAGS.md
@@ -141,7 +141,7 @@ EdgeGuard defines **6** primary DAGs in `dags/edgeguard_pipeline.py` (baseline +
 |-----|------|
 | **`EdgeGuard`** | Platform provenance (e.g. ResilMesh / EdgeGuard pipeline). **Only** event-level tag added on create. |
 
-**`Event.info`** remains **`EdgeGuard-{SECTOR}-{source}-{date}`** — the `SECTOR` token is the **routing/grouping key** for which MISP event receives the batch, not a duplicate of attribute zones.
+**`Event.info`** uses **`EdgeGuard-{source}-{date}`** (e.g., `EdgeGuard-nvd-2026-03-29`). Zone classification lives on attribute-level tags (`zone:Finance`, `zone:Healthcare`), not in the event name. A single event can contain multi-zone attributes.
 
 **Legacy:** Older events may still carry `sector:…`, `source:…`, or TLP on the event; sync and parsers still understand them. New writes follow the model above — see [MISP_SOURCES.md](MISP_SOURCES.md).
 

--- a/docs/AIRFLOW_DAGS.md
+++ b/docs/AIRFLOW_DAGS.md
@@ -260,6 +260,31 @@ airflow tasks list edgeguard_pipeline
 airflow dags list-runs -d edgeguard_pipeline
 ```
 
+### EdgeGuard CLI (recommended — wraps Airflow REST API)
+
+```bash
+# See all DAG run states (color-coded)
+python src/edgeguard.py dag status
+
+# See only running/queued runs
+python src/edgeguard.py dag status --state running
+
+# Force-fail stuck DAG runs (preserves checkpoints + incremental state)
+python src/edgeguard.py dag kill
+
+# Kill a specific DAG only
+python src/edgeguard.py dag kill --dag-id edgeguard_baseline
+
+# Check data counts (by zone, by source, MISP breakdown)
+python src/edgeguard.py stats --full
+
+# Check baseline checkpoint progress
+python src/edgeguard.py checkpoint status
+
+# Pre-run readiness check (env vars, APIs, Neo4j, MISP, Airflow, disk)
+python src/edgeguard.py preflight
+```
+
 ### View Logs
 ```bash
 airflow logs <task_id> <dag_run_id>

--- a/docs/AIRFLOW_DAGS.md
+++ b/docs/AIRFLOW_DAGS.md
@@ -1,6 +1,6 @@
 # EdgeGuard Airflow DAGs (operations guide)
 
-**Last Updated:** 2026-03-21  
+**Last Updated:** 2026-03-29
 **Purpose:** Automated ETL pipeline for threat intelligence collection and synchronization.  
 **DAG Python files:** repository `dags/` directory.
 
@@ -49,6 +49,23 @@ EdgeGuard defines **6** primary DAGs in `dags/edgeguard_pipeline.py` (baseline +
 | `edgeguard_low_freq` | Every 8 hours | Low-frequency sources | NVD |
 | `edgeguard_daily` | Daily at 2 AM | Daily feeds | MITRE, ThreatFox, AbuseIPDB, URLhaus, CyberCure, Feodo, SSLBlacklist |
 | `edgeguard_neo4j_sync` | `0 3 */3 * *` (every 3 days at 03:00) | MISP → Neo4j sync + `build_relationships` + `run_enrichment_jobs` | All sources |
+
+**Concurrency and timeout guards (all 6 DAGs):**
+
+| DAG | `max_active_runs` | `dagrun_timeout` | Notes |
+|-----|-------------------|------------------|-------|
+| `edgeguard_pipeline` | 1 | 5h 30m | Covers OTX with full retry chain |
+| `edgeguard_medium_freq` | 1 | 5h | CISA + VT parallel with retries |
+| `edgeguard_low_freq` | 1 | 8h 30m | NVD with full retry chain |
+| `edgeguard_daily` | 1 | 8h 30m | 7 parallel collectors with retries |
+| `edgeguard_neo4j_sync` | 1 | 22h | Full sync + relationships + enrichment |
+| `edgeguard_baseline` | 1 | 32h | Full historical collection + sync |
+
+`max_active_runs=1` prevents run pile-up when a run is slow. `dagrun_timeout` is wall-clock time from DAG run start — if the entire run (including retries) exceeds this, Airflow marks it as failed. These are calculated as worst-case: `execution_timeout x (1 + retries) + retries x retry_delay` summed across the sequential task chain, with a 20% buffer.
+
+**Callbacks:** All DAGs inherit `on_failure_callback` (logs `[ALERT]`, sends Slack if enabled, increments Prometheus error counter) and `on_success_callback` (updates `edgeguard_dag_last_success_timestamp` gauge for stuck-run detection).
+
+**Baseline note:** `edgeguard_baseline` uses `is_paused_upon_creation=False` so manual triggers execute immediately without needing to unpause first.
 
 **Metrics (optional):** `edgeguard_metrics_server` (+ `…_scheduled`) and **`edgeguard_metrics_helpers`** in `dags/edgeguard_metrics_server.py` — default scrape URL `http://127.0.0.1:8001/metrics` (`EDGEGUARD_METRICS_HOST` / `EDGEGUARD_METRICS_PORT`).
 
@@ -199,9 +216,15 @@ Neo4j uses unique constraints:
 - ✅ Container health verification
 - ✅ Rate limit awareness (each source group has its own DAG schedule)
 - ✅ Incremental sync support
-- ✅ Error handling and retry logic
+- ✅ Error handling and retry logic (`retries=2`, `retry_delay=5min`; baseline: `retries=1`)
 - ✅ Execution timeouts on all tasks (prevents hung workers)
-- ✅ `ShortCircuitOperator` gates the Neo4j sync (skips when nothing new)
+- ✅ `dagrun_timeout` on all DAGs (prevents entire DAG runs from hanging indefinitely)
+- ✅ `max_active_runs=1` on all DAGs (prevents concurrent run pile-up)
+- ✅ `on_failure_callback` / `on_success_callback` for alerting and metrics
+- ✅ `ShortCircuitOperator` gates the Neo4j sync (skips when nothing new; error-tolerant on corrupted state file)
+- ✅ Pipeline lock file (`checkpoints/pipeline.lock`) for CLI runs to prevent concurrent `run_pipeline.py` invocations
+- ✅ `clear_checkpoint()` preserves incremental state on `--fresh-baseline`
+- ✅ MISP dedup logging: `[DEDUP]` when all items already exist, `[SKIP]` when nothing new to push
 
 ### Metrics Exported
 ```

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -110,7 +110,7 @@ Priority 2: Event-level zone/sector tags + zone from Event.info  (merged; "globa
 Priority 3: "global"  (fallback only)
 ```
 
-**MISP events created by current `MISPWriter`** carry only the **`EdgeGuard`** tag at event level; **`Event.info`** still encodes **`EdgeGuard-{SECTOR}-{source}-{date}`** for grouping. Attribute **`zone:`** tags remain the primary classification signal for sync.
+**MISP events created by `MISPWriter`** use **`EdgeGuard-{source}-{date}`** as the event name, with the **`EdgeGuard`** tag at event level. **Zone classification** lives exclusively on **attribute-level tags** (`zone:Finance`, `zone:Healthcare`) — a single event can contain multi-zone attributes. Attribute `zone:` tags are the primary classification signal for Neo4j sync.
 
 **Collectors → MISP:** Optional **per-event attribute prefetch** and **source-specific** incremental cursors reduce duplicate writes when event names rotate by date — see [COLLECTORS.md](COLLECTORS.md) § *Duplicate avoidance*.
 

--- a/docs/DEPLOYMENT_READINESS_CHECKLIST.md
+++ b/docs/DEPLOYMENT_READINESS_CHECKLIST.md
@@ -57,6 +57,7 @@ Execute from the **same network context** as Airflow tasks (e.g. `docker exec` i
 
 | Done | Check | Command | Pass |
 |------|--------|---------|------|
+| [ ] | Preflight (recommended) | `python src/edgeguard.py preflight` | All 7 checks pass (env vars, APIs, Neo4j, MISP, Airflow, disk, breakers) |
 | [ ] | MISP + Neo4j | `python src/health_check.py` or `make health` | `overall_healthy`; APOC noted for Neo4j ([ENVIRONMENTS.md](ENVIRONMENTS.md)) |
 | [ ] | REST API health | `curl -s http://<api-host>:8000/health` (or your URL) | **HTTP 200** always; JSON `status: ok` and `neo4j_connected: true` when Neo4j ping + APOC pass ([README.md](../README.md) § Health) |
 | [ ] | GraphQL health | `curl -sf http://<api-host>:4001/health` | **HTTP 200** when Neo4j is healthy; **503** if no driver or Neo4j/APOC unhealthy (`curl -f` fails on 503 — intended for “must be up” checks) |

--- a/docs/DEPLOYMENT_READINESS_CHECKLIST.md
+++ b/docs/DEPLOYMENT_READINESS_CHECKLIST.md
@@ -72,6 +72,8 @@ Execute from the **same network context** as Airflow tasks (e.g. `docker exec` i
 | Done | Check | Action | Pass |
 |------|--------|--------|------|
 | [ ] | DAG import | `airflow dags list-import-errors` (after DB init) | Empty |
+| [ ] | DAG concurrency guards | Airflow UI → each DAG → Details | `max_active_runs=1` and `dagrun_timeout` per [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
+| [ ] | Baseline DAG unpaused | Airflow UI → `edgeguard_baseline` | `is_paused_upon_creation=False`; verify DAG is active |
 | [ ] | MISP preflight | Run a tier DAG once; open `misp_health_check` logs | **`healthy`** / **`healthy_for_collection`** (API + DB); workers only if **`EDGEGUARD_MISP_HEALTH_REQUIRE_WORKERS=true`** ([AIRFLOW_DAGS.md](AIRFLOW_DAGS.md)) |
 | [ ] | Collector tasks | Logs for `collect_*` | Status dict; skips show `skipped` + reason class; real failures → task failed as designed |
 | [ ] | Neo4j sync gate | Observe `full_neo4j_sync` / short-circuit | Matches [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
@@ -85,7 +87,8 @@ Execute from the **same network context** as Airflow tasks (e.g. `docker exec` i
 |------|--------|--------|
 | [ ] | Prometheus / metrics | [PROMETHEUS_SETUP.md](PROMETHEUS_SETUP.md), [docker-compose.monitoring.yml](../docker-compose.monitoring.yml) |
 | [ ] | Collector skips | `edgeguard_collector_skips_total` — [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
-| [ ] | Alerts | [prometheus/alerts.yml](../prometheus/alerts.yml) |
+| [ ] | Alerts | [prometheus/alerts.yml](../prometheus/alerts.yml) — verify `EdgeGuardDAGRunStuck`, `EdgeGuardDAGLastSuccessStale` and Alertmanager target (`alertmanager:9093`) |
+| [ ] | Failure callbacks | Trigger a task failure; check logs for `[ALERT] Task FAILED:` message |
 
 ---
 

--- a/docs/GRAPH_EXPLORER.md
+++ b/docs/GRAPH_EXPLORER.md
@@ -24,7 +24,7 @@ If your deployment uses Neo4j Enterprise or Aura, Bloom can be used alongside or
    docker compose up api
 
    # Or directly
-   uvicorn src.query_api:app --host 0.0.0.0 --port 8000
+   uvicorn src.query_api:app --host 127.0.0.1 --port 8000
    ```
 
 2. **Open the explorer** in your browser:

--- a/docs/KNOWLEDGE_GRAPH.md
+++ b/docs/KNOWLEDGE_GRAPH.md
@@ -189,7 +189,7 @@ When `run_misp_to_neo4j.py` resolves the zone for an attribute, it applies a str
 | Priority | Source | Logic |
 |----------|--------|-------|
 | 1 (highest) | Attribute-level tags | If the attribute itself carries specific `zone:*` tags, use those exclusively |
-| 2 | Event-level tags + event name | If attribute has no specific zone, merge `zone:*` / `sector:*` tags from the parent event AND the zone keyword extracted from **`Event.info`** (e.g. `EdgeGuard-FINANCE-…` → `finance`). **Note:** new EdgeGuard events may only have the **`EdgeGuard`** event tag; zone then comes from attributes and/or the event name token. |
+| 2 | Event-level tags | If attribute has no specific zone, check `zone:*` / `sector:*` tags from the parent event. Event names (`EdgeGuard-{source}-{date}`) do not contain zone information — zone lives exclusively on attribute tags. |
 | 3 (fallback) | `global` | Only if neither of the above produces a specific sector |
 
 **Merging logic (event name + event tags):**

--- a/docs/MISP_SOURCES.md
+++ b/docs/MISP_SOURCES.md
@@ -14,7 +14,7 @@ External feeds (OTX, NVD, CISA, MITRE, VirusTotal, abuse.ch, …) push into **MI
 
 ### How EdgeGuard events are found for sync
 
-Collectors create/update MISP events whose **`Event.info`** looks like **`EdgeGuard-{SECTOR}-{source}-{date}`**. The event carries a single tag **`EdgeGuard`** (platform provenance for downstream systems such as ResilMesh). **Sector/source/TLP context** is on **attributes** (`zone:…`, `source:…`, confidence, etc.); the `SECTOR` token in the event name is the **grouping key** for MISP event routing, not a duplicate event-level sector tag. **`MISPWriter._get_or_create_event`** filters **`restSearch`** hits to an **exact** `info` string match (MISP’s `info` parameter is often substring-based; parallel Tier1 collectors share the `EdgeGuard-GLOBAL-` prefix) and serializes event creation with a cross-process file lock — see `src/collectors/misp_writer.py`.
+Collectors create/update MISP events whose **`Event.info`** looks like **`EdgeGuard-{source}-{date}`** (e.g., `EdgeGuard-nvd-2026-03-29`). The event carries a single tag **`EdgeGuard`** (platform provenance for downstream systems such as ResilMesh). **Zone and source classification** lives on **attribute-level tags** (`zone:Finance`, `zone:Healthcare`, `source:NVD`, confidence, etc.) — a single event can contain multi-zone attributes. **`MISPWriter._get_or_create_event`** filters **`restSearch`** hits to an **exact** `info` string match and serializes event creation with a cross-process file lock — see `src/collectors/misp_writer.py`.
 
 ### Collector → MISP duplicate avoidance
 

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -217,7 +217,7 @@ python3 src/edgeguard.py --baseline
 docker-compose -f docker-compose.monitoring.yml up -d
 
 # 5. (Optional) Start Airflow for automated recurring collection
-airflow webserver --port 8080 &
+airflow webserver --port 8082 &
 airflow scheduler &
 ```
 

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -28,6 +28,7 @@ The core pipeline is functional, well-documented, and CI-verified. All CI jobs p
 | **Neo4j Client** | ✅ Ready | Constraints, indexes, batch ops, sector labels applied |
 | **Health Checks** | ✅ Ready | MISP health sensor + Docker service healthchecks |
 | **Documentation** | ✅ Ready | 20+ docs updated to match current code |
+| **Production CLI** | ✅ Ready | 16 commands: `preflight`, `stats --full`, `dag status/kill`, `checkpoint status/clear`, `doctor`, `heal`, `validate`, `monitor` |
 | **Security Hardening** | ✅ Ready | Input sanitization, injection guards, SSL, rate limiting |
 | **Monitoring/Metrics** | ✅ Ready | Prometheus on **8001** (loopback); Alertmanager enabled; alerts: `EdgeGuardDAGRunStuck`, `EdgeGuardDAGLastSuccessStale` + 12 others; Grafana dashboard |
 | **CI/CD Pipeline** | ✅ Ready | GitHub Actions: lint, type-check, unit tests, Docker build, security scan |

--- a/docs/PRODUCTION_READINESS.md
+++ b/docs/PRODUCTION_READINESS.md
@@ -23,13 +23,13 @@ The core pipeline is functional, well-documented, and CI-verified. All CI jobs p
 |-----------|--------|-------|
 | **Knowledge Graph Schema** | ✅ Ready | Full node/relationship design, UNIQUE constraints |
 | **MISP Integration** | ✅ Ready | Writer with sanitization, retry, rate limiting |
-| **Airflow DAGs** | ✅ Ready | **6** DAGs in `edgeguard_pipeline.py` + optional metrics DAGs in `edgeguard_metrics_server.py`; timeouts + `ShortCircuitOperator` on Neo4j sync |
+| **Airflow DAGs** | ✅ Ready | **6** DAGs; `max_active_runs=1` + `dagrun_timeout` on all; `on_failure_callback`/`on_success_callback`; baseline `is_paused_upon_creation=False`; `ShortCircuitOperator` on Neo4j sync |
 | **Data Collectors** | ✅ Ready | 11 active collectors → MISP → Neo4j |
 | **Neo4j Client** | ✅ Ready | Constraints, indexes, batch ops, sector labels applied |
 | **Health Checks** | ✅ Ready | MISP health sensor + Docker service healthchecks |
 | **Documentation** | ✅ Ready | 20+ docs updated to match current code |
 | **Security Hardening** | ✅ Ready | Input sanitization, injection guards, SSL, rate limiting |
-| **Monitoring/Metrics** | ✅ Ready | Prometheus metrics endpoint default **8001** / loopback (`EDGEGUARD_METRICS_*`); Grafana via `docker-compose.monitoring.yml` |
+| **Monitoring/Metrics** | ✅ Ready | Prometheus on **8001** (loopback); Alertmanager enabled; alerts: `EdgeGuardDAGRunStuck`, `EdgeGuardDAGLastSuccessStale` + 12 others; Grafana dashboard |
 | **CI/CD Pipeline** | ✅ Ready | GitHub Actions: lint, type-check, unit tests, Docker build, security scan |
 | **Automated Code Review** | ✅ Ready | Bugbot active on every PR with comprehensive rules |
 

--- a/docs/PROMETHEUS_SETUP.md
+++ b/docs/PROMETHEUS_SETUP.md
@@ -295,6 +295,8 @@ The following alerts are pre-configured in `prometheus/alerts.yml`:
 | `EdgeGuardCircuitBreakerOpen` | Circuit open | critical |
 | `EdgeGuardServiceDown` | Health check fail | critical |
 | `EdgeGuardDAGRunFailures` | >3 failures/hour | warning |
+| `EdgeGuardDAGRunStuck` | DAG run running >1 hour without completing | critical |
+| `EdgeGuardDAGLastSuccessStale` | No successful DAG run in >6 hours | warning |
 
 ### Custom Alerts
 

--- a/docs/RESILMESH_INTEROPERABILITY.md
+++ b/docs/RESILMESH_INTEROPERABILITY.md
@@ -1,6 +1,6 @@
 # EdgeGuard ↔ ResilMesh Interoperability Guide
 
-**Last updated: 2026-03-28* 2026-03-21  
+**Last updated: 2026-03-28**
 **Document type:** Integration contract — shared reference between EdgeGuard (IICT-BAS + Ratio1) and ResilMesh  
 **Purpose:** Defines exactly what EdgeGuard produces, what it relies on ResilMesh to provide, and what neither system covers today.
 

--- a/docs/SETUP_GUIDE.md
+++ b/docs/SETUP_GUIDE.md
@@ -101,7 +101,7 @@ Airflow and collectors resolve **`MISP_URL`** from **inside** containers. `local
 
 **Apache vhost / `Host` header:** If MISP only answers for a specific name, set **`EDGEGUARD_MISP_HTTP_HOST`** (no `https://`).
 
-**MISP event vs attribute tags:** New EdgeGuard events carry the **`EdgeGuard`** tag only at event level; **`Event.info`** still uses **`EdgeGuard-{SECTOR}-{source}-{date}`** for grouping. **`zone:`** and **`source:`** tags are on **attributes** (see [MISP_SOURCES.md](MISP_SOURCES.md)). Sector keyword scoring thresholds: **`EDGEGUARD_ZONE_DETECT_THRESHOLD`** / **`EDGEGUARD_ZONE_ITEM_THRESHOLD`** in **`.env.example`**.
+**MISP event vs attribute tags:** EdgeGuard events use **`EdgeGuard-{source}-{date}`** as the event name (e.g., `EdgeGuard-nvd-2026-03-29`). The event carries the **`EdgeGuard`** tag at event level. **Zone and source classification** lives on **attribute-level tags** (`zone:Finance`, `source:NVD`) — a single event can contain multi-zone attributes. See [MISP_SOURCES.md](MISP_SOURCES.md). Sector keyword scoring thresholds: **`EDGEGUARD_ZONE_DETECT_THRESHOLD`** / **`EDGEGUARD_ZONE_ITEM_THRESHOLD`** in **`.env.example`**.
 
 ### 3.4 Build and start
 

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -510,7 +510,7 @@ Auth:    Configured via environment variables
 CREATE CONSTRAINT vulnerability_key FOR (v:Vulnerability) REQUIRE (v.cve_id, v.tag, v.zone) IS UNIQUE;
 CREATE CONSTRAINT indicator_key FOR (i:Indicator) REQUIRE (i.indicator_type, i.value, i.tag, i.zone) IS UNIQUE;
 CREATE CONSTRAINT malware_key FOR (m:Malware) REQUIRE (m.name, m.tag) IS UNIQUE;
-CREATE CONSTRAINT actor_key FOR (a:ThreatActor) REQUIRE (a.name, m.tag) IS UNIQUE;
+CREATE CONSTRAINT actor_key FOR (a:ThreatActor) REQUIRE (a.name, a.tag) IS UNIQUE;
 CREATE CONSTRAINT technique_key FOR (t:Technique) REQUIRE (t.mitre_id, t.tag) IS UNIQUE;
 
 // ResilMesh constraints
@@ -778,10 +778,8 @@ curl "http://localhost:8000/zone/healthcare?limit=20&active_only=true"
 
 ---
 
-*Technical Specification Version: 2.0*  
-*Last Updated: 2026-03-07*  
+*Technical Specification Version: 2.0*
 *For ResilMesh Engineers*
-
 
 ---
 

--- a/docs/sources/MISP/docker-compose.yml
+++ b/docs/sources/MISP/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: misp_misp_1
     restart: unless-stopped
     ports:
-      - "8443:443"
-      - "5000:80"
+      - "127.0.0.1:8443:443"
+      - "127.0.0.1:5000:80"
     environment:
       - MISP_ADMIN_EMAIL=admin@admin.test
       - MISP_ADMIN_PASSWORD=admin

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -174,13 +174,26 @@ groups:
         expr: |
           edgeguard_dag_last_success_timestamp > 0
           and (time() - edgeguard_dag_last_success_timestamp) > 21600
+          and edgeguard_dag_last_success_timestamp{dag_id!~"edgeguard_daily|edgeguard_neo4j_sync|edgeguard_baseline"}
         for: 15m
         labels:
           severity: warning
           component: pipeline
         annotations:
           summary: "No successful {{ $labels.dag_id }} run in 6 hours"
-          description: "Last successful run of {{ $labels.dag_id }} was {{ $value | humanizeDuration }} ago."
+          description: "Last successful run of {{ $labels.dag_id }} was over 6 hours ago. Only applies to high/medium-frequency DAGs."
+
+      - alert: EdgeGuardDailyDAGStale
+        expr: |
+          edgeguard_dag_last_success_timestamp{dag_id="edgeguard_daily"} > 0
+          and (time() - edgeguard_dag_last_success_timestamp{dag_id="edgeguard_daily"}) > 90000
+        for: 15m
+        labels:
+          severity: warning
+          component: pipeline
+        annotations:
+          summary: "Daily DAG has not succeeded in over 25 hours"
+          description: "edgeguard_daily runs once per day — no success in 25+ hours indicates a problem."
 
   # ================================================================================
   # Neo4j Alerts

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -157,15 +157,18 @@ groups:
 
       - alert: EdgeGuardDAGRunStuck
         expr: |
-          edgeguard_dag_run_start_timestamp > 0
-          and (time() - edgeguard_dag_run_start_timestamp) > 3600
+          (
+            edgeguard_dag_run_start_timestamp > 0
+            and (time() - edgeguard_dag_run_start_timestamp) > 3600
+            and changes(edgeguard_dag_run_start_timestamp[30m]) == 0
+          )
         for: 5m
         labels:
           severity: critical
           component: pipeline
         annotations:
           summary: "DAG run {{ $labels.dag_id }} appears stuck"
-          description: "DAG {{ $labels.dag_id }} has been running for over 1 hour without completing."
+          description: "DAG {{ $labels.dag_id }} has had no task progress in over 1 hour (gauge unchanged for 30m)."
 
       - alert: EdgeGuardDAGLastSuccessStale
         expr: |

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -155,6 +155,30 @@ groups:
           summary: "DAG {{ $labels.dag_id }} has multiple failures"
           description: "DAG {{ $labels.dag_id }} has had more than 3 failures in the last hour."
 
+      - alert: EdgeGuardDAGRunStuck
+        expr: |
+          edgeguard_dag_run_start_timestamp > 0
+          and (time() - edgeguard_dag_run_start_timestamp) > 3600
+        for: 5m
+        labels:
+          severity: critical
+          component: pipeline
+        annotations:
+          summary: "DAG run {{ $labels.dag_id }} appears stuck"
+          description: "DAG {{ $labels.dag_id }} has been running for over 1 hour without completing."
+
+      - alert: EdgeGuardDAGLastSuccessStale
+        expr: |
+          edgeguard_dag_last_success_timestamp > 0
+          and (time() - edgeguard_dag_last_success_timestamp) > 21600
+        for: 15m
+        labels:
+          severity: warning
+          component: pipeline
+        annotations:
+          summary: "No successful {{ $labels.dag_id }} run in 6 hours"
+          description: "Last successful run of {{ $labels.dag_id }} was {{ $value | humanizeDuration }} ago."
+
   # ================================================================================
   # Neo4j Alerts
   # ================================================================================

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -16,7 +16,7 @@ alerting:
   alertmanagers:
     - static_configs:
         - targets:
-          # - alertmanager:9093  # Uncomment when using AlertManager
+          - alertmanager:9093
 
 # Load rules once and periodically evaluate them
 rule_files:

--- a/scripts/clear_misp.py
+++ b/scripts/clear_misp.py
@@ -285,8 +285,8 @@ Examples:
         try:
             from baseline_checkpoint import clear_checkpoint
 
-            clear_checkpoint()
-            logger.info("Cleared baseline checkpoint (ETag/cursor cache)")
+            clear_checkpoint(include_incremental=True)
+            logger.info("Cleared baseline checkpoint + incremental cursors (full reset)")
         except Exception as e:
             logger.warning("Could not clear checkpoint: %s", e)
 

--- a/scripts/clear_neo4j.py
+++ b/scripts/clear_neo4j.py
@@ -303,8 +303,8 @@ Examples:
             try:
                 from baseline_checkpoint import clear_checkpoint
 
-                clear_checkpoint()
-                logging.getLogger(__name__).info("Cleared baseline checkpoint (ETag/cursor cache)")
+                clear_checkpoint(include_incremental=True)
+                logging.getLogger(__name__).info("Cleared baseline checkpoint + incremental cursors (full reset)")
             except Exception as e:
                 logging.getLogger(__name__).warning("Could not clear checkpoint: %s", e)
 

--- a/src/airflow_client.py
+++ b/src/airflow_client.py
@@ -24,7 +24,9 @@ logger = logging.getLogger(__name__)
 # Constants
 # ---------------------------------------------------------------------------
 
-EDGEGUARD_DAG_IDS = [
+# Known DAG IDs — used as fallback when Airflow API is unreachable.
+# Keep in sync with dags/edgeguard_pipeline.py DAG definitions.
+_KNOWN_DAG_IDS = [
     "edgeguard_pipeline",
     "edgeguard_medium_freq",
     "edgeguard_low_freq",
@@ -34,6 +36,35 @@ EDGEGUARD_DAG_IDS = [
 ]
 
 _TIMEOUT = 15  # seconds
+_cached_dag_ids: Optional[List[str]] = None
+
+
+def get_edgeguard_dag_ids() -> List[str]:
+    """Return EdgeGuard DAG IDs, auto-discovered from Airflow if reachable.
+
+    Falls back to the hardcoded ``_KNOWN_DAG_IDS`` list if Airflow is
+    unreachable.  Caches the result for the process lifetime.
+    """
+    global _cached_dag_ids
+    if _cached_dag_ids is not None:
+        return _cached_dag_ids
+
+    try:
+        result = _get("/dags", params={"dag_id_pattern": "edgeguard", "limit": 50})
+        if "error" not in result:
+            ids = [d["dag_id"] for d in result.get("dags", []) if d.get("dag_id", "").startswith("edgeguard")]
+            if ids:
+                _cached_dag_ids = ids
+                return ids
+    except Exception:
+        pass
+
+    _cached_dag_ids = list(_KNOWN_DAG_IDS)
+    return _cached_dag_ids
+
+
+# Backward-compatible alias
+EDGEGUARD_DAG_IDS = _KNOWN_DAG_IDS  # used by existing callers; prefer get_edgeguard_dag_ids()
 
 
 # ---------------------------------------------------------------------------

--- a/src/airflow_client.py
+++ b/src/airflow_client.py
@@ -180,7 +180,7 @@ def list_all_active_dag_runs(
     dag_ids: Optional[List[str]] = None,
 ) -> List[Dict[str, Any]]:
     """Collect running and queued DAG runs across all EdgeGuard DAGs."""
-    ids = dag_ids or EDGEGUARD_DAG_IDS
+    ids = dag_ids or get_edgeguard_dag_ids()
     active: List[Dict[str, Any]] = []
     for dag_id in ids:
         for state in ("running", "queued"):

--- a/src/airflow_client.py
+++ b/src/airflow_client.py
@@ -1,0 +1,205 @@
+"""
+EdgeGuard — Airflow REST API client
+====================================
+Thin wrapper around the Airflow stable REST API (v1) for DAG status
+querying and run management.  Used by the ``edgeguard`` CLI and could
+be reused by monitoring scripts.
+
+Requires:
+    AIRFLOW_WEBSERVER_URL  (default http://localhost:8082)
+    AIRFLOW_API_USER       (optional — basic-auth username)
+    AIRFLOW_API_PASSWORD   (optional — basic-auth password)
+"""
+
+import logging
+import os
+from datetime import datetime, timezone
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+EDGEGUARD_DAG_IDS = [
+    "edgeguard_pipeline",
+    "edgeguard_medium_freq",
+    "edgeguard_low_freq",
+    "edgeguard_daily",
+    "edgeguard_neo4j_sync",
+    "edgeguard_baseline",
+]
+
+_TIMEOUT = 15  # seconds
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _base_url() -> str:
+    return os.getenv("AIRFLOW_WEBSERVER_URL", "http://localhost:8082").rstrip("/")
+
+
+def _auth() -> Optional[Tuple[str, str]]:
+    user = os.getenv("AIRFLOW_API_USER", "airflow")
+    password = os.getenv("AIRFLOW_API_PASSWORD")
+    if password:
+        return (user, password)
+    return None
+
+
+def _get(path: str, params: Optional[Dict] = None) -> Dict[str, Any]:
+    """GET request to Airflow API.  Returns parsed JSON or ``{"error": ...}``."""
+    url = f"{_base_url()}/api/v1{path}"
+    try:
+        resp = requests.get(url, params=params, auth=_auth(), timeout=_TIMEOUT)
+        if resp.status_code == 401:
+            return {"error": "Airflow API returned 401 Unauthorized. Set AIRFLOW_API_USER/AIRFLOW_API_PASSWORD."}
+        if resp.status_code == 403:
+            return {"error": "Airflow API returned 403 Forbidden. Check user permissions."}
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}. Is it running?"}
+    except requests.exceptions.Timeout:
+        return {"error": f"Airflow API timed out ({_TIMEOUT}s)."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _patch(path: str, body: Dict) -> Dict[str, Any]:
+    """PATCH request to Airflow API."""
+    url = f"{_base_url()}/api/v1{path}"
+    try:
+        resp = requests.patch(url, json=body, auth=_auth(), timeout=_TIMEOUT)
+        if resp.status_code in (401, 403):
+            return {"error": f"Airflow API returned {resp.status_code}. Check auth."}
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}."}
+    except requests.exceptions.Timeout:
+        return {"error": f"Airflow API timed out ({_TIMEOUT}s)."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def _post(path: str, body: Dict) -> Dict[str, Any]:
+    """POST request to Airflow API."""
+    url = f"{_base_url()}/api/v1{path}"
+    try:
+        resp = requests.post(url, json=body, auth=_auth(), timeout=_TIMEOUT)
+        if resp.status_code in (401, 403):
+            return {"error": f"Airflow API returned {resp.status_code}. Check auth."}
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}."}
+    except requests.exceptions.Timeout:
+        return {"error": f"Airflow API timed out ({_TIMEOUT}s)."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def airflow_health() -> Dict[str, Any]:
+    """Check Airflow scheduler and metadatabase health.
+
+    Returns dict with 'metadatabase' and 'scheduler' status, or 'error'.
+    """
+    url = f"{_base_url()}/health"
+    try:
+        resp = requests.get(url, auth=_auth(), timeout=_TIMEOUT)
+        resp.raise_for_status()
+        return resp.json()
+    except requests.exceptions.ConnectionError:
+        return {"error": f"Cannot connect to Airflow at {_base_url()}."}
+    except Exception as e:
+        return {"error": str(e)}
+
+
+def list_dag_runs(
+    dag_id: str,
+    state: Optional[str] = None,
+    limit: int = 5,
+) -> List[Dict[str, Any]]:
+    """List recent DAG runs for a specific DAG.
+
+    Returns list of run dicts, or a single-element list with ``{"error": ...}``.
+    """
+    params: Dict[str, Any] = {"order_by": "-start_date", "limit": limit}
+    if state:
+        params["state"] = state
+    result = _get(f"/dags/{dag_id}/dagRuns", params=params)
+    if "error" in result:
+        return [result]
+    return result.get("dag_runs", [])
+
+
+def list_all_active_dag_runs(
+    dag_ids: Optional[List[str]] = None,
+) -> List[Dict[str, Any]]:
+    """Collect running and queued DAG runs across all EdgeGuard DAGs."""
+    ids = dag_ids or EDGEGUARD_DAG_IDS
+    active: List[Dict[str, Any]] = []
+    for dag_id in ids:
+        for state in ("running", "queued"):
+            runs = list_dag_runs(dag_id, state=state, limit=25)
+            if runs and "error" not in runs[0]:
+                for run in runs:
+                    run["dag_id"] = dag_id  # ensure dag_id is on each run
+                    active.append(run)
+    return active
+
+
+def patch_dag_run_state(dag_id: str, dag_run_id: str, state: str = "failed") -> Dict[str, Any]:
+    """Force a DAG run into a specific state (typically 'failed')."""
+    return _patch(f"/dags/{dag_id}/dagRuns/{dag_run_id}", {"state": state})
+
+
+def clear_task_instances(dag_id: str, dag_run_id: str) -> Dict[str, Any]:
+    """Clear (reset) task instances for a DAG run."""
+    body = {
+        "dry_run": False,
+        "dag_run_id": dag_run_id,
+        "reset_dag_runs": True,
+        "only_running": False,
+        "only_failed": False,
+    }
+    return _post(f"/dags/{dag_id}/clearTaskInstances", body)
+
+
+def get_registered_dags() -> List[Dict[str, Any]]:
+    """List EdgeGuard DAGs registered in Airflow."""
+    result = _get("/dags", params={"dag_id_pattern": "edgeguard", "limit": 25})
+    if "error" in result:
+        return [result]
+    return result.get("dags", [])
+
+
+def format_duration(start_str: Optional[str], end_str: Optional[str] = None) -> str:
+    """Human-readable duration from ISO timestamps."""
+    if not start_str:
+        return "—"
+    try:
+        start = datetime.fromisoformat(start_str.replace("Z", "+00:00"))
+        end = datetime.fromisoformat(end_str.replace("Z", "+00:00")) if end_str else datetime.now(timezone.utc)
+        delta = end - start
+        hours, remainder = divmod(int(delta.total_seconds()), 3600)
+        minutes, seconds = divmod(remainder, 60)
+        if hours > 0:
+            return f"{hours}h {minutes}m"
+        if minutes > 0:
+            return f"{minutes}m {seconds}s"
+        return f"{seconds}s"
+    except (ValueError, TypeError):
+        return "—"

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -179,30 +179,44 @@ def update_source_incremental(source: str, **kwargs) -> None:
         save_checkpoint(checkpoints)
 
 
-def clear_checkpoint(source: str = None) -> None:
+def clear_checkpoint(source: str = None, *, include_incremental: bool = False) -> None:
     """Clear baseline checkpoint for *source*, or all baseline checkpoints if source is None.
 
-    Preserves incremental state (``"incremental"`` sub-dict inside each source
-    entry) so that scheduled runs don't lose their "where I left off" cursors
-    after a fresh baseline.
+    By default, preserves incremental state (``"incremental"`` sub-dict inside
+    each source entry) so that scheduled runs don't lose their cursors after a
+    fresh baseline.  Pass ``include_incremental=True`` to wipe everything
+    (used by database wipe scripts that need a full reset).
     """
     if source:
         checkpoints = load_checkpoint()
         if source in checkpoints:
-            del checkpoints[source]
+            if include_incremental:
+                del checkpoints[source]
+            else:
+                # Preserve incremental sub-dict for this source
+                inc = checkpoints[source].get("incremental") if isinstance(checkpoints[source], dict) else None
+                if inc:
+                    checkpoints[source] = {"incremental": inc}
+                else:
+                    del checkpoints[source]
             save_checkpoint(checkpoints)
     else:
-        checkpoints = load_checkpoint()
-        # Keep only incremental state from each source
-        preserved = {}
-        for src, data in checkpoints.items():
-            inc = data.get("incremental") if isinstance(data, dict) else None
-            if inc:
-                preserved[src] = {"incremental": inc}
-        if preserved:
-            save_checkpoint(preserved)
-        elif CHECKPOINT_FILE.exists():
-            CHECKPOINT_FILE.unlink()
+        if include_incremental:
+            # Full wipe — used by clear_misp.py / clear_neo4j.py
+            if CHECKPOINT_FILE.exists():
+                CHECKPOINT_FILE.unlink()
+        else:
+            checkpoints = load_checkpoint()
+            # Keep only incremental state from each source
+            preserved = {}
+            for src, data in checkpoints.items():
+                inc = data.get("incremental") if isinstance(data, dict) else None
+                if inc:
+                    preserved[src] = {"incremental": inc}
+            if preserved:
+                save_checkpoint(preserved)
+            elif CHECKPOINT_FILE.exists():
+                CHECKPOINT_FILE.unlink()
 
 
 def get_baseline_status() -> dict:

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -180,14 +180,33 @@ def update_source_incremental(source: str, **kwargs) -> None:
 
 
 def clear_checkpoint(source: str = None) -> None:
-    """Clear checkpoint for *source*, or all checkpoints if source is None."""
+    """Clear baseline checkpoint for *source*, or all baseline checkpoints if source is None.
+
+    Preserves incremental state (``"incremental"`` sub-dict inside each source
+    entry) so that scheduled runs don't lose their "where I left off" cursors
+    after a fresh baseline.
+    """
     if source:
         checkpoints = load_checkpoint()
         if source in checkpoints:
-            del checkpoints[source]
+            # Preserve incremental sub-dict if it exists
+            inc = checkpoints[source].get("incremental")
+            if inc:
+                checkpoints[source] = {"incremental": inc}
+            else:
+                del checkpoints[source]
             save_checkpoint(checkpoints)
     else:
-        if CHECKPOINT_FILE.exists():
+        checkpoints = load_checkpoint()
+        # Keep only incremental state from each source
+        preserved = {}
+        for src, data in checkpoints.items():
+            inc = data.get("incremental") if isinstance(data, dict) else None
+            if inc:
+                preserved[src] = {"incremental": inc}
+        if preserved:
+            save_checkpoint(preserved)
+        elif CHECKPOINT_FILE.exists():
             CHECKPOINT_FILE.unlink()
 
 

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -220,17 +220,28 @@ def clear_checkpoint(source: str = None, *, include_incremental: bool = False) -
 
 
 def get_baseline_status() -> dict:
-    """Return a summary of all baseline checkpoints."""
+    """Return a summary of all baseline checkpoints.
+
+    Excludes entries that only contain incremental state (no baseline
+    progress) — these are leftover from ``clear_checkpoint()`` which
+    preserves incremental cursors.
+    """
     checkpoints = load_checkpoint()
-    return {
-        src: {
+    result = {}
+    for src, data in checkpoints.items():
+        if not isinstance(data, dict):
+            continue
+        # Skip entries that only have incremental state (no baseline fields)
+        has_baseline = any(k in data for k in ("page", "pages", "items_collected", "completed", "started_at"))
+        if not has_baseline:
+            continue
+        result[src] = {
             "pages_collected": len(data.get("pages", [])),
             "items_collected": data.get("items_collected", 0),
             "completed": data.get("completed", False),
             "last_updated": data.get("updated_at", "unknown"),
         }
-        for src, data in checkpoints.items()
-    }
+    return result
 
 
 if __name__ == "__main__":

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -189,12 +189,7 @@ def clear_checkpoint(source: str = None) -> None:
     if source:
         checkpoints = load_checkpoint()
         if source in checkpoints:
-            # Preserve incremental sub-dict if it exists
-            inc = checkpoints[source].get("incremental")
-            if inc:
-                checkpoints[source] = {"incremental": inc}
-            else:
-                del checkpoints[source]
+            del checkpoints[source]
             save_checkpoint(checkpoints)
     else:
         checkpoints = load_checkpoint()

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -362,23 +362,24 @@ class MISPWriter:
         return keys
 
     @retry_with_backoff(max_retries=4, base_delay=10.0)
-    def _get_or_create_event(self, sector: str, source: str, date: str = None) -> Optional[str]:
-        """Get or create a MISP event for a sector/source/date combination.
+    def _get_or_create_event(self, source: str, date: str = None, **_kwargs) -> Optional[str]:
+        """Get or create a MISP event for a source/date combination.
+
+        Event naming: ``EdgeGuard-{source}-{date}``.  Zone classification lives
+        on attribute-level tags (``zone:Finance``, ``zone:Healthcare``), not in
+        the event name — a single event can contain multi-zone attributes.
 
         Uses MISP's ``restSearch`` endpoint, then filters to an **exact** ``Event.info`` match.
-        MISP's ``info`` search parameter is typically substring-based; combined with ``limit: 1``,
-        parallel collectors could previously receive another source's event (e.g. all data under the
-        MITRE-named event). Event **creation** is serialized with a file lock so two processes do not
+        Event **creation** is serialized with a file lock so two processes do not
         create duplicate same-day events after a miss.
 
         Returns:
             Event ID if successful, None otherwise.
         """
-        sector = sanitize_value(sector, max_length=50)
         source = sanitize_value(source, max_length=50)
 
         date = date or datetime.now(timezone.utc).strftime("%Y-%m-%d")
-        event_name = f"EdgeGuard-{sector.upper()}-{source}-{date}"
+        event_name = f"EdgeGuard-{source}-{date}"
 
         try:
             rows = self._restsearch_events_for_name(event_name)
@@ -398,9 +399,10 @@ class MISPWriter:
                 "analysis": 0,  # Initial
                 "date": date,
                 "Attribute": [],
-                # Event is an organizational container: ``EdgeGuard-{SECTOR}-{source}-{date}`` encodes
-                # grouping; source + zone classification live on **attributes** (``source:…``, ``zone:…``).
-                # Single event tag marks data from this platform for consumers (e.g. ResilMesh).
+                # Event is an organizational container: ``EdgeGuard-{source}-{date}`` groups by
+                # source + day.  Zone classification lives on **attributes** (``zone:…`` tags)
+                # so multi-zone items are handled correctly.  Single event tag marks data
+                # from this platform for consumers (e.g. ResilMesh).
                 "Tag": [{"name": "EdgeGuard"}],
             }
         }
@@ -481,19 +483,6 @@ class MISPWriter:
             # Only global - tag it (or fallback to default)
             global_zones = [z for z in zones if z]
             return global_zones if global_zones else [DEFAULT_SECTOR]
-
-    def _primary_sector_for_event_grouping(self, item: Dict) -> str:
-        """
-        Single sector key for MISP event routing in push_items.
-
-        Must stay consistent with _get_zones_to_tag: if specifics exist, ignore global
-        and use a deterministic primary (sorted) so order in item['zone'] does not
-        split one logical batch across two events.
-        """
-        tagged = self._get_zones_to_tag(item)
-        if not tagged:
-            return str(DEFAULT_SECTOR).lower()
-        return sorted(str(z).lower() for z in tagged)[0]
 
     def map_indicator_type(self, edgeguard_type: str, value: str = None) -> str:
         """
@@ -1107,15 +1096,14 @@ class MISPWriter:
         # Guard against invalid batch_size (0 would crash range())
         batch_size = max(1, batch_size)
 
-        # Group items by (sector, source, date)
+        # Group items by (source, date) — zone lives on attribute tags, not event name
         grouped = {}
 
         for item in items:
-            sector = self._primary_sector_for_event_grouping(item)
             source = item.get("tag", "unknown")
             date = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 
-            key = (sector, source, date)
+            key = (source, date)
             if key not in grouped:
                 grouped[key] = []
 
@@ -1150,7 +1138,7 @@ class MISPWriter:
         start_time = time.time()
         push_queue: List[Tuple[str, List[Dict]]] = []
 
-        for (sector, source, date), attributes in grouped.items():
+        for (source, date), attributes in grouped.items():
             # Deduplicate attributes by value
             seen = set()
             unique_attrs = []
@@ -1161,7 +1149,7 @@ class MISPWriter:
                     unique_attrs.append(attr)
 
             # Get or create event
-            event_id = self._get_or_create_event(sector, source, date)
+            event_id = self._get_or_create_event(source, date)
             if not event_id:
                 total_failed += len(unique_attrs)
                 continue

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1102,6 +1102,8 @@ class MISPWriter:
         if not items:
             return 0, 0
 
+        total_items = len(items)
+
         # Guard against invalid batch_size (0 would crash range())
         batch_size = max(1, batch_size)
 
@@ -1181,6 +1183,13 @@ class MISPWriter:
 
         total_batches = sum((len(attrs) + batch_size - 1) // batch_size for _, attrs in push_queue)
 
+        if not push_queue and total_items > 0:
+            logger.warning(
+                "[DEDUP] All %d items were already present in MISP — nothing new to push. "
+                "This is normal on re-runs. Use --fresh-baseline to force re-collection.",
+                total_items,
+            )
+
         # Throttle delay between batches — gives MISP time to free memory
         # when processing large events (e.g. 95K NVD attributes).
         try:
@@ -1221,9 +1230,16 @@ class MISPWriter:
 
         # Final summary
         total_elapsed = time.time() - start_time
-        logger.info(
-            f"[OK] MISP push complete: {total_success} succeeded, {total_failed} failed in {total_elapsed:.1f}s"
-        )
+        if total_success > 0 or total_failed > 0:
+            logger.info(
+                f"[OK] MISP push complete: {total_success} succeeded, {total_failed} failed in {total_elapsed:.1f}s"
+            )
+        elif total_items > 0:
+            logger.info(
+                f"[SKIP] MISP push: 0 new attributes to push ({total_items} items all deduplicated) in {total_elapsed:.1f}s"
+            )
+        else:
+            logger.info("[OK] MISP push: no items provided")
 
         return total_success, total_failed
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1263,44 +1263,114 @@ def cmd_checkpoint_clear(args) -> int:
 
 
 def cmd_stats(args) -> int:
-    """Quick dashboard: node counts, last sync, recent runs."""
+    """Dashboard: node counts, by-zone, by-source, MISP events, sync, runs."""
     use_json = getattr(args, "json", False)
+    show_full = getattr(args, "full", False)
+    show_zone = show_full or getattr(args, "by_zone", False)
+    show_source = show_full or getattr(args, "by_source", False)
+    show_misp = show_full or getattr(args, "misp", False)
 
     section("EdgeGuard Stats")
 
     result = {}
+    neo4j_stats = None
 
-    # Neo4j node counts
+    # ── Neo4j full stats (by_source and by_zone come from get_stats()) ──
     try:
-        from health_check import get_neo4j_node_counts
+        from neo4j_client import Neo4jClient
 
-        counts = get_neo4j_node_counts()
-        if counts and "error" not in counts:
-            result["nodes"] = counts
-            print(f"\n  {'Node Type':<20} {'Count':>10}")
-            print(f"  {'—' * 20} {'—' * 10}")
-            for label, count in sorted(counts.items(), key=lambda x: -x[1]):
-                if label != "relationships":
-                    print(f"  {label:<20} {count:>10,}")
-            if "relationships" in counts:
-                print(f"  {'Relationships':<20} {counts['relationships']:>10,}")
-        else:
-            warn("Neo4j: could not fetch node counts")
+        client = Neo4jClient()
+        if client.connect():
+            neo4j_stats = client.get_stats()
+            client.close()
     except Exception as e:
         warn(f"Neo4j: {e}")
 
-    # Last sync
+    # 1. Node counts by label
+    if neo4j_stats and "error" not in neo4j_stats:
+        label_order = [
+            "Vulnerability",
+            "Indicator",
+            "CVE",
+            "Malware",
+            "ThreatActor",
+            "Technique",
+            "Tactic",
+            "Campaign",
+            "Tool",
+            "CVSSv31",
+            "CVSSv40",
+            "CVSSv30",
+            "CVSSv2",
+            "Alert",
+            "Sector",
+            "Sources",
+        ]
+        result["nodes"] = {k: neo4j_stats.get(k, 0) for k in label_order if neo4j_stats.get(k, 0) > 0}
+        result["nodes"]["relationships"] = neo4j_stats.get("sourced_relationships", 0)
+
+        if not use_json:
+            print(f"\n  {'Node Type':<20} {'Count':>10}")
+            print(f"  {'—' * 20} {'—' * 10}")
+            for label in label_order:
+                count = neo4j_stats.get(label, 0)
+                if count > 0:
+                    print(f"  {label:<20} {count:>10,}")
+            sr = neo4j_stats.get("sourced_relationships", 0)
+            if sr:
+                print(f"  {'SOURCED_FROM rels':<20} {sr:>10,}")
+
+    # 2. By zone
+    if show_zone and neo4j_stats:
+        by_zone = neo4j_stats.get("by_zone", {})
+        result["by_zone"] = by_zone
+        if by_zone and not use_json:
+            print(f"\n  {'Zone':<20} {'Nodes':>10}")
+            print(f"  {'—' * 20} {'—' * 10}")
+            for zone, count in sorted(by_zone.items(), key=lambda x: -x[1]):
+                print(f"  {zone:<20} {count:>10,}")
+
+    # 3. By source
+    if show_source and neo4j_stats:
+        by_source = neo4j_stats.get("by_source", {})
+        result["by_source"] = by_source
+        if by_source and not use_json:
+            print(f"\n  {'Source':<28} {'Nodes':>10}")
+            print(f"  {'—' * 28} {'—' * 10}")
+            for source, count in sorted(by_source.items(), key=lambda x: -x[1]):
+                print(f"  {source:<28} {count:>10,}")
+
+    # 4. MISP event summary
+    if show_misp:
+        try:
+            misp_summary = _fetch_misp_event_summary()
+            result["misp"] = misp_summary
+            if misp_summary and not use_json:
+                print(
+                    f"\n  MISP Events: {misp_summary['total_events']} events, "
+                    f"{misp_summary['total_attributes']:,} attributes"
+                )
+                if misp_summary.get("by_source"):
+                    print(f"\n  {'MISP Source':<28} {'Events':>8} {'Attributes':>12}")
+                    print(f"  {'—' * 28} {'—' * 8} {'—' * 12}")
+                    for src in sorted(misp_summary["by_source"], key=lambda x: -x["attributes"]):
+                        print(f"  {src['source']:<28} {src['events']:>8} {src['attributes']:>12,}")
+        except Exception as e:
+            warn(f"MISP: {e}")
+
+    # 5. Last sync
     try:
         sync = get_sync_status()
         result["last_sync"] = sync
-        if sync.get("last_sync"):
-            ok(f"Last sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
-        else:
-            warn("No sync recorded yet")
+        if not use_json:
+            if sync.get("last_sync"):
+                ok(f"\nLast sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
+            else:
+                warn("\nNo sync recorded yet")
     except Exception:
         pass
 
-    # Pipeline metrics
+    # 6. Pipeline metrics
     try:
         from metrics import PipelineMetrics
 
@@ -1308,14 +1378,14 @@ def cmd_stats(args) -> int:
         pm.load()
         summary = pm.get_summary()
         result["pipeline"] = summary
-        if summary.get("total_runs", 0) > 0:
+        if not use_json and summary.get("total_runs", 0) > 0:
             print(f"\n  Pipeline: {summary['total_runs']} runs, {summary.get('success_rate', 0):.0f}% success")
             if summary.get("avg_duration"):
                 print(f"  Avg duration: {summary['avg_duration']:.0f}s")
     except Exception:
         pass
 
-    # Checkpoint summary
+    # 7. Checkpoint summary
     try:
         from baseline_checkpoint import get_baseline_status
 
@@ -1324,7 +1394,8 @@ def cmd_stats(args) -> int:
             completed = sum(1 for d in cp.values() if isinstance(d, dict) and d.get("completed"))
             in_progress = len(cp) - completed
             result["checkpoints"] = {"completed": completed, "in_progress": in_progress}
-            print(f"\n  Checkpoints: {completed} completed, {in_progress} in-progress")
+            if not use_json:
+                print(f"\n  Checkpoints: {completed} completed, {in_progress} in-progress")
     except Exception:
         pass
 
@@ -1333,8 +1404,72 @@ def cmd_stats(args) -> int:
 
         print(_json.dumps(result, indent=2, default=str))
 
+    if not use_json and not (show_zone or show_source or show_misp):
+        info("\nTip: use --full for zone/source/MISP breakdowns, or --by-zone, --by-source, --misp individually.")
+
     print()
     return 0
+
+
+def _fetch_misp_event_summary() -> dict:
+    """Query MISP for event/attribute counts grouped by source tag."""
+    import requests as _requests
+    import urllib3
+
+    if not SSL_VERIFY:
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+    session = _requests.Session()
+    session.headers.update(
+        {
+            "Authorization": MISP_API_KEY,
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+    )
+
+    # Fetch EdgeGuard events index (lightweight — no attributes)
+    resp = session.get(
+        f"{MISP_URL}/events/index",
+        params={"limit": 500, "searchall": "EdgeGuard"},
+        verify=SSL_VERIFY,
+        timeout=(15, 60),
+    )
+    resp.raise_for_status()
+    events = resp.json()
+    if not isinstance(events, list):
+        events = []
+
+    total_events = 0
+    total_attrs = 0
+    source_map = {}  # source_tag -> {events: N, attributes: N}
+
+    for ev in events:
+        info_field = ev.get("info", "") or ev.get("Event", {}).get("info", "")
+        attr_count = int(ev.get("attribute_count", 0) or ev.get("Event", {}).get("attribute_count", 0) or 0)
+
+        # Parse source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
+        source_tag = "unknown"
+        if info_field.startswith("EdgeGuard-"):
+            parts = info_field.split("-")
+            if len(parts) >= 3:
+                source_tag = parts[2]  # e.g., "alienvault_otx"
+
+        total_events += 1
+        total_attrs += attr_count
+        if source_tag not in source_map:
+            source_map[source_tag] = {"events": 0, "attributes": 0}
+        source_map[source_tag]["events"] += 1
+        source_map[source_tag]["attributes"] += attr_count
+
+    return {
+        "total_events": total_events,
+        "total_attributes": total_attrs,
+        "by_source": [
+            {"source": src, "events": data["events"], "attributes": data["attributes"]}
+            for src, data in source_map.items()
+        ],
+    }
 
 
 # ================================================================================
@@ -1672,6 +1807,12 @@ Examples:
 
     # Stats dashboard
     stats_parser = subparsers.add_parser("stats", help="Quick dashboard: node counts, sync, runs")
+    stats_parser.add_argument(
+        "--full", action="store_true", help="Include breakdowns by zone, source, and MISP event summary"
+    )
+    stats_parser.add_argument("--by-zone", action="store_true", help="Show node counts per zone")
+    stats_parser.add_argument("--by-source", action="store_true", help="Show node counts per source")
+    stats_parser.add_argument("--misp", action="store_true", help="Show MISP event summary")
     stats_parser.add_argument("--json", action="store_true", help="Output as JSON")
 
     # Preflight

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1779,18 +1779,24 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  edgeguard.py doctor             # Run diagnostics (needs .env)
-  edgeguard.py preflight          # Comprehensive pre-run readiness check
-  edgeguard.py stats              # Quick dashboard: nodes, sync, runs
-  edgeguard.py dag status         # Show Airflow DAG run status
-  edgeguard.py dag kill           # Force-fail stuck DAG runs
-  edgeguard.py checkpoint status  # Show per-source checkpoint state
-  edgeguard.py checkpoint clear   # Clear baseline checkpoints
-  edgeguard.py heal               # Auto-repair
-  edgeguard.py validate           # Validate config
-  edgeguard.py monitor            # Show health status
-  edgeguard.py update             # git pull + reinstall
-  edgeguard.py version            # CalVer + git SHA
+  edgeguard.py preflight             # Pre-run readiness (env vars, APIs, Neo4j, MISP, Airflow)
+  edgeguard.py stats                 # Quick dashboard: node counts, last sync, runs
+  edgeguard.py stats --full          # + breakdown by zone, source, and MISP events
+  edgeguard.py stats --by-zone       # Node counts per zone (shows multi-zone overlap)
+  edgeguard.py stats --by-source     # Node counts per source
+  edgeguard.py stats --misp          # MISP event/attribute counts by source and zone
+  edgeguard.py stats --json          # Machine-readable JSON output
+  edgeguard.py dag status            # Show Airflow DAG run states (color-coded)
+  edgeguard.py dag status --state running  # Only running/queued runs
+  edgeguard.py dag kill              # Force-fail stuck DAG runs (preserves checkpoints)
+  edgeguard.py dag kill --dry-run    # Show what would be killed
+  edgeguard.py checkpoint status     # Per-source baseline progress + incremental cursors
+  edgeguard.py checkpoint clear      # Clear baseline (keeps incremental cursors)
+  edgeguard.py doctor                # Diagnose connectivity issues
+  edgeguard.py heal                  # Auto-repair (circuit breakers, locks, retries)
+  edgeguard.py validate              # Validate config + Neo4j schema
+  edgeguard.py monitor               # Real-time health display
+  edgeguard.py version               # CalVer + git SHA
         """,
     )
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1514,15 +1514,10 @@ def _fetch_misp_event_summary() -> dict:
         # Parse zone and source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
         source_tag = "unknown"
         if info_field.startswith("EdgeGuard-"):
-            # New format: EdgeGuard-{source}-{date}
-            # Legacy:     EdgeGuard-{ZONE}-{source}-{date}
-            parts = info_field.split("-", 3)
+            # Format: EdgeGuard-{source}-{date}
+            parts = info_field.split("-", 2)
             if len(parts) >= 2:
-                valid_zones = {"global", "finance", "energy", "healthcare"}
-                if parts[1].lower() in valid_zones and len(parts) >= 3:
-                    source_tag = parts[2]  # Legacy format
-                else:
-                    source_tag = parts[1]  # New format
+                source_tag = parts[1]  # e.g., "nvd", "alienvault_otx"
 
         total_events += 1
         total_attrs += attr_count

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1018,7 +1018,7 @@ def cmd_dag_status(args) -> int:
         return 1
     ok("Airflow is reachable")
 
-    dag_ids = [args.dag_id] if getattr(args, "dag_id", None) else ac.EDGEGUARD_DAG_IDS
+    dag_ids = [args.dag_id] if getattr(args, "dag_id", None) else ac.get_edgeguard_dag_ids()
     state_filter = getattr(args, "state", None)
     limit = getattr(args, "limit", 5) or 5
     use_json = getattr(args, "json", False)
@@ -1211,6 +1211,28 @@ def cmd_checkpoint_clear(args) -> int:
     from baseline_checkpoint import clear_checkpoint, get_baseline_status
 
     section("Clear Checkpoints")
+
+    # Safety: check if a pipeline is currently running
+    lock_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "checkpoints", "pipeline.lock")
+    try:
+        if os.path.exists(lock_path):
+            with open(lock_path) as f:
+                pid = int(f.read().strip())
+            try:
+                os.kill(pid, 0)
+                err(
+                    f"A pipeline process (PID {pid}) is currently running. "
+                    "Clearing checkpoints now could lose completed source progress. "
+                    "Wait for the pipeline to finish, or use --force to override."
+                )
+                if not getattr(args, "force", False):
+                    return 1
+                warn("--force: proceeding despite active pipeline.")
+            except (ProcessLookupError, PermissionError):
+                pass  # Stale lock — safe to proceed
+    except (ValueError, IOError):
+        pass
+
     source = getattr(args, "source", None)
     include_inc = getattr(args, "include_incremental", False)
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -194,9 +194,8 @@ def check_last_sync():
             try:
                 with open(path, "r") as f:
                     state = json.load(f)
-                    last_sync = datetime.fromisoformat(state.get("last_sync", "2000-01-01")).replace(
-                        tzinfo=timezone.utc
-                    )
+                    raw = state.get("last_sync", "2000-01-01T00:00:00+00:00")
+                    last_sync = datetime.fromisoformat(raw if "+" in raw or "Z" in raw else raw + "+00:00")
                     age = datetime.now(timezone.utc) - last_sync
 
                     if age > timedelta(days=7):
@@ -915,7 +914,8 @@ def get_sync_status():
             try:
                 with open(path, "r") as f:
                     state = json.load(f)
-                    last_sync = datetime.fromisoformat(state.get("last_sync", "unknown")).replace(tzinfo=timezone.utc)
+                    raw = state.get("last_sync", "2000-01-01T00:00:00+00:00")
+                    last_sync = datetime.fromisoformat(raw if "+" in raw or "Z" in raw else raw + "+00:00")
                     return {
                         "last_sync": last_sync.strftime("%Y-%m-%d %H:%M"),
                         "age_hours": (datetime.now(timezone.utc) - last_sync).total_seconds() / 3600,

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -990,6 +990,517 @@ def cmd_monitor(args):
 
 
 # ================================================================================
+# DAG MANAGEMENT
+# ================================================================================
+
+
+def cmd_dag(args) -> int:
+    """Dispatch dag subcommands."""
+    sub = getattr(args, "dag_command", None)
+    if sub == "status":
+        return cmd_dag_status(args)
+    elif sub == "kill":
+        return cmd_dag_kill(args)
+    else:
+        print("Usage: edgeguard dag {status|kill}")
+        return 1
+
+
+def cmd_dag_status(args) -> int:
+    """Show DAG run status from Airflow REST API."""
+    import airflow_client as ac
+
+    section("Airflow DAG Status")
+
+    health = ac.airflow_health()
+    if "error" in health:
+        err(f"Airflow: {health['error']}")
+        return 1
+    ok("Airflow is reachable")
+
+    dag_ids = [args.dag_id] if getattr(args, "dag_id", None) else ac.EDGEGUARD_DAG_IDS
+    state_filter = getattr(args, "state", None)
+    limit = getattr(args, "limit", 5) or 5
+    use_json = getattr(args, "json", False)
+
+    all_runs = []
+    for dag_id in dag_ids:
+        runs = ac.list_dag_runs(dag_id, state=state_filter, limit=limit)
+        if runs and "error" in runs[0]:
+            warn(f"{dag_id}: {runs[0]['error']}")
+            continue
+        for r in runs:
+            r["dag_id"] = dag_id
+        all_runs.extend(runs)
+
+    if use_json:
+        import json as _json
+
+        print(_json.dumps(all_runs, indent=2, default=str))
+        return 0
+
+    if not all_runs:
+        info("No DAG runs found.")
+        return 0
+
+    # Table header
+    print(f"\n  {'DAG':<28} {'State':<10} {'Start':<20} {'Duration':<12}")
+    print(f"  {'—' * 28} {'—' * 10} {'—' * 20} {'—' * 12}")
+    for r in all_runs:
+        dag_id = r.get("dag_id", "?")
+        state = r.get("state", "?")
+        start = (r.get("start_date") or "")[:19]
+        duration = ac.format_duration(r.get("start_date"), r.get("end_date"))
+
+        # Color-code state
+        if state == "success":
+            state_str = f"{Colors.GREEN}{state}{Colors.RESET}"
+        elif state in ("running", "queued"):
+            state_str = f"{Colors.YELLOW}{state}{Colors.RESET}"
+        elif state == "failed":
+            state_str = f"{Colors.RED}{state}{Colors.RESET}"
+        else:
+            state_str = state
+
+        print(f"  {dag_id:<28} {state_str:<22} {start:<20} {duration:<12}")
+
+    print()
+    return 0
+
+
+def cmd_dag_kill(args) -> int:
+    """Force-fail stuck DAG runs with checkpoint preservation."""
+    import airflow_client as ac
+
+    section("Kill Active DAG Runs")
+
+    health = ac.airflow_health()
+    if "error" in health:
+        err(f"Airflow: {health['error']}")
+        return 1
+
+    dag_id_filter = getattr(args, "dag_id", None)
+    dag_ids = [dag_id_filter] if dag_id_filter else None
+    active = ac.list_all_active_dag_runs(dag_ids)
+
+    if not active:
+        ok("No active (running/queued) DAG runs to kill.")
+        return 0
+
+    info(f"Found {len(active)} active run(s):")
+    for r in active:
+        print(f"  {r.get('dag_id', '?'):<28} {r.get('state', '?'):<10} started {(r.get('start_date') or '?')[:19]}")
+
+    if getattr(args, "dry_run", False):
+        info("Dry run — no action taken.")
+        return 0
+
+    if not getattr(args, "force", False):
+        confirm = input("\nKill these runs? Checkpoints will be preserved. [y/N]: ")
+        if confirm.lower() not in ("y", "yes"):
+            info("Aborted.")
+            return 0
+
+    # Checkpoint preservation — read-only snapshot
+    try:
+        from baseline_checkpoint import get_baseline_status
+
+        cp_status = get_baseline_status()
+        if cp_status:
+            ok(f"Checkpoint state: {len(cp_status)} source(s) tracked — preserved (read-only).")
+    except Exception:
+        pass
+
+    # Kill each run
+    killed = 0
+    for r in active:
+        dag_id = r.get("dag_id", "")
+        run_id = r.get("dag_run_id", "")
+        if not run_id:
+            continue
+
+        result = ac.patch_dag_run_state(dag_id, run_id, "failed")
+        if "error" in result:
+            err(f"  Failed to kill {dag_id}/{run_id}: {result['error']}")
+        else:
+            ok(f"  Killed: {dag_id} / {run_id}")
+            killed += 1
+
+    # Reset circuit breakers since services are fine — it was the DAG that was stuck
+    try:
+        from resilience import reset_all_circuit_breakers
+
+        reset_all_circuit_breakers()
+        ok("Circuit breakers reset.")
+    except Exception:
+        pass
+
+    section(f"Killed {killed}/{len(active)} run(s). Checkpoints preserved.")
+    info("Run 'edgeguard dag status' to verify.")
+    return 0
+
+
+# ================================================================================
+# CHECKPOINT MANAGEMENT
+# ================================================================================
+
+
+def cmd_checkpoint(args) -> int:
+    """Dispatch checkpoint subcommands."""
+    sub = getattr(args, "checkpoint_command", None)
+    if sub == "status":
+        return cmd_checkpoint_status(args)
+    elif sub == "clear":
+        return cmd_checkpoint_clear(args)
+    else:
+        print("Usage: edgeguard checkpoint {status|clear}")
+        return 1
+
+
+def cmd_checkpoint_status(args) -> int:
+    """Show baseline checkpoint state per source."""
+    from baseline_checkpoint import get_source_incremental, load_checkpoint
+
+    section("Checkpoint Status")
+    use_json = getattr(args, "json", False)
+    source_filter = getattr(args, "source", None)
+
+    checkpoints = load_checkpoint()
+    if not checkpoints:
+        info("No checkpoints found.")
+        return 0
+
+    if use_json:
+        import json as _json
+
+        data = {source_filter: checkpoints.get(source_filter, {})} if source_filter else checkpoints
+        print(_json.dumps(data, indent=2, default=str))
+        return 0
+
+    print(f"\n  {'Source':<20} {'Pages':<8} {'Items':<10} {'Status':<12} {'Incremental':<14} {'Last Updated':<20}")
+    print(f"  {'—' * 20} {'—' * 8} {'—' * 10} {'—' * 12} {'—' * 14} {'—' * 20}")
+
+    for source, data in sorted(checkpoints.items()):
+        if source_filter and source != source_filter:
+            continue
+        if not isinstance(data, dict):
+            continue
+
+        pages = data.get("page", data.get("pages_collected", "—"))
+        items = data.get("items_collected", "—")
+        completed = data.get("completed", False)
+        updated = (data.get("updated_at") or "")[:19]
+        inc = get_source_incremental(source)
+        has_inc = "yes" if inc else "no"
+
+        if completed:
+            status = f"{Colors.GREEN}completed{Colors.RESET}"
+        elif items and items != "—":
+            status = f"{Colors.YELLOW}in-progress{Colors.RESET}"
+        else:
+            status = "—"
+
+        print(f"  {source:<20} {str(pages):<8} {str(items):<10} {status:<24} {has_inc:<14} {updated:<20}")
+
+    print()
+    return 0
+
+
+def cmd_checkpoint_clear(args) -> int:
+    """Clear baseline checkpoints (preserves incremental state by default)."""
+    from baseline_checkpoint import clear_checkpoint, get_baseline_status, load_checkpoint, save_checkpoint
+
+    section("Clear Checkpoints")
+    source = getattr(args, "source", None)
+    include_inc = getattr(args, "include_incremental", False)
+
+    status = get_baseline_status()
+    if not status:
+        info("No checkpoints to clear.")
+        return 0
+
+    info(f"Current checkpoints: {len(status)} source(s)")
+    for s, d in status.items():
+        if source and s != source:
+            continue
+        print(f"  {s}: {d.get('items_collected', 0)} items, completed={d.get('completed', False)}")
+
+    if include_inc:
+        warn("--include-incremental: This will also clear incremental cursors (modified_since, ETags).")
+        warn("Next collection will do a FULL re-fetch for affected sources.")
+
+    if not getattr(args, "force", False):
+        target = source or "ALL sources"
+        confirm = input(f"\nClear checkpoint for {target}? [y/N]: ")
+        if confirm.lower() not in ("y", "yes"):
+            info("Aborted.")
+            return 0
+
+    clear_checkpoint(source)
+    ok(f"Baseline checkpoint cleared for {source or 'all sources'}.")
+
+    if include_inc:
+        cp = load_checkpoint()
+        if source:
+            if source in cp:
+                cp[source].pop("incremental", None)
+                save_checkpoint(cp)
+        else:
+            for s in cp:
+                if isinstance(cp[s], dict):
+                    cp[s].pop("incremental", None)
+            save_checkpoint(cp)
+        ok("Incremental state also cleared.")
+    else:
+        ok("Incremental state preserved (next scheduled run resumes from cursor).")
+
+    return 0
+
+
+# ================================================================================
+# STATS DASHBOARD
+# ================================================================================
+
+
+def cmd_stats(args) -> int:
+    """Quick dashboard: node counts, last sync, recent runs."""
+    use_json = getattr(args, "json", False)
+
+    section("EdgeGuard Stats")
+
+    result = {}
+
+    # Neo4j node counts
+    try:
+        from health_check import get_neo4j_node_counts
+
+        counts = get_neo4j_node_counts()
+        if counts and "error" not in counts:
+            result["nodes"] = counts
+            print(f"\n  {'Node Type':<20} {'Count':>10}")
+            print(f"  {'—' * 20} {'—' * 10}")
+            for label, count in sorted(counts.items(), key=lambda x: -x[1]):
+                if label != "relationships":
+                    print(f"  {label:<20} {count:>10,}")
+            if "relationships" in counts:
+                print(f"  {'Relationships':<20} {counts['relationships']:>10,}")
+        else:
+            warn("Neo4j: could not fetch node counts")
+    except Exception as e:
+        warn(f"Neo4j: {e}")
+
+    # Last sync
+    try:
+        sync = get_sync_status()
+        result["last_sync"] = sync
+        if sync.get("last_sync"):
+            ok(f"Last sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
+        else:
+            warn("No sync recorded yet")
+    except Exception:
+        pass
+
+    # Pipeline metrics
+    try:
+        from metrics import PipelineMetrics
+
+        pm = PipelineMetrics()
+        pm.load()
+        summary = pm.get_summary()
+        result["pipeline"] = summary
+        if summary.get("total_runs", 0) > 0:
+            print(f"\n  Pipeline: {summary['total_runs']} runs, {summary.get('success_rate', 0):.0f}% success")
+            if summary.get("avg_duration"):
+                print(f"  Avg duration: {summary['avg_duration']:.0f}s")
+    except Exception:
+        pass
+
+    # Checkpoint summary
+    try:
+        from baseline_checkpoint import get_baseline_status
+
+        cp = get_baseline_status()
+        if cp:
+            completed = sum(1 for d in cp.values() if isinstance(d, dict) and d.get("completed"))
+            in_progress = len(cp) - completed
+            result["checkpoints"] = {"completed": completed, "in_progress": in_progress}
+            print(f"\n  Checkpoints: {completed} completed, {in_progress} in-progress")
+    except Exception:
+        pass
+
+    if use_json:
+        import json as _json
+
+        print(_json.dumps(result, indent=2, default=str))
+
+    print()
+    return 0
+
+
+# ================================================================================
+# PREFLIGHT
+# ================================================================================
+
+
+def cmd_preflight(args) -> int:
+    """Comprehensive pre-run readiness check."""
+    strict = getattr(args, "strict", False)
+    use_json = getattr(args, "json", False)
+
+    section("EdgeGuard Preflight Check")
+    errors = 0
+    warnings = 0
+    checks = {}
+
+    # 1. Required env vars
+    section("1. Environment Variables")
+    required = {"NEO4J_PASSWORD": NEO4J_PASSWORD, "MISP_API_KEY": MISP_API_KEY, "MISP_URL": MISP_URL}
+    for name, val in required.items():
+        if val:
+            ok(f"{name}: set")
+        else:
+            err(f"{name}: NOT SET (required)")
+            errors += 1
+    optional = {
+        "OTX_API_KEY": OTX_API_KEY,
+        "NVD_API_KEY": NVD_API_KEY,
+        "VIRUSTOTAL_API_KEY": os.getenv("VIRUSTOTAL_API_KEY"),
+        "ABUSEIPDB_API_KEY": os.getenv("ABUSEIPDB_API_KEY"),
+    }
+    for name, val in optional.items():
+        if val:
+            ok(f"{name}: set ({len(val)} chars)")
+        else:
+            info(f"{name}: not set (optional — source will be skipped)")
+    checks["env_vars"] = {"errors": errors}
+
+    # 2. Neo4j
+    section("2. Neo4j")
+    try:
+        from health_check import health_check_neo4j
+
+        neo4j_result = health_check_neo4j()
+        if neo4j_result.get("status") == "connected":
+            ok(f"Neo4j: connected ({NEO4J_URI})")
+            if neo4j_result.get("apoc_available"):
+                ok("APOC plugin: available")
+            else:
+                err("APOC plugin: NOT available (required)")
+                errors += 1
+        else:
+            err(f"Neo4j: {neo4j_result.get('error', 'unreachable')}")
+            errors += 1
+        checks["neo4j"] = neo4j_result
+    except Exception as e:
+        err(f"Neo4j: {e}")
+        errors += 1
+
+    # 3. MISP
+    section("3. MISP")
+    try:
+        from misp_health import MISPHealthCheck
+
+        checker = MISPHealthCheck()
+        misp_result = checker.check_health()
+        healthy = misp_result.get("healthy", False) if isinstance(misp_result, dict) else False
+        if healthy:
+            ok("MISP: healthy")
+        else:
+            err(f"MISP: unhealthy — {misp_result}")
+            errors += 1
+        checks["misp"] = misp_result
+    except Exception as e:
+        err(f"MISP: {e}")
+        errors += 1
+
+    # 4. Airflow
+    section("4. Airflow")
+    try:
+        import airflow_client as ac
+
+        af_health = ac.airflow_health()
+        if "error" in af_health:
+            warn(f"Airflow: {af_health['error']}")
+            warnings += 1
+        else:
+            ok("Airflow: reachable")
+            dags = ac.get_registered_dags()
+            if dags and "error" not in dags[0]:
+                ok(f"  {len(dags)} EdgeGuard DAG(s) registered")
+            else:
+                warn("  Could not query DAG list")
+                warnings += 1
+        checks["airflow"] = af_health
+    except Exception as e:
+        warn(f"Airflow: {e}")
+        warnings += 1
+
+    # 5. Disk space
+    section("5. Disk Space")
+    try:
+        stat = os.statvfs(".")
+        free_gb = (stat.f_bavail * stat.f_frsize) / (1024**3)
+        if free_gb < 1.0:
+            err(f"Disk: {free_gb:.1f} GB free (need at least 1 GB)")
+            errors += 1
+        else:
+            ok(f"Disk: {free_gb:.1f} GB free")
+        checks["disk"] = {"free_gb": round(free_gb, 1)}
+    except Exception as e:
+        warn(f"Disk check: {e}")
+        warnings += 1
+
+    # 6. Checkpoint state
+    section("6. Checkpoints")
+    try:
+        from baseline_checkpoint import get_baseline_status
+
+        cp = get_baseline_status()
+        if cp:
+            incomplete = [s for s, d in cp.items() if isinstance(d, dict) and not d.get("completed")]
+            if incomplete:
+                warn(f"Incomplete baselines: {', '.join(incomplete)}")
+                warnings += 1
+            else:
+                ok(f"{len(cp)} source(s) baselined")
+        else:
+            info("No baselines run yet")
+        checks["checkpoints"] = cp or {}
+    except Exception:
+        pass
+
+    # 7. Circuit breakers
+    section("7. Circuit Breakers")
+    try:
+        from resilience import _circuit_breakers
+
+        open_breakers = [name for name, cb in _circuit_breakers.items() if cb._state != "CLOSED"]
+        if open_breakers:
+            err(f"OPEN circuit breakers: {', '.join(open_breakers)}")
+            errors += 1
+        else:
+            ok("All circuit breakers CLOSED")
+    except Exception:
+        info("No circuit breaker state (fresh start)")
+
+    # Summary
+    section("Preflight Summary")
+    total_checks = 7
+    passed = total_checks - errors - (warnings if strict else 0)
+    if errors == 0 and (warnings == 0 or not strict):
+        ok(f"READY — {passed}/{total_checks} checks passed, {warnings} warning(s)")
+    else:
+        err(f"NOT READY — {errors} error(s), {warnings} warning(s)")
+
+    if use_json:
+        import json as _json
+
+        print(_json.dumps({"errors": errors, "warnings": warnings, "checks": checks}, indent=2, default=str))
+
+    return 1 if errors > 0 or (strict and warnings > 0) else 0
+
+
+# ================================================================================
 # CODE UPDATE (git pull + install.sh --update)
 # ================================================================================
 
@@ -1102,15 +1613,18 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-  edgeguard.py doctor           # Run diagnostics (needs .env)
-  edgeguard.py heal             # Auto-repair
-  edgeguard.py validate         # Validate config
-  edgeguard.py monitor          # Show health status
-  edgeguard.py update           # git pull + reinstall (auto: Docker or pip)
-  edgeguard.py update --docker  # force Docker Compose path
-  edgeguard.py update --python  # force pip editable reinstall
-  edgeguard.py --update         # same as: edgeguard update
-  edgeguard.py version          # CalVer + git SHA (no .env required)
+  edgeguard.py doctor             # Run diagnostics (needs .env)
+  edgeguard.py preflight          # Comprehensive pre-run readiness check
+  edgeguard.py stats              # Quick dashboard: nodes, sync, runs
+  edgeguard.py dag status         # Show Airflow DAG run status
+  edgeguard.py dag kill           # Force-fail stuck DAG runs
+  edgeguard.py checkpoint status  # Show per-source checkpoint state
+  edgeguard.py checkpoint clear   # Clear baseline checkpoints
+  edgeguard.py heal               # Auto-repair
+  edgeguard.py validate           # Validate config
+  edgeguard.py monitor            # Show health status
+  edgeguard.py update             # git pull + reinstall
+  edgeguard.py version            # CalVer + git SHA
         """,
     )
 
@@ -1127,6 +1641,43 @@ Examples:
 
     # Monitor command
     subparsers.add_parser("monitor", help="Show health status")
+
+    # DAG management
+    dag_parser = subparsers.add_parser("dag", help="Airflow DAG operations")
+    dag_subparsers = dag_parser.add_subparsers(dest="dag_command", help="DAG commands")
+
+    dag_status_parser = dag_subparsers.add_parser("status", help="Show DAG run status")
+    dag_status_parser.add_argument("--dag-id", help="Filter to specific DAG ID")
+    dag_status_parser.add_argument("--state", choices=["running", "queued", "failed", "success"])
+    dag_status_parser.add_argument("--limit", type=int, default=5, help="Max runs per DAG (default: 5)")
+    dag_status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    dag_kill_parser = dag_subparsers.add_parser("kill", help="Force-fail stuck DAG runs")
+    dag_kill_parser.add_argument("--dag-id", help="Kill runs for specific DAG (default: all)")
+    dag_kill_parser.add_argument("--dry-run", action="store_true", help="Show what would be killed")
+    dag_kill_parser.add_argument("--force", action="store_true", help="Skip confirmation")
+
+    # Checkpoint management
+    cp_parser = subparsers.add_parser("checkpoint", help="Manage pipeline checkpoints")
+    cp_subparsers = cp_parser.add_subparsers(dest="checkpoint_command", help="Checkpoint commands")
+
+    cp_status_parser = cp_subparsers.add_parser("status", help="Show checkpoint state per source")
+    cp_status_parser.add_argument("--source", help="Filter to specific source")
+    cp_status_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    cp_clear_parser = cp_subparsers.add_parser("clear", help="Clear baseline checkpoints")
+    cp_clear_parser.add_argument("--source", help="Clear specific source only")
+    cp_clear_parser.add_argument("--include-incremental", action="store_true", help="Also clear incremental cursors")
+    cp_clear_parser.add_argument("--force", action="store_true", help="Skip confirmation")
+
+    # Stats dashboard
+    stats_parser = subparsers.add_parser("stats", help="Quick dashboard: node counts, sync, runs")
+    stats_parser.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # Preflight
+    preflight_parser = subparsers.add_parser("preflight", help="Comprehensive pre-run readiness check")
+    preflight_parser.add_argument("--json", action="store_true", help="Output as JSON")
+    preflight_parser.add_argument("--strict", action="store_true", help="Treat warnings as errors")
 
     # Source management
     source_parser = subparsers.add_parser("source", help="Manage data sources")
@@ -1238,6 +1789,14 @@ Examples:
         return cmd_monitor(args)
     elif args.command == "source":
         return cmd_source(args)
+    elif args.command == "dag":
+        return cmd_dag(args)
+    elif args.command == "checkpoint":
+        return cmd_checkpoint(args)
+    elif args.command == "stats":
+        return cmd_stats(args)
+    elif args.command == "preflight":
+        return cmd_preflight(args)
     else:
         parser.print_help()
         return 1

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1511,7 +1511,7 @@ def _fetch_misp_event_summary() -> dict:
         info_field = ev.get("info", "") or ev.get("Event", {}).get("info", "")
         attr_count = int(ev.get("attribute_count", 0) or ev.get("Event", {}).get("attribute_count", 0) or 0)
 
-        # Parse zone and source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
+        # Parse source from event name: EdgeGuard-{source}-{date}
         source_tag = "unknown"
         if info_field.startswith("EdgeGuard-"):
             # Format: EdgeGuard-{source}-{date}

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1494,7 +1494,9 @@ def _fetch_misp_event_summary() -> dict:
         source_tag = "unknown"
         zone_tag = "unknown"
         if info_field.startswith("EdgeGuard-"):
-            parts = info_field.split("-")
+            # Pattern: EdgeGuard-{ZONE}-{source}-{date}
+            # Split with maxsplit=3 so date hyphens (2026-03-29) stay intact
+            parts = info_field.split("-", 3)
             if len(parts) >= 2:
                 zone_tag = parts[1].lower()  # e.g., "healthcare"
             if len(parts) >= 3:

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1208,7 +1208,7 @@ def cmd_checkpoint_status(args) -> int:
 
 def cmd_checkpoint_clear(args) -> int:
     """Clear baseline checkpoints (preserves incremental state by default)."""
-    from baseline_checkpoint import clear_checkpoint, get_baseline_status, load_checkpoint, save_checkpoint
+    from baseline_checkpoint import clear_checkpoint, get_baseline_status
 
     section("Clear Checkpoints")
     source = getattr(args, "source", None)
@@ -1236,20 +1236,9 @@ def cmd_checkpoint_clear(args) -> int:
             info("Aborted.")
             return 0
 
-    clear_checkpoint(source)
+    clear_checkpoint(source, include_incremental=include_inc)
     ok(f"Baseline checkpoint cleared for {source or 'all sources'}.")
-
     if include_inc:
-        cp = load_checkpoint()
-        if source:
-            if source in cp:
-                cp[source].pop("incremental", None)
-                save_checkpoint(cp)
-        else:
-            for s in cp:
-                if isinstance(cp[s], dict):
-                    cp[s].pop("incremental", None)
-            save_checkpoint(cp)
         ok("Incremental state also cleared.")
     else:
         ok("Incremental state preserved (next scheduled run resumes from cursor).")

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1309,15 +1309,37 @@ def cmd_stats(args) -> int:
             if sr:
                 print(f"  {'SOURCED_FROM rels':<20} {sr:>10,}")
 
-    # 2. By zone
+    # 2. By zone (with multi-zone detection)
     if show_zone and neo4j_stats:
         by_zone = neo4j_stats.get("by_zone", {})
         result["by_zone"] = by_zone
         if by_zone and not use_json:
-            print(f"\n  {'Zone':<20} {'Nodes':>10}")
+            zone_total = sum(by_zone.values())
+            # Count total unique nodes that have any zone
+            try:
+                from neo4j_client import Neo4jClient as _NC2
+
+                _c2 = _NC2()
+                if _c2.connect():
+                    _r = _c2.run("MATCH (n) WHERE n.zone IS NOT NULL RETURN count(n) AS c")
+                    unique_zoned = _r[0]["c"] if _r else 0
+                    _c2.close()
+                else:
+                    unique_zoned = 0
+            except Exception:
+                unique_zoned = 0
+            multi_zone = zone_total - unique_zoned if unique_zoned > 0 else 0
+
+            print(f"\n  {'Zone':<20} {'Nodes':>10}  (nodes may appear in multiple zones)")
             print(f"  {'—' * 20} {'—' * 10}")
             for zone, count in sorted(by_zone.items(), key=lambda x: -x[1]):
                 print(f"  {zone:<20} {count:>10,}")
+            if multi_zone > 0:
+                print(f"  {'—' * 20} {'—' * 10}")
+                print(f"  {'Unique nodes':<20} {unique_zoned:>10,}")
+                print(f"  {'Multi-zone overlap':<20} {multi_zone:>10,}")
+            result["by_zone_unique"] = unique_zoned
+            result["by_zone_overlap"] = multi_zone
 
     # 3. By source
     if show_source and neo4j_stats:
@@ -1340,10 +1362,15 @@ def cmd_stats(args) -> int:
                     f"{misp_summary['total_attributes']:,} attributes"
                 )
                 if misp_summary.get("by_source"):
-                    print(f"\n  {'MISP Source':<28} {'Events':>8} {'Attributes':>12}")
+                    print(f"\n  {'MISP by Source':<28} {'Events':>8} {'Attributes':>12}")
                     print(f"  {'—' * 28} {'—' * 8} {'—' * 12}")
                     for src in sorted(misp_summary["by_source"], key=lambda x: -x["attributes"]):
                         print(f"  {src['source']:<28} {src['events']:>8} {src['attributes']:>12,}")
+                if misp_summary.get("by_zone"):
+                    print(f"\n  {'MISP by Zone':<28} {'Events':>8} {'Attributes':>12}")
+                    print(f"  {'—' * 28} {'—' * 8} {'—' * 12}")
+                    for z in sorted(misp_summary["by_zone"], key=lambda x: -x["attributes"]):
+                        print(f"  {z['zone']:<28} {z['events']:>8} {z['attributes']:>12,}")
         except Exception as e:
             warn(f"MISP: {e}")
 
@@ -1434,24 +1461,34 @@ def _fetch_misp_event_summary() -> dict:
     total_events = 0
     total_attrs = 0
     source_map = {}  # source_tag -> {events: N, attributes: N}
+    zone_map = {}  # zone -> {events: N, attributes: N}
 
     for ev in events:
         info_field = ev.get("info", "") or ev.get("Event", {}).get("info", "")
         attr_count = int(ev.get("attribute_count", 0) or ev.get("Event", {}).get("attribute_count", 0) or 0)
 
-        # Parse source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
+        # Parse zone and source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
         source_tag = "unknown"
+        zone_tag = "unknown"
         if info_field.startswith("EdgeGuard-"):
             parts = info_field.split("-")
+            if len(parts) >= 2:
+                zone_tag = parts[1].lower()  # e.g., "healthcare"
             if len(parts) >= 3:
                 source_tag = parts[2]  # e.g., "alienvault_otx"
 
         total_events += 1
         total_attrs += attr_count
+
         if source_tag not in source_map:
             source_map[source_tag] = {"events": 0, "attributes": 0}
         source_map[source_tag]["events"] += 1
         source_map[source_tag]["attributes"] += attr_count
+
+        if zone_tag not in zone_map:
+            zone_map[zone_tag] = {"events": 0, "attributes": 0}
+        zone_map[zone_tag]["events"] += 1
+        zone_map[zone_tag]["attributes"] += attr_count
 
     return {
         "total_events": total_events,
@@ -1459,6 +1496,9 @@ def _fetch_misp_event_summary() -> dict:
         "by_source": [
             {"source": src, "events": data["events"], "attributes": data["attributes"]}
             for src, data in source_map.items()
+        ],
+        "by_zone": [
+            {"zone": z, "events": data["events"], "attributes": data["attributes"]} for z, data in zone_map.items()
         ],
     }
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -179,11 +179,12 @@ def check_disk_space():
 
 def check_last_sync():
     """Check last sync timestamp from state file."""
-    state_file = os.path.join(os.path.dirname(SCRIPT_DIR), "dags", "edgeguard_last_neo4j_sync.json")
+    repo_root = os.path.dirname(SCRIPT_DIR)
 
-    # Try alternative locations
+    # Try alternative locations (DAG writer uses state/, legacy used dags/)
     alt_paths = [
-        state_file,
+        os.path.join(repo_root, "state", "edgeguard_last_neo4j_sync.json"),
+        os.path.join(repo_root, "dags", "edgeguard_last_neo4j_sync.json"),
         os.path.join(tempfile.gettempdir(), "edgeguard_last_neo4j_sync.json"),
         os.path.expanduser("~/.edgeguard/last_sync.json"),
     ]
@@ -902,10 +903,10 @@ def get_neo4j_status():
 
 def get_sync_status():
     """Get sync status."""
-    state_file = os.path.join(os.path.dirname(SCRIPT_DIR), "dags", "edgeguard_last_neo4j_sync.json")
-
+    repo_root = os.path.dirname(SCRIPT_DIR)
     alt_paths = [
-        state_file,
+        os.path.join(repo_root, "state", "edgeguard_last_neo4j_sync.json"),  # DAG writer path
+        os.path.join(repo_root, "dags", "edgeguard_last_neo4j_sync.json"),  # legacy path
         os.path.join(tempfile.gettempdir(), "edgeguard_last_neo4j_sync.json"),
     ]
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1353,7 +1353,7 @@ def cmd_stats(args) -> int:
         result["last_sync"] = sync
         if not use_json:
             if sync.get("last_sync"):
-                ok(f"\nLast sync: {sync['last_sync'][:19]} ({sync.get('age', '?')})")
+                ok(f"\nLast sync: {sync['last_sync'][:19]} ({sync.get('age_hours', '?')}h ago)")
             else:
                 warn("\nNo sync recorded yet")
     except Exception:

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1054,11 +1054,11 @@ def cmd_dag_status(args) -> int:
 
         # Color-code state
         if state == "success":
-            state_str = f"{Colors.GREEN}{state}{Colors.RESET}"
+            state_str = f"{Colors.GREEN}{state}{Colors.END}"
         elif state in ("running", "queued"):
-            state_str = f"{Colors.YELLOW}{state}{Colors.RESET}"
+            state_str = f"{Colors.YELLOW}{state}{Colors.END}"
         elif state == "failed":
-            state_str = f"{Colors.RED}{state}{Colors.RESET}"
+            state_str = f"{Colors.RED}{state}{Colors.END}"
         else:
             state_str = state
 
@@ -1194,9 +1194,9 @@ def cmd_checkpoint_status(args) -> int:
         has_inc = "yes" if inc else "no"
 
         if completed:
-            status = f"{Colors.GREEN}completed{Colors.RESET}"
+            status = f"{Colors.GREEN}completed{Colors.END}"
         elif items and items != "—":
-            status = f"{Colors.YELLOW}in-progress{Colors.RESET}"
+            status = f"{Colors.YELLOW}in-progress{Colors.END}"
         else:
             status = "—"
 
@@ -1402,11 +1402,10 @@ def cmd_stats(args) -> int:
 
 def _fetch_misp_event_summary() -> dict:
     """Query MISP for event/attribute counts grouped by source tag."""
+    import warnings
+
     import requests as _requests
     import urllib3
-
-    if not SSL_VERIFY:
-        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
     session = _requests.Session()
     session.headers.update(
@@ -1418,12 +1417,15 @@ def _fetch_misp_event_summary() -> dict:
     )
 
     # Fetch EdgeGuard events index (lightweight — no attributes)
-    resp = session.get(
-        f"{MISP_URL}/events/index",
-        params={"limit": 500, "searchall": "EdgeGuard"},
-        verify=SSL_VERIFY,
-        timeout=(15, 60),
-    )
+    with warnings.catch_warnings():
+        if not SSL_VERIFY:
+            warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+        resp = session.get(
+            f"{MISP_URL}/events/index",
+            params={"limit": 500, "searchall": "EdgeGuard"},
+            verify=SSL_VERIFY,
+            timeout=(15, 60),
+        )
     resp.raise_for_status()
     events = resp.json()
     if not isinstance(events, list):
@@ -1596,9 +1598,9 @@ def cmd_preflight(args) -> int:
     # 7. Circuit breakers
     section("7. Circuit Breakers")
     try:
-        from resilience import _circuit_breakers
+        from resilience import CircuitState, _circuit_breakers
 
-        open_breakers = [name for name, cb in _circuit_breakers.items() if cb._state != "CLOSED"]
+        open_breakers = [name for name, cb in _circuit_breakers.items() if cb._state != CircuitState.CLOSED]
         if open_breakers:
             err(f"OPEN circuit breakers: {', '.join(open_breakers)}")
             errors += 1

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1332,37 +1332,64 @@ def cmd_stats(args) -> int:
             if sr:
                 print(f"  {'SOURCED_FROM rels':<20} {sr:>10,}")
 
-    # 2. By zone (with multi-zone detection)
+    # 2. By zone (precise: single-zone counts + combo breakdown)
     if show_zone and neo4j_stats:
-        by_zone = neo4j_stats.get("by_zone", {})
-        result["by_zone"] = by_zone
-        if by_zone and not use_json:
-            zone_total = sum(by_zone.values())
-            # Count total unique nodes that have any zone
-            try:
-                from neo4j_client import Neo4jClient as _NC2
+        try:
+            from neo4j_client import Neo4jClient as _NC2
 
-                _c2 = _NC2()
-                if _c2.connect():
-                    _r = _c2.run("MATCH (n) WHERE n.zone IS NOT NULL RETURN count(n) AS c")
-                    unique_zoned = _r[0]["c"] if _r else 0
-                    _c2.close()
-                else:
-                    unique_zoned = 0
-            except Exception:
-                unique_zoned = 0
-            multi_zone = zone_total - unique_zoned if unique_zoned > 0 else 0
+            _c2 = _NC2()
+            zone_data = {}
+            if _c2.connect():
+                # Precise zone counting: group by the EXACT zone array
+                _r = _c2.run("""
+                    MATCH (n) WHERE n.zone IS NOT NULL
+                    WITH n.zone AS zones, count(n) AS cnt
+                    RETURN zones, cnt ORDER BY cnt DESC
+                """)
+                combo_counts = {tuple(sorted(row["zones"])): row["cnt"] for row in _r} if _r else {}
 
-            print(f"\n  {'Zone':<20} {'Nodes':>10}  (nodes may appear in multiple zones)")
-            print(f"  {'—' * 20} {'—' * 10}")
-            for zone, count in sorted(by_zone.items(), key=lambda x: -x[1]):
-                print(f"  {zone:<20} {count:>10,}")
-            if multi_zone > 0:
-                print(f"  {'—' * 20} {'—' * 10}")
-                print(f"  {'Unique nodes':<20} {unique_zoned:>10,}")
-                print(f"  {'Multi-zone overlap':<20} {multi_zone:>10,}")
-            result["by_zone_unique"] = unique_zoned
-            result["by_zone_overlap"] = multi_zone
+                # Build: single-zone totals (exclusive), combo totals, total
+                single_zone = {}
+                combos = {}
+                for zones, cnt in combo_counts.items():
+                    if len(zones) == 1:
+                        single_zone[zones[0]] = cnt
+                    else:
+                        combos["+".join(zones)] = cnt
+
+                total_nodes = sum(combo_counts.values())
+                _c2.close()
+
+                zone_data = {
+                    "single_zone": single_zone,
+                    "combos": combos,
+                    "total": total_nodes,
+                }
+            result["by_zone"] = zone_data
+
+            if zone_data and not use_json:
+                print(f"\n  {'Zone':<30} {'Nodes':>10}")
+                print(f"  {'—' * 30} {'—' * 10}")
+                # Single-zone counts (exclusive — not counted in combos)
+                for zone, count in sorted(single_zone.items(), key=lambda x: -x[1]):
+                    print(f"  {zone:<30} {count:>10,}")
+                # Combos
+                if combos:
+                    print(f"  {'—' * 30} {'—' * 10}")
+                    for combo, count in sorted(combos.items(), key=lambda x: -x[1]):
+                        print(f"  {combo:<30} {count:>10,}  (multi-zone)")
+                print(f"  {'—' * 30} {'—' * 10}")
+                print(f"  {'TOTAL':<30} {total_nodes:>10,}")
+
+        except Exception as e:
+            # Fallback to the basic by_zone from get_stats
+            by_zone = neo4j_stats.get("by_zone", {})
+            result["by_zone"] = by_zone
+            if by_zone and not use_json:
+                print(f"\n  {'Zone':<30} {'Nodes':>10}")
+                print(f"  {'—' * 30} {'—' * 10}")
+                for zone, count in sorted(by_zone.items(), key=lambda x: -x[1]):
+                    print(f"  {zone:<30} {count:>10,}")
 
     # 3. By source
     if show_source and neo4j_stats:
@@ -1389,11 +1416,6 @@ def cmd_stats(args) -> int:
                     print(f"  {'—' * 28} {'—' * 8} {'—' * 12}")
                     for src in sorted(misp_summary["by_source"], key=lambda x: -x["attributes"]):
                         print(f"  {src['source']:<28} {src['events']:>8} {src['attributes']:>12,}")
-                if misp_summary.get("by_zone"):
-                    print(f"\n  {'MISP by Zone':<28} {'Events':>8} {'Attributes':>12}")
-                    print(f"  {'—' * 28} {'—' * 8} {'—' * 12}")
-                    for z in sorted(misp_summary["by_zone"], key=lambda x: -x["attributes"]):
-                        print(f"  {z['zone']:<28} {z['events']:>8} {z['attributes']:>12,}")
         except Exception as e:
             warn(f"MISP: {e}")
 
@@ -1484,7 +1506,6 @@ def _fetch_misp_event_summary() -> dict:
     total_events = 0
     total_attrs = 0
     source_map = {}  # source_tag -> {events: N, attributes: N}
-    zone_map = {}  # zone -> {events: N, attributes: N}
 
     for ev in events:
         info_field = ev.get("info", "") or ev.get("Event", {}).get("info", "")
@@ -1492,15 +1513,16 @@ def _fetch_misp_event_summary() -> dict:
 
         # Parse zone and source from event name pattern: EdgeGuard-{ZONE}-{source}-{date}
         source_tag = "unknown"
-        zone_tag = "unknown"
         if info_field.startswith("EdgeGuard-"):
-            # Pattern: EdgeGuard-{ZONE}-{source}-{date}
-            # Split with maxsplit=3 so date hyphens (2026-03-29) stay intact
+            # New format: EdgeGuard-{source}-{date}
+            # Legacy:     EdgeGuard-{ZONE}-{source}-{date}
             parts = info_field.split("-", 3)
             if len(parts) >= 2:
-                zone_tag = parts[1].lower()  # e.g., "healthcare"
-            if len(parts) >= 3:
-                source_tag = parts[2]  # e.g., "alienvault_otx"
+                valid_zones = {"global", "finance", "energy", "healthcare"}
+                if parts[1].lower() in valid_zones and len(parts) >= 3:
+                    source_tag = parts[2]  # Legacy format
+                else:
+                    source_tag = parts[1]  # New format
 
         total_events += 1
         total_attrs += attr_count
@@ -1510,20 +1532,12 @@ def _fetch_misp_event_summary() -> dict:
         source_map[source_tag]["events"] += 1
         source_map[source_tag]["attributes"] += attr_count
 
-        if zone_tag not in zone_map:
-            zone_map[zone_tag] = {"events": 0, "attributes": 0}
-        zone_map[zone_tag]["events"] += 1
-        zone_map[zone_tag]["attributes"] += attr_count
-
     return {
         "total_events": total_events,
         "total_attributes": total_attrs,
         "by_source": [
             {"source": src, "events": data["events"], "attributes": data["attributes"]}
             for src, data in source_map.items()
-        ],
-        "by_zone": [
-            {"zone": z, "events": data["events"], "attributes": data["attributes"]} for z, data in zone_map.items()
         ],
     }
 

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -65,6 +65,13 @@ MISP_URL = os.getenv("MISP_URL", "").rstrip("/")
 # Auth helper
 # ---------------------------------------------------------------------------
 EDGEGUARD_API_KEY = os.getenv("EDGEGUARD_API_KEY", "")
+_ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()
+
+if _ENV == "prod" and not EDGEGUARD_API_KEY:
+    raise RuntimeError(
+        "EDGEGUARD_API_KEY must be set when EDGEGUARD_ENV=prod. "
+        "Set a strong random value before starting the GraphQL API in production."
+    )
 
 
 def _verify_api_key(x_api_key: Optional[str] = Header(None, alias="X-API-Key")) -> None:
@@ -630,6 +637,9 @@ async def health():
 if __name__ == "__main__":
     import uvicorn
 
-    port = int(os.getenv("EDGEGUARD_GRAPHQL_PORT", "4001"))
+    try:
+        port = int(os.getenv("EDGEGUARD_GRAPHQL_PORT", "4001"))
+    except (ValueError, TypeError):
+        port = 4001
     host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "0.0.0.0")
     uvicorn.run("graphql_api:app", host=host, port=port, reload=False)

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -6,7 +6,7 @@ Strawberry + FastAPI GraphQL endpoint, mirroring the ISIM GraphQL convention
 queries ISIM.
 
 Run standalone:
-    uvicorn src.graphql_api:app --host 0.0.0.0 --port 4001
+    uvicorn src.graphql_api:app --host 127.0.0.1 --port 4001
 
 Or import `app` into a combined runner alongside the REST API.
 
@@ -641,5 +641,5 @@ if __name__ == "__main__":
         port = int(os.getenv("EDGEGUARD_GRAPHQL_PORT", "4001"))
     except (ValueError, TypeError):
         port = 4001
-    host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "0.0.0.0")
+    host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")
     uvicorn.run("graphql_api:app", host=host, port=port, reload=False)

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -134,6 +134,19 @@ PIPELINE_STAGES = Gauge("edgeguard_pipeline_stage", "Current pipeline stage (1=r
 # DAG/Airflow metrics
 DAG_RUNS = Counter("edgeguard_dag_runs_total", "Total DAG runs", ["dag_id", "status", "run_type"])
 
+# Stuck-run detection: set to time.time() on success, alert if stale
+DAG_LAST_SUCCESS = Gauge(
+    "edgeguard_dag_last_success_timestamp",
+    "Unix timestamp of last successful DAG run (0 = never succeeded)",
+    ["dag_id"],
+)
+
+DAG_RUN_START = Gauge(
+    "edgeguard_dag_run_start_timestamp",
+    "Unix timestamp when the current DAG run started (0 = idle)",
+    ["dag_id"],
+)
+
 DAG_RUN_DURATION = Histogram(
     "edgeguard_dag_run_duration_seconds",
     "DAG run duration",

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -435,7 +435,10 @@ def get_metrics_server(host: str = None, port: int = None) -> MetricsServer:
 
     if _server_instance is None:
         host = host or os.getenv("EDGEGUARD_METRICS_HOST", "127.0.0.1")
-        port = port or int(os.getenv("EDGEGUARD_METRICS_PORT", "8001"))
+        try:
+            port = port or int(os.getenv("EDGEGUARD_METRICS_PORT", "8001"))
+        except (ValueError, TypeError):
+            port = port or 8001
         _server_instance = MetricsServer(host=host, port=port)
 
     return _server_instance

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -390,7 +390,12 @@ class MetricsServer:
 
     def start(self):
         """Start the metrics server (blocking)."""
-        self.server = ThreadedHTTPServer((self.host, self.port), MetricsHandler)
+        try:
+            self.server = ThreadedHTTPServer((self.host, self.port), MetricsHandler)
+        except OSError as e:
+            logger.error(f"Cannot start metrics server on {self.host}:{self.port}: {e}")
+            logger.error("Port may be in use. Pipeline will continue without metrics.")
+            return
         self._running = True
         logger.info(f"Prometheus metrics server starting on http://{self.host}:{self.port}")
         logger.info(f"  - Metrics: http://{self.host}:{self.port}/metrics")
@@ -404,7 +409,12 @@ class MetricsServer:
 
     def start_threaded(self) -> threading.Thread:
         """Start the metrics server in a separate thread (non-blocking)."""
-        self.server = ThreadedHTTPServer((self.host, self.port), MetricsHandler)
+        try:
+            self.server = ThreadedHTTPServer((self.host, self.port), MetricsHandler)
+        except OSError as e:
+            logger.error(f"Cannot start metrics server on {self.host}:{self.port}: {e}")
+            logger.error("Port may be in use. Pipeline will continue without metrics.")
+            return None
         self._running = True
 
         self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -368,7 +368,7 @@ class MetricsServer:
         server.start_threaded()
     """
 
-    def __init__(self, host: str = "0.0.0.0", port: int = 8001):
+    def __init__(self, host: str = "127.0.0.1", port: int = 8001):
         self.host = host
         self.port = port
         self.server: Optional[ThreadedHTTPServer] = None
@@ -449,7 +449,7 @@ def start_metrics_server(host: str = None, port: int = None, threaded: bool = Tr
     Convenience function to start the metrics server.
 
     Args:
-        host: Bind host (default: 0.0.0.0)
+        host: Bind host (default: 127.0.0.1)
         port: Bind port (default: 8001)
         threaded: If True, start in background thread; if False, block
 
@@ -474,7 +474,7 @@ if __name__ == "__main__":
     import argparse
 
     parser = argparse.ArgumentParser(description="EdgeGuard Prometheus Metrics Server")
-    parser.add_argument("--host", default="0.0.0.0", help="Bind host (default: 0.0.0.0)")
+    parser.add_argument("--host", default="127.0.0.1", help="Bind host (default: 127.0.0.1)")
     parser.add_argument("--port", type=int, default=8001, help="Bind port (default: 8001)")
     parser.add_argument("--test-metrics", action="store_true", help="Generate test metrics")
 

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -448,10 +448,11 @@ def get_metrics_server(host: str = None, port: int = None) -> MetricsServer:
 
     if _server_instance is None:
         host = host or os.getenv("EDGEGUARD_METRICS_HOST", "127.0.0.1")
-        try:
-            port = port or int(os.getenv("EDGEGUARD_METRICS_PORT", "8001"))
-        except (ValueError, TypeError):
-            port = port or 8001
+        if port is None:
+            try:
+                port = int(os.getenv("EDGEGUARD_METRICS_PORT", "8001"))
+            except (ValueError, TypeError):
+                port = 8001
         _server_instance = MetricsServer(host=host, port=port)
 
     return _server_instance

--- a/src/neo4j/docker-compose.yml
+++ b/src/neo4j/docker-compose.yml
@@ -4,8 +4,8 @@ services:
     container_name: edgeguard_neo4j
     restart: unless-stopped
     ports:
-      - "7474:7474"
-      - "7687:7687"
+      - "127.0.0.1:7474:7474"
+      - "127.0.0.1:7687:7687"
     environment:
       # NEO4J_PASSWORD must be set in the environment or a .env file — no default.
       - NEO4J_AUTH=${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD}

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -207,7 +207,7 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
                     logger.error(f"{func.__name__} failed with non-retryable error: {e}")
                     raise
 
-            logger.error(f"{func.__name__} failed after {max_retries} attempts")
+            logger.error(f"{func.__name__} failed after {max_retries + 1} attempts")
             raise last_exception
 
         return wrapper

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -3597,12 +3597,14 @@ class Neo4jClient:
 
         query = """
         MERGE (i:Indicator {indicator_type: $indicator_type, value: $value, tag: $tag})
-        SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN $first_seen ELSE i.first_seen END,
-            i.last_updated = $last_updated,
+        SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN datetime() ELSE i.first_seen END,
+            i.last_updated = datetime(),
             i.source = CASE WHEN i.source IS NULL THEN $source ELSE apoc.coll.union(i.source, $source) END,
             i.confidence_score = $confidence_score,
             i.original_source = $original_source,
-            i.zone = $zone
+            i.zone = $zone,
+            i.edgeguard_managed = true,
+            i.active = true
         """
 
         try:

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -185,7 +185,7 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
         @wraps(func)
         def wrapper(*args, **kwargs):
             last_exception = None
-            for attempt in range(max_retries):
+            for attempt in range(max_retries + 1):  # +1: first attempt + max_retries retries (matches collector_utils)
                 try:
                     return func(*args, **kwargs)
                 except (
@@ -195,9 +195,11 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
                     TimeoutError,
                 ) as e:
                     last_exception = e
+                    if attempt >= max_retries:
+                        break  # exhausted all retries
                     delay = base_delay * (2**attempt)
                     logger.warning(
-                        f"{func.__name__} failed (attempt {attempt + 1}/{max_retries}): {e}. Retrying in {delay}s..."
+                        f"{func.__name__} failed (attempt {attempt + 1}/{max_retries + 1}): {e}. Retrying in {delay}s..."
                     )
                     time.sleep(delay)
                 except Exception as e:

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -955,7 +955,7 @@ if __name__ == "__main__":
     import uvicorn
 
     # Get configuration from environment
-    host = os.getenv("EDGEGUARD_API_HOST", "0.0.0.0")
+    host = os.getenv("EDGEGUARD_API_HOST", "127.0.0.1")
     try:
         port = int(os.getenv("EDGEGUARD_API_PORT", "8000"))
     except (ValueError, TypeError):

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -106,7 +106,10 @@ app = FastAPI(
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
-_MAX_BODY_BYTES = int(os.getenv("EDGEGUARD_MAX_BODY_BYTES", str(1 * 1024 * 1024)))  # 1 MB default
+try:
+    _MAX_BODY_BYTES = int(os.getenv("EDGEGUARD_MAX_BODY_BYTES", str(1 * 1024 * 1024)))
+except (ValueError, TypeError):
+    _MAX_BODY_BYTES = 1 * 1024 * 1024  # 1 MB default
 
 
 @app.middleware("http")
@@ -953,7 +956,10 @@ if __name__ == "__main__":
 
     # Get configuration from environment
     host = os.getenv("EDGEGUARD_API_HOST", "0.0.0.0")
-    port = int(os.getenv("EDGEGUARD_API_PORT", "8000"))
+    try:
+        port = int(os.getenv("EDGEGUARD_API_PORT", "8000"))
+    except (ValueError, TypeError):
+        port = 8000
     reload = os.getenv("EDGEGUARD_API_RELOAD", "false").lower() == "true"
 
     logger.info(f"[START] Starting EdgeGuard Query API on {host}:{port}")

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -377,7 +377,7 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
         @wraps(func)
         def wrapper(*args, **kwargs):
             last_exception = None
-            for attempt in range(max_retries):
+            for attempt in range(max_retries + 1):  # +1: first attempt + max_retries retries (matches collector_utils)
                 try:
                     return func(*args, **kwargs)
                 except (
@@ -387,9 +387,11 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
                     requests.exceptions.ChunkedEncodingError,
                 ) as e:
                     last_exception = e
+                    if attempt >= max_retries:
+                        break  # exhausted all retries
                     delay = base_delay * (2**attempt)
                     logger.warning(
-                        f"{func.__name__} failed (attempt {attempt + 1}/{max_retries}): {e}. Retrying in {delay}s..."
+                        f"{func.__name__} failed (attempt {attempt + 1}/{max_retries + 1}): {e}. Retrying in {delay}s..."
                     )
                     time.sleep(delay)
                 except Exception as e:

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -399,7 +399,7 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
                     logger.error(f"{func.__name__} failed with non-retryable error: {type(e).__name__}: {e}")
                     raise
 
-            logger.error(f"{func.__name__} failed after {max_retries} attempts")
+            logger.error(f"{func.__name__} failed after {max_retries + 1} attempts")
             raise last_exception
 
         return wrapper

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2398,26 +2398,27 @@ class MISPToNeo4jSync:
                     or item.get("cvss_v30_data")
                     or item.get("cvss_v2_data")
                 ):
-                    self.neo4j.merge_cve(item, source_id=source_id)
+                    ok = self.neo4j.merge_cve(item, source_id=source_id)
                 else:
-                    self.neo4j.merge_vulnerability(item, source_id=source_id)
-                self.stats["vulnerabilities_synced"] += 1
+                    ok = self.neo4j.merge_vulnerability(item, source_id=source_id)
+                if ok:
+                    self.stats["vulnerabilities_synced"] += 1
 
             elif item.get("indicator_type") and item.get("value"):
-                self.neo4j.merge_indicator(item, source_id=source_id)
-                self.stats["indicators_synced"] += 1
+                if self.neo4j.merge_indicator(item, source_id=source_id):
+                    self.stats["indicators_synced"] += 1
 
             elif item_type == "malware":
-                self.neo4j.merge_malware(item, source_id=source_id)
-                self.stats["malware_synced"] += 1
+                if self.neo4j.merge_malware(item, source_id=source_id):
+                    self.stats["malware_synced"] += 1
 
             elif item_type == "actor":
-                self.neo4j.merge_actor(item, source_id=source_id)
-                self.stats["actors_synced"] += 1
+                if self.neo4j.merge_actor(item, source_id=source_id):
+                    self.stats["actors_synced"] += 1
 
             elif item_type == "technique":
-                self.neo4j.merge_technique(item, source_id=source_id)
-                self.stats["techniques_synced"] += 1
+                if self.neo4j.merge_technique(item, source_id=source_id):
+                    self.stats["techniques_synced"] += 1
 
             elif item_type == "tactic":
                 self.neo4j.merge_tactic(item, source_id=source_id)

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -100,7 +100,7 @@ NEO4J_SYNC_SINGLE_PASS_STRONG_WARN_THRESHOLD = 5000
 # Substring matched against event metadata in MISP restSearch (not exact event title).
 # PyMISP/MISP ``eventinfo=`` filtering is unreliable on some 2.4.x builds (e.g. 2.4.123);
 # ``search`` maps to the server-side substring / full-text style filter our events need
-# (titles look like ``EdgeGuard-{source}-{date}``; legacy: ``EdgeGuard-{sector}-{source}-{date}``).
+# (titles look like ``EdgeGuard-{source}-{date}``).
 MISP_EDGEGUARD_DISCOVERY_SEARCH = os.getenv("EDGEGUARD_MISP_EVENT_SEARCH", "EdgeGuard").strip() or "EdgeGuard"
 
 # Lightweight event list (no attribute scan). restSearch with ``search=`` can scan all attributes and
@@ -1068,29 +1068,13 @@ class MISPToNeo4jSync:
 
     def _extract_zone_from_event_name(self, event_info: str) -> Optional[str]:
         """
-        Extract zone from MISP event name (legacy support).
+        Extract zone from MISP event name — always returns None.
 
-        Current event names: ``EdgeGuard-{source}-{date}`` (no zone in name).
-        Legacy event names:  ``EdgeGuard-{SECTOR}-{source}-{date}`` (zone in name).
-
-        Zone data now lives on attribute-level tags (``zone:Finance`` etc.),
-        so this is only a fallback for legacy events.
-
-        Returns:
-            Zone name (lowercase) or None if not an old-format name.
+        Event names use ``EdgeGuard-{source}-{date}`` (no zone in name).
+        Zone data lives exclusively on attribute-level tags (``zone:Finance``).
+        This method exists as a no-op stub so call sites don't need changing.
         """
-        if not event_info:
-            return None
-
-        parts = event_info.split("-")
-        if len(parts) >= 2 and parts[0].upper() == "EDGEGUARD":
-            # Check if parts[1] is a known zone (legacy format) or a source (new format)
-            candidate = parts[1].lower()
-            valid_zones = ["global", "finance", "energy", "healthcare"]
-            if candidate in valid_zones:
-                return candidate  # Legacy format: EdgeGuard-ZONE-source-date
-
-        return None  # New format: EdgeGuard-source-date (zone from tags only)
+        return None
 
     def _manual_convert_to_stix21(self, misp_event: dict) -> dict:
         """

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -100,7 +100,7 @@ NEO4J_SYNC_SINGLE_PASS_STRONG_WARN_THRESHOLD = 5000
 # Substring matched against event metadata in MISP restSearch (not exact event title).
 # PyMISP/MISP ``eventinfo=`` filtering is unreliable on some 2.4.x builds (e.g. 2.4.123);
 # ``search`` maps to the server-side substring / full-text style filter our events need
-# (titles look like ``EdgeGuard-{sector}-{source}-{date}``).
+# (titles look like ``EdgeGuard-{source}-{date}``; legacy: ``EdgeGuard-{sector}-{source}-{date}``).
 MISP_EDGEGUARD_DISCOVERY_SEARCH = os.getenv("EDGEGUARD_MISP_EVENT_SEARCH", "EdgeGuard").strip() or "EdgeGuard"
 
 # Lightweight event list (no attribute scan). restSearch with ``search=`` can scan all attributes and
@@ -1068,36 +1068,29 @@ class MISPToNeo4jSync:
 
     def _extract_zone_from_event_name(self, event_info: str) -> Optional[str]:
         """
-        Extract zone from MISP event name.
+        Extract zone from MISP event name (legacy support).
 
-        Event names follow pattern: EdgeGuard-{SECTOR}-{source}-{date}
-        Examples:
-        - "EdgeGuard-FINANCE-alienvault_otx-2024-01-01" → "finance"
-        - "EdgeGuard-ENERGY-cisa-2024-01-01" → "energy"
-        - "EdgeGuard-GLOBAL-nvd-2024-01-01" → "global"
+        Current event names: ``EdgeGuard-{source}-{date}`` (no zone in name).
+        Legacy event names:  ``EdgeGuard-{SECTOR}-{source}-{date}`` (zone in name).
 
-        Args:
-            event_info: MISP event info/name
+        Zone data now lives on attribute-level tags (``zone:Finance`` etc.),
+        so this is only a fallback for legacy events.
 
         Returns:
-            Zone name (lowercase) or None if not found
+            Zone name (lowercase) or None if not an old-format name.
         """
         if not event_info:
             return None
 
-        # Match pattern: EdgeGuard-{SECTOR}-{source}-{date}
-        # Event names are like: EdgeGuard-FINANCE-alienvault_otx-2024-03-08
         parts = event_info.split("-")
-
-        # Check if this is an EdgeGuard event
         if len(parts) >= 2 and parts[0].upper() == "EDGEGUARD":
-            # The second part should be the sector/zone
-            zone = parts[1].lower()
+            # Check if parts[1] is a known zone (legacy format) or a source (new format)
+            candidate = parts[1].lower()
             valid_zones = ["global", "finance", "energy", "healthcare"]
-            if zone in valid_zones:
-                return zone
+            if candidate in valid_zones:
+                return candidate  # Legacy format: EdgeGuard-ZONE-source-date
 
-        return None
+        return None  # New format: EdgeGuard-source-date (zone from tags only)
 
     def _manual_convert_to_stix21(self, misp_event: dict) -> dict:
         """

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -796,7 +796,9 @@ class EdgeGuardPipeline:
             fresh_baseline: If True with baseline, discard any existing checkpoints and start
                 from scratch. Default False preserves partial progress for resume.
         """
-        # ── Pipeline lock: prevent concurrent runs ──
+        # ── Pipeline lock: prevent concurrent CLI runs ──
+        # NOTE: This lock only protects CLI invocations (python run_pipeline.py).
+        # Airflow DAGs use max_active_runs=1 for concurrency control instead.
         lock_dir = os.path.join(os.path.dirname(__file__), "..", "checkpoints")
         os.makedirs(lock_dir, exist_ok=True)
         lock_path = os.path.join(lock_dir, "pipeline.lock")
@@ -807,10 +809,12 @@ class EdgeGuardPipeline:
                 # Check if the process is still alive
                 try:
                     os.kill(old_pid, 0)
-                    logger.warning(
-                        f"Another pipeline process (PID {old_pid}) appears to be running. "
+                    logger.error(
+                        f"Another pipeline process (PID {old_pid}) is still running. "
+                        "Aborting to prevent data races. "
                         "If this is stale, delete checkpoints/pipeline.lock and retry."
                     )
+                    return False
                 except (OSError, ProcessLookupError):
                     logger.info(f"Stale lock file found (PID {old_pid} is gone) — removing.")
         except (ValueError, IOError):
@@ -819,8 +823,17 @@ class EdgeGuardPipeline:
             f.write(str(os.getpid()))
 
         import atexit
+        import signal
 
-        atexit.register(lambda: os.remove(lock_path) if os.path.exists(lock_path) else None)
+        def _cleanup_lock(*_args):
+            try:
+                if os.path.exists(lock_path):
+                    os.remove(lock_path)
+            except OSError:
+                pass
+
+        atexit.register(_cleanup_lock)
+        signal.signal(signal.SIGTERM, lambda s, f: (_cleanup_lock(), sys.exit(1)))
 
         # Import baseline checkpoint utilities
         from baseline_checkpoint import clear_checkpoint, get_baseline_status

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -406,7 +406,7 @@ class EdgeGuardPipeline:
                     # Parse pattern to extract indicator value
                     indicator_data = self._parse_stix_pattern(pattern)
                     if indicator_data:
-                        self.neo4j.merge_indicator(
+                        ok = self.neo4j.merge_indicator(
                             {
                                 "indicator_type": indicator_data.get("type", "unknown"),
                                 "value": indicator_data.get("value", ""),
@@ -420,7 +420,8 @@ class EdgeGuardPipeline:
                             },
                             source_id=obj.get("x_edgeguard_source", "unknown"),
                         )
-                        stats["indicators"] += 1
+                        if ok:
+                            stats["indicators"] += 1
 
                 # Handle Vulnerability objects (CVE)
                 elif obj_type == "vulnerability":
@@ -429,7 +430,7 @@ class EdgeGuardPipeline:
                     import re
 
                     if re.match(r"^CVE-\d{4}-\d{4,}$", vuln_name, re.IGNORECASE):
-                        self.neo4j.merge_vulnerability(
+                        ok = self.neo4j.merge_vulnerability(
                             {
                                 "cve_id": vuln_name.upper(),
                                 "description": obj.get("description", ""),
@@ -446,11 +447,12 @@ class EdgeGuardPipeline:
                             },
                             source_id=obj.get("x_edgeguard_source", "unknown"),
                         )
-                        stats["vulnerabilities"] += 1
+                        if ok:
+                            stats["vulnerabilities"] += 1
 
                 # Handle Threat Actor objects
                 elif obj_type == "threat-actor":
-                    self.neo4j.merge_actor(
+                    ok = self.neo4j.merge_actor(
                         {
                             "name": obj.get("name", ""),
                             "aliases": obj.get("aliases", []),
@@ -462,11 +464,12 @@ class EdgeGuardPipeline:
                         },
                         source_id=obj.get("x_edgeguard_source", "unknown"),
                     )
-                    stats["actors"] += 1
+                    if ok:
+                        stats["actors"] += 1
 
                 # Handle Malware objects
                 elif obj_type == "malware":
-                    self.neo4j.merge_malware(
+                    ok = self.neo4j.merge_malware(
                         {
                             "name": obj.get("name", ""),
                             "malware_types": obj.get("malware_types", []),
@@ -479,7 +482,8 @@ class EdgeGuardPipeline:
                         },
                         source_id=obj.get("x_edgeguard_source", "unknown"),
                     )
-                    stats["malware"] += 1
+                    if ok:
+                        stats["malware"] += 1
 
                 # Handle Tool objects (Cobalt Strike, Mimikatz, etc.)
                 elif obj_type == "tool":
@@ -792,6 +796,32 @@ class EdgeGuardPipeline:
             fresh_baseline: If True with baseline, discard any existing checkpoints and start
                 from scratch. Default False preserves partial progress for resume.
         """
+        # ── Pipeline lock: prevent concurrent runs ──
+        lock_dir = os.path.join(os.path.dirname(__file__), "..", "checkpoints")
+        os.makedirs(lock_dir, exist_ok=True)
+        lock_path = os.path.join(lock_dir, "pipeline.lock")
+        try:
+            if os.path.exists(lock_path):
+                with open(lock_path) as f:
+                    old_pid = int(f.read().strip())
+                # Check if the process is still alive
+                try:
+                    os.kill(old_pid, 0)
+                    logger.warning(
+                        f"Another pipeline process (PID {old_pid}) appears to be running. "
+                        "If this is stale, delete checkpoints/pipeline.lock and retry."
+                    )
+                except (OSError, ProcessLookupError):
+                    logger.info(f"Stale lock file found (PID {old_pid} is gone) — removing.")
+        except (ValueError, IOError):
+            pass
+        with open(lock_path, "w") as f:
+            f.write(str(os.getpid()))
+
+        import atexit
+
+        atexit.register(lambda: os.remove(lock_path) if os.path.exists(lock_path) else None)
+
         # Import baseline checkpoint utilities
         from baseline_checkpoint import clear_checkpoint, get_baseline_status
 

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -710,19 +710,12 @@ class EdgeGuardPipeline:
                     continue
                 logger.debug(f"   Converting event {event_id} to STIX 2.1")
 
-                # Extract source from event info
-                # New format: EdgeGuard-{SOURCE}-{DATE} -> parts[1]
-                # Legacy:     EdgeGuard-{ZONE}-{SOURCE}-{DATE} -> parts[2]
+                # Extract source from event info (format: EdgeGuard-{source}-{date})
                 source_from_event = "unknown"
                 try:
-                    parts = event_info.split("-", 3)
+                    parts = event_info.split("-", 2)
                     if len(parts) >= 2:
-                        # Check if parts[1] is a zone (legacy) or source (new)
-                        valid_zones = {"global", "finance", "energy", "healthcare"}
-                        if parts[1].lower() in valid_zones and len(parts) >= 3:
-                            source_from_event = parts[2]  # Legacy: EdgeGuard-ZONE-source-date
-                        else:
-                            source_from_event = parts[1]  # New: EdgeGuard-source-date
+                        source_from_event = parts[1]  # e.g., "alienvault_otx"
                 except Exception as e:
                     logger.debug(f"Could not extract source from event info '{event_info}': {e}")
 

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -833,7 +833,12 @@ class EdgeGuardPipeline:
                 pass
 
         atexit.register(_cleanup_lock)
-        signal.signal(signal.SIGTERM, lambda s, f: (_cleanup_lock(), sys.exit(1)))
+
+        def _sigterm_handler(signum, frame):
+            _cleanup_lock()
+            sys.exit(1)
+
+        signal.signal(signal.SIGTERM, _sigterm_handler)
 
         # Import baseline checkpoint utilities
         from baseline_checkpoint import clear_checkpoint, get_baseline_status

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -780,7 +780,7 @@ class EdgeGuardPipeline:
         stix_event_id: str = None,
         use_stix_flow: bool = False,
         baseline: bool = False,
-        baseline_days: int = 365,
+        baseline_days: int = 730,
         fresh_baseline: bool = False,
     ):
         """
@@ -809,13 +809,21 @@ class EdgeGuardPipeline:
                 # Check if the process is still alive
                 try:
                     os.kill(old_pid, 0)
+                    # Process exists (signal 0 succeeded) — could be ours or another user's
                     logger.error(
                         f"Another pipeline process (PID {old_pid}) is still running. "
                         "Aborting to prevent data races. "
                         "If this is stale, delete checkpoints/pipeline.lock and retry."
                     )
                     return False
-                except (OSError, ProcessLookupError):
+                except PermissionError:
+                    # PID exists but owned by another user — treat as alive (safe side)
+                    logger.error(
+                        f"Pipeline lock held by PID {old_pid} (different user). "
+                        "Aborting. Delete checkpoints/pipeline.lock if stale."
+                    )
+                    return False
+                except ProcessLookupError:
                     logger.info(f"Stale lock file found (PID {old_pid} is gone) — removing.")
         except (ValueError, IOError):
             pass

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -840,6 +840,30 @@ class EdgeGuardPipeline:
 
         signal.signal(signal.SIGTERM, _sigterm_handler)
 
+        try:
+            return self._run_pipeline_inner(
+                stix_export=stix_export,
+                stix_output=stix_output,
+                stix_event_id=stix_event_id,
+                use_stix_flow=use_stix_flow,
+                baseline=baseline,
+                baseline_days=baseline_days,
+                fresh_baseline=fresh_baseline,
+            )
+        finally:
+            _cleanup_lock()
+
+    def _run_pipeline_inner(
+        self,
+        stix_export=False,
+        stix_output=None,
+        stix_event_id=None,
+        use_stix_flow=False,
+        baseline=False,
+        baseline_days=730,
+        fresh_baseline=False,
+    ):
+        """Inner pipeline logic, separated so the lock is always cleaned up."""
         # Import baseline checkpoint utilities
         from baseline_checkpoint import clear_checkpoint, get_baseline_status
 

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -710,13 +710,19 @@ class EdgeGuardPipeline:
                     continue
                 logger.debug(f"   Converting event {event_id} to STIX 2.1")
 
-                # Extract source from event info (format: EdgeGuard-{ZONE}-{SOURCE}-{DATE})
-                # Example: EdgeGuard-HEALTHCARE-alienvault_otx-2026-03-10 -> alienvault_otx
+                # Extract source from event info
+                # New format: EdgeGuard-{SOURCE}-{DATE} -> parts[1]
+                # Legacy:     EdgeGuard-{ZONE}-{SOURCE}-{DATE} -> parts[2]
                 source_from_event = "unknown"
                 try:
-                    parts = event_info.split("-")
-                    if len(parts) >= 3:
-                        source_from_event = parts[2]  # alienvault_otx, cisa_kev, etc.
+                    parts = event_info.split("-", 3)
+                    if len(parts) >= 2:
+                        # Check if parts[1] is a zone (legacy) or source (new)
+                        valid_zones = {"global", "finance", "energy", "healthcare"}
+                        if parts[1].lower() in valid_zones and len(parts) >= 3:
+                            source_from_event = parts[2]  # Legacy: EdgeGuard-ZONE-source-date
+                        else:
+                            source_from_event = parts[1]  # New: EdgeGuard-source-date
                 except Exception as e:
                     logger.debug(f"Could not extract source from event info '{event_info}': {e}")
 

--- a/tests/test_incremental_dedup.py
+++ b/tests/test_incremental_dedup.py
@@ -6,12 +6,12 @@ from unittest.mock import MagicMock, patch
 def test_update_source_incremental_merges_under_incremental_key():
     from baseline_checkpoint import clear_checkpoint, get_source_incremental, update_source_incremental
 
-    clear_checkpoint("testsrc_incr")
+    clear_checkpoint("testsrc_incr", include_incremental=True)  # full cleanup for test isolation
     update_source_incremental("testsrc_incr", foo="bar")
     assert get_source_incremental("testsrc_incr") == {"foo": "bar"}
     update_source_incremental("testsrc_incr", baz=1)
     assert get_source_incremental("testsrc_incr") == {"foo": "bar", "baz": 1}
-    clear_checkpoint("testsrc_incr")
+    clear_checkpoint("testsrc_incr", include_incremental=True)  # cleanup after test
 
 
 def test_misp_writer_push_items_skips_prefetched_type_value():

--- a/tests/test_misp_writer_event_exact_match.py
+++ b/tests/test_misp_writer_event_exact_match.py
@@ -24,10 +24,13 @@ def test_exact_info_flat_row_shape():
     assert mw._event_id_exact_from_restsearch_rows(rows, "EdgeGuard-GLOBAL-nvd-2026-03-24") == "7"
 
 
-def test_primary_sector_for_event_grouping_matches_zone_tag_logic():
-    """push_items must not use zones[0] when global is mixed with specifics."""
+def test_event_grouping_by_source_not_zone():
+    """Events are grouped by (source, date) — zone is on attribute tags only."""
     w = mw.MISPWriter.__new__(mw.MISPWriter)
-    assert w._primary_sector_for_event_grouping({"zone": ["global", "energy"]}) == "energy"
-    assert w._primary_sector_for_event_grouping({"zone": ["energy", "global"]}) == "energy"
-    assert w._primary_sector_for_event_grouping({"zone": ["finance", "healthcare"]}) == "finance"
-    assert w._primary_sector_for_event_grouping({"zone": ["global"]}) == "global"
+    # Zone should NOT appear in event names; _primary_sector_for_event_grouping is removed.
+    # Verify _get_zones_to_tag still returns all zones for attribute tags.
+    assert "energy" in w._get_zones_to_tag({"zone": ["global", "energy"]})
+    assert "global" not in w._get_zones_to_tag({"zone": ["global", "energy"]})  # global filtered when specifics exist
+    zones = w._get_zones_to_tag({"zone": ["finance", "healthcare"]})
+    assert "finance" in zones
+    assert "healthcare" in zones

--- a/tests/test_resilmesh_integration.py
+++ b/tests/test_resilmesh_integration.py
@@ -6,7 +6,7 @@ Validates the Phase 1 integration between EdgeGuard and ResilMesh schemas.
 
 import os
 import sys
-from datetime import datetime
+from datetime import datetime, timezone
 
 import pytest
 
@@ -34,7 +34,7 @@ def test_alert_node_creation():
         "alert_id": "test-resilmesh-001",
         "source": "wazuh",
         "zone": "healthcare",
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "tags": ["healthcare", "finance"],
         "threat": {
             "indicator": "192.168.100.50",
@@ -172,7 +172,7 @@ def test_multi_zone_alert():
         "alert_id": "test-multizone-001",
         "source": "wazuh",
         "zone": "healthcare",
-        "timestamp": datetime.now().isoformat(),
+        "timestamp": datetime.now(timezone.utc).isoformat(),
         "tags": ["healthcare", "finance", "energy"],  # Multi-zone
         "threat": {
             "indicator": "evil-apt-c2.com",

--- a/tests/test_stix21_integration.py
+++ b/tests/test_stix21_integration.py
@@ -69,7 +69,7 @@ def test_stix21_bundle_creation(tmp_path):
     logger.info("\nTesting STIX 2.1 bundle creation...")
 
     import uuid
-    from datetime import datetime
+    from datetime import datetime, timezone
 
     # Create a STIX 2.1 bundle manually
     bundle = {
@@ -93,12 +93,12 @@ def test_stix21_bundle_creation(tmp_path):
                 "type": "indicator",
                 "spec_version": "2.1",
                 "id": f"indicator--{uuid.uuid4()}",
-                "created": datetime.now().isoformat(),
-                "modified": datetime.now().isoformat(),
+                "created": datetime.now(timezone.utc).isoformat(),
+                "modified": datetime.now(timezone.utc).isoformat(),
                 "name": "Malicious IP Indicator",
                 "pattern": "[ipv4-addr:value = '192.168.1.100']",
                 "pattern_type": "stix",
-                "valid_from": datetime.now().isoformat(),
+                "valid_from": datetime.now(timezone.utc).isoformat(),
             },
         ],
     }


### PR DESCRIPTION
## Summary

Complete production readiness sweep + 6 new CLI commands + rich stats dashboard.

### Code hardening
- All Docker ports bound to 127.0.0.1 (loopback only)
- GraphQL prod-mode API key enforcement
- Safe int/float env var parsing (no import-time crashes)
- Stats inflation fix (check merge return values)
- Pipeline lock file for concurrent run prevention
- clear_checkpoint preserves incremental state

### Airflow DAG improvements
- max_active_runs=1 on all 6 DAGs
- dagrun_timeout calculated from worst-case task chains
- on_failure_callback + on_success_callback for alerting/metrics
- Baseline DAG is_paused_upon_creation=False
- ShortCircuit error handling for corrupted state files

### New CLI commands
- `edgeguard dag status` — Airflow DAG run states
- `edgeguard dag kill` — Force-fail stuck runs (preserves checkpoints)
- `edgeguard preflight` — 8-category readiness check
- `edgeguard stats [--full|--by-zone|--by-source|--misp]` — Data dashboard
- `edgeguard checkpoint status` — Per-source checkpoint state
- `edgeguard checkpoint clear` — Clear with incremental preservation

### Monitoring
- New Prometheus alerts: EdgeGuardDAGRunStuck, EdgeGuardDAGLastSuccessStale
- Alertmanager target enabled
- DAG-level success/activity gauges wired into callbacks

### Documentation
- 5 docs updated (AIRFLOW_DAGS, PRODUCTION_READINESS, PROMETHEUS_SETUP, DEPLOYMENT_CHECKLIST, INTEROPERABILITY)
- BUGBOT.md: 10 new rules for timing, retries, concurrency
- CI badges + EU funding acknowledgment in README

## Test plan
- [x] 161 tests pass, 0 failures
- [x] ruff lint + format clean
- [x] Zero secrets in code or git history
- [x] All 8 robustness checks pass (3-agent verification)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production-facing surfaces (service bind addresses, GraphQL auth enforcement) and Airflow orchestration/metrics wiring, which could impact accessibility and pipeline execution if misconfigured. Changes are mostly additive/guard-rail focused but span multiple runtime components (DAGs, collectors, CLI, Prometheus).
> 
> **Overview**
> Improves production hardening by defaulting service exposure to loopback (Docker Compose ports, `EDGEGUARD_GRAPHQL_HOST` in `.env.example`, and metrics server bind host), and adds GraphQL startup enforcement of `EDGEGUARD_API_KEY` when `EDGEGUARD_ENV=prod`.
> 
> Strengthens Airflow reliability/observability: all 6 DAGs now set `max_active_runs=1` and explicit `dagrun_timeout`, add task-level success/failure callbacks for Slack + Prometheus, align Prometheus metric label sets with `metrics_server.py`, and make the Neo4j sync short-circuit tolerant of corrupted state files.
> 
> Refactors MISP event routing to `EdgeGuard-{source}-{date}` (zone only on attribute tags) with improved dedup/skip logging, updates checkpoint clearing to preserve incremental cursors by default (with `include_incremental` for full wipes), fixes stats inflation by only incrementing when Neo4j `merge_*` calls succeed, and adds a new `airflow_client.py` plus expanded `edgeguard` CLI commands (`preflight`, `stats`, `dag status/kill`, `checkpoint status/clear`). Prometheus alerting is extended with DAG stuck/stale alerts and Alertmanager is enabled in `prometheus.yml`, with docs updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit be84e101779e6c985a960482f97845db4a85e184. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->