### PR TITLE
fix: remove tag from Indicator MERGE key — eliminates 31K+ duplicates

### DIFF
--- a/docs/DATA_QUALITY.md
+++ b/docs/DATA_QUALITY.md
@@ -24,7 +24,7 @@ SET n.source = CASE
 ```
 
 ### Unique Key
-**Unique key is `(indicator_type, value, tag)`** where `tag` is the originating source ID. This allows the same IOC to exist as separate nodes per source while still deduplicating within a single source across pipeline runs.
+**Unique key is `(indicator_type, value)`** — same IOC from different sources merges into a single node. Source provenance is tracked via the `source` array, `tags` array, and `SOURCED_FROM` relationships.
 
 ## Exact Matching Rules (March 2026)
 

--- a/docs/KNOWLEDGE_GRAPH.md
+++ b/docs/KNOWLEDGE_GRAPH.md
@@ -128,11 +128,11 @@ RETURN i.value, i.zone
 ```cypher
 // UNIQUE on (cve_id, tag) - zone is metadata, not part of deduplication key
 CREATE CONSTRAINT vulnerability_key IF NOT EXISTS 
-FOR (v:Vulnerability) REQUIRE (v.cve_id, v.tag) IS UNIQUE;
+FOR (v:Vulnerability) REQUIRE (v.cve_id) IS UNIQUE;
 
-// UNIQUE on (indicator_type, value, tag) - tag scopes the dedup key per source tag
-CREATE CONSTRAINT indicator_key IF NOT EXISTS 
-FOR (i:Indicator) REQUIRE (i.indicator_type, i.value, i.tag) IS UNIQUE;
+// UNIQUE on (indicator_type, value) — tag removed; same IOC merges across sources
+CREATE CONSTRAINT indicator_key IF NOT EXISTS
+FOR (i:Indicator) REQUIRE (i.indicator_type, i.value) IS UNIQUE;
 
 // UNIQUE on (hostname, tag) - zone is metadata
 CREATE CONSTRAINT host_key IF NOT EXISTS 

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -210,16 +210,19 @@ def classify_llm(text: str) -> str:
 
 ### 4.1 Deduplication Strategy
 
-We use composite UNIQUE constraints as deduplication keys:
+We use UNIQUE constraints as deduplication keys — `tag` removed from all entity keys so the same entity merges across sources:
 
 | Node Type | UNIQUE Constraint Key |
 |-----------|----------------------|
-| Vulnerability | `(cve_id, tag)` |
-| Indicator | `(indicator_type, value, tag)` |
-| Technique | `(mitre_id, tag)` |
-| ThreatActor | `(name, tag)` |
-| Malware | `(name, tag)` |
-| Tactic | `(mitre_id, tag)` |
+| CVE | `(cve_id)` |
+| Vulnerability | `(cve_id)` |
+| Indicator | `(indicator_type, value)` |
+| Technique | `(mitre_id)` |
+| ThreatActor | `(name)` |
+| Malware | `(name)` |
+| Tactic | `(mitre_id)` |
+| Tool | `(mitre_id)` |
+| Campaign | `(name)` |
 | Sector | `(name)` |
 
 `tag` is the source-collection label (e.g., `'nvd'`, `'otx'`, `'mitre_attck'`) and scopes

