### PR TITLE
Sprint 2: dedup fix, missing indexes, co-occurrence sampling, calibration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## 🤔 What is EdgeGuard?
 
-EdgeGuard is a **Knowledge Graph framework** that merges threat intelligence from 11+ collectors into **MISP as the single source of truth**, then links the most important data from **Energy, Healthcare, and Finance** sectors — enriched with global intelligence — into a **Neo4j knowledge graph**. The architecture goes both ways: **Neo4j is the linked intelligence layer** for fast graph queries and cross-source correlation, while **MISP holds the ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight.
+As part of the **EdgeGuard framework** for Graph-Augmented xAI on edge infrastructure, **EdgeGuard-Knowledge-Graph** is the first module — responsible for collecting, linking, and enriching threat intelligence. It merges data from 11+ collectors into **MISP as the single source of truth**, then links the most important data from **Energy, Healthcare, and Finance** sectors — enriched with global intelligence — into a **Neo4j knowledge graph**. The architecture goes both ways: **Neo4j is the linked intelligence layer** for fast graph queries and cross-source correlation, while **MISP holds the ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight. In later stages, a fine-tuned LLM/SLM layer will add explainable AI (xAI) capabilities on top of this knowledge graph.
 
 ### What it does
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## 🤔 What is EdgeGuard?
 
-As part of the **EdgeGuard framework** for Graph-Augmented xAI on edge infrastructure, **EdgeGuard-Knowledge-Graph** is the first module — responsible for collecting, linking, and enriching threat intelligence. It merges data from 11+ collectors into **MISP as the single source of truth**, then links the most important data from **Energy, Healthcare, and Finance** sectors — enriched with global intelligence — into a **Neo4j knowledge graph**. The architecture goes both ways: **Neo4j is the linked intelligence layer** for fast graph queries and cross-source correlation, while **MISP holds the ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight. In later stages, a fine-tuned LLM/SLM layer will add explainable AI (xAI) capabilities on top of this knowledge graph.
+As part of the **EdgeGuard framework** for Graph-Augmented xAI on edge infrastructure, **EdgeGuard-Knowledge-Graph** is the first module — responsible for collecting, linking, and enriching threat intelligence. It merges threat intelligence from 11+ collectors into **MISP as the single source of truth**, then links the most important data from **Energy, Healthcare, and Finance** sectors — enriched with global intelligence — into a **Neo4j knowledge graph**. The architecture goes both ways: **Neo4j is the linked intelligence layer** for fast graph queries and cross-source correlation, while **MISP holds the ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight.
 
 ### What it does
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@
 
 ## 🤔 What is EdgeGuard?
 
-As part of the **EdgeGuard framework** for Graph-Augmented xAI on edge infrastructure, **EdgeGuard-Knowledge-Graph** is the first module — responsible for collecting, linking, and enriching threat intelligence. It merges threat intelligence from 11+ collectors into **MISP as the single source of truth**, then links the most important data from **Energy, Healthcare, and Finance** sectors — enriched with global intelligence — into a **Neo4j knowledge graph**. The architecture goes both ways: **Neo4j is the linked intelligence layer** for fast graph queries and cross-source correlation, while **MISP holds the ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight.
+As part of the EdgeGuard framework for Graph-Augmented xAI on edge infrastructure, **EdgeGuard-Knowledge-Graph** is the first module. It is responsible for collecting, linking, and enriching threat intelligence by merging data from 11+ collectors into MISP as the single source of truth, then linking the most important data from **Energy, Healthcare, and Finance** sectors, enriched with global intelligence, into a Neo4j knowledge graph. The architecture goes both ways: Neo4j is the linked intelligence layer for fast graph queries and cross-source correlation, while MISP holds the ground truth with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight.
 
 ### What it does
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,9 @@
 
 ## 🤔 What is EdgeGuard?
 
-Imagine your company's computer network is a city. EdgeGuard is like having a **smart security system** that:
+EdgeGuard is a **Knowledge Graph framework** that merges threat intelligence from 11+ collectors into **MISP as the single source of truth**, then links the most important data from **Energy, Healthcare, and Finance** sectors — enriched with global intelligence — into a **Neo4j knowledge graph**. The architecture goes both ways: **Neo4j is the linked intelligence layer** for fast graph queries and cross-source correlation, while **MISP holds the ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events, so analysts can always verify the raw evidence behind any graph insight.
+
+### What it does
 
 1. **Collects** threat intelligence from multiple external feeds (11 active collector types + 2 sector placeholders — see `docs/DATA_SOURCES.md`)
 2. **Stages** everything in MISP — the single source of truth — with full provenance and timestamps

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -991,8 +991,8 @@ def run_neo4j_sync():
                 skip = _Var.get("SKIP_NEXT_NEO4J_SYNC", default_var="false").lower() == "true"
                 if skip:
                     _Var.set("SKIP_NEXT_NEO4J_SYNC", "false")
-                    logger.info("SKIP_NEXT_NEO4J_SYNC was set — skipping this incremental sync")
-                    return
+                    logger.info("SKIP_NEXT_NEO4J_SYNC was set — skipping this incremental sync (not a failure)")
+                    return  # Task completes as "success" — skip is intentional (post-baseline cooldown)
             except Exception as e:
                 logger.debug("Could not check SKIP_NEXT_NEO4J_SYNC Variable: %s", e)
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1192,6 +1192,7 @@ log_medium_summary = BashOperator(
     task_id="log_summary",
     bash_command='echo "Medium Frequency Collectors Complete - $(date)"',
     execution_timeout=timedelta(minutes=5),
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=medium_freq_dag,
 )
 
@@ -1323,6 +1324,7 @@ log_daily_summary = BashOperator(
         echo "  - SSL Blacklist"
     """,
     execution_timeout=timedelta(minutes=5),
+    trigger_rule=TriggerRule.ALL_DONE,
     dag=daily_dag,
 )
 
@@ -1753,8 +1755,8 @@ baseline_start = PythonOperator(
     dag=baseline_dag,
 )
 
-# Tier 1 — Core intelligence (must complete before feeds, rate-limited APIs)
-with TaskGroup("tier1_core", dag=baseline_dag) as baseline_tier1:
+# Tier 1 — Core intelligence (rate-limited APIs). ALL_DONE: one failure doesn't block others.
+with TaskGroup("tier1_core", dag=baseline_dag, default_args={"trigger_rule": TriggerRule.ALL_DONE}) as baseline_tier1:
     bl_otx = PythonOperator(
         task_id="collect_otx",
         python_callable=run_baseline_otx,

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1443,7 +1443,7 @@ def run_build_relationships(**context):
         ["python3", os.path.join(BASE_DIR, "src", "build_relationships.py")],
         capture_output=True,
         text=True,
-        timeout=1800,
+        timeout=3600,
     )
     if result.returncode != 0:
         logger.error(f"build_relationships failed:\n{result.stderr}")
@@ -1471,7 +1471,7 @@ def run_enrichment_jobs(**context):
 build_relationships_task = PythonOperator(
     task_id="build_relationships",
     python_callable=run_build_relationships,
-    execution_timeout=timedelta(minutes=30),
+    execution_timeout=timedelta(minutes=60),
     dag=neo4j_sync_dag,
 )
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1033,8 +1033,12 @@ def run_neo4j_sync():
                 except Exception as e:
                     logger.debug("Could not set SKIP_NEXT_NEO4J_SYNC Variable: %s", e)
 
-            with open(state_file, "w") as f:
-                json.dump({"last_sync": datetime.now(timezone.utc).isoformat()}, f)
+            try:
+                with open(state_file, "w") as f:
+                    json.dump({"last_sync": datetime.now(timezone.utc).isoformat()}, f)
+                logger.info("Neo4j sync state persisted to %s", state_file)
+            except OSError as e:
+                logger.error("Failed to write sync state file %s: %s — sync succeeded but 'last sync' will show stale", state_file, e)
             logger.info("Neo4j sync completed successfully")
             record_dag_run("edgeguard_pipeline", "success")
         else:

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1038,7 +1038,11 @@ def run_neo4j_sync():
                     json.dump({"last_sync": datetime.now(timezone.utc).isoformat()}, f)
                 logger.info("Neo4j sync state persisted to %s", state_file)
             except OSError as e:
-                logger.error("Failed to write sync state file %s: %s — sync succeeded but 'last sync' will show stale", state_file, e)
+                logger.error(
+                    "Failed to write sync state file %s: %s — sync succeeded but 'last sync' will show stale",
+                    state_file,
+                    e,
+                )
             logger.info("Neo4j sync completed successfully")
             record_dag_run("edgeguard_pipeline", "success")
         else:

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -33,7 +33,7 @@ graph TB
         MISP[(MISP 2.4.x<br/>Single Source of Truth<br/>port 8443)]
         SYNC[MISP-to-Neo4j Sync<br/>Paged streaming<br/>OOM-safe chunking]
         NEO4J[(Neo4j 5.27<br/>Knowledge Graph<br/>ports 7474 / 7687)]
-        BREL[build_relationships<br/>13 relationship types]
+        BREL[build_relationships<br/>11 relationship types]
         ENRICH[Enrichment Jobs<br/>Decay / Campaigns /<br/>Calibration / CVE Bridge]
     end
 
@@ -180,7 +180,7 @@ gantt
 flowchart LR
     A[check_sync_needed<br/>ShortCircuitOperator] -->|sync needed| B[neo4j_preflight<br/>Health check]
     B --> C[run_neo4j_sync<br/>MISP to Neo4j<br/>up to 4h timeout]
-    C --> D[build_relationships<br/>13 edge types]
+    C --> D[build_relationships<br/>11 edge types]
     D --> E[run_enrichment_jobs<br/>4 post-sync jobs]
     E --> F[check_neo4j_quality<br/>Node/edge counts]
 

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -3,6 +3,8 @@
 > Graph-Augmented xAI for Threat Intelligence on Edge Infrastructure
 > (IICT-BAS + Ratio1, funded by ResilMesh)
 
+**Design philosophy:** Neo4j is the **linked intelligence layer** for fast graph queries and cross-source correlation. MISP holds the **ground truth** with full provenance, raw data, and audit trails. Every node in Neo4j traces back to its MISP source events via `misp_event_ids` and `SOURCED_FROM` relationships.
+
 All diagrams are written in [Mermaid](https://mermaid.js.org/) and render natively on GitHub.
 To export for papers: paste into [mermaid.live](https://mermaid.live) and download as PNG/SVG/PDF.
 

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -140,6 +140,7 @@ def build_relationships():
               AND (
                   i.misp_event_id = m.misp_event_id
                   OR i.misp_event_id IN coalesce(m.misp_event_ids, [])
+                  OR m.misp_event_id IN coalesce(i.misp_event_ids, [])
               )
             MERGE (i)-[r:INDICATES]->(m)
             SET r.confidence_score = 0.5,

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -50,7 +50,7 @@ def build_relationships():
 
     try:
         # 1. Technique → Tactic (IN_TACTIC) — kill-chain phase match
-        logger.info("[LINK] 1/13 Technique → Tactic (kill-chain phase match)...")
+        logger.info("[LINK] 1/11 Technique → Tactic (kill-chain phase match)...")
         if not _safe_run(
             client,
             "Technique → Tactic",
@@ -69,7 +69,7 @@ def build_relationships():
             failures += 1
 
         # 2. Malware → ThreatActor (ATTRIBUTED_TO) — exact name match
-        logger.info("[LINK] 2/13 Malware → ThreatActor (exact name match)...")
+        logger.info("[LINK] 2/11 Malware → ThreatActor (exact name match)...")
         if not _safe_run(
             client,
             "Malware → ThreatActor",
@@ -88,7 +88,7 @@ def build_relationships():
             failures += 1
 
         # 3a. Indicator → Vulnerability (EXPLOITS) — exact CVE match (indexed)
-        logger.info("[LINK] 3a/14 Indicator → Vulnerability (exact CVE match)...")
+        logger.info("[LINK] 3a/11 Indicator → Vulnerability (exact CVE match)...")
         if not _safe_run(
             client,
             "Indicator → Vulnerability (EXPLOITS)",
@@ -109,7 +109,7 @@ def build_relationships():
             failures += 1
 
         # 3b. Indicator → CVE (EXPLOITS) — exact CVE match (indexed)
-        logger.info("[LINK] 3b/14 Indicator → CVE (exact CVE match)...")
+        logger.info("[LINK] 3b/11 Indicator → CVE (exact CVE match)...")
         if not _safe_run(
             client,
             "Indicator → CVE (EXPLOITS)",
@@ -130,7 +130,7 @@ def build_relationships():
             failures += 1
 
         # 4. Indicator → Malware (INDICATES) — MISP event co-occurrence
-        logger.info("[LINK] 4/13 Indicator → Malware (MISP event co-occurrence)...")
+        logger.info("[LINK] 4/11 Indicator → Malware (MISP event co-occurrence)...")
         if not _safe_run(
             client,
             "Indicator → Malware (co-occurrence)",
@@ -152,7 +152,7 @@ def build_relationships():
             failures += 1
 
         # 5. ThreatActor → Technique (USES) — explicit ATT&CK uses_techniques list
-        logger.info("[LINK] 5/13 ThreatActor → Technique (ATT&CK explicit)...")
+        logger.info("[LINK] 5/11 ThreatActor → Technique (ATT&CK explicit)...")
         if not _safe_run(
             client,
             "ThreatActor → Technique (ATT&CK explicit)",
@@ -173,7 +173,7 @@ def build_relationships():
             failures += 1
 
         # 6. Malware → Technique (USES) — MITRE STIX uses relationships
-        logger.info("[LINK] 6/13 Malware → Technique (MITRE explicit)...")
+        logger.info("[LINK] 6/11 Malware → Technique (MITRE explicit)...")
         if not _safe_run(
             client,
             "Malware → Technique (MITRE explicit)",
@@ -194,7 +194,7 @@ def build_relationships():
             failures += 1
 
         # 7a. Indicator → Sector (TARGETS)
-        logger.info("[LINK] 7a/13 Indicator → Sector (TARGETS)...")
+        logger.info("[LINK] 7a/11 Indicator → Sector (TARGETS)...")
         if not _safe_run(
             client,
             "Indicator → Sector (TARGETS)",
@@ -216,7 +216,7 @@ def build_relationships():
             failures += 1
 
         # 7b. Vulnerability/CVE → Sector (AFFECTS)
-        logger.info("[LINK] 7b/13 Vulnerability/CVE → Sector (AFFECTS)...")
+        logger.info("[LINK] 7b/11 Vulnerability/CVE → Sector (AFFECTS)...")
         if not _safe_run(
             client,
             "Vulnerability/CVE → Sector (AFFECTS)",
@@ -238,7 +238,7 @@ def build_relationships():
             failures += 1
 
         # 8. Indicator → Technique (USES_TECHNIQUE) — OTX attack_ids
-        logger.info("[LINK] 8/13 Indicator → Technique (OTX attack_ids)...")
+        logger.info("[LINK] 8/11 Indicator → Technique (OTX attack_ids)...")
         if not _safe_run(
             client,
             "Indicator → Technique (attack_ids)",
@@ -259,7 +259,7 @@ def build_relationships():
             failures += 1
 
         # 9. Indicator → Malware (INDICATES) — malware_family name match
-        logger.info("[LINK] 9/13 Indicator → Malware (malware_family match)...")
+        logger.info("[LINK] 9/11 Indicator → Malware (malware_family match)...")
         if not _safe_run(
             client,
             "Indicator → Malware (family match)",
@@ -282,7 +282,7 @@ def build_relationships():
             failures += 1
 
         # 10. Tool → Technique (USES) — MITRE uses_techniques
-        logger.info("[LINK] 10/13 Tool → Technique (MITRE explicit)...")
+        logger.info("[LINK] 10/11 Tool → Technique (MITRE explicit)...")
         if not _safe_run(
             client,
             "Tool → Technique (MITRE explicit)",
@@ -332,7 +332,7 @@ def build_relationships():
         total_rels = sum(v for k, v in stats.items() if k != "multi_zone_indicators")
         logger.info(f"\nTotal relationships created: {total_rels}")
         if failures:
-            logger.warning(f"Relationship types failed: {failures}/13 — partial success")
+            logger.warning(f"Relationship types failed: {failures}/11 — partial success")
 
         return failures == 0
 

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -87,16 +87,15 @@ def build_relationships():
         ):
             failures += 1
 
-        # 3. Indicator → Vulnerability/CVE (EXPLOITS) — exact CVE match
-        logger.info("[LINK] 3/13 Indicator → Vulnerability/CVE (exact CVE match)...")
+        # 3a. Indicator → Vulnerability (EXPLOITS) — exact CVE match (indexed)
+        logger.info("[LINK] 3a/14 Indicator → Vulnerability (exact CVE match)...")
         if not _safe_run(
             client,
-            "Indicator → Vulnerability/CVE (EXPLOITS)",
+            "Indicator → Vulnerability (EXPLOITS)",
             """
             MATCH (i:Indicator)
             WHERE i.cve_id IS NOT NULL AND i.cve_id <> ''
-            MATCH (v)
-            WHERE (v:Vulnerability OR v:CVE) AND v.cve_id = i.cve_id
+            MATCH (v:Vulnerability {cve_id: i.cve_id})
             MERGE (i)-[r:EXPLOITS]->(v)
             SET r.confidence_score = 1.0,
                 r.match_type = 'cve_tag',
@@ -105,7 +104,28 @@ def build_relationships():
             RETURN count(*) as count
         """,
             stats,
-            "exploits",
+            "exploits_vuln",
+        ):
+            failures += 1
+
+        # 3b. Indicator → CVE (EXPLOITS) — exact CVE match (indexed)
+        logger.info("[LINK] 3b/14 Indicator → CVE (exact CVE match)...")
+        if not _safe_run(
+            client,
+            "Indicator → CVE (EXPLOITS)",
+            """
+            MATCH (i:Indicator)
+            WHERE i.cve_id IS NOT NULL AND i.cve_id <> ''
+            MATCH (c:CVE {cve_id: i.cve_id})
+            MERGE (i)-[r:EXPLOITS]->(c)
+            SET r.confidence_score = 1.0,
+                r.match_type = 'cve_tag',
+                r.source_id = 'cve_tag_match',
+                r.created_at = datetime()
+            RETURN count(*) as count
+        """,
+            stats,
+            "exploits_cve",
         ):
             failures += 1
 
@@ -282,68 +302,12 @@ def build_relationships():
         ):
             failures += 1
 
-        # 11. Malware cross-source correlation (IS_SAME_AS)
-        logger.info("[LINK] 11/13 Malware cross-source (IS_SAME_AS)...")
-        if not _safe_run(
-            client,
-            "Malware cross-source (IS_SAME_AS)",
-            """
-            MATCH (m1:Malware), (m2:Malware)
-            WHERE m1.tag < m2.tag
-              AND (toLower(m1.name) = toLower(m2.name)
-                OR toLower(m1.name) IN [x IN coalesce(m2.aliases, []) | toLower(x)]
-                OR toLower(m2.name) IN [x IN coalesce(m1.aliases, []) | toLower(x)])
-            MERGE (m1)-[r:IS_SAME_AS]->(m2)
-            ON CREATE SET r.confidence_score = 0.9,
-                r.match_type = 'name_match',
-                r.created_at = datetime()
-            RETURN count(*) as count
-        """,
-            stats,
-            "malware_same_as",
-        ):
-            failures += 1
-
-        # 12. CVE cross-source correlation (IS_SAME_AS)
-        logger.info("[LINK] 12/13 CVE cross-source (IS_SAME_AS)...")
-        if not _safe_run(
-            client,
-            "CVE cross-source (IS_SAME_AS)",
-            """
-            MATCH (c1:CVE), (c2:CVE)
-            WHERE c1.tag < c2.tag
-              AND c1.cve_id = c2.cve_id
-            MERGE (c1)-[r:IS_SAME_AS]->(c2)
-            ON CREATE SET r.confidence_score = 1.0,
-                r.match_type = 'cve_id_match',
-                r.created_at = datetime()
-            RETURN count(*) as count
-        """,
-            stats,
-            "cve_same_as",
-        ):
-            failures += 1
-
-        # 13. Vulnerability cross-source correlation (IS_SAME_AS)
-        logger.info("[LINK] 13/13 Vulnerability cross-source (IS_SAME_AS)...")
-        if not _safe_run(
-            client,
-            "Vulnerability cross-source (IS_SAME_AS)",
-            """
-            MATCH (v1:Vulnerability), (v2:Vulnerability)
-            WHERE v1.tag < v2.tag
-              AND v1.cve_id IS NOT NULL AND v2.cve_id IS NOT NULL
-              AND v1.cve_id = v2.cve_id
-            MERGE (v1)-[r:IS_SAME_AS]->(v2)
-            ON CREATE SET r.confidence_score = 1.0,
-                r.match_type = 'cve_id_match',
-                r.created_at = datetime()
-            RETURN count(*) as count
-        """,
-            stats,
-            "vuln_same_as",
-        ):
-            failures += 1
+        # 11-13. IS_SAME_AS cross-source correlation
+        # With tag removed from MERGE keys, same-name entities and same-cve_id
+        # nodes already merge into a single node. IS_SAME_AS is no longer needed
+        # for Malware (name-keyed), CVE (cve_id-keyed), or Vulnerability (cve_id-keyed).
+        # Source provenance is tracked via the accumulated `source` and `tags` arrays.
+        logger.info("[LINK] 11/11 Cross-source dedup — skipped (entities merge on name/cve_id, no IS_SAME_AS needed)")
 
         # Get final stats
         try:

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -137,8 +137,10 @@ def build_relationships():
             """
             MATCH (i:Indicator), (m:Malware)
             WHERE i.misp_event_id IS NOT NULL AND i.misp_event_id <> ''
-              AND m.misp_event_id IS NOT NULL AND m.misp_event_id <> ''
-              AND i.misp_event_id = m.misp_event_id
+              AND (
+                  i.misp_event_id = m.misp_event_id
+                  OR i.misp_event_id IN coalesce(m.misp_event_ids, [])
+              )
             MERGE (i)-[r:INDICATES]->(m)
             SET r.confidence_score = 0.5,
                 r.match_type = 'misp_cooccurrence',

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -141,6 +141,7 @@ def build_relationships():
                   i.misp_event_id = m.misp_event_id
                   OR i.misp_event_id IN coalesce(m.misp_event_ids, [])
                   OR m.misp_event_id IN coalesce(i.misp_event_ids, [])
+                  OR size(apoc.coll.intersection(coalesce(i.misp_event_ids, []), coalesce(m.misp_event_ids, []))) > 0
               )
             MERGE (i)-[r:INDICATES]->(m)
             SET r.confidence_score = 0.5,

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1432,6 +1432,9 @@ def cmd_clear_misp(args) -> int:
             return 1
         if total_found == 0:
             info("No EdgeGuard events found in MISP.")
