### PR TITLE
fix: add r.source_id to single-relationship functions for calibration consistency

### DIFF
--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1484,6 +1484,7 @@ class Neo4jClient:
         MATCH (t:Technique {mitre_id: $technique_mitre_id})
         MERGE (a)-[r:USES]->(t)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.7,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1531,6 +1532,7 @@ class Neo4jClient:
         WHERE (a.name = $actor_name OR $actor_name IN coalesce(a.aliases, []))
         MERGE (m)-[r:ATTRIBUTED_TO]->(a)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.7,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1575,6 +1577,7 @@ class Neo4jClient:
         MATCH (v:Vulnerability {cve_id: $cve_id})
         MERGE (i)-[r:INDICATES]->(v)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.5,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1585,6 +1588,7 @@ class Neo4jClient:
         MATCH (v:CVE {cve_id: $cve_id})
         MERGE (i)-[r:INDICATES]->(v)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.5,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1623,6 +1627,7 @@ class Neo4jClient:
         WHERE (m.name = $malware_name OR $malware_name IN coalesce(m.aliases, []))
         MERGE (i)-[r:INDICATES]->(m)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.6,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1668,6 +1673,7 @@ class Neo4jClient:
         MATCH (s:Sector {name: $sector_name})
         MERGE (i)-[r:TARGETS]->(s)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.5,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()
@@ -1712,6 +1718,7 @@ class Neo4jClient:
 
         rel_props = """
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
+            r.source_id = $source_id,
             r.confidence_score = 0.5,
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime()


### PR DESCRIPTION
## Summary
7 single-relationship functions set `r.sources` (array) but not `r.source_id` (scalar), while batch equivalents set both. Calibration job checks `r.source_id` — edges from these functions were invisible.

## Test plan
- [ ] Verify `MATCH ()-[r]->() WHERE r.source_id IS NOT NULL RETURN count(r)` increases after sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes only add an extra relationship property (`r.source_id`) to existing `MERGE`d edges, affecting provenance/queryability but not match logic or node keys.
> 
> **Overview**
> Fixes provenance consistency for several single-relationship Cypher upserts by setting scalar `r.source_id` alongside the existing `r.sources` array.
> 
> This updates the one-off relationship creators (e.g., actor→technique `USES`, malware→actor `ATTRIBUTED_TO`, indicator `INDICATES`, and `TARGETS` sector links) so downstream jobs that filter on `r.source_id` can see edges created outside the batch `UNWIND` path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fd759ba5cc55f12930092c203e0aa6c397cdb927. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->