### PR TITLE
fix: tactic/tool parsing, CVE label consistency, dedupe key alignment

### DIFF
--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -345,10 +345,12 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
         elif item.get("value"):
             # Indicators keep tag in key (Indicator MERGE key includes tag)
             key = f"{item.get('indicator_type', 'unknown')}:{item['value']}:{tag}"
-        elif item.get("name"):
-            key = f"{item['type']}:{item['name']}"  # no tag — entity merges on name only
         elif item.get("mitre_id"):
-            key = f"{item.get('type', 'technique')}:{item['mitre_id']}"  # no tag — merges on mitre_id only
+            # Techniques, tactics, tools merge on mitre_id — check BEFORE name
+            key = f"{item.get('type', 'technique')}:{item['mitre_id']}"
+        elif item.get("name"):
+            # Actors, malware merge on name only
+            key = f"{item['type']}:{item['name']}"
         else:
             logger.debug("Dedup: dropping item with no identifiable key (type=%s, tag=%s)", item.get("type"), tag)
             _dropped += 1

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1889,7 +1889,7 @@ class MISPToNeo4jSync:
             # Parse NVD_META JSON from comment (written by MISPWriter for NVD-sourced CVEs).
             # This restores the full CVSS/CWE/ref_tags payload so merge_cve() can create
             # CVSSv4/v3.1/v3.0/v2 sub-nodes without calling NVD again.
-            raw_comment = attr.get("comment", "")
+            raw_comment = attr.get("comment", "") or ""
             nvd_meta: dict = {}
             if raw_comment.startswith("NVD_META:"):
                 try:
@@ -2133,7 +2133,7 @@ class MISPToNeo4jSync:
             # Format: "MITRE_USES_TECHNIQUES:{"t":["T1059","T1071"]}\nDescription..."
             uses_techniques = []
             description = ""
-            raw_comment = attr.get("comment", "")
+            raw_comment = attr.get("comment", "") or ""
             if "MITRE_USES_TECHNIQUES:" in raw_comment:
                 try:
                     uses_json = raw_comment.split("MITRE_USES_TECHNIQUES:", 1)[1].strip()
@@ -2228,7 +2228,7 @@ class MISPToNeo4jSync:
 
             # Parse OTX_META or TF_META JSON from comment (written by MISPWriter).
             # Mirrors the NVD_META pattern for vulnerability attributes.
-            raw_comment = attr.get("comment", "")
+            raw_comment = attr.get("comment", "") or ""
             otx_meta: dict = {}
             tf_meta: dict = {}
             if raw_comment.startswith("OTX_META:"):

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2061,64 +2061,64 @@ class MISPToNeo4jSync:
             return item, relationships
 
         # Handle MITRE technique (text format "T1234: Name") — exclude "TA" (tactics, handled below)
-        elif attr_type == "text" and value.startswith("T") and not value.startswith("TA"):
+        elif attr_type == "text" and len(value) >= 5 and value[0] == "T" and value[1:5].isdigit():
+            # MITRE technique format: T followed by 4 digits (T1059, T1059.001)
             parts = value.split(": ", 1)
             mitre_id = parts[0]
             name = parts[1] if len(parts) > 1 else ""
 
-            if mitre_id.startswith("T") and len(mitre_id) >= 5:
-                platforms = []
-                for tag in tags:
-                    tag_name = tag.get("name", "")
-                    if tag_name.startswith("platform:"):
-                        platforms.append(tag_name.replace("platform:", ""))
+            platforms = []
+            for tag in tags:
+                tag_name = tag.get("name", "")
+                if tag_name.startswith("platform:"):
+                    platforms.append(tag_name.replace("platform:", ""))
 