+        elif deleted < total_found:
+            err(f"Partial clear: deleted {deleted}/{total_found} EdgeGuard events ({total_found - deleted} failed)")
+            return 1
         else:
             ok(f"Deleted {deleted}/{total_found} EdgeGuard events from MISP")
     except Exception as e:

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -158,11 +158,11 @@ def build_campaign_nodes(neo4j_client) -> Dict:
                      reduce(z=[], ind IN collect(DISTINCT i) | z + coalesce(ind.zone, []))
                  ) AS all_zones
             WHERE size(malware_list) > 0 AND size(indicators) > 0
-            MERGE (c:Campaign {name: a.name + ' Campaign', tag: a.tag})
+            MERGE (c:Campaign {name: a.name + ' Campaign'})
             ON CREATE SET c.created_at = datetime(),
-                          c.actor_name = a.name,
-                          c.tag        = a.tag
-            SET c.last_updated     = datetime(),
+                          c.actor_name = a.name
+            SET c.tags = apoc.coll.toSet(coalesce(c.tags, []) + coalesce(a.tags, [])),
+                c.last_updated     = datetime(),
                 c.indicator_count  = size(indicators),
                 c.malware_count    = size(malware_list),
                 c.first_seen       = first_seen,
@@ -178,7 +178,7 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             # Step 2: Link malware to their campaigns
             link_malware = """
             MATCH (a:ThreatActor)<-[:ATTRIBUTED_TO]-(m:Malware)
-            MATCH (c:Campaign {actor_name: a.name, tag: a.tag})
+            MATCH (c:Campaign {actor_name: a.name})
             MERGE (m)-[:PART_OF]->(c)
             RETURN count(*) AS links
             """
@@ -190,7 +190,7 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             # Using LIMIT inside WITH to avoid huge relationship fans
             link_indicators = """
             MATCH (c:Campaign)
-            MATCH (a:ThreatActor {name: c.actor_name, tag: c.tag})<-[:ATTRIBUTED_TO]-(m:Malware)<-[:INDICATES]-(i:Indicator)
+            MATCH (a:ThreatActor {name: c.actor_name})<-[:ATTRIBUTED_TO]-(m:Malware)<-[:INDICATES]-(i:Indicator)
             WITH c, collect(i)[0..100] AS indicators
             UNWIND indicators AS i
             MERGE (i)-[:PART_OF]->(c)

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -252,11 +252,14 @@ def calibrate_cooccurrence_confidence(neo4j_client) -> Dict:
     results = {}
 
     # Map: (min_size, max_size, new_confidence)
+    # Co-occurrence confidence tiers — capped at 0.50 per co-occurrence ceiling.
+    # Tight events (few indicators) get higher confidence within the range;
+    # bulk dumps get lower confidence.
     tiers = [
-        (0, 10, 0.90),
-        (11, 20, 0.80),
-        (21, 100, 0.70),
-        (101, 500, 0.50),
+        (0, 10, 0.50),
+        (11, 20, 0.45),
+        (21, 100, 0.40),
+        (101, 500, 0.35),
         (501, None, 0.30),
     ]
 

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -766,15 +766,20 @@ class Neo4jClient:
                 n.edgeguard_managed = true
             """
 
-            # Add misp_event_id if present in data
+            # Add misp_event_id if present — accumulated as array for multi-event provenance.
+            # Keeps scalar misp_event_id for backward compat (first-seen event).
             misp_event_id = data.get("misp_event_id")
             if misp_event_id:
-                query += ", n.misp_event_id = $misp_event_id"
+                query += """,
+                n.misp_event_id = coalesce(n.misp_event_id, $misp_event_id),
+                n.misp_event_ids = apoc.coll.toSet(coalesce(n.misp_event_ids, []) + [$misp_event_id])"""
 
             # Add misp_attribute_id if present in data (for indicators)
             misp_attribute_id = data.get("misp_attribute_id")
             if misp_attribute_id:
-                query += ", n.misp_attribute_id = $misp_attribute_id"
+                query += """,
+                n.misp_attribute_id = coalesce(n.misp_attribute_id, $misp_attribute_id),
+                n.misp_attribute_ids = apoc.coll.toSet(coalesce(n.misp_attribute_ids, []) + [$misp_attribute_id])"""
 
             # Add original_source if present in data
             if original_source:
@@ -1260,7 +1265,9 @@ class Neo4jClient:
                     n.active = true,
                     n.edgeguard_managed = true,
                     n.misp_event_id = coalesce(n.misp_event_id, item.misp_event_id),
+                    n.misp_event_ids = apoc.coll.toSet(coalesce(n.misp_event_ids, []) + CASE WHEN item.misp_event_id IS NOT NULL THEN [item.misp_event_id] ELSE [] END),
                     n.misp_attribute_id = coalesce(n.misp_attribute_id, item.misp_attribute_id),
+                    n.misp_attribute_ids = apoc.coll.toSet(coalesce(n.misp_attribute_ids, []) + CASE WHEN item.misp_attribute_id IS NOT NULL THEN [item.misp_attribute_id] ELSE [] END),
                     n.indicator_role = coalesce(item.indicator_role, n.indicator_role),
                     n.url_status = coalesce(item.url_status, n.url_status),
                     n.last_online = coalesce(item.last_online, n.last_online),
@@ -1384,7 +1391,9 @@ class Neo4jClient:
                     n.active = true,
                     n.edgeguard_managed = true,
                     n.misp_event_id = coalesce(n.misp_event_id, item.misp_event_id),
+                    n.misp_event_ids = apoc.coll.toSet(coalesce(n.misp_event_ids, []) + CASE WHEN item.misp_event_id IS NOT NULL THEN [item.misp_event_id] ELSE [] END),
                     n.misp_attribute_id = coalesce(n.misp_attribute_id, item.misp_attribute_id),
+                    n.misp_attribute_ids = apoc.coll.toSet(coalesce(n.misp_attribute_ids, []) + CASE WHEN item.misp_attribute_id IS NOT NULL THEN [item.misp_attribute_id] ELSE [] END),
                     n.version_constraints = coalesce(item.version_constraints, n.version_constraints),
                     n.cisa_cwes = apoc.coll.toSet(coalesce(n.cisa_cwes, []) + coalesce(item.cisa_cwes, [])),
                     n.cisa_notes = coalesce(item.cisa_notes, n.cisa_notes)

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -789,9 +789,14 @@ class Neo4jClient:
             # Validate every property name before interpolating into Cypher.
             # Array properties that should ACCUMULATE (deduplicated) across sources,
             # not overwrite. Scalar properties are set with last-write-wins.
-            _ARRAY_ACCUMULATE_PROPS = frozenset({
-                "aliases", "malware_types", "uses_techniques", "tactic_phases",
-            })
+            _ARRAY_ACCUMULATE_PROPS = frozenset(
+                {
+                    "aliases",
+                    "malware_types",
+                    "uses_techniques",
+                    "tactic_phases",
+                }
+            )
             extra_props = extra_props or {}
             params_extra = {}
             for prop_name, prop_value in extra_props.items():
@@ -1807,7 +1812,11 @@ class Neo4jClient:
                     _dropped_rels += 1
 
         if _dropped_rels:
-            logger.warning("Relationship batch: %s/%s definitions dropped (blank/missing endpoints)", _dropped_rels, len(relationships))
+            logger.warning(
+                "Relationship batch: %s/%s definitions dropped (blank/missing endpoints)",
+                _dropped_rels,
+                len(relationships),
+            )
 
         total = 0
 

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1753,6 +1753,7 @@ class Neo4jClient:
         tgt_vuln_rows: List[Dict[str, Any]] = []
         expl_rows: List[Dict[str, Any]] = []
 
+        _dropped_rels = 0
         for rel in relationships:
             rt = rel.get("rel_type")
             fk = rel.get("from_key") or {}
@@ -1763,34 +1764,50 @@ class Neo4jClient:
                 mid = nonempty_graph_string(tk.get("mitre_id"))
                 if an and mid:
                     uses_rows.append({"actor": an, "mitre_id": mid, "source_id": source_id, "confidence": conf})
+                else:
+                    _dropped_rels += 1
             elif rt == "ATTRIBUTED_TO":
                 mn = nonempty_graph_string(fk.get("name"))
                 an = nonempty_graph_string(tk.get("name"))
                 if mn and an:
                     attr_rows.append({"malware": mn, "actor": an, "source_id": source_id, "confidence": conf})
+                else:
+                    _dropped_rels += 1
             elif rt == "INDICATES" and rel.get("to_type") == "Malware":
                 iv = nonempty_graph_string(fk.get("value"))
                 mn = nonempty_graph_string(tk.get("name"))
                 if iv and mn:
                     ind_mal_rows.append({"value": iv, "malware": mn, "source_id": source_id, "confidence": conf})
+                else:
+                    _dropped_rels += 1
             elif rt == "TARGETS":
                 sec = nonempty_graph_string(tk.get("name"))
                 if not sec:
+                    _dropped_rels += 1
                     continue
                 ft = rel.get("from_type")
                 if ft == "Indicator":
                     iv = nonempty_graph_string(fk.get("value"))
                     if iv:
                         tgt_ind_rows.append({"value": iv, "sector": sec, "source_id": source_id, "confidence": conf})
+                    else:
+                        _dropped_rels += 1
                 elif ft == "Vulnerability":
                     cid = normalize_cve_id_for_graph(fk.get("cve_id"))
                     if cid:
                         tgt_vuln_rows.append({"cve_id": cid, "sector": sec, "source_id": source_id, "confidence": conf})
+                    else:
+                        _dropped_rels += 1
             elif rt == "EXPLOITS":
                 iv = nonempty_graph_string(fk.get("value"))
                 cid = normalize_cve_id_for_graph(tk.get("cve_id"))
                 if iv and cid:
                     expl_rows.append({"value": iv, "cve_id": cid, "source_id": source_id, "confidence": conf})
+                else:
+                    _dropped_rels += 1
+
+        if _dropped_rels:
+            logger.warning("Relationship batch: %s/%s definitions dropped (blank/missing endpoints)", _dropped_rels, len(relationships))
 
         total = 0
 

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1265,6 +1265,7 @@ class Neo4jClient:
                         ELSE n.confidence_score END,
                     n.source = apoc.coll.toSet(coalesce(n.source, []) + item.source_array),
                     n.zone = apoc.coll.toSet(coalesce(n.zone, []) + item.zone),
+                    n.tags = apoc.coll.toSet(coalesce(n.tags, []) + [item.tag]),
                     n.last_updated = datetime(),
                     n.last_imported_from = item.source_id,
                     n.active = true,

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -458,6 +458,7 @@ class Neo4jClient:
             "DROP CONSTRAINT technique_key IF EXISTS",
             "DROP CONSTRAINT tactic_key IF EXISTS",
             "DROP CONSTRAINT campaign_key IF EXISTS",
+            "DROP CONSTRAINT tool_key IF EXISTS",
             "DROP CONSTRAINT indicator_key IF EXISTS",
         ]
         with self.driver.session() as session:
@@ -482,6 +483,8 @@ class Neo4jClient:
             "CREATE CONSTRAINT technique_key IF NOT EXISTS FOR (t:Technique) REQUIRE (t.mitre_id) IS UNIQUE",
             # MITRE tactics — 14 fixed nodes; unique by mitre_id only
             "CREATE CONSTRAINT tactic_key IF NOT EXISTS FOR (t:Tactic) REQUIRE (t.mitre_id) IS UNIQUE",
+            # Tool nodes — MITRE tools, keyed by mitre_id only
+            "CREATE CONSTRAINT tool_key IF NOT EXISTS FOR (t:Tool) REQUIRE (t.mitre_id) IS UNIQUE",
             # Sector nodes — created dynamically; must stay unique by name
             "CREATE CONSTRAINT sector_key IF NOT EXISTS FOR (s:Sector) REQUIRE (s.name) IS UNIQUE",
             # ResilMesh-compatible CVSS sub-nodes — keyed by (cve_id, tag)

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1896,6 +1896,7 @@ class Neo4jClient:
         MATCH (v:Vulnerability {cve_id: row.cve_id})
         MERGE (i)-[r:EXPLOITS]->(v)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.match_type = 'cve_tag',
             r.imported_at = coalesce(r.imported_at, datetime()),
@@ -1907,6 +1908,7 @@ class Neo4jClient:
         MATCH (v:CVE {cve_id: row.cve_id})
         MERGE (i)-[r:EXPLOITS]->(v)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.match_type = 'cve_tag',
             r.imported_at = coalesce(r.imported_at, datetime()),

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -991,7 +991,7 @@ class Neo4jClient:
             set_clause = ", ".join(prop_assignments) if prop_assignments else "n.created = true"
 
             query = f"""
-            MATCH (cve:CVE {{cve_id: $cve_id, tag: $tag}})
+            MATCH (cve:CVE {{cve_id: $cve_id}})
             MERGE (n:{label} {{cve_id: $cve_id, tag: $tag}})
             SET {set_clause},
                 n.last_updated = datetime()

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2605,10 +2605,10 @@ class Neo4jClient:
         This is the ResilMesh-native path. The MISP pipeline uses
         ``merge_cve()`` which sets the same properties plus EdgeGuard
         extensions (CISA KEV, reference_urls). Both produce compatible
-        CVE nodes keyed on ``(cve_id, tag)``.
+        CVE nodes keyed on ``cve_id``.
         """
         query = """
-        MERGE (c:CVE {cve_id: $cve_id, tag: $tag})
+        MERGE (c:CVE {cve_id: $cve_id})
         SET c.description = $description,
             c.published = $published,
             c.last_modified = $last_modified,
@@ -2617,11 +2617,12 @@ class Neo4jClient:
             c.ref_tags = $ref_tags,
             c.cwe = $cwe,
             c.edgeguard_managed = true,
+            c.tags = apoc.coll.toSet(coalesce(c.tags, []) + [$tag]),
+            c.tag = coalesce(c.tag, $tag),
             c.first_seen = CASE WHEN c.first_seen IS NULL THEN datetime() ELSE c.first_seen END,
             c.last_updated = datetime()
         """
         try:
-            # Provide default tag if not present
             tag = data.get("tag", "default")
             with self.driver.session() as session:
                 session.run(

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -782,12 +782,20 @@ class Neo4jClient:
 
             # Add extra_props (aliases, description, etc.) if provided.
             # Validate every property name before interpolating into Cypher.
+            # Array properties that should ACCUMULATE (deduplicated) across sources,
+            # not overwrite. Scalar properties are set with last-write-wins.
+            _ARRAY_ACCUMULATE_PROPS = frozenset({
+                "aliases", "malware_types", "uses_techniques",
+            })
             extra_props = extra_props or {}
             params_extra = {}
             for prop_name, prop_value in extra_props.items():
                 _validate_prop_name(prop_name)
                 if prop_value is not None and prop_value != "":
-                    query += f", n.{prop_name} = ${prop_name}"
+                    if prop_name in _ARRAY_ACCUMULATE_PROPS and isinstance(prop_value, list):
+                        query += f", n.{prop_name} = apoc.coll.toSet(coalesce(n.{prop_name}, []) + ${prop_name})"
+                    else:
+                        query += f", n.{prop_name} = ${prop_name}"
                     params_extra[prop_name] = prop_value
 
             # Check existing confidence before update for audit logging

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -785,7 +785,7 @@ class Neo4jClient:
             # Array properties that should ACCUMULATE (deduplicated) across sources,
             # not overwrite. Scalar properties are set with last-write-wins.
             _ARRAY_ACCUMULATE_PROPS = frozenset({
-                "aliases", "malware_types", "uses_techniques",
+                "aliases", "malware_types", "uses_techniques", "tactic_phases",
             })
             extra_props = extra_props or {}
             params_extra = {}
@@ -1264,9 +1264,9 @@ class Neo4jClient:
                     n.indicator_role = coalesce(item.indicator_role, n.indicator_role),
                     n.url_status = coalesce(item.url_status, n.url_status),
                     n.last_online = coalesce(item.last_online, n.last_online),
-                    n.abuse_categories = coalesce(item.abuse_categories, n.abuse_categories),
-                    n.yara_rules = coalesce(item.yara_rules, n.yara_rules),
-                    n.sigma_rules = coalesce(item.sigma_rules, n.sigma_rules),
+                    n.abuse_categories = apoc.coll.toSet(coalesce(n.abuse_categories, []) + coalesce(item.abuse_categories, [])),
+                    n.yara_rules = apoc.coll.toSet(coalesce(n.yara_rules, []) + coalesce(item.yara_rules, [])),
+                    n.sigma_rules = apoc.coll.toSet(coalesce(n.sigma_rules, []) + coalesce(item.sigma_rules, [])),
                     n.threat_label = coalesce(item.threat_label, n.threat_label)
                 WITH n, item
                 MATCH (s:Source {source_id: item.source_id})
@@ -1386,7 +1386,7 @@ class Neo4jClient:
                     n.misp_event_id = coalesce(n.misp_event_id, item.misp_event_id),
                     n.misp_attribute_id = coalesce(n.misp_attribute_id, item.misp_attribute_id),
                     n.version_constraints = coalesce(item.version_constraints, n.version_constraints),
-                    n.cisa_cwes = coalesce(item.cisa_cwes, n.cisa_cwes),
+                    n.cisa_cwes = apoc.coll.toSet(coalesce(n.cisa_cwes, []) + coalesce(item.cisa_cwes, [])),
                     n.cisa_notes = coalesce(item.cisa_notes, n.cisa_notes)
                 WITH n, item
                 MATCH (s:Source {source_id: item.source_id})
@@ -3697,10 +3697,10 @@ class Neo4jClient:
         MERGE (i:Indicator {indicator_type: $indicator_type, value: $value, tag: $tag})
         SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN datetime() ELSE i.first_seen END,
             i.last_updated = datetime(),
-            i.source = CASE WHEN i.source IS NULL THEN $source ELSE apoc.coll.union(i.source, $source) END,
+            i.source = apoc.coll.toSet(coalesce(i.source, []) + $source),
             i.confidence_score = $confidence_score,
             i.original_source = $original_source,
-            i.zone = $zone,
+            i.zone = apoc.coll.toSet(coalesce(i.zone, []) + $zone),
             i.edgeguard_managed = true,
             i.active = true
         """
@@ -3717,7 +3717,7 @@ class Neo4jClient:
                 i.last_updated = $last_updated,
                 i.confidence_score = $confidence_score,
                 i.original_source = $original_source,
-                i.zone = $zone
+                i.zone = apoc.coll.toSet(coalesce(i.zone, []) + $zone)
             """
             try:
                 with self.driver.session() as session:

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 # Configuration constants
 NEO4J_CONNECTION_TIMEOUT = 60  # seconds
-NEO4J_READ_TIMEOUT = 120  # seconds
+NEO4J_READ_TIMEOUT = 300  # seconds (5 min; 120s was too low for 441K-node graph)
 MAX_RETRIES = 5
 RETRY_DELAY_BASE = 2  # seconds (exponential backoff base)
 BATCH_SIZE = 1000  # Maximum items per batch
@@ -448,21 +448,40 @@ class Neo4jClient:
             logger.error("Cannot create constraints: no connection")
             return 0, 0
 
+        # Migration: drop old compound (name/cve_id, tag) constraints before creating
+        # single-key ones. Harmless if they don't exist (IF EXISTS).
+        old_constraints = [
+            "DROP CONSTRAINT cve_key IF EXISTS",
+            "DROP CONSTRAINT vulnerability_key IF EXISTS",
+            "DROP CONSTRAINT malware_key IF EXISTS",
+            "DROP CONSTRAINT actor_key IF EXISTS",
+            "DROP CONSTRAINT technique_key IF EXISTS",
+            "DROP CONSTRAINT tactic_key IF EXISTS",
+            "DROP CONSTRAINT campaign_key IF EXISTS",
+            "DROP CONSTRAINT indicator_key IF EXISTS",
+        ]
+        with self.driver.session() as session:
+            for stmt in old_constraints:
+                try:
+                    session.run(stmt, timeout=NEO4J_READ_TIMEOUT)
+                except Exception:
+                    pass  # constraint didn't exist — fine
+
         constraints = [
             # Source nodes
             "CREATE CONSTRAINT source_key IF NOT EXISTS FOR (s:Source) REQUIRE (s.source_id) IS UNIQUE",
             # CVE / Vulnerability — separate labels kept for backward compat
-            "CREATE CONSTRAINT cve_key IF NOT EXISTS FOR (c:CVE) REQUIRE (c.cve_id, c.tag) IS UNIQUE",
+            "CREATE CONSTRAINT cve_key IF NOT EXISTS FOR (c:CVE) REQUIRE (c.cve_id) IS UNIQUE",
             # Vulnerability: match the 2-field MERGE key used in merge_vulnerabilities_batch
-            "CREATE CONSTRAINT vulnerability_key IF NOT EXISTS FOR (v:Vulnerability) REQUIRE (v.cve_id, v.tag) IS UNIQUE",
+            "CREATE CONSTRAINT vulnerability_key IF NOT EXISTS FOR (v:Vulnerability) REQUIRE (v.cve_id) IS UNIQUE",
             # Indicator: match the 3-field MERGE key used in merge_indicators_batch
             "CREATE CONSTRAINT indicator_key IF NOT EXISTS FOR (i:Indicator) REQUIRE (i.indicator_type, i.value, i.tag) IS UNIQUE",
             # Threat-graph node types
-            "CREATE CONSTRAINT malware_key IF NOT EXISTS FOR (m:Malware) REQUIRE (m.name, m.tag) IS UNIQUE",
-            "CREATE CONSTRAINT actor_key IF NOT EXISTS FOR (a:ThreatActor) REQUIRE (a.name, a.tag) IS UNIQUE",
-            "CREATE CONSTRAINT technique_key IF NOT EXISTS FOR (t:Technique) REQUIRE (t.mitre_id, t.tag) IS UNIQUE",
-            # MITRE tactics — 14 fixed nodes; unique by mitre_id + tag
-            "CREATE CONSTRAINT tactic_key IF NOT EXISTS FOR (t:Tactic) REQUIRE (t.mitre_id, t.tag) IS UNIQUE",
+            "CREATE CONSTRAINT malware_key IF NOT EXISTS FOR (m:Malware) REQUIRE (m.name) IS UNIQUE",
+            "CREATE CONSTRAINT actor_key IF NOT EXISTS FOR (a:ThreatActor) REQUIRE (a.name) IS UNIQUE",
+            "CREATE CONSTRAINT technique_key IF NOT EXISTS FOR (t:Technique) REQUIRE (t.mitre_id) IS UNIQUE",
+            # MITRE tactics — 14 fixed nodes; unique by mitre_id only
+            "CREATE CONSTRAINT tactic_key IF NOT EXISTS FOR (t:Tactic) REQUIRE (t.mitre_id) IS UNIQUE",
             # Sector nodes — created dynamically; must stay unique by name
             "CREATE CONSTRAINT sector_key IF NOT EXISTS FOR (s:Sector) REQUIRE (s.name) IS UNIQUE",
             # ResilMesh-compatible CVSS sub-nodes — keyed by (cve_id, tag)
@@ -471,7 +490,7 @@ class Neo4jClient:
             "CREATE CONSTRAINT cvssv30_key IF NOT EXISTS FOR (n:CVSSv30) REQUIRE (n.cve_id, n.tag) IS UNIQUE",
             "CREATE CONSTRAINT cvssv40_key IF NOT EXISTS FOR (n:CVSSv40) REQUIRE (n.cve_id, n.tag) IS UNIQUE",
             # Campaign nodes — one per actor, keyed by (name, tag)
-            "CREATE CONSTRAINT campaign_key IF NOT EXISTS FOR (c:Campaign) REQUIRE (c.name, c.tag) IS UNIQUE",
+            "CREATE CONSTRAINT campaign_key IF NOT EXISTS FOR (c:Campaign) REQUIRE (c.name) IS UNIQUE",
         ]
 
         success_count = 0
@@ -537,6 +556,11 @@ class Neo4jClient:
             # Decay / active tracking
             "CREATE INDEX indicator_last_updated IF NOT EXISTS FOR (i:Indicator) ON (i.last_updated)",
             "CREATE INDEX vulnerability_last_updated IF NOT EXISTS FOR (v:Vulnerability) ON (v.last_updated)",
+            # build_relationships performance: CVE.cve_id needed for EXPLOITS query + IS_SAME_AS
+            "CREATE INDEX cve_cve_id IF NOT EXISTS FOR (c:CVE) ON (c.cve_id)",
+            # Co-occurrence join: Malware/ThreatActor by misp_event_id
+            "CREATE INDEX malware_misp_event_id IF NOT EXISTS FOR (m:Malware) ON (m.misp_event_id)",
+            "CREATE INDEX actor_misp_event_id IF NOT EXISTS FOR (a:ThreatActor) ON (a.misp_event_id)",
         ]
 
         success_count = 0
@@ -717,6 +741,9 @@ class Neo4jClient:
 
             confidence = data.get("confidence_score", 0.5)
             zone = data.get("zone", ["global"])  # zone is an array
+            # Accumulate tag into tags array (tag removed from MERGE key)
+            tag_value = data.get("tag", source_id)
+            tag_array = [tag_value] if tag_value else [source_id]
 
             _validate_label(label)
             query = f"""
@@ -731,6 +758,8 @@ class Neo4jClient:
                     ELSE n.confidence_score END,
                 n.source = apoc.coll.toSet(coalesce(n.source, []) + $source_array),
                 n.zone = apoc.coll.toSet(coalesce(n.zone, []) + $zone),
+                n.tags = apoc.coll.toSet(coalesce(n.tags, []) + $tag_array),
+                n.tag = coalesce(n.tag, $tag_value),
                 n.last_updated = datetime(),
                 n.last_imported_from = $source_id,
                 n.active = true,
@@ -789,6 +818,8 @@ class Neo4jClient:
                     "source_array": source_array,
                     "confidence": confidence,
                     "zone": zone,
+                    "tag_array": tag_array,
+                    "tag_value": tag_value,
                     **params_extra,
                 }
                 if misp_event_id:
@@ -862,7 +893,7 @@ class Neo4jClient:
             return False
         data = dict(data)
         data["cve_id"] = cve_id
-        key_props = {"cve_id": cve_id, "tag": data.get("tag", "default")}
+        key_props = {"cve_id": cve_id}
         return self.merge_node_with_source("Vulnerability", key_props, data, source_id)
 
     def merge_indicator(self, data: Dict, source_id: str = "alienvault_otx") -> bool:
@@ -906,7 +937,7 @@ class Neo4jClient:
             return False
         data = dict(data)
         data["cve_id"] = cve_id
-        key_props = {"cve_id": cve_id, "tag": data.get("tag", "default")}
+        key_props = {"cve_id": cve_id}
 
         # Promote CISA KEV fields and reference_urls to queryable node properties
         # so analysts can filter on e.g. "all CVEs on the CISA KEV list".
@@ -978,7 +1009,7 @@ class Neo4jClient:
 
     def merge_malware(self, data: Dict, source_id: str = "alienvault_otx") -> bool:
         """MERGE a Malware node with source tracking."""
-        key_props = {"name": data.get("name"), "tag": data.get("tag", "default")}
+        key_props = {"name": data.get("name")}
         # Store malware types and aliases on the node for easier querying
         malware_types = data.get("malware_types", [])
         aliases = data.get("aliases", [])
@@ -999,7 +1030,7 @@ class Neo4jClient:
 
     def merge_actor(self, data: Dict, source_id: str = "mitre_attck") -> bool:
         """MERGE a ThreatActor node with source tracking."""
-        key_props = {"name": data.get("name"), "tag": data.get("tag", "default")}
+        key_props = {"name": data.get("name")}
         aliases = data.get("aliases", [])
         description = data.get("description", "")
         # uses_techniques: list of MITRE technique IDs this actor explicitly uses,
@@ -1022,7 +1053,6 @@ class Neo4jClient:
         """MERGE a Technique node with source tracking."""
         key_props = {
             "mitre_id": data.get("mitre_id"),
-            "tag": data.get("tag", "default"),
         }
         extra_props: Dict[str, Any] = {"tactic_phases": data.get("tactic_phases", [])}
         extra_props["detection"] = data.get("detection", "")
@@ -1033,7 +1063,6 @@ class Neo4jClient:
         """MERGE a Tactic node with source tracking."""
         key_props = {
             "mitre_id": data.get("mitre_id"),
-            "tag": data.get("tag", "default"),
         }
         shortname = data.get("shortname", "")
         return self.merge_node_with_source("Tactic", key_props, data, source_id, extra_props={"shortname": shortname})
@@ -1042,7 +1071,6 @@ class Neo4jClient:
         """MERGE a Tool node with source tracking."""
         key_props = {
             "mitre_id": data.get("mitre_id"),
-            "tag": data.get("tag", "default"),
         }
         extra_props: Dict[str, Any] = {}
         if data.get("uses_techniques"):
@@ -1332,7 +1360,7 @@ class Neo4jClient:
 
                 query = """
                 UNWIND $batch as item
-                MERGE (n:Vulnerability {cve_id: item.cve_id, tag: item.tag})
+                MERGE (n:Vulnerability {cve_id: item.cve_id})
                 ON CREATE SET n.first_imported_at = datetime(),
                     n.status = item.status
                 SET n.confidence_score = CASE
@@ -1341,6 +1369,8 @@ class Neo4jClient:
                         ELSE n.confidence_score END,
                     n.source = apoc.coll.toSet(coalesce(n.source, []) + item.source_array),
                     n.zone = apoc.coll.toSet(coalesce(n.zone, []) + item.zone),
+                    n.tags = apoc.coll.toSet(coalesce(n.tags, []) + [item.tag]),
+                    n.tag = coalesce(n.tag, item.tag),
                     n.last_updated = datetime(),
                     n.last_imported_from = item.source_id,
                     n.active = true,

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -489,7 +489,7 @@ class Neo4jClient:
             "CREATE CONSTRAINT cvssv2_key IF NOT EXISTS FOR (n:CVSSv2) REQUIRE (n.cve_id, n.tag) IS UNIQUE",
             "CREATE CONSTRAINT cvssv30_key IF NOT EXISTS FOR (n:CVSSv30) REQUIRE (n.cve_id, n.tag) IS UNIQUE",
             "CREATE CONSTRAINT cvssv40_key IF NOT EXISTS FOR (n:CVSSv40) REQUIRE (n.cve_id, n.tag) IS UNIQUE",
-            # Campaign nodes — one per actor, keyed by (name, tag)
+            # Campaign nodes — one per actor, keyed by name only
             "CREATE CONSTRAINT campaign_key IF NOT EXISTS FOR (c:Campaign) REQUIRE (c.name) IS UNIQUE",
         ]
 
@@ -1818,6 +1818,7 @@ class Neo4jClient:
         MATCH (t:Technique {mitre_id: row.mitre_id})
         MERGE (a)-[r:USES]->(t)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1830,6 +1831,7 @@ class Neo4jClient:
         WHERE (a.name = row.actor OR row.actor IN coalesce(a.aliases, []))
         MERGE (m)-[r:ATTRIBUTED_TO]->(a)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1841,6 +1843,7 @@ class Neo4jClient:
         WHERE (m.name = row.malware OR row.malware IN coalesce(m.aliases, []))
         MERGE (i)-[r:INDICATES]->(m)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1854,6 +1857,7 @@ class Neo4jClient:
         MATCH (i:Indicator {value: row.value})
         MERGE (i)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1867,6 +1871,7 @@ class Neo4jClient:
         MATCH (v:Vulnerability {cve_id: row.cve_id})
         MERGE (v)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1880,6 +1885,7 @@ class Neo4jClient:
         MATCH (v:CVE {cve_id: row.cve_id})
         MERGE (v)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
             r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1740,21 +1740,22 @@ class Neo4jClient:
             rt = rel.get("rel_type")
             fk = rel.get("from_key") or {}
             tk = rel.get("to_key") or {}
+            conf = rel.get("confidence", 0.5)
             if rt == "USES":
                 an = nonempty_graph_string(fk.get("name"))
                 mid = nonempty_graph_string(tk.get("mitre_id"))
                 if an and mid:
-                    uses_rows.append({"actor": an, "mitre_id": mid, "source_id": source_id})
+                    uses_rows.append({"actor": an, "mitre_id": mid, "source_id": source_id, "confidence": conf})
             elif rt == "ATTRIBUTED_TO":
                 mn = nonempty_graph_string(fk.get("name"))
                 an = nonempty_graph_string(tk.get("name"))
                 if mn and an:
-                    attr_rows.append({"malware": mn, "actor": an, "source_id": source_id})
+                    attr_rows.append({"malware": mn, "actor": an, "source_id": source_id, "confidence": conf})
             elif rt == "INDICATES" and rel.get("to_type") == "Malware":
                 iv = nonempty_graph_string(fk.get("value"))
                 mn = nonempty_graph_string(tk.get("name"))
                 if iv and mn:
-                    ind_mal_rows.append({"value": iv, "malware": mn, "source_id": source_id})
+                    ind_mal_rows.append({"value": iv, "malware": mn, "source_id": source_id, "confidence": conf})
             elif rt == "TARGETS":
                 sec = nonempty_graph_string(tk.get("name"))
                 if not sec:
@@ -1763,16 +1764,16 @@ class Neo4jClient:
                 if ft == "Indicator":
                     iv = nonempty_graph_string(fk.get("value"))
                     if iv:
-                        tgt_ind_rows.append({"value": iv, "sector": sec, "source_id": source_id})
+                        tgt_ind_rows.append({"value": iv, "sector": sec, "source_id": source_id, "confidence": conf})
                 elif ft == "Vulnerability":
                     cid = normalize_cve_id_for_graph(fk.get("cve_id"))
                     if cid:
-                        tgt_vuln_rows.append({"cve_id": cid, "sector": sec, "source_id": source_id})
+                        tgt_vuln_rows.append({"cve_id": cid, "sector": sec, "source_id": source_id, "confidence": conf})
             elif rt == "EXPLOITS":
                 iv = nonempty_graph_string(fk.get("value"))
                 cid = normalize_cve_id_for_graph(tk.get("cve_id"))
                 if iv and cid:
-                    expl_rows.append({"value": iv, "cve_id": cid, "source_id": source_id})
+                    expl_rows.append({"value": iv, "cve_id": cid, "source_id": source_id, "confidence": conf})
 
         total = 0
 
@@ -1783,7 +1784,7 @@ class Neo4jClient:
         MATCH (t:Technique {mitre_id: row.mitre_id})
         MERGE (a)-[r:USES]->(t)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 0.7,
+            r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
         """
@@ -1795,7 +1796,7 @@ class Neo4jClient:
         WHERE (a.name = row.actor OR row.actor IN coalesce(a.aliases, []))
         MERGE (m)-[r:ATTRIBUTED_TO]->(a)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 0.7,
+            r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
         """
@@ -1806,7 +1807,7 @@ class Neo4jClient:
         WHERE (m.name = row.malware OR row.malware IN coalesce(m.aliases, []))
         MERGE (i)-[r:INDICATES]->(m)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 0.6,
+            r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
         """
@@ -1819,7 +1820,7 @@ class Neo4jClient:
         MATCH (i:Indicator {value: row.value})
         MERGE (i)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 0.5,
+            r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
         """
@@ -1832,7 +1833,7 @@ class Neo4jClient:
         MATCH (v:Vulnerability {cve_id: row.cve_id})
         MERGE (v)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 0.5,
+            r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
         """
@@ -1845,7 +1846,7 @@ class Neo4jClient:
         MATCH (v:CVE {cve_id: row.cve_id})
         MERGE (v)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 0.5,
+            r.confidence_score = row.confidence,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
         """
@@ -1855,7 +1856,7 @@ class Neo4jClient:
         MATCH (v:Vulnerability {cve_id: row.cve_id})
         MERGE (i)-[r:EXPLOITS]->(v)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 1.0,
+            r.confidence_score = row.confidence,
             r.match_type = 'cve_tag',
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1866,7 +1867,7 @@ class Neo4jClient:
         MATCH (v:CVE {cve_id: row.cve_id})
         MERGE (i)-[r:EXPLOITS]->(v)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
-            r.confidence_score = 1.0,
+            r.confidence_score = row.confidence,
             r.match_type = 'cve_tag',
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2618,10 +2618,11 @@ class Neo4jClient:
         This is the ResilMesh-native path used when data arrives from the
         ResilMesh platform directly (e.g., via ISIM GraphQL or NATS).
         The MISP pipeline uses ``merge_vulnerabilities_batch()`` instead,
-        which keys on ``(cve_id, tag)`` — both produce compatible nodes.
+        which keys on ``cve_id`` — both produce compatible nodes.
         """
         query = """
-        MERGE (v:Vulnerability {name: $name, cve_id: $cve_id})
+        MERGE (v:Vulnerability {cve_id: $cve_id})
+        SET v.name = coalesce(v.name, $name)
         SET v.status = $status,
             v.description = $description,
             v.edgeguard_managed = true,

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2082,7 +2082,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "INDICATES",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
+                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
                         "to_type": "Malware",
                         "to_key": {"name": malware_name},
                         "confidence": confidence,
@@ -2095,7 +2095,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "TARGETS",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
+                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
                         "to_type": "Sector",
                         "to_key": {"name": target_sector},
                         "confidence": confidence,
@@ -2111,7 +2111,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "EXPLOITS",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
+                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
                         "to_type": "Vulnerability",
                         "to_key": {"cve_id": exp_cve},
                         "confidence": confidence,

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1674,7 +1674,7 @@ class MISPToNeo4jSync:
                         "from_key": {"name": actor["name"]},
                         "to_type": "Technique",
                         "to_key": {"mitre_id": technique["mitre_id"]},
-                        "confidence": 0.7,
+                        "confidence": 0.5,
                     }
                 )
 
@@ -1738,7 +1738,7 @@ class MISPToNeo4jSync:
                             },
                             "to_type": "Vulnerability",
                             "to_key": {"cve_id": cve_id},
-                            "confidence": 0.7,
+                            "confidence": 0.5,
                         }
                     )
 
@@ -2122,7 +2122,7 @@ class MISPToNeo4jSync:
                         "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
                         "to_type": "Vulnerability",
                         "to_key": {"cve_id": exp_cve},
-                        "confidence": 1.0,  # explicit CVE match = highest confidence
+                        "confidence": max(confidence, 0.9),  # explicit CVE match floors at 0.9, respects tag confidence
                     }
                 )
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2114,7 +2114,7 @@ class MISPToNeo4jSync:
                         "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
                         "to_type": "Vulnerability",
                         "to_key": {"cve_id": exp_cve},
-                        "confidence": confidence,
+                        "confidence": 1.0,  # explicit CVE match = highest confidence
                     }
                 )
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1695,7 +1695,7 @@ class MISPToNeo4jSync:
                         "from_key": {"name": malware["name"]},
                         "to_type": "ThreatActor",
                         "to_key": {"name": actor["name"]},
-                        "confidence": 0.6,
+                        "confidence": 0.5,
                     }
                 )
 
@@ -1717,7 +1717,7 @@ class MISPToNeo4jSync:
                             },
                             "to_type": "Malware",
                             "to_key": {"name": malware["name"]},
-                            "confidence": 0.6,
+                            "confidence": 0.5,
                         }
                     )
 
@@ -2134,7 +2134,9 @@ class MISPToNeo4jSync:
                         "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
                         "to_type": "Vulnerability",
                         "to_key": {"cve_id": exp_cve},
-                        "confidence": max(confidence, 0.9),  # explicit CVE match floors at 0.9, respects tag confidence
+                        "confidence": max(
+                            confidence, 0.7
+                        ),  # explicit CVE tag match floors at 0.7, respects tag confidence
                     }
                 )
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -331,6 +331,7 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
     """
     seen = set()
     unique_items: List[Dict] = []
+    _dropped = 0
     for item in items:
         tag = item.get("tag", "default")
         if _item_is_vulnerability_sync_bucket(item):
@@ -338,6 +339,8 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
             if cid:
                 key = f"cve:{cid}:{tag}"
             else:
+                logger.debug("Dedup: dropping vulnerability with unresolvable CVE ID (tag=%s)", tag)
+                _dropped += 1
                 continue
         elif item.get("value"):
             key = f"{item.get('indicator_type', 'unknown')}:{item['value']}:{tag}"
@@ -346,11 +349,16 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
         elif item.get("mitre_id"):
             key = f"technique:{item['mitre_id']}:{tag}"
         else:
+            logger.debug("Dedup: dropping item with no identifiable key (type=%s, tag=%s)", item.get("type"), tag)
+            _dropped += 1
             continue
 
         if key not in seen:
             seen.add(key)
             unique_items.append(item)
+    _dupes = len(items) - len(unique_items) - _dropped
+    if _dropped or _dupes:
+        logger.info("Dedup: %s items → %s unique (%s duplicates removed, %s dropped for missing keys)", len(items), len(unique_items), _dupes, _dropped)
     return unique_items
 
 
@@ -2106,6 +2114,7 @@ class MISPToNeo4jSync:
             for raw_cve in exploits_cves:
                 exp_cve = normalize_cve_id_for_graph(raw_cve)
                 if not exp_cve:
+                    logger.debug("Skipping malformed CVE reference in EXPLOITS: %s", raw_cve[:50] if raw_cve else "None")
                     continue
                 relationships.append(
                     {

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -358,7 +358,13 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
             unique_items.append(item)
     _dupes = len(items) - len(unique_items) - _dropped
     if _dropped or _dupes:
-        logger.info("Dedup: %s items → %s unique (%s duplicates removed, %s dropped for missing keys)", len(items), len(unique_items), _dupes, _dropped)
+        logger.info(
+            "Dedup: %s items → %s unique (%s duplicates removed, %s dropped for missing keys)",
+            len(items),
+            len(unique_items),
+            _dupes,
+            _dropped,
+        )
     return unique_items
 
 
@@ -1778,7 +1784,11 @@ class MISPToNeo4jSync:
                                 {
                                     "rel_type": "TARGETS",
                                     "from_type": "Indicator",
-                                    "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
+                                    "from_key": {
+                                        "value": value,
+                                        "indicator_type": indicator_type,
+                                        "tag": item.get("tag", "misp"),
+                                    },
                                     "to_type": "Sector",
                                     "to_key": {"name": sector_name},
                                     "confidence": 0.5,
@@ -2113,7 +2123,9 @@ class MISPToNeo4jSync:
             for raw_cve in exploits_cves:
                 exp_cve = normalize_cve_id_for_graph(raw_cve)
                 if not exp_cve:
-                    logger.debug("Skipping malformed CVE reference in EXPLOITS: %s", raw_cve[:50] if raw_cve else "None")
+                    logger.debug(
+                        "Skipping malformed CVE reference in EXPLOITS: %s", raw_cve[:50] if raw_cve else "None"
+                    )
                     continue
                 relationships.append(
                     {
@@ -2734,7 +2746,6 @@ class MISPToNeo4jSync:
         )
 
         return total_parsed, total_cross_rels, total_errors
-
 
     def run(self, incremental: bool = True, since: datetime = None, sector: str = None) -> bool:
         """

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2715,8 +2715,6 @@ class MISPToNeo4jSync:
 
         return total_parsed, total_cross_rels, total_errors
 
-    # Maximum items to feed into co-occurrence builder from paged events (O(n²) guard)
-    _MAX_COOCCURRENCE_PAGED_ITEMS = 5000
 
     def run(self, incremental: bool = True, since: datetime = None, sector: str = None) -> bool:
         """

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2294,8 +2294,12 @@ class MISPToNeo4jSync:
             for tactic in tactics:
                 try:
                     source_id = tactic.get("tag", "misp")
-                    self.neo4j.merge_tactic(tactic, source_id=source_id)
-                    success += 1
+                    if self.neo4j.merge_tactic(tactic, source_id=source_id):
+                        self.stats.setdefault("tactics_synced", 0)
+                        self.stats["tactics_synced"] += 1
+                        success += 1
+                    else:
+                        errors += 1
                 except Exception as e:
                     logger.warning(f"Error syncing tactic: {e}")
                     errors += 1
@@ -2306,9 +2310,11 @@ class MISPToNeo4jSync:
             for technique in techniques:
                 try:
                     source_id = technique.get("tag", "misp")
-                    self.neo4j.merge_technique(technique, source_id=source_id)
-                    self.stats["techniques_synced"] += 1
-                    success += 1
+                    if self.neo4j.merge_technique(technique, source_id=source_id):
+                        self.stats["techniques_synced"] += 1
+                        success += 1
+                    else:
+                        errors += 1
                 except Exception as e:
                     logger.warning(f"Error syncing technique: {e}")
                     errors += 1
@@ -2319,9 +2325,11 @@ class MISPToNeo4jSync:
             for malware in malware_items:
                 try:
                     source_id = malware.get("tag", "misp")
-                    self.neo4j.merge_malware(malware, source_id=source_id)
-                    self.stats["malware_synced"] += 1
-                    success += 1
+                    if self.neo4j.merge_malware(malware, source_id=source_id):
+                        self.stats["malware_synced"] += 1
+                        success += 1
+                    else:
+                        errors += 1
                 except Exception as e:
                     logger.warning(f"Error syncing malware: {e}")
                     errors += 1
@@ -2332,9 +2340,11 @@ class MISPToNeo4jSync:
             for actor in actors:
                 try:
                     source_id = actor.get("tag", "misp")
-                    self.neo4j.merge_actor(actor, source_id=source_id)
-                    self.stats["actors_synced"] += 1
-                    success += 1
+                    if self.neo4j.merge_actor(actor, source_id=source_id):
+                        self.stats["actors_synced"] += 1
+                        success += 1
+                    else:
+                        errors += 1
                 except Exception as e:
                     actor_name = actor.get("name", "unknown")[:30]
                     logger.warning(f"[WARN] Error syncing actor ({actor_name}): {type(e).__name__}: {e}")
@@ -2346,10 +2356,12 @@ class MISPToNeo4jSync:
             for tool in tools:
                 try:
                     source_id = tool.get("tag", "misp")
-                    self.neo4j.merge_tool(tool, source_id=source_id)
-                    self.stats.setdefault("tools_synced", 0)
-                    self.stats["tools_synced"] += 1
-                    success += 1
+                    if self.neo4j.merge_tool(tool, source_id=source_id):
+                        self.stats.setdefault("tools_synced", 0)
+                        self.stats["tools_synced"] += 1
+                        success += 1
+                    else:
+                        errors += 1
                 except Exception as e:
                     tool_name = tool.get("name", "unknown")[:30]
                     logger.warning(f"[WARN] Error syncing tool ({tool_name}): {type(e).__name__}: {e}")

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1626,6 +1626,35 @@ class MISPToNeo4jSync:
         malware_items = [i for i in items if i.get("type") == "malware"]
         indicators = [i for i in items if i.get("indicator_type") or i.get("type") == "indicator"]
 
+        # Type-based sampling caps to prevent O(n²) blowup on large events.
+        # Each cross-product is capped independently; smaller entity types (actors,
+        # techniques, malware) keep all items, only indicators are sampled.
+        _MAX_ACTORS = 500
+        _MAX_TECHNIQUES = 500
+        _MAX_MALWARE = 500
+        _MAX_INDICATORS = 2000
+        _MAX_VULNS = 1000
+
+        sampled = False
+        if len(actors) > _MAX_ACTORS:
+            logger.info("Sampling actors: %s → %s", len(actors), _MAX_ACTORS)
+            actors = actors[:_MAX_ACTORS]
+            sampled = True
+        if len(techniques) > _MAX_TECHNIQUES:
+            logger.info("Sampling techniques: %s → %s", len(techniques), _MAX_TECHNIQUES)
+            techniques = techniques[:_MAX_TECHNIQUES]
+            sampled = True
+        if len(malware_items) > _MAX_MALWARE:
+            logger.info("Sampling malware: %s → %s", len(malware_items), _MAX_MALWARE)
+            malware_items = malware_items[:_MAX_MALWARE]
+            sampled = True
+        if len(indicators) > _MAX_INDICATORS:
+            logger.info("Sampling indicators: %s → %s", len(indicators), _MAX_INDICATORS)
+            indicators = indicators[:_MAX_INDICATORS]
+            sampled = True
+        if sampled:
+            logger.info("Type-based sampling applied to keep cross-products manageable")
+
         # Build actor -> technique relationships (USES)
         # When an event has both actors and techniques, assume the actors use those techniques
         for actor in actors:
@@ -1634,9 +1663,9 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "USES",
                         "from_type": "ThreatActor",
-                        "from_key": {"name": actor["name"], "tag": actor.get("tag", "misp")},
+                        "from_key": {"name": actor["name"]},
                         "to_type": "Technique",
-                        "to_key": {"mitre_id": technique["mitre_id"], "tag": technique.get("tag", "misp")},
+                        "to_key": {"mitre_id": technique["mitre_id"]},
                         "confidence": 0.7,
                     }
                 )
@@ -1649,9 +1678,9 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "ATTRIBUTED_TO",
                         "from_type": "Malware",
-                        "from_key": {"name": malware["name"], "tag": malware.get("tag", "misp")},
+                        "from_key": {"name": malware["name"]},
                         "to_type": "ThreatActor",
-                        "to_key": {"name": actor["name"], "tag": actor.get("tag", "misp")},
+                        "to_key": {"name": actor["name"]},
                         "confidence": 0.6,
                     }
                 )
@@ -1673,7 +1702,7 @@ class MISPToNeo4jSync:
                                 "tag": indicator.get("tag", "misp"),
                             },
                             "to_type": "Malware",
-                            "to_key": {"name": malware["name"], "tag": malware.get("tag", "misp")},
+                            "to_key": {"name": malware["name"]},
                             "confidence": 0.6,
                         }
                     )
@@ -1682,6 +1711,9 @@ class MISPToNeo4jSync:
         # Indicators in the same MISP event as a CVE are likely exploiting it.
         # Only items we can key by CVE (value-only MISP vulnerability attributes included).
         vulnerabilities = [i for i in items if resolve_vulnerability_cve_id(i) is not None]
+        if len(vulnerabilities) > _MAX_VULNS:
+            logger.info("Sampling vulnerabilities: %s → %s", len(vulnerabilities), _MAX_VULNS)
+            vulnerabilities = vulnerabilities[:_MAX_VULNS]
         for indicator in indicators:
             for vuln in vulnerabilities:
                 indicator_value = indicator.get("value")
@@ -1697,7 +1729,7 @@ class MISPToNeo4jSync:
                                 "tag": indicator.get("tag", "misp"),
                             },
                             "to_type": "Vulnerability",
-                            "to_key": {"cve_id": cve_id, "tag": vuln.get("tag", "misp")},
+                            "to_key": {"cve_id": cve_id},
                             "confidence": 0.7,
                         }
                     )
@@ -1724,7 +1756,7 @@ class MISPToNeo4jSync:
                                 {
                                     "rel_type": "TARGETS",
                                     "from_type": "Vulnerability",
-                                    "from_key": {"cve_id": cve_id, "tag": source_id},
+                                    "from_key": {"cve_id": cve_id},
                                     "to_type": "Sector",
                                     "to_key": {"name": sector_name},
                                     "confidence": 0.5,
@@ -1739,7 +1771,7 @@ class MISPToNeo4jSync:
                                 {
                                     "rel_type": "TARGETS",
                                     "from_type": "Indicator",
-                                    "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                                    "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
                                     "to_type": "Sector",
                                     "to_key": {"name": sector_name},
                                     "confidence": 0.5,
@@ -2050,7 +2082,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "INDICATES",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
                         "to_type": "Malware",
                         "to_key": {"name": malware_name, "tag": source_id},
                         "confidence": confidence,
@@ -2063,7 +2095,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "TARGETS",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
                         "to_type": "Sector",
                         "to_key": {"name": target_sector},
                         "confidence": confidence,
@@ -2079,7 +2111,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "EXPLOITS",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
                         "to_type": "Vulnerability",
                         "to_key": {"cve_id": exp_cve, "tag": source_id},
                         "confidence": confidence,
@@ -2553,17 +2585,8 @@ class MISPToNeo4jSync:
 
         unique_event_items = _dedupe_parsed_items(event_items)
 
-        # Guard against O(n²) blowup on dense events (same cap as paged path).
-        if len(unique_event_items) > self._MAX_COOCCURRENCE_PAGED_ITEMS:
-            logger.warning(
-                "Event %s: %s unique items exceeds co-occurrence cap (%s) — skipping cross-item relationships to avoid O(n²) blowup",
-                event_id,
-                len(unique_event_items),
-                self._MAX_COOCCURRENCE_PAGED_ITEMS,
-            )
-            cross_rels = []
-        else:
-            cross_rels = self._build_cross_item_relationships(unique_event_items)
+        # Type-based sampling inside _build_cross_item_relationships handles O(n²) risk.
+        cross_rels = self._build_cross_item_relationships(unique_event_items)
 
         logger.info(
             "Event %s: %s parsed -> %s unique items; %s embedded rel defs; %s cross-item rel defs",
@@ -2576,10 +2599,13 @@ class MISPToNeo4jSync:
 
         _s, ev_errors, _u = self.sync_to_neo4j(unique_event_items)
 
-        rel_batch = event_embedded_rels + cross_rels
-        if rel_batch:
-            logger.info("Event %s: creating %s relationships...", event_id, len(rel_batch))
-            rels_created = self._create_relationships(rel_batch, "misp")
+        if event_embedded_rels:
+            rels_created = self._create_relationships(event_embedded_rels, "misp")
+            self.stats["relationships_created"] += rels_created
+        if cross_rels:
+            # Cross-item (co-occurrence) rels use distinct source_id so calibration
+            # job can find and rescore them by MISP event size.
+            rels_created = self._create_relationships(cross_rels, "misp_cooccurrence")
             self.stats["relationships_created"] += rels_created
 
         return len(event_items), len(cross_rels), ev_errors
@@ -2664,23 +2690,15 @@ class MISPToNeo4jSync:
 
         # Build cross-item relationships across ALL pages (now that all nodes are in Neo4j).
         # Uses the lightweight accumulator, not the full parsed items.
-        # Guard against O(n²) blowup on very large events.
+        # Type-based sampling inside _build_cross_item_relationships handles O(n²) risk.
         cross_rels = []
-        if _rel_items and len(_rel_items) > self._MAX_COOCCURRENCE_PAGED_ITEMS:
-            logger.warning(
-                "Event %s: %s items exceeds co-occurrence cap (%s) — skipping cross-item relationships to avoid O(n²) blowup",
-                event_id,
-                len(_rel_items),
-                self._MAX_COOCCURRENCE_PAGED_ITEMS,
-            )
-            _rel_items = []
         if _rel_items:
             cross_rels = self._build_cross_item_relationships(_rel_items)
             if cross_rels:
                 logger.info(
                     "Event %s: building %s cross-item relationships from all pages...", event_id, len(cross_rels)
                 )
-                rels_created = self._create_relationships(cross_rels, "misp")
+                rels_created = self._create_relationships(cross_rels, "misp_cooccurrence")
                 self.stats["relationships_created"] += rels_created
                 total_cross_rels += rels_created
             del _rel_items

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1754,7 +1754,6 @@ class MISPToNeo4jSync:
                 if zone and zone != "global":
                     sector_name = zone.lower()
                     item_type = item.get("type", "")
-                    source_id = item.get("tag", "misp")
 
                     # Only MISP vulnerability rows become :Vulnerability TARGETS (not arbitrary cve_id fields).
                     if item_type == "vulnerability":

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1904,7 +1904,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "TARGETS",
                         "from_type": "Vulnerability",
-                        "from_key": {"cve_id": canon_cve, "tag": source_id},
+                        "from_key": {"cve_id": canon_cve},
                         "to_type": "Sector",
                         "to_key": {"name": target_sector},
                         "confidence": confidence,
@@ -1959,9 +1959,9 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "USES",
                         "from_type": "ThreatActor",
-                        "from_key": {"name": actor_name, "tag": source_id},
+                        "from_key": {"name": actor_name},
                         "to_type": "Technique",
-                        "to_key": {"mitre_id": technique["mitre_id"], "tag": source_id},
+                        "to_key": {"mitre_id": technique["mitre_id"]},
                         "confidence": confidence,
                         "technique_name": technique.get("name", ""),
                     }
@@ -2017,9 +2017,9 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "ATTRIBUTED_TO",
                         "from_type": "Malware",
-                        "from_key": {"name": malware_name, "tag": source_id},
+                        "from_key": {"name": malware_name},
                         "to_type": "ThreatActor",
-                        "to_key": {"name": threat_actor, "tag": source_id},
+                        "to_key": {"name": threat_actor},
                         "confidence": confidence,
                     }
                 )
@@ -2084,7 +2084,7 @@ class MISPToNeo4jSync:
                         "from_type": "Indicator",
                         "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
                         "to_type": "Malware",
-                        "to_key": {"name": malware_name, "tag": source_id},
+                        "to_key": {"name": malware_name},
                         "confidence": confidence,
                     }
                 )
@@ -2113,7 +2113,7 @@ class MISPToNeo4jSync:
                         "from_type": "Indicator",
                         "from_key": {"value": value, "indicator_type": indicator_type, "tag": item.get("tag", "misp")},
                         "to_type": "Vulnerability",
-                        "to_key": {"cve_id": exp_cve, "tag": source_id},
+                        "to_key": {"cve_id": exp_cve},
                         "confidence": confidence,
                     }
                 )

--- a/tests/test_merge_key_dedup.py
+++ b/tests/test_merge_key_dedup.py
@@ -80,44 +80,32 @@ class TestMergeKeyProps:
     def test_merge_actor_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {"name": "APT28", "tag": "mitre_attck", "zone": ["global"]}
-        self._assert_merge_called_without_tag_in_key(
-            client, session, client.merge_actor, data, "ThreatActor"
-        )
+        self._assert_merge_called_without_tag_in_key(client, session, client.merge_actor, data, "ThreatActor")
 
     def test_merge_malware_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {"name": "Emotet", "tag": "alienvault_otx", "zone": ["global"]}
-        self._assert_merge_called_without_tag_in_key(
-            client, session, client.merge_malware, data, "Malware"
-        )
+        self._assert_merge_called_without_tag_in_key(client, session, client.merge_malware, data, "Malware")
 
     def test_merge_technique_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {"mitre_id": "T1059", "name": "Command-Line Interface", "tag": "mitre_attck", "zone": ["global"]}
-        self._assert_merge_called_without_tag_in_key(
-            client, session, client.merge_technique, data, "Technique"
-        )
+        self._assert_merge_called_without_tag_in_key(client, session, client.merge_technique, data, "Technique")
 
     def test_merge_tactic_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {"mitre_id": "TA0001", "name": "Initial Access", "tag": "mitre_attck", "zone": ["global"]}
-        self._assert_merge_called_without_tag_in_key(
-            client, session, client.merge_tactic, data, "Tactic"
-        )
+        self._assert_merge_called_without_tag_in_key(client, session, client.merge_tactic, data, "Tactic")
 
     def test_merge_tool_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {"mitre_id": "S0154", "name": "Cobalt Strike", "tag": "mitre_attck", "zone": ["global"]}
-        self._assert_merge_called_without_tag_in_key(
-            client, session, client.merge_tool, data, "Tool"
-        )
+        self._assert_merge_called_without_tag_in_key(client, session, client.merge_tool, data, "Tool")
 
     def test_merge_vulnerability_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {"cve_id": "CVE-2021-44228", "tag": "nvd", "zone": ["global"]}
-        self._assert_merge_called_without_tag_in_key(
-            client, session, client.merge_vulnerability, data, "Vulnerability"
-        )
+        self._assert_merge_called_without_tag_in_key(client, session, client.merge_vulnerability, data, "Vulnerability")
 
     def test_merge_cve_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
@@ -287,8 +275,13 @@ class TestCrossItemRelKeys:
 
     def test_vulnerability_sector_targets_no_tag(self):
         items = [
-            {"type": "vulnerability", "cve_id": "CVE-2021-44228", "value": "CVE-2021-44228",
-             "tag": "nvd", "zone": ["energy"]},
+            {
+                "type": "vulnerability",
+                "cve_id": "CVE-2021-44228",
+                "value": "CVE-2021-44228",
+                "tag": "nvd",
+                "zone": ["energy"],
+            },
         ]
         rels = self._build_rels(items)
         tgt = [r for r in rels if r["rel_type"] == "TARGETS" and r["from_type"] == "Vulnerability"]
@@ -345,14 +338,17 @@ class TestSourceIdRouting:
         syncer.neo4j.merge_indicators_batch.return_value = (2, 0)
         syncer.neo4j.merge_vulnerabilities_batch.return_value = (0, 0)
         syncer.stats = {
-            "events_processed": 0, "events_failed": 0,
-            "indicators_synced": 0, "vulnerabilities_synced": 0,
-            "relationships_created": 0, "errors": 0,
+            "events_processed": 0,
+            "events_failed": 0,
+            "indicators_synced": 0,
+            "vulnerabilities_synced": 0,
+            "relationships_created": 0,
+            "errors": 0,
         }
 
         # Mock _create_relationships to capture source_id
         source_ids_used = []
-        original_create = syncer._create_relationships if hasattr(syncer, '_create_relationships') else None
+        original_create = syncer._create_relationships if hasattr(syncer, "_create_relationships") else None
 
         def _mock_create_rels(rels, source_id):
             source_ids_used.append((source_id, len(rels)))
@@ -360,9 +356,9 @@ class TestSourceIdRouting:
 
         syncer._create_relationships = _mock_create_rels
         syncer.sync_to_neo4j = MagicMock(return_value=(2, 0, []))
-        syncer._build_cross_item_relationships = MagicMock(return_value=[
-            {"rel_type": "INDICATES", "from_type": "Indicator", "to_type": "Malware"}
-        ])
+        syncer._build_cross_item_relationships = MagicMock(
+            return_value=[{"rel_type": "INDICATES", "from_type": "Indicator", "to_type": "Malware"}]
+        )
 
         # Simulate parse_attribute returning items + embedded rels
         def _mock_parse(attr, event):
@@ -406,7 +402,7 @@ class TestTypeSamplingCaps:
     def test_large_indicator_list_sampled(self):
         """3000 indicators should be sampled to 2000."""
         items = [
-            {"type": "indicator", "indicator_type": "ipv4", "value": f"10.0.{i//256}.{i%256}", "tag": "misp"}
+            {"type": "indicator", "indicator_type": "ipv4", "value": f"10.0.{i // 256}.{i % 256}", "tag": "misp"}
             for i in range(3000)
         ]
         items.append({"type": "malware", "name": "TestMalware", "tag": "misp"})
@@ -418,13 +414,9 @@ class TestTypeSamplingCaps:
     def test_small_event_not_sampled(self):
         """50 indicators + 5 malware should NOT be sampled."""
         items = [
-            {"type": "indicator", "indicator_type": "ipv4", "value": f"10.0.0.{i}", "tag": "misp"}
-            for i in range(50)
+            {"type": "indicator", "indicator_type": "ipv4", "value": f"10.0.0.{i}", "tag": "misp"} for i in range(50)
         ]
-        items.extend([
-            {"type": "malware", "name": f"Malware{i}", "tag": "misp"}
-            for i in range(5)
-        ])
+        items.extend([{"type": "malware", "name": f"Malware{i}", "tag": "misp"} for i in range(5)])
         rels = self._build_rels(items)
         indicates = [r for r in rels if r["rel_type"] == "INDICATES"]
         assert len(indicates) == 250, f"Expected 50*5=250 INDICATES, got {len(indicates)}"
@@ -445,6 +437,7 @@ class TestConstraintDefinitions:
 
         # Extract constraint strings from create_constraints source
         import inspect
+
         source = inspect.getsource(client.create_constraints)
 
         # These should be single-key (no tag)
@@ -455,6 +448,7 @@ class TestConstraintDefinitions:
     def test_indicator_constraint_keeps_tag(self):
         """Indicator constraint should include tag."""
         import inspect
+
         client = Neo4jClient.__new__(Neo4jClient)
         client.driver = MagicMock()
         source = inspect.getsource(client.create_constraints)
@@ -463,6 +457,7 @@ class TestConstraintDefinitions:
     def test_cvss_constraints_keep_tag(self):
         """CVSS sub-node constraints should include tag (different scores per source)."""
         import inspect
+
         client = Neo4jClient.__new__(Neo4jClient)
         client.driver = MagicMock()
         source = inspect.getsource(client.create_constraints)

--- a/tests/test_merge_key_dedup.py
+++ b/tests/test_merge_key_dedup.py
@@ -16,12 +16,9 @@ caused ThreatActor/Malware/Technique nodes to fragment: APT28 had 7 separate nod
 8. Tag is accumulated into ``tags`` array, not lost
 """
 
-import json
 import os
 import sys
-from unittest.mock import MagicMock, call, patch
-
-import pytest
+from unittest.mock import MagicMock
 
 _SRC = os.path.join(os.path.dirname(__file__), "..", "src")
 if _SRC not in sys.path:
@@ -34,7 +31,6 @@ for _mod in ("neo4j_client", "run_misp_to_neo4j"):
 
 from neo4j_client import Neo4jClient  # noqa: E402
 from run_misp_to_neo4j import MISPToNeo4jSync  # noqa: E402
-
 
 # ---------------------------------------------------------------------------
 # Helpers

--- a/tests/test_merge_key_dedup.py
+++ b/tests/test_merge_key_dedup.py
@@ -1,0 +1,473 @@
+"""
+Merge key deduplication tests — ensure entity nodes merge correctly across sources.
+
+The production baseline (441K nodes) revealed that including ``tag`` in MERGE keys
+caused ThreatActor/Malware/Technique nodes to fragment: APT28 had 7 separate nodes
+(one per source tag) instead of 1. These tests verify:
+
+1. MERGE key_props for each entity type do NOT include ``tag``
+2. Indicator MERGE key STILL includes ``tag`` (intentional — different sources have
+   different IOC metadata)
+3. CVSS sub-nodes STILL include ``tag`` (different CVSS scores per source)
+4. Neo4j constraints match the MERGE keys
+5. Batch MERGE queries use the correct keys
+6. Cross-item relationship dicts use correct from_key/to_key (no tag for entities)
+7. Embedded (parse_attribute) relationship dicts use correct keys
+8. Tag is accumulated into ``tags`` array, not lost
+"""
+
+import json
+import os
+import sys
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+# Drop stale cached modules so we always get fresh imports
+for _mod in ("neo4j_client", "run_misp_to_neo4j"):
+    if _mod in sys.modules:
+        del sys.modules[_mod]
+
+from neo4j_client import Neo4jClient  # noqa: E402
+from run_misp_to_neo4j import MISPToNeo4jSync  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_neo4j_mock():
+    """Return a Neo4jClient with a mocked driver that captures Cypher queries."""
+    client = Neo4jClient.__new__(Neo4jClient)
+    client.driver = MagicMock()
+    client._connection_healthy = True
+    # session.run returns a mock result with .single() -> None
+    mock_session = MagicMock()
+    mock_result = MagicMock()
+    mock_result.single.return_value = None
+    mock_session.run.return_value = mock_result
+    client.driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+    client.driver.session.return_value.__exit__ = MagicMock(return_value=False)
+    return client, mock_session
+
+
+# ===========================================================================
+# 1. MERGE key_props — tag must NOT be in entity keys
+# ===========================================================================
+
+
+class TestMergeKeyProps:
+    """Verify each merge_* function builds key_props without tag (except Indicator)."""
+
+    def _assert_merge_called_without_tag_in_key(self, client, session, merge_fn, data, label):
+        """Call merge function, capture the Cypher, verify tag is not in MERGE key."""
+        merge_fn(data, source_id="test_source")
+        # Find the MERGE call (second session.run — first is the audit check)
+        calls = session.run.call_args_list
+        assert len(calls) >= 2, f"Expected at least 2 session.run calls for {label}, got {len(calls)}"
+        merge_call = calls[1]  # second call is the MERGE
+        cypher = merge_call[0][0]  # first positional arg
+        # The MERGE pattern should NOT contain "tag:" for entity nodes
+        merge_line = [line for line in cypher.split("\n") if "MERGE" in line]
+        assert merge_line, f"No MERGE statement found in Cypher for {label}"
+        merge_stmt = merge_line[0]
+        assert "tag:" not in merge_stmt, (
+            f"{label} MERGE key still contains 'tag:' — should merge on name/mitre_id only.\n"
+            f"MERGE statement: {merge_stmt}"
+        )
+
+    def test_merge_actor_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"name": "APT28", "tag": "mitre_attck", "zone": ["global"]}
+        self._assert_merge_called_without_tag_in_key(
+            client, session, client.merge_actor, data, "ThreatActor"
+        )
+
+    def test_merge_malware_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"name": "Emotet", "tag": "alienvault_otx", "zone": ["global"]}
+        self._assert_merge_called_without_tag_in_key(
+            client, session, client.merge_malware, data, "Malware"
+        )
+
+    def test_merge_technique_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"mitre_id": "T1059", "name": "Command-Line Interface", "tag": "mitre_attck", "zone": ["global"]}
+        self._assert_merge_called_without_tag_in_key(
+            client, session, client.merge_technique, data, "Technique"
+        )
+
+    def test_merge_tactic_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"mitre_id": "TA0001", "name": "Initial Access", "tag": "mitre_attck", "zone": ["global"]}
+        self._assert_merge_called_without_tag_in_key(
+            client, session, client.merge_tactic, data, "Tactic"
+        )
+
+    def test_merge_tool_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"mitre_id": "S0154", "name": "Cobalt Strike", "tag": "mitre_attck", "zone": ["global"]}
+        self._assert_merge_called_without_tag_in_key(
+            client, session, client.merge_tool, data, "Tool"
+        )
+
+    def test_merge_vulnerability_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"cve_id": "CVE-2021-44228", "tag": "nvd", "zone": ["global"]}
+        self._assert_merge_called_without_tag_in_key(
+            client, session, client.merge_vulnerability, data, "Vulnerability"
+        )
+
+    def test_merge_cve_no_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {"cve_id": "CVE-2021-44228", "tag": "nvd", "zone": ["global"]}
+        # merge_cve calls merge_node_with_source + _merge_cvss_node; just check first call
+        client.merge_cve(data, source_id="nvd")
+        calls = session.run.call_args_list
+        assert len(calls) >= 2
+        merge_cypher = calls[1][0][0]
+        merge_line = [l for l in merge_cypher.split("\n") if "MERGE" in l][0]
+        assert "tag:" not in merge_line, f"CVE MERGE key has tag: {merge_line}"
+
+
+# ===========================================================================
+# 2. Indicator MERGE key MUST include tag
+# ===========================================================================
+
+
+class TestIndicatorKeepsTag:
+    """Indicator is intentionally keyed by (indicator_type, value, tag)."""
+
+    def test_merge_indicator_has_tag_in_key(self):
+        client, session = _make_neo4j_mock()
+        data = {
+            "indicator_type": "ipv4",
+            "value": "1.2.3.4",
+            "tag": "alienvault_otx",
+            "zone": ["global"],
+        }
+        client.merge_indicator(data, source_id="alienvault_otx")
+        calls = session.run.call_args_list
+        assert len(calls) >= 2
+        merge_cypher = calls[1][0][0]
+        merge_line = [l for l in merge_cypher.split("\n") if "MERGE" in l][0]
+        assert "tag:" in merge_line, f"Indicator MERGE key should have tag: {merge_line}"
+
+
+# ===========================================================================
+# 3. Tag accumulated into tags array
+# ===========================================================================
+
+
+class TestTagAccumulation:
+    """Verify the Cypher accumulates tag into n.tags array."""
+
+    def test_merge_node_cypher_has_tags_accumulation(self):
+        client, session = _make_neo4j_mock()
+        data = {"name": "APT28", "tag": "mitre_attck", "zone": ["global"]}
+        client.merge_actor(data, source_id="mitre_attck")
+        calls = session.run.call_args_list
+        merge_cypher = calls[1][0][0]
+        assert "n.tags = apoc.coll.toSet(coalesce(n.tags, []) + $tag_array)" in merge_cypher
+        # Verify tag_array param was passed
+        merge_kwargs = calls[1][1]
+        assert "tag_array" in merge_kwargs
+        assert merge_kwargs["tag_array"] == ["mitre_attck"]
+
+    def test_tag_value_preserved_as_scalar(self):
+        client, session = _make_neo4j_mock()
+        data = {"name": "APT28", "tag": "mitre_attck", "zone": ["global"]}
+        client.merge_actor(data, source_id="mitre_attck")
+        merge_kwargs = session.run.call_args_list[1][1]
+        assert merge_kwargs["tag_value"] == "mitre_attck"
+
+
+# ===========================================================================
+# 4. Batch MERGE queries
+# ===========================================================================
+
+
+class TestBatchMergeKeys:
+    """Verify batch MERGE Cypher uses correct keys."""
+
+    def test_vulnerability_batch_no_tag_in_merge(self):
+        client, session = _make_neo4j_mock()
+        items = [
+            {"cve_id": "CVE-2021-44228", "tag": "nvd", "zone": ["global"]},
+            {"cve_id": "CVE-2021-44228", "tag": "cisa_kev", "zone": ["energy"]},
+        ]
+        client.merge_vulnerabilities_batch(items, source_id="misp")
+        calls = session.run.call_args_list
+        assert len(calls) >= 1
+        cypher = calls[0][0][0]
+        merge_line = [l for l in cypher.split("\n") if "MERGE" in l][0]
+        assert "tag" not in merge_line, f"Vulnerability batch MERGE has tag: {merge_line}"
+        # Same CVE from different tags should produce ONE batch item key
+        assert "item.cve_id" in merge_line
+
+    def test_vulnerability_batch_accumulates_tags(self):
+        client, session = _make_neo4j_mock()
+        items = [{"cve_id": "CVE-2021-44228", "tag": "nvd", "zone": ["global"]}]
+        client.merge_vulnerabilities_batch(items, source_id="misp")
+        cypher = session.run.call_args_list[0][0][0]
+        assert "n.tags = apoc.coll.toSet(coalesce(n.tags, []) + [item.tag])" in cypher
+
+    def test_indicator_batch_keeps_tag_in_merge(self):
+        client, session = _make_neo4j_mock()
+        items = [
+            {"indicator_type": "ipv4", "value": "1.2.3.4", "tag": "otx", "zone": ["global"]},
+        ]
+        client.merge_indicators_batch(items, source_id="misp")
+        cypher = session.run.call_args_list[0][0][0]
+        merge_line = [l for l in cypher.split("\n") if "MERGE" in l][0]
+        assert "tag: item.tag" in merge_line, f"Indicator batch should keep tag: {merge_line}"
+
+
+# ===========================================================================
+# 5. Cross-item relationship keys (from _build_cross_item_relationships)
+# ===========================================================================
+
+
+class TestCrossItemRelKeys:
+    """Verify _build_cross_item_relationships builds correct from_key/to_key."""
+
+    def _build_rels(self, items):
+        syncer = MISPToNeo4jSync.__new__(MISPToNeo4jSync)
+        return syncer._build_cross_item_relationships(items)
+
+    def test_actor_technique_uses_no_tag(self):
+        items = [
+            {"type": "actor", "name": "APT28", "tag": "mitre_attck"},
+            {"type": "technique", "mitre_id": "T1059", "name": "CLI", "tag": "mitre_attck"},
+        ]
+        rels = self._build_rels(items)
+        uses = [r for r in rels if r["rel_type"] == "USES"]
+        assert len(uses) == 1
+        assert "tag" not in uses[0]["from_key"], f"USES from_key has tag: {uses[0]['from_key']}"
+        assert "tag" not in uses[0]["to_key"], f"USES to_key has tag: {uses[0]['to_key']}"
+        assert uses[0]["from_key"] == {"name": "APT28"}
+        assert uses[0]["to_key"] == {"mitre_id": "T1059"}
+
+    def test_malware_actor_attributed_to_no_tag(self):
+        items = [
+            {"type": "malware", "name": "Emotet", "tag": "misp"},
+            {"type": "actor", "name": "TA542", "tag": "misp"},
+        ]
+        rels = self._build_rels(items)
+        attr = [r for r in rels if r["rel_type"] == "ATTRIBUTED_TO"]
+        assert len(attr) == 1
+        assert "tag" not in attr[0]["from_key"]
+        assert "tag" not in attr[0]["to_key"]
+
+    def test_indicator_malware_indicates_indicator_has_tag(self):
+        items = [
+            {"type": "indicator", "indicator_type": "ipv4", "value": "1.2.3.4", "tag": "misp"},
+            {"type": "malware", "name": "Emotet", "tag": "misp"},
+        ]
+        rels = self._build_rels(items)
+        ind = [r for r in rels if r["rel_type"] == "INDICATES"]
+        assert len(ind) == 1
+        # Indicator from_key SHOULD have tag (indicator keeps tag in merge key)
+        assert "tag" in ind[0]["from_key"], "INDICATES from_key (Indicator) should have tag"
+        # Malware to_key should NOT have tag
+        assert "tag" not in ind[0]["to_key"], f"INDICATES to_key (Malware) has tag: {ind[0]['to_key']}"
+
+    def test_indicator_vulnerability_exploits_no_tag_on_vuln(self):
+        items = [
+            {"type": "indicator", "indicator_type": "ipv4", "value": "1.2.3.4", "tag": "misp"},
+            {"type": "vulnerability", "cve_id": "CVE-2021-44228", "value": "CVE-2021-44228", "tag": "nvd"},
+        ]
+        rels = self._build_rels(items)
+        expl = [r for r in rels if r["rel_type"] == "EXPLOITS"]
+        assert len(expl) == 1
+        assert "tag" in expl[0]["from_key"], "EXPLOITS from_key (Indicator) should have tag"
+        assert "tag" not in expl[0]["to_key"], f"EXPLOITS to_key (Vulnerability) has tag: {expl[0]['to_key']}"
+        assert expl[0]["to_key"] == {"cve_id": "CVE-2021-44228"}
+
+    def test_vulnerability_sector_targets_no_tag(self):
+        items = [
+            {"type": "vulnerability", "cve_id": "CVE-2021-44228", "value": "CVE-2021-44228",
+             "tag": "nvd", "zone": ["energy"]},
+        ]
+        rels = self._build_rels(items)
+        tgt = [r for r in rels if r["rel_type"] == "TARGETS" and r["from_type"] == "Vulnerability"]
+        assert len(tgt) == 1
+        assert "tag" not in tgt[0]["from_key"], f"TARGETS from_key (Vuln) has tag: {tgt[0]['from_key']}"
+
+
+# ===========================================================================
+# 6. Dedup hypothesis: same entity from 3 sources produces 1 merge call
+# ===========================================================================
+
+
+class TestDedupHypothesis:
+    """Simulate what happens when 3 sources provide the same actor."""
+
+    def test_same_actor_three_sources_same_key(self):
+        """APT28 from mitre, otx, and misp should all produce key_props={'name': 'APT28'}."""
+        client, _ = _make_neo4j_mock()
+
+        for tag in ["mitre_attck", "alienvault_otx", "misp"]:
+            data = {"name": "APT28", "tag": tag, "zone": ["global"]}
+            key_props = {"name": data.get("name")}
+            # This is what merge_actor builds — verify it's the same across sources
+            assert key_props == {"name": "APT28"}, f"Key mismatch for tag={tag}: {key_props}"
+
+    def test_same_cve_two_sources_same_key(self):
+        """CVE-2021-44228 from NVD and CISA should produce same key."""
+        client, _ = _make_neo4j_mock()
+
+        for tag in ["nvd", "cisa_kev"]:
+            data = {"cve_id": "CVE-2021-44228", "tag": tag, "zone": ["global"]}
+            key_props = {"cve_id": "CVE-2021-44228"}
+            assert "tag" not in key_props
+
+    def test_same_indicator_different_tags_different_keys(self):
+        """Same IP from different sources SHOULD be different nodes (tag in key)."""
+        key_otx = {"indicator_type": "ipv4", "value": "1.2.3.4", "tag": "alienvault_otx"}
+        key_misp = {"indicator_type": "ipv4", "value": "1.2.3.4", "tag": "misp"}
+        assert key_otx != key_misp, "Indicator keys should differ by tag"
+
+
+# ===========================================================================
+# 7. source_id routing: embedded=misp, cross-item=misp_cooccurrence
+# ===========================================================================
+
+
+class TestSourceIdRouting:
+    """Verify cross-item rels use misp_cooccurrence for calibration compatibility."""
+
+    def test_process_event_attributes_source_id_split(self):
+        """Embedded rels → 'misp', cross-item rels → 'misp_cooccurrence'."""
+        syncer = MISPToNeo4jSync.__new__(MISPToNeo4jSync)
+        syncer.neo4j = MagicMock()
+        syncer.neo4j.merge_indicators_batch.return_value = (2, 0)
+        syncer.neo4j.merge_vulnerabilities_batch.return_value = (0, 0)
+        syncer.stats = {
+            "events_processed": 0, "events_failed": 0,
+            "indicators_synced": 0, "vulnerabilities_synced": 0,
+            "relationships_created": 0, "errors": 0,
+        }
+
+        # Mock _create_relationships to capture source_id
+        source_ids_used = []
+        original_create = syncer._create_relationships if hasattr(syncer, '_create_relationships') else None
+
+        def _mock_create_rels(rels, source_id):
+            source_ids_used.append((source_id, len(rels)))
+            return len(rels)
+
+        syncer._create_relationships = _mock_create_rels
+        syncer.sync_to_neo4j = MagicMock(return_value=(2, 0, []))
+        syncer._build_cross_item_relationships = MagicMock(return_value=[
+            {"rel_type": "INDICATES", "from_type": "Indicator", "to_type": "Malware"}
+        ])
+
+        # Simulate parse_attribute returning items + embedded rels
+        def _mock_parse(attr, event):
+            return (
+                {"indicator_type": "ipv4", "value": attr["value"], "tag": "misp"},
+                [{"rel_type": "TARGETS", "embedded": True}],  # embedded rel
+            )
+
+        syncer.parse_attribute = _mock_parse
+
+        attributes = [
+            {"type": "ip-src", "value": "1.1.1.1"},
+            {"type": "ip-src", "value": "2.2.2.2"},
+        ]
+        full_event = {"Event": {"id": "1"}}
+
+        syncer._process_event_attributes("1", full_event, attributes)
+
+        # Should have 2 _create_relationships calls:
+        # 1st: embedded rels with "misp"
+        # 2nd: cross-item rels with "misp_cooccurrence"
+        assert len(source_ids_used) == 2, f"Expected 2 _create_relationships calls, got {len(source_ids_used)}"
+        assert source_ids_used[0][0] == "misp", f"Embedded rels should use 'misp', got '{source_ids_used[0][0]}'"
+        assert source_ids_used[1][0] == "misp_cooccurrence", (
+            f"Cross-item rels should use 'misp_cooccurrence', got '{source_ids_used[1][0]}'"
+        )
+
+
+# ===========================================================================
+# 8. Type-based sampling caps
+# ===========================================================================
+
+
+class TestTypeSamplingCaps:
+    """Verify _build_cross_item_relationships samples large type groups."""
+
+    def _build_rels(self, items):
+        syncer = MISPToNeo4jSync.__new__(MISPToNeo4jSync)
+        return syncer._build_cross_item_relationships(items)
+
+    def test_large_indicator_list_sampled(self):
+        """3000 indicators should be sampled to 2000."""
+        items = [
+            {"type": "indicator", "indicator_type": "ipv4", "value": f"10.0.{i//256}.{i%256}", "tag": "misp"}
+            for i in range(3000)
+        ]
+        items.append({"type": "malware", "name": "TestMalware", "tag": "misp"})
+        rels = self._build_rels(items)
+        # With 2000 indicators x 1 malware = 2000 INDICATES rels (not 3000)
+        indicates = [r for r in rels if r["rel_type"] == "INDICATES"]
+        assert len(indicates) == 2000, f"Expected 2000 sampled INDICATES, got {len(indicates)}"
+
+    def test_small_event_not_sampled(self):
+        """50 indicators + 5 malware should NOT be sampled."""
+        items = [
+            {"type": "indicator", "indicator_type": "ipv4", "value": f"10.0.0.{i}", "tag": "misp"}
+            for i in range(50)
+        ]
+        items.extend([
+            {"type": "malware", "name": f"Malware{i}", "tag": "misp"}
+            for i in range(5)
+        ])
+        rels = self._build_rels(items)
+        indicates = [r for r in rels if r["rel_type"] == "INDICATES"]
+        assert len(indicates) == 250, f"Expected 50*5=250 INDICATES, got {len(indicates)}"
+
+
+# ===========================================================================
+# 9. Constraint definitions (regression guard)
+# ===========================================================================
+
+
+class TestConstraintDefinitions:
+    """Verify constraint Cypher strings match the MERGE key patterns."""
+
+    def test_entity_constraints_single_key(self):
+        """Entity constraints should NOT include tag."""
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+
+        # Extract constraint strings from create_constraints source
+        import inspect
+        source = inspect.getsource(client.create_constraints)
+
+        # These should be single-key (no tag)
+        assert "REQUIRE (m.name) IS UNIQUE" in source, "Malware constraint should be single-key"
+        assert "REQUIRE (a.name) IS UNIQUE" in source, "ThreatActor constraint should be single-key"
+        assert "REQUIRE (c.cve_id) IS UNIQUE" in source, "CVE constraint should be single-key"
+
+    def test_indicator_constraint_keeps_tag(self):
+        """Indicator constraint should include tag."""
+        import inspect
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        source = inspect.getsource(client.create_constraints)
+        assert "REQUIRE (i.indicator_type, i.value, i.tag) IS UNIQUE" in source
+
+    def test_cvss_constraints_keep_tag(self):
+        """CVSS sub-node constraints should include tag (different scores per source)."""
+        import inspect
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        source = inspect.getsource(client.create_constraints)
+        assert "REQUIRE (n.cve_id, n.tag) IS UNIQUE" in source

--- a/tests/test_merge_key_dedup.py
+++ b/tests/test_merge_key_dedup.py
@@ -131,7 +131,7 @@ class TestMergeKeyProps:
         calls = session.run.call_args_list
         assert len(calls) >= 2
         merge_cypher = calls[1][0][0]
-        merge_line = [l for l in merge_cypher.split("\n") if "MERGE" in l][0]
+        merge_line = [ln for ln in merge_cypher.split("\n") if "MERGE" in ln][0]
         assert "tag:" not in merge_line, f"CVE MERGE key has tag: {merge_line}"
 
 
@@ -155,7 +155,7 @@ class TestIndicatorKeepsTag:
         calls = session.run.call_args_list
         assert len(calls) >= 2
         merge_cypher = calls[1][0][0]
-        merge_line = [l for l in merge_cypher.split("\n") if "MERGE" in l][0]
+        merge_line = [ln for ln in merge_cypher.split("\n") if "MERGE" in ln][0]
         assert "tag:" in merge_line, f"Indicator MERGE key should have tag: {merge_line}"
 
 
@@ -205,7 +205,7 @@ class TestBatchMergeKeys:
         calls = session.run.call_args_list
         assert len(calls) >= 1
         cypher = calls[0][0][0]
-        merge_line = [l for l in cypher.split("\n") if "MERGE" in l][0]
+        merge_line = [ln for ln in cypher.split("\n") if "MERGE" in ln][0]
         assert "tag" not in merge_line, f"Vulnerability batch MERGE has tag: {merge_line}"
         # Same CVE from different tags should produce ONE batch item key
         assert "item.cve_id" in merge_line
@@ -224,7 +224,7 @@ class TestBatchMergeKeys:
         ]
         client.merge_indicators_batch(items, source_id="misp")
         cypher = session.run.call_args_list[0][0][0]
-        merge_line = [l for l in cypher.split("\n") if "MERGE" in l][0]
+        merge_line = [ln for ln in cypher.split("\n") if "MERGE" in ln][0]
         assert "tag: item.tag" in merge_line, f"Indicator batch should keep tag: {merge_line}"
 
 


### PR DESCRIPTION
## Summary
Production baseline test (441K nodes) revealed 5 issues. All fixed in this branch.

- **ThreatActor dedup broken** — `tag` removed from MERGE keys; APT28 now merges to 1 node (was 7)
- **build_relationships hangs** — added CVE.cve_id, Malware.misp_event_id indexes; split OR query; removed O(n²) IS_SAME_AS; timeout 120s→300s
- **Relationship density too low** — global co-occurrence cap replaced with type-based sampling (actors 500, techniques 500, malware 500, indicators 2000)
- **Calibration job finds 0 edges** — cross-item rels now use `source_id="misp_cooccurrence"`
- **Airflow timeout** — build_relationships bumped from 30min to 60min

## Test plan
- [ ] Drop existing Neo4j database (old compound constraints conflict with new single-key)
- [ ] Re-run baseline sync
- [ ] Verify: `MATCH (a:ThreatActor {name: 'APT28'}) RETURN count(a)` = 1
- [ ] Verify: `build_relationships.py` completes in <10 minutes
- [ ] Verify: relationship density > 3 rels/indicator
- [ ] Verify: calibration logs show `[CALIBRATE]` edges rescored

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Alters Neo4j uniqueness constraints and `MERGE` keys, which can require dropping/recreating constraints and will change how production data deduplicates; incorrect migration or key selection could merge previously distinct nodes and affect graph integrity/performance.
> 
> **Overview**
> This PR changes Neo4j identity/constraint strategy so core entities (`ThreatActor`, `Malware`, `Technique`, `Tactic`, `Tool`, `CVE`, `Vulnerability`, `Campaign`) **no longer include `tag` in their `MERGE` keys**, collapsing cross-source duplicates into single nodes while preserving provenance by accumulating `tags[]`, `source[]`, `misp_event_ids[]`, and `misp_attribute_ids[]`.
> 
> It updates relationship generation/performance and calibration: `build_relationships.py` drops `IS_SAME_AS` edge creation, splits `Indicator->EXPLOITS` into indexed `Vulnerability` vs `CVE` queries, broadens MISP co-occurrence matching to multi-event provenance, and the MISP sync now uses **type-based sampling caps** to avoid O(n²) explosions while routing co-occurrence edges under `source_id="misp_cooccurrence"` so the calibration job can rescore them; relationship merges now carry per-edge confidence and warn when invalid endpoints are dropped.
> 
> Operationally, Airflow sync is made more resilient (explicit “intentional skip” logging, state-file write error handling, `ALL_DONE` summaries, longer `build_relationships` timeouts, baseline tier trigger rules), Neo4j read timeout is increased, new indexes are added for key lookups, and docs/tests are updated to reflect the new merge-key model (including a new `test_merge_key_dedup.py`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da7dd7851d730aed315de504b7e2e7e427846f1b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->