### PR TITLE
improve: memory recommendations table in README + doctor memory check

### DIFF
--- a/README.md
+++ b/README.md
@@ -666,9 +666,23 @@ Use this when **`200`** or **`500`** in docs/code look contradictory.
 | `EDGEGUARD_MAX_EVENT_ATTRIBUTES` | MISP→Neo4j sync: events exceeding this attribute count are **deferred** to the end of the sync run (smaller events process first). Prevents large events from OOM-killing the worker before critical data lands. Set to `0` to disable. | `50000` |
 | `EDGEGUARD_DEV_MODE` | Enable console trace output (dev only) | *(unset)* |
 
-**MISP→Neo4j memory:** Large first-time syncs need enough RAM for parsed items; **per-event** processing + Python-side node chunking + `merge_*_batch` UNWINDs keep peak usage bounded. If sync **dies during Neo4j writes** with exit **-9**, check **Docker cgroup** limits: Compose defaults **`AIRFLOW_MEMORY_LIMIT=4g`** for **`airflow`** — raise in **`.env`** or reduce **`EDGEGUARD_NEO4J_SYNC_CHUNK_SIZE`** / **`EDGEGUARD_REL_BATCH_SIZE`**. See [docs/SETUP_GUIDE.md](docs/SETUP_GUIDE.md), [docs/HEARTBEAT.md](docs/HEARTBEAT.md), [docs/AIRFLOW_DAGS.md](docs/AIRFLOW_DAGS.md). Do **not** set **`0`** / **`all`** for chunk size unless you understand the OOM tradeoff.
+### Recommended Memory Settings (730-day baseline)
 
-**MISP Apache tuning (large baselines):** MISP's default Apache `MaxRequestWorkers 150` can cause memory exhaustion when the pipeline pushes large events (e.g. ~95K NVD attributes). **Lower to 25** inside the MISP container (`/etc/apache2/mods-enabled/mpm_prefork.conf`). The pipeline also throttles writes automatically — see **`EDGEGUARD_MISP_BATCH_THROTTLE_SEC`** (default 5s between batches) and **`EDGEGUARD_MISP_EVENT_FETCH_THROTTLE_SEC`** (default 2s between event fetches). Full details in [docs/DOCKER_SETUP_GUIDE.md](docs/DOCKER_SETUP_GUIDE.md) § *MISP performance tuning*.
+A full 730-day baseline processes ~99K CVEs + ~115K indicators + CVSS sub-nodes. These settings are tested on a 32 GB Mac Mini and Ratio1 infrastructure:
+
+| Setting | Recommended | Where to set | Notes |
+|---------|-------------|-------------|-------|
+| **MISP PHP `memory_limit`** | `4096M` | MISP container PHP config | Large events (95K+ attributes) need 2–4 GB per request |
+| **MISP `MaxRequestWorkers`** | `25` | `/etc/apache2/mods-enabled/mpm_prefork.conf` | Default 150 causes OOM — each worker can use 1–2 GB on large events |
+| **MISP `MaxConnectionsPerChild`** | `500` | Same Apache config file | Recycles workers to free leaked memory |
+| **`AIRFLOW_MEMORY_LIMIT`** | `12g` | `.env` or `docker-compose.yml` | MISP→Neo4j sync needs 8–12 GB for 100K+ attribute events |
+| **`NEO4J_HEAP_MAX`** | `12g` | `.env` | Neo4j JVM heap — handles 245K+ nodes and relationship building |
+| **`NEO4J_PAGECACHE`** | `8g` | `.env` | Graph data caching for fast queries |
+| **`NEO4J_CONTAINER_MEMORY_LIMIT`** | `24g` | `.env` or `docker-compose.yml` | Must exceed heap + pagecache + OS overhead |
+
+Run `python src/edgeguard.py doctor` to verify settings before triggering a baseline. Full tuning guide: [docs/DOCKER_SETUP_GUIDE.md](docs/DOCKER_SETUP_GUIDE.md).
+
+**MISP→Neo4j memory:** If sync **dies during Neo4j writes** with exit **-9**, check **Docker cgroup** limits. Raise **`AIRFLOW_MEMORY_LIMIT`** in **`.env`** or reduce **`EDGEGUARD_NEO4J_SYNC_CHUNK_SIZE`** / **`EDGEGUARD_REL_BATCH_SIZE`**. See [docs/SETUP_GUIDE.md](docs/SETUP_GUIDE.md), [docs/HEARTBEAT.md](docs/HEARTBEAT.md), [docs/AIRFLOW_DAGS.md](docs/AIRFLOW_DAGS.md). Do **not** set **`0`** / **`all`** for chunk size unless you understand the OOM tradeoff.
 
 **Baseline collection** is controlled by Airflow Variables (not env vars). These caps apply to **each external collector** in the baseline DAG (OTX, NVD, …) — **not** to the MISP→Neo4j sync’s MISP event search (see [COLLECTION_AND_SYNC_LIMITS.md](docs/COLLECTION_AND_SYNC_LIMITS.md)).
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -424,14 +424,22 @@ def cmd_doctor(args):
         val = os.getenv(var_name, "").strip()
         if val:
             try:
-                num = int(val.lower().replace("g", "").replace("gb", ""))
+                # Parse value like "12g", "12gb", "12G", "12" → integer GB
+                import re as _re
+
+                match = _re.match(r"^(\d+)\s*[gG]?[bB]?$", val.strip())
+                if not match:
+                    warn(f"{var_name}={val} — could not parse (expected format: 12g)")
+                    _mem_ok = False
+                    continue
+                num = int(match.group(1))
                 if num < min_gb:
                     warn(f"{var_name}={val} — below recommended {recommended} for 730-day baseline")
                     _mem_ok = False
                 else:
                     ok(f"{var_name}={val}")
-            except ValueError:
-                ok(f"{var_name}={val}")
+            except (ValueError, TypeError):
+                warn(f"{var_name}={val} — could not parse")
     if _mem_ok and not any(os.getenv(v) for v in _mem_checks):
         info("Memory env vars not set — Docker Compose defaults will apply (see docs/DOCKER_SETUP_GUIDE.md)")
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -422,7 +422,10 @@ def cmd_doctor(args):
     _mem_ok = True
     for var_name, (recommended, min_gb) in _mem_checks.items():
         val = os.getenv(var_name, "").strip()
-        if val:
+        if not val:
+            info(f"  {var_name}: not set (Docker Compose default applies)")
+            continue
+        else:
             try:
                 # Parse value like "12g", "12gb", "12G", "12" → integer GB
                 import re as _re
@@ -440,8 +443,7 @@ def cmd_doctor(args):
                     ok(f"{var_name}={val}")
             except (ValueError, TypeError):
                 warn(f"{var_name}={val} — could not parse")
-    if _mem_ok and not any(os.getenv(v) for v in _mem_checks):
-        info("Memory env vars not set — Docker Compose defaults will apply (see docs/DOCKER_SETUP_GUIDE.md)")
+    # (each var is now individually reported above)
 
     # Validate API keys
     info("Validating API keys...")

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -411,6 +411,30 @@ def cmd_doctor(args):
     else:
         info("NATS: skipped (NATS_URL not set)")
 
+    # Check Docker memory settings (if env vars are set)
+    info("Checking memory configuration...")
+    _mem_checks = {
+        "AIRFLOW_MEMORY_LIMIT": ("12g", 12),
+        "NEO4J_HEAP_MAX": ("12g", 12),
+        "NEO4J_PAGECACHE": ("8g", 8),
+        "NEO4J_CONTAINER_MEMORY_LIMIT": ("24g", 24),
+    }
+    _mem_ok = True
+    for var_name, (recommended, min_gb) in _mem_checks.items():
+        val = os.getenv(var_name, "").strip()
+        if val:
+            try:
+                num = int(val.lower().replace("g", "").replace("gb", ""))
+                if num < min_gb:
+                    warn(f"{var_name}={val} — below recommended {recommended} for 730-day baseline")
+                    _mem_ok = False
+                else:
+                    ok(f"{var_name}={val}")
+            except ValueError:
+                ok(f"{var_name}={val}")
+    if _mem_ok and not any(os.getenv(v) for v in _mem_checks):
+        info("Memory env vars not set — Docker Compose defaults will apply (see docs/DOCKER_SETUP_GUIDE.md)")
+
     # Validate API keys
     info("Validating API keys...")
     ok_flag, msg = validate_api_keys()


### PR DESCRIPTION
## Summary

Production baseline failed with MISP HTTP 500 because PHP had 2048M (too low for 95K NVD attributes). Memory settings were scattered across docs — operators couldn't find the recommended values quickly.

### Changes

**README.md:**
- New "Recommended Memory Settings (730-day baseline)" table with 7 settings
- Fixed stale AIRFLOW_MEMORY_LIMIT reference (said 4g, actual default is 12g)

**edgeguard.py doctor:**
- New "Checking memory configuration..." section
- Reads AIRFLOW_MEMORY_LIMIT, NEO4J_HEAP_MAX, NEO4J_PAGECACHE, NEO4J_CONTAINER_MEMORY_LIMIT
- Warns if any value is below recommended minimum

## Test plan
- [x] 224 tests pass, lint clean
- [ ] Run `python src/edgeguard.py doctor` and verify memory section appears


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: documentation updates plus an additive `edgeguard doctor` diagnostic that only reads env vars and emits warnings, with no impact on pipeline execution.
> 
> **Overview**
> Adds a new **“Recommended Memory Settings (730-day baseline)”** table to `README.md` consolidating tested MISP/Airflow/Neo4j memory values and clarifying OOM troubleshooting guidance (including correcting the `AIRFLOW_MEMORY_LIMIT` reference).
> 
> Extends `src/edgeguard.py` `doctor` to **validate memory-related env vars** (e.g. `AIRFLOW_MEMORY_LIMIT`, `NEO4J_HEAP_MAX`, `NEO4J_PAGECACHE`, `NEO4J_CONTAINER_MEMORY_LIMIT`), parsing simple `12g`-style values and warning when missing, unparsable, or below the recommended baseline thresholds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 571c4112e3043b879400a8cba7b0135ceef3449f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->