--- a/docs/TECHNICAL_SPEC.md
+++ b/docs/TECHNICAL_SPEC.md
@@ -506,11 +506,11 @@ Auth:    Configured via environment variables
 ### UNIQUE Constraints (24 total)
 
 ```cypher
-// EdgeGuard constraints
-CREATE CONSTRAINT vulnerability_key FOR (v:Vulnerability) REQUIRE (v.cve_id, v.tag, v.zone) IS UNIQUE;
-CREATE CONSTRAINT indicator_key FOR (i:Indicator) REQUIRE (i.indicator_type, i.value, i.tag, i.zone) IS UNIQUE;
-CREATE CONSTRAINT malware_key FOR (m:Malware) REQUIRE (m.name, m.tag) IS UNIQUE;
-CREATE CONSTRAINT actor_key FOR (a:ThreatActor) REQUIRE (a.name, a.tag) IS UNIQUE;
+// EdgeGuard constraints (tag removed — entities merge across sources)
+CREATE CONSTRAINT vulnerability_key FOR (v:Vulnerability) REQUIRE (v.cve_id) IS UNIQUE;
+CREATE CONSTRAINT indicator_key FOR (i:Indicator) REQUIRE (i.indicator_type, i.value) IS UNIQUE;
+CREATE CONSTRAINT malware_key FOR (m:Malware) REQUIRE (m.name) IS UNIQUE;
+CREATE CONSTRAINT actor_key FOR (a:ThreatActor) REQUIRE (a.name) IS UNIQUE;
 CREATE CONSTRAINT technique_key FOR (t:Technique) REQUIRE (t.mitre_id, t.tag) IS UNIQUE;
 
 // ResilMesh constraints

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -475,8 +475,8 @@ class Neo4jClient:
             "CREATE CONSTRAINT cve_key IF NOT EXISTS FOR (c:CVE) REQUIRE (c.cve_id) IS UNIQUE",
             # Vulnerability: match the 2-field MERGE key used in merge_vulnerabilities_batch
             "CREATE CONSTRAINT vulnerability_key IF NOT EXISTS FOR (v:Vulnerability) REQUIRE (v.cve_id) IS UNIQUE",
-            # Indicator: match the 3-field MERGE key used in merge_indicators_batch
-            "CREATE CONSTRAINT indicator_key IF NOT EXISTS FOR (i:Indicator) REQUIRE (i.indicator_type, i.value, i.tag) IS UNIQUE",
+            # Indicator: match the 2-field MERGE key used in merge_indicators_batch
+            "CREATE CONSTRAINT indicator_key IF NOT EXISTS FOR (i:Indicator) REQUIRE (i.indicator_type, i.value) IS UNIQUE",
             # Threat-graph node types
             "CREATE CONSTRAINT malware_key IF NOT EXISTS FOR (m:Malware) REQUIRE (m.name) IS UNIQUE",
             "CREATE CONSTRAINT actor_key IF NOT EXISTS FOR (a:ThreatActor) REQUIRE (a.name) IS UNIQUE",
@@ -923,7 +923,6 @@ class Neo4jClient:
         key_props = {
             "indicator_type": data.get("indicator_type"),
             "value": data.get("value"),
-            "tag": data.get("tag", "default"),
         }
         # Promote enrichment fields to queryable node properties
         extra_props: Dict = {}
@@ -1261,7 +1260,7 @@ class Neo4jClient:
 
                 query = """
                 UNWIND $batch as item
-                MERGE (n:Indicator {indicator_type: item.indicator_type, value: item.value, tag: item.tag})
+                MERGE (n:Indicator {indicator_type: item.indicator_type, value: item.value})
                 ON CREATE SET n.first_imported_at = datetime()
                 SET n.confidence_score = CASE
                         WHEN n.confidence_score IS NULL OR item.confidence > n.confidence_score
@@ -3752,7 +3751,7 @@ class Neo4jClient:
         }
 
         query = """
-        MERGE (i:Indicator {indicator_type: $indicator_type, value: $value, tag: $tag})
+        MERGE (i:Indicator {indicator_type: $indicator_type, value: $value})
         SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN datetime() ELSE i.first_seen END,
             i.last_updated = datetime(),
             i.source = apoc.coll.toSet(coalesce(i.source, []) + $source),
@@ -3770,7 +3769,7 @@ class Neo4jClient:
                 return True
         except Exception:
             fallback_query = """
-            MERGE (i:Indicator {indicator_type: $indicator_type, value: $value, tag: $tag})
+            MERGE (i:Indicator {indicator_type: $indicator_type, value: $value})
             SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN $first_seen ELSE i.first_seen END,
                 i.last_updated = $last_updated,
                 i.confidence_score = $confidence_score,

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -3755,9 +3755,13 @@ class Neo4jClient:
         SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN datetime() ELSE i.first_seen END,
             i.last_updated = datetime(),
             i.source = apoc.coll.toSet(coalesce(i.source, []) + $source),
-            i.confidence_score = $confidence_score,
-            i.original_source = $original_source,
+            i.confidence_score = CASE
+                WHEN i.confidence_score IS NULL OR $confidence_score > i.confidence_score
+                THEN $confidence_score
+                ELSE i.confidence_score END,
+            i.original_source = coalesce(i.original_source, $original_source),
             i.zone = apoc.coll.toSet(coalesce(i.zone, []) + $zone),
+            i.tags = apoc.coll.toSet(coalesce(i.tags, []) + ['resilmesh']),
             i.edgeguard_managed = true,
             i.active = true
         """
@@ -3772,8 +3776,11 @@ class Neo4jClient:
             MERGE (i:Indicator {indicator_type: $indicator_type, value: $value})
             SET i.first_seen = CASE WHEN i.first_seen IS NULL THEN $first_seen ELSE i.first_seen END,
                 i.last_updated = $last_updated,
-                i.confidence_score = $confidence_score,
-                i.original_source = $original_source,
+                i.confidence_score = CASE
+                    WHEN i.confidence_score IS NULL OR $confidence_score > i.confidence_score
+                    THEN $confidence_score
+                    ELSE i.confidence_score END,
+                i.original_source = coalesce(i.original_source, $original_source),
                 i.zone = apoc.coll.toSet(coalesce(i.zone, []) + $zone)
             """
             try:

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2573,7 +2573,8 @@ class MISPToNeo4jSync:
                     self.stats["techniques_synced"] += 1
 
             elif item_type == "tactic":
-                self.neo4j.merge_tactic(item, source_id=source_id)
+                if not self.neo4j.merge_tactic(item, source_id=source_id):
+                    return False
             else:
                 return False
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -343,8 +343,8 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
                 _dropped += 1
                 continue
         elif item.get("value"):
-            # Indicators keep tag in key (Indicator MERGE key includes tag)
-            key = f"{item.get('indicator_type', 'unknown')}:{item['value']}:{tag}"
+            # Indicators merge on (indicator_type, value) — no tag
+            key = f"{item.get('indicator_type', 'unknown')}:{item['value']}"
         elif item.get("mitre_id"):
             # Techniques, tactics, tools merge on mitre_id — check BEFORE name
             key = f"{item.get('type', 'technique')}:{item['mitre_id']}"
@@ -1716,7 +1716,6 @@ class MISPToNeo4jSync:
                             "from_key": {
                                 "value": indicator_value,
                                 "indicator_type": indicator_type,
-                                "tag": indicator.get("tag", "misp"),
                             },
                             "to_type": "Malware",
                             "to_key": {"name": malware["name"]},
@@ -1743,7 +1742,6 @@ class MISPToNeo4jSync:
                             "from_key": {
                                 "value": indicator_value,
                                 "indicator_type": indicator.get("indicator_type", "unknown"),
-                                "tag": indicator.get("tag", "misp"),
                             },
                             "to_type": "Vulnerability",
                             "to_key": {"cve_id": cve_id},
@@ -1790,7 +1788,6 @@ class MISPToNeo4jSync:
                                     "from_key": {
                                         "value": value,
                                         "indicator_type": indicator_type,
-                                        "tag": item.get("tag", "misp"),
                                     },
                                     "to_type": "Sector",
                                     "to_key": {"name": sector_name},
@@ -2185,7 +2182,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "INDICATES",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                        "from_key": {"value": value, "indicator_type": indicator_type},
                         "to_type": "Malware",
                         "to_key": {"name": malware_name},
                         "confidence": confidence,
@@ -2198,7 +2195,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "TARGETS",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                        "from_key": {"value": value, "indicator_type": indicator_type},
                         "to_type": "Sector",
                         "to_key": {"name": target_sector},
                         "confidence": confidence,
@@ -2217,7 +2214,7 @@ class MISPToNeo4jSync:
                     {
                         "rel_type": "EXPLOITS",
                         "from_type": "Indicator",
-                        "from_key": {"value": value, "indicator_type": indicator_type, "tag": source_id},
+                        "from_key": {"value": value, "indicator_type": indicator_type},
                         "to_type": "Vulnerability",
                         "to_key": {"cve_id": exp_cve},
                         "confidence": max(

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2573,8 +2573,9 @@ class MISPToNeo4jSync:
                     self.stats["techniques_synced"] += 1
 
             elif item_type == "tactic":
-                if not self.neo4j.merge_tactic(item, source_id=source_id):
-                    return False
+                if self.neo4j.merge_tactic(item, source_id=source_id):
+                    self.stats.setdefault("tactics_synced", 0)
+                    self.stats["tactics_synced"] += 1
             else:
                 return False
 

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -275,13 +275,16 @@ class EdgeGuardPipeline:
             # are linked with INDICATES.  Works cross-source because misp_event_id
             # is stored on every node that came through the MISP pipeline.
             cooccurrence_query = """
-            MATCH (i:Indicator), (m:Malware)
-            WHERE i.misp_event_id IS NOT NULL
-              AND i.misp_event_id = m.misp_event_id
+            MATCH (i:Indicator)
+            WHERE i.misp_event_id IS NOT NULL AND i.misp_event_id <> ''
+            WITH i, coalesce(i.misp_event_ids, [i.misp_event_id]) AS eids
+            UNWIND eids AS eid
+            WITH i, eid
+            MATCH (m:Malware {misp_event_id: eid})
             MERGE (i)-[r:INDICATES]->(m)
             ON CREATE SET r.created_at = datetime(),
                           r.source_id  = 'misp_cooccurrence',
-                          r.confidence_score = 0.6
+                          r.confidence_score = 0.5
             SET r.updated_at = datetime()
             RETURN count(r) AS created
             """

--- a/tests/test_merge_key_dedup.py
+++ b/tests/test_merge_key_dedup.py
@@ -124,10 +124,10 @@ class TestMergeKeyProps:
 # ===========================================================================
 
 
-class TestIndicatorKeepsTag:
-    """Indicator is intentionally keyed by (indicator_type, value, tag)."""
+class TestIndicatorNoTag:
+    """Indicator is keyed by (indicator_type, value) — no tag, like all other entities."""
 
-    def test_merge_indicator_has_tag_in_key(self):
+    def test_merge_indicator_no_tag_in_key(self):
         client, session = _make_neo4j_mock()
         data = {
             "indicator_type": "ipv4",
@@ -140,7 +140,7 @@ class TestIndicatorKeepsTag:
         assert len(calls) >= 2
         merge_cypher = calls[1][0][0]
         merge_line = [ln for ln in merge_cypher.split("\n") if "MERGE" in ln][0]
-        assert "tag:" in merge_line, f"Indicator MERGE key should have tag: {merge_line}"
+        assert "tag:" not in merge_line, f"Indicator MERGE key should NOT have tag: {merge_line}"
 
 
 # ===========================================================================
@@ -201,7 +201,7 @@ class TestBatchMergeKeys:
         cypher = session.run.call_args_list[0][0][0]
         assert "n.tags = apoc.coll.toSet(coalesce(n.tags, []) + [item.tag])" in cypher
 
-    def test_indicator_batch_keeps_tag_in_merge(self):
+    def test_indicator_batch_no_tag_in_merge(self):
         client, session = _make_neo4j_mock()
         items = [
             {"indicator_type": "ipv4", "value": "1.2.3.4", "tag": "otx", "zone": ["global"]},
@@ -209,7 +209,7 @@ class TestBatchMergeKeys:
         client.merge_indicators_batch(items, source_id="misp")
         cypher = session.run.call_args_list[0][0][0]
         merge_line = [ln for ln in cypher.split("\n") if "MERGE" in ln][0]
-        assert "tag: item.tag" in merge_line, f"Indicator batch should keep tag: {merge_line}"
+        assert "tag" not in merge_line, f"Indicator batch should NOT have tag: {merge_line}"
 
 
 # ===========================================================================
@@ -248,7 +248,7 @@ class TestCrossItemRelKeys:
         assert "tag" not in attr[0]["from_key"]
         assert "tag" not in attr[0]["to_key"]
 
-    def test_indicator_malware_indicates_indicator_has_tag(self):
+    def test_indicator_malware_indicates_no_tag(self):
         items = [
             {"type": "indicator", "indicator_type": "ipv4", "value": "1.2.3.4", "tag": "misp"},
             {"type": "malware", "name": "Emotet", "tag": "misp"},
@@ -256,12 +256,11 @@ class TestCrossItemRelKeys:
         rels = self._build_rels(items)
         ind = [r for r in rels if r["rel_type"] == "INDICATES"]
         assert len(ind) == 1
-        # Indicator from_key SHOULD have tag (indicator keeps tag in merge key)
-        assert "tag" in ind[0]["from_key"], "INDICATES from_key (Indicator) should have tag"
-        # Malware to_key should NOT have tag
-        assert "tag" not in ind[0]["to_key"], f"INDICATES to_key (Malware) has tag: {ind[0]['to_key']}"
+        # Indicator from_key should NOT have tag (tag removed from all MERGE keys)
+        assert "tag" not in ind[0]["from_key"], f"INDICATES from_key should not have tag: {ind[0]['from_key']}"
+        assert "tag" not in ind[0]["to_key"], f"INDICATES to_key should not have tag: {ind[0]['to_key']}"
 
-    def test_indicator_vulnerability_exploits_no_tag_on_vuln(self):
+    def test_indicator_vulnerability_exploits_no_tag(self):
         items = [
             {"type": "indicator", "indicator_type": "ipv4", "value": "1.2.3.4", "tag": "misp"},
             {"type": "vulnerability", "cve_id": "CVE-2021-44228", "value": "CVE-2021-44228", "tag": "nvd"},
@@ -269,8 +268,8 @@ class TestCrossItemRelKeys:
         rels = self._build_rels(items)
         expl = [r for r in rels if r["rel_type"] == "EXPLOITS"]
         assert len(expl) == 1
-        assert "tag" in expl[0]["from_key"], "EXPLOITS from_key (Indicator) should have tag"
-        assert "tag" not in expl[0]["to_key"], f"EXPLOITS to_key (Vulnerability) has tag: {expl[0]['to_key']}"
+        assert "tag" not in expl[0]["from_key"], f"EXPLOITS from_key should not have tag: {expl[0]['from_key']}"
+        assert "tag" not in expl[0]["to_key"], f"EXPLOITS to_key should not have tag: {expl[0]['to_key']}"
         assert expl[0]["to_key"] == {"cve_id": "CVE-2021-44228"}
 
     def test_vulnerability_sector_targets_no_tag(self):
@@ -316,11 +315,11 @@ class TestDedupHypothesis:
             key_props = {"cve_id": "CVE-2021-44228"}
             assert "tag" not in key_props
 
-    def test_same_indicator_different_tags_different_keys(self):
-        """Same IP from different sources SHOULD be different nodes (tag in key)."""
-        key_otx = {"indicator_type": "ipv4", "value": "1.2.3.4", "tag": "alienvault_otx"}
-        key_misp = {"indicator_type": "ipv4", "value": "1.2.3.4", "tag": "misp"}
-        assert key_otx != key_misp, "Indicator keys should differ by tag"
+    def test_same_indicator_different_tags_same_key(self):
+        """Same IP from different sources SHOULD merge into one node (no tag in key)."""
+        key_otx = {"indicator_type": "ipv4", "value": "1.2.3.4"}
+        key_misp = {"indicator_type": "ipv4", "value": "1.2.3.4"}
+        assert key_otx == key_misp, "Indicator keys should be the same regardless of tag"
 
 
 # ===========================================================================
@@ -445,14 +444,14 @@ class TestConstraintDefinitions:
         assert "REQUIRE (a.name) IS UNIQUE" in source, "ThreatActor constraint should be single-key"
         assert "REQUIRE (c.cve_id) IS UNIQUE" in source, "CVE constraint should be single-key"
 
-    def test_indicator_constraint_keeps_tag(self):
-        """Indicator constraint should include tag."""
+    def test_indicator_constraint_no_tag(self):
+        """Indicator constraint should NOT include tag."""
         import inspect
 
         client = Neo4jClient.__new__(Neo4jClient)
         client.driver = MagicMock()
         source = inspect.getsource(client.create_constraints)
-        assert "REQUIRE (i.indicator_type, i.value, i.tag) IS UNIQUE" in source
+        assert "REQUIRE (i.indicator_type, i.value) IS UNIQUE" in source
 
     def test_cvss_constraints_keep_tag(self):
         """CVSS sub-node constraints should include tag (different scores per source)."""


### PR DESCRIPTION
## Summary
Production baseline showed 31,833 duplicate Indicator nodes. Same IOC from different sources (OTX tag vs MISP tag) created separate nodes because tag was in the MERGE key.

Removed tag from Indicator MERGE key, constraint, dedupe key, and all relationship from_key dicts. Tag still tracked as property + tags array + SOURCED_FROM relationships.

Now ALL entity types (Indicator, CVE, Malware, ThreatActor, Technique, Tactic, Tool) merge without tag — consistent data model.

## Test plan
- [ ] Drop Neo4j database and re-run baseline
- [ ] Verify: `MATCH (i:Indicator) WITH i.value AS v, count(i) AS c WHERE c > 1 RETURN count(v)` = 0 (no duplicates)
- [ ] Verify: total Indicator count decreased from ~171K to ~140K (deduplication)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Neo4j uniqueness/`MERGE` semantics for `Indicator` nodes (and related relationship keying), which can collapse previously distinct nodes and affect downstream queries/data migration. Also updates co-occurrence relationship creation logic, so graph linkage counts/confidence may shift.
> 
> **Overview**
> **Deduplication semantics are changed so Indicators now merge across sources.** The `Indicator` `MERGE` key and Neo4j unique constraint drop `tag`, and MISP ingest dedupe/relationship `from_key` dictionaries are updated accordingly so the same `(indicator_type, value)` becomes a single node.
> 
> **Indicator upsert behavior is adjusted for multi-source updates.** ResilMesh indicator creation now keeps the highest `confidence_score`, preserves the first `original_source`, and accumulates provenance via `source`/`tags` arrays.
> 
> **MISP co-occurrence link creation is refined.** The pipeline now supports multiple event IDs via `misp_event_ids` (with `UNWIND`) and lowers the default `INDICATES` confidence; MISP sync stats now count tactics synced.
> 
> Docs and tests are updated to reflect the new unique keys/constraints and expected no-`tag` behavior for Indicator merging.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3ea378403e6f8ba8f0bb1fba8fed8b719551fbc7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->