-                item = {
-                    "type": "technique",
-                    "mitre_id": mitre_id,
-                    "name": name,
-                    "description": attr.get("comment", ""),
-                    "zone": zones,  # zone is now an array
-                    "tag": source_id,
-                    "source": [source_id],
-                    "platforms": platforms,
-                    "first_seen": _coerce_to_iso(event_info.get("date")),
-                    "last_updated": _coerce_to_iso(attr.get("timestamp")),
-                    "confidence_score": 0.8,  # MITRE is authoritative
-                    "misp_event_id": str(event_info.get("id", "")),
-                    "relationships": relationships,
-                }
-                return item, relationships
+            item = {
+                "type": "technique",
+                "mitre_id": mitre_id,
+                "name": name,
+                "description": attr.get("comment", ""),
+                "zone": zones,
+                "tag": source_id,
+                "source": [source_id],
+                "platforms": platforms,
+                "first_seen": _coerce_to_iso(event_info.get("date")),
+                "last_updated": _coerce_to_iso(attr.get("timestamp")),
+                "confidence_score": 0.8,
+                "misp_event_id": str(event_info.get("id", "")),
+                "relationships": relationships,
+            }
+            return item, relationships
 
         # Handle MITRE tactic (text format "TA0001: Name")
-        elif attr_type == "text" and value.startswith("TA"):
+        elif attr_type == "text" and len(value) >= 5 and value.startswith("TA") and value[2:5].isdigit():
+            # MITRE tactic format: "TA0001: Initial Access" (TA + 4 digits + ": Name")
             parts = value.split(": ", 1)
             mitre_id = parts[0]
             name = parts[1] if len(parts) > 1 else ""
 
-            if mitre_id.startswith("TA") and len(mitre_id) >= 5:
-                shortname = ""
-                for tag in tags:
-                    tag_name = tag.get("name", "")
-                    if tag_name.startswith("mitre-tactic:"):
-                        shortname = tag_name.replace("mitre-tactic:", "")
-                        break
+            shortname = ""
+            for tag in tags:
+                tag_name = tag.get("name", "")
+                if tag_name.startswith("mitre-tactic:"):
+                    shortname = tag_name.replace("mitre-tactic:", "")
+                    break
 
-                item = {
-                    "type": "tactic",
-                    "mitre_id": mitre_id,
-                    "name": name,
-                    "shortname": shortname,
-                    "description": attr.get("comment", ""),
-                    "zone": zones,
-                    "tag": source_id,
-                    "source": [source_id],
-                    "first_seen": _coerce_to_iso(event_info.get("date")),
-                    "last_updated": _coerce_to_iso(attr.get("timestamp")),
-                    "confidence_score": 0.95,  # MITRE ATT&CK range
-                    "misp_event_id": str(event_info.get("id", "")),
-                }
-                return item, []
+            item = {
+                "type": "tactic",
+                "mitre_id": mitre_id,
+                "name": name,
+                "shortname": shortname,
+                "description": attr.get("comment", ""),
+                "zone": zones,
+                "tag": source_id,
+                "source": [source_id],
+                "first_seen": _coerce_to_iso(event_info.get("date")),
+                "last_updated": _coerce_to_iso(attr.get("timestamp")),
+                "confidence_score": 0.95,  # MITRE ATT&CK range
+                "misp_event_id": str(event_info.get("id", "")),
+            }
+            return item, []
 
         # Handle MITRE tool (text format "S0001: Name")
         elif attr_type == "text" and len(value) >= 5 and value[0] == "S" and value[1:5].isdigit():

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -348,7 +348,7 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
         elif item.get("name"):
             key = f"{item['type']}:{item['name']}"  # no tag — entity merges on name only
         elif item.get("mitre_id"):
-            key = f"technique:{item['mitre_id']}"  # no tag — technique merges on mitre_id only
+            key = f"{item.get('type', 'technique')}:{item['mitre_id']}"  # no tag — merges on mitre_id only
         else:
             logger.debug("Dedup: dropping item with no identifiable key (type=%s, tag=%s)", item.get("type"), tag)
             _dropped += 1

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2091,7 +2091,7 @@ class MISPToNeo4jSync:
             return item, relationships
 
         # Handle MITRE tactic (text format "TA0001: Name")
-        elif attr_type == "text" and len(value) >= 5 and value.startswith("TA") and value[2:5].isdigit():
+        elif attr_type == "text" and len(value) >= 6 and value.startswith("TA") and value[2:6].isdigit():
             # MITRE tactic format: "TA0001: Initial Access" (TA + 4 digits + ": Name")
             parts = value.split(": ", 1)
             mitre_id = parts[0]

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -337,17 +337,18 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
         if _item_is_vulnerability_sync_bucket(item):
             cid = resolve_vulnerability_cve_id(item)
             if cid:
-                key = f"cve:{cid}:{tag}"
+                key = f"cve:{cid}"  # no tag — CVE merges on cve_id only
             else:
                 logger.debug("Dedup: dropping vulnerability with unresolvable CVE ID (tag=%s)", tag)
                 _dropped += 1
                 continue
         elif item.get("value"):
+            # Indicators keep tag in key (Indicator MERGE key includes tag)
             key = f"{item.get('indicator_type', 'unknown')}:{item['value']}:{tag}"
         elif item.get("name"):
-            key = f"{item['type']}:{item['name']}:{tag}"
+            key = f"{item['type']}:{item['name']}"  # no tag — entity merges on name only
         elif item.get("mitre_id"):
-            key = f"technique:{item['mitre_id']}:{tag}"
+            key = f"technique:{item['mitre_id']}"  # no tag — technique merges on mitre_id only
         else:
             logger.debug("Dedup: dropping item with no identifiable key (type=%s, tag=%s)", item.get("type"), tag)
             _dropped += 1
@@ -2089,6 +2090,76 @@ class MISPToNeo4jSync:
                 }
                 return item, relationships
 
+        # Handle MITRE tactic (text format "TA0001: Name")
+        elif attr_type == "text" and value.startswith("TA"):
+            parts = value.split(": ", 1)
+            mitre_id = parts[0]
+            name = parts[1] if len(parts) > 1 else ""
+
+            if mitre_id.startswith("TA") and len(mitre_id) >= 5:
+                shortname = ""
+                for tag in tags:
+                    tag_name = tag.get("name", "")
+                    if tag_name.startswith("mitre-tactic:"):
+                        shortname = tag_name.replace("mitre-tactic:", "")
+                        break
+
+                item = {
+                    "type": "tactic",
+                    "mitre_id": mitre_id,
+                    "name": name,
+                    "shortname": shortname,
+                    "description": attr.get("comment", ""),
+                    "zone": zones,
+                    "tag": source_id,
+                    "source": [source_id],
+                    "first_seen": _coerce_to_iso(event_info.get("date")),
+                    "last_updated": _coerce_to_iso(attr.get("timestamp")),
+                    "confidence_score": 1.0,
+                    "misp_event_id": str(event_info.get("id", "")),
+                }
+                return item, []
+
+        # Handle MITRE tool (text format "S0001: Name")
+        elif attr_type == "text" and value.startswith("S"):
+            parts = value.split(": ", 1)
+            mitre_id = parts[0]
+            name = parts[1] if len(parts) > 1 else ""
+
+            if mitre_id.startswith("S") and len(mitre_id) >= 5:
+                # Extract uses_techniques from MITRE_USES_TECHNIQUES comment
+                uses_techniques = []
+                raw_comment = attr.get("comment", "")
+                if "MITRE_USES_TECHNIQUES:" in raw_comment:
+                    try:
+                        uses_json = raw_comment.split("MITRE_USES_TECHNIQUES:", 1)[1].strip()
+                        uses_techniques = json.loads(uses_json)
+                    except (ValueError, IndexError):
+                        pass
+
+                tool_types = []
+                for tag in tags:
+                    tag_name = tag.get("name", "")
+                    if tag_name.startswith("tool-type:"):
+                        tool_types.append(tag_name.replace("tool-type:", ""))
+
+                item = {
+                    "type": "tool",
+                    "mitre_id": mitre_id,
+                    "name": name,
+                    "description": attr.get("comment", ""),
+                    "zone": zones,
+                    "tag": source_id,
+                    "source": [source_id],
+                    "tool_types": tool_types,
+                    "uses_techniques": uses_techniques,
+                    "first_seen": _coerce_to_iso(event_info.get("date")),
+                    "last_updated": _coerce_to_iso(attr.get("timestamp")),
+                    "confidence_score": 0.9,
+                    "misp_event_id": str(event_info.get("id", "")),
+                }
+                return item, []
+
         # Handle indicators (IP, domain, hash, etc.)
         else:
             indicator_type = self.TYPE_MAPPING.get(attr_type, "unknown")
@@ -2290,26 +2361,22 @@ class MISPToNeo4jSync:
                         errors += 1
 
             if plain_vulns:
-                by_source: dict = {}
+                # Plain CVEs (no CVSS sub-nodes) also use merge_cve() to ensure :CVE label
+                # consistency. Previously used merge_vulnerabilities_batch() which created
+                # :Vulnerability nodes — wrong label for CVEs.
+                logger.info(f"  Processing {len(plain_vulns)} plain CVEs (no CVSS sub-nodes)...")
                 for vuln in plain_vulns:
                     src = vuln.get("tag", "misp")
-                    if src not in by_source:
-                        by_source[src] = []
-                    by_source[src].append(vuln)
-
-                for source_id, source_vulns in by_source.items():
                     try:
-                        batch_success, batch_errors = self.neo4j.merge_vulnerabilities_batch(
-                            source_vulns, source_id=source_id
-                        )
-                        success += batch_success
-                        errors += batch_errors
-                        self.stats["vulnerabilities_synced"] += batch_success
-                        logger.info(f"  ✓ {source_id}: {batch_success} vulnerabilities")
+                        if self.neo4j.merge_cve(vuln, source_id=src):
+                            self.stats["vulnerabilities_synced"] += 1
+                            success += 1
+                        else:
+                            errors += 1
                     except Exception as e:
-                        logger.error(f"Batch vulnerability sync error for {source_id}: {e}")
-                        self.neo4j_circuit.record_failure()
-                        errors += len(source_vulns)
+                        cve_id = vuln.get("cve_id", "?")[:20]
+                        logger.warning(f"[WARN] Error syncing plain CVE ({cve_id}): {type(e).__name__}: {e}")
+                        errors += 1
 
         if tactics:
             logger.info(f"Processing {len(tactics)} tactics...")

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2060,8 +2060,8 @@ class MISPToNeo4jSync:
             }
             return item, relationships
 
-        # Handle MITRE technique (text format "T1234: Name")
-        elif attr_type == "text" and value.startswith("T"):
+        # Handle MITRE technique (text format "T1234: Name") — exclude "TA" (tactics, handled below)
+        elif attr_type == "text" and value.startswith("T") and not value.startswith("TA"):
             parts = value.split(": ", 1)
             mitre_id = parts[0]
             name = parts[1] if len(parts) > 1 else ""
@@ -2115,7 +2115,7 @@ class MISPToNeo4jSync:
                     "source": [source_id],
                     "first_seen": _coerce_to_iso(event_info.get("date")),
                     "last_updated": _coerce_to_iso(attr.get("timestamp")),
-                    "confidence_score": 1.0,
+                    "confidence_score": 0.95,  # MITRE ATT&CK range
                     "misp_event_id": str(event_info.get("id", "")),
                 }
                 return item, []
@@ -2128,12 +2128,21 @@ class MISPToNeo4jSync:
 
             if mitre_id.startswith("S") and len(mitre_id) >= 5:
                 # Extract uses_techniques from MITRE_USES_TECHNIQUES comment
+                # Format: "MITRE_USES_TECHNIQUES:{"t":["T1059","T1071"]}\nDescription..."
                 uses_techniques = []
                 raw_comment = attr.get("comment", "")
                 if "MITRE_USES_TECHNIQUES:" in raw_comment:
                     try:
                         uses_json = raw_comment.split("MITRE_USES_TECHNIQUES:", 1)[1].strip()
-                        uses_techniques = json.loads(uses_json)
+                        # Strip trailing description after newline before JSON parse
+                        if "\n" in uses_json:
+                            uses_json = uses_json.split("\n", 1)[0].strip()
+                        parsed = json.loads(uses_json)
+                        # Extract "t" key from metadata dict (same pattern as malware handler)
+                        if isinstance(parsed, dict):
+                            uses_techniques = parsed.get("t", [])
+                        elif isinstance(parsed, list):
+                            uses_techniques = parsed
                     except (ValueError, IndexError):
                         pass
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2121,53 +2121,56 @@ class MISPToNeo4jSync:
                 return item, []
 
         # Handle MITRE tool (text format "S0001: Name")
-        elif attr_type == "text" and value.startswith("S"):
+        elif attr_type == "text" and value.startswith("S") and len(value.split(": ", 1)[0]) >= 5:
             parts = value.split(": ", 1)
             mitre_id = parts[0]
             name = parts[1] if len(parts) > 1 else ""
 
-            if mitre_id.startswith("S") and len(mitre_id) >= 5:
-                # Extract uses_techniques from MITRE_USES_TECHNIQUES comment
-                # Format: "MITRE_USES_TECHNIQUES:{"t":["T1059","T1071"]}\nDescription..."
-                uses_techniques = []
-                raw_comment = attr.get("comment", "")
-                if "MITRE_USES_TECHNIQUES:" in raw_comment:
-                    try:
-                        uses_json = raw_comment.split("MITRE_USES_TECHNIQUES:", 1)[1].strip()
-                        # Strip trailing description after newline before JSON parse
-                        if "\n" in uses_json:
-                            uses_json = uses_json.split("\n", 1)[0].strip()
-                        parsed = json.loads(uses_json)
-                        # Extract "t" key from metadata dict (same pattern as malware handler)
-                        if isinstance(parsed, dict):
-                            uses_techniques = parsed.get("t", [])
-                        elif isinstance(parsed, list):
-                            uses_techniques = parsed
-                    except (ValueError, IndexError):
-                        pass
+            # Extract uses_techniques from MITRE_USES_TECHNIQUES comment
+            # Format: "MITRE_USES_TECHNIQUES:{"t":["T1059","T1071"]}\nDescription..."
+            uses_techniques = []
+            description = ""
+            raw_comment = attr.get("comment", "")
+            if "MITRE_USES_TECHNIQUES:" in raw_comment:
+                try:
+                    uses_json = raw_comment.split("MITRE_USES_TECHNIQUES:", 1)[1].strip()
+                    if "\n" in uses_json:
+                        json_part, description = uses_json.split("\n", 1)
+                        description = description.strip()
+                    else:
+                        json_part = uses_json
+                    parsed = json.loads(json_part)
+                    if isinstance(parsed, dict):
+                        uses_techniques = parsed.get("t", [])
+                    elif isinstance(parsed, list):
+                        uses_techniques = parsed
+                except (ValueError, IndexError):
+                    description = raw_comment
+            else:
+                description = raw_comment
 
-                tool_types = []
-                for tag in tags:
-                    tag_name = tag.get("name", "")
-                    if tag_name.startswith("tool-type:"):
-                        tool_types.append(tag_name.replace("tool-type:", ""))
+            tool_types = []
+            for tag in tags:
+                tag_name = tag.get("name", "")
+                if tag_name.startswith("tool-type:"):
+                    tool_types.append(tag_name.replace("tool-type:", ""))
 
-                item = {
-                    "type": "tool",
-                    "mitre_id": mitre_id,
-                    "name": name,
-                    "description": attr.get("comment", ""),
-                    "zone": zones,
-                    "tag": source_id,
-                    "source": [source_id],
-                    "tool_types": tool_types,
-                    "uses_techniques": uses_techniques,
-                    "first_seen": _coerce_to_iso(event_info.get("date")),
-                    "last_updated": _coerce_to_iso(attr.get("timestamp")),
-                    "confidence_score": 0.9,
-                    "misp_event_id": str(event_info.get("id", "")),
-                }
-                return item, []
+            item = {
+                "type": "tool",
+                "mitre_id": mitre_id,
+                "name": name,
+                "description": description,
+                "zone": zones,
+                "tag": source_id,
+                "source": [source_id],
+                "tool_types": tool_types,
+                "uses_techniques": uses_techniques,
+                "first_seen": _coerce_to_iso(event_info.get("date")),
+                "last_updated": _coerce_to_iso(attr.get("timestamp")),
+                "confidence_score": 0.9,
+                "misp_event_id": str(event_info.get("id", "")),
+            }
+            return item, []
 
         # Handle indicators (IP, domain, hash, etc.)
         else:
@@ -2299,14 +2302,14 @@ class MISPToNeo4jSync:
                 vulnerabilities.append(item)
             elif item_type == "tactic":
                 tactics.append(item)
+            elif item_type == "tool":
+                tools.append(item)
             elif item_type == "technique" or item.get("mitre_id"):
                 techniques.append(item)
             elif item_type == "malware":
                 malware_items.append(item)
             elif item_type == "actor":
                 actors.append(item)
-            elif item_type == "tool":
-                tools.append(item)
             elif item.get("indicator_type") and item.get("value"):
                 indicators.append(item)
             else:

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2121,7 +2121,8 @@ class MISPToNeo4jSync:
                 return item, []
 
         # Handle MITRE tool (text format "S0001: Name")
-        elif attr_type == "text" and value.startswith("S") and len(value.split(": ", 1)[0]) >= 5:
+        elif attr_type == "text" and len(value) >= 5 and value[0] == "S" and value[1:5].isdigit():
+            # MITRE tool format: "S0154: Cobalt Strike" (S + 4 digits + ": Name")
             parts = value.split(": ", 1)
             mitre_id = parts[0]
             name = parts[1] if len(parts) > 1 else ""


### PR DESCRIPTION
## Summary
4 production bugs found during baseline run (430K nodes).

- **Tactic nodes missing**: `parse_attribute()` had no branch for "TA####" text attributes — fell through to indicator. Added tactic parsing.
- **Tool nodes missing**: Same — no branch for "S####" text attributes. Added tool parsing with uses_techniques extraction.
- **CVE label split**: Plain CVEs created as `:Vulnerability`, rich CVEs as `:CVE`. Now ALL CVEs use `merge_cve()` for consistent `:CVE` label.
- **Dedupe key mismatch**: Entity dedupe keys included `tag` but MERGE keys don't. Removed tag from entity dedupe keys (kept for indicators).

Bug #8 (0 relationships) is a cascade from Bug #6 — with no Technique nodes, USES relationships had no targets. This fix unblocks relationship creation.

## Test plan
- [ ] Run 30-day baseline sync
- [ ] Verify: `MATCH (t:Technique) RETURN count(t)` > 0 (was 0)
- [ ] Verify: `MATCH (t:Tactic) RETURN count(t)` = 14
- [ ] Verify: `MATCH (t:Tool) RETURN count(t)` > 0
- [ ] Verify: `MATCH (c:CVE) RETURN count(c)` includes all CVEs (no :Vulnerability nodes for CVEs)
- [ ] Verify: `MATCH ()-[r:USES]->() RETURN count(r)` > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how entities are deduplicated and merged into Neo4j (CVE labeling and MITRE entity keys), which can alter node identity and graph shape on resync. Parsing logic for `text` attributes is expanded (tactic/tool) and tightened (technique), with low algorithmic risk but meaningful data-impact risk.
> 
> **Overview**
> Fixes several ingestion gaps in `run_misp_to_neo4j.py` that were preventing consistent graph construction from MISP.
> 
> Entity deduplication keys are realigned to match Neo4j MERGE semantics: **CVEs no longer include `tag`**, MITRE entities (technique/tactic/tool) dedupe on `mitre_id`, and actor/malware dedupe on `name` (indicators still include `tag`).
> 
> `parse_attribute()` now correctly parses **MITRE tactics (`TA####`) and tools (`S####`)** from `text` attributes (including extracting `uses_techniques` and `tool_types`), and tightens technique detection to avoid misclassifying tactics as techniques. Plain CVEs are now merged via `merge_cve()` (not `merge_vulnerabilities_batch`) to keep a consistent `:CVE` label, and comment parsing is hardened against `None` values.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 50c4a3cce14fe80f926172a28d81b242cd1d222c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->