### PR TITLE
fix: retry MISP 5xx on fetch/push and defer failed events

### DIFF
--- a/src/collectors/collector_utils.py
+++ b/src/collectors/collector_utils.py
@@ -26,6 +26,32 @@ _MAX_RATE_LIMIT_SLEEP_SEC = 600.0
 
 
 # ---------------------------------------------------------------------------
+# Shared transient-error base class
+# ---------------------------------------------------------------------------
+
+
+class TransientServerError(requests.exceptions.HTTPError):
+    """Base class for HTTP 5xx-style errors that callers opt in to retry.
+
+    Callers (e.g. ``MISPWriter._push_batch``, ``fetch_event_details``) subclass
+    this and ``raise`` it when an HTTP 5xx response comes back. The
+    ``retry_with_backoff`` decorator below catches this base class by name,
+    so opting into retry is just "define a subclass of
+    ``TransientServerError`` and raise it". Ordinary ``HTTPError`` (including
+    any 4xx that might sneak in via ``response.raise_for_status()``) is NOT
+    a subclass of this and will not be retried — that way permanent
+    validation errors don't spin on the backoff loop.
+
+    Introduced 2026-04 after a regression where ``_push_batch`` raised
+    ``requests.exceptions.HTTPError`` directly. The decorator only retried
+    connection/timeout errors, so the raised ``HTTPError`` fell through to
+    ``except Exception: raise`` and crashed the entire push — strictly worse
+    than the pre-fix behaviour where 5xx returned ``(0, len(attributes))``
+    and subsequent batches kept going.
+    """
+
+
+# ---------------------------------------------------------------------------
 # Retry decorator
 # ---------------------------------------------------------------------------
 
@@ -33,9 +59,11 @@ _MAX_RATE_LIMIT_SLEEP_SEC = 600.0
 def retry_with_backoff(max_retries: int = 3, base_delay: float = 2.0):
     """Decorator for retry logic with exponential backoff.
 
-    Only retries on transient network errors
-    (ConnectionError, Timeout, ReadTimeout, ChunkedEncodingError).
-    Any other exception propagates immediately without retrying.
+    Retries on transient network errors
+    (ConnectionError, Timeout, ReadTimeout, ChunkedEncodingError) and on
+    ``TransientServerError`` subclasses raised by callers that opt in to
+    server-error retry (see class docstring above). Any other exception
+    propagates immediately without retrying.
 
     Args:
         max_retries:  Number of retry attempts after the first failure.
@@ -60,6 +88,7 @@ def retry_with_backoff(max_retries: int = 3, base_delay: float = 2.0):
                     requests.exceptions.Timeout,
                     requests.exceptions.ReadTimeout,
                     requests.exceptions.ChunkedEncodingError,
+                    TransientServerError,
                 ) as exc:
                     last_exception = exc
                     if attempt < max_retries:

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -55,16 +55,22 @@ def _resolve_vulnerability_cve_id_for_misp(item: Dict) -> Optional[str]:
     return None
 
 
+class MispTransientError(requests.exceptions.HTTPError):
+    """Raised manually for HTTP 5xx from MISP so @retry_with_backoff can catch
+    it selectively. Subclassing HTTPError means any future call to
+    ``response.raise_for_status()`` on a 4xx will NOT accidentally be retried
+    through this path — only code that explicitly raises MispTransientError
+    opts in to the transient-error contract."""
+
+
 # Let @retry_with_backoff on _get_or_create_event / _push_batch retry these (must re-raise, not swallow).
-# HTTPError is included for 5xx server errors raised manually by _push_batch; 4xx
-# responses continue to be returned as (0, failed) without raising so we don't
-# spin on permanent validation errors.
+# The subclass above is the only HTTPError we retry; 4xx stays permanent.
 _TRANSIENT_HTTP_ERRORS = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
     requests.exceptions.ReadTimeout,
     requests.exceptions.ChunkedEncodingError,
-    requests.exceptions.HTTPError,
+    MispTransientError,
 )
 
 
@@ -1339,16 +1345,20 @@ class MISPWriter:
                     types_in_batch,
                     detail,
                 )
-                self.stats["errors"] += 1
                 # 5xx is usually transient (MISP under memory pressure on large
                 # NVD events); raise so @retry_with_backoff can give it another
-                # shot with exponential delay. 4xx is permanent validation
-                # failure — don't retry, just report what failed.
+                # shot with exponential delay. Do NOT increment stats["errors"]
+                # here — the decorator may succeed on a later attempt, and we
+                # don't want to inflate the counter once per retry. The
+                # terminal failure path (last raise from the decorator) is
+                # handled by the outer caller which counts failed_count.
                 if response.status_code >= 500:
-                    raise requests.exceptions.HTTPError(
+                    raise MispTransientError(
                         f"MISP {response.status_code} pushing batch to event {event_id}",
                         response=response,
                     )
+                # 4xx: permanent validation failure — count once and return.
+                self.stats["errors"] += 1
                 return 0, len(attributes)
 
         except _TRANSIENT_HTTP_ERRORS as e:

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -56,11 +56,15 @@ def _resolve_vulnerability_cve_id_for_misp(item: Dict) -> Optional[str]:
 
 
 # Let @retry_with_backoff on _get_or_create_event / _push_batch retry these (must re-raise, not swallow).
+# HTTPError is included for 5xx server errors raised manually by _push_batch; 4xx
+# responses continue to be returned as (0, failed) without raising so we don't
+# spin on permanent validation errors.
 _TRANSIENT_HTTP_ERRORS = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,
     requests.exceptions.ReadTimeout,
     requests.exceptions.ChunkedEncodingError,
+    requests.exceptions.HTTPError,
 )
 
 
@@ -1109,7 +1113,11 @@ class MISPWriter:
 
         Args:
             items: List of EdgeGuard items (indicators, vulnerabilities, etc.)
-            batch_size: Number of items per batch
+            batch_size: Number of items per batch. Overridden by
+                ``EDGEGUARD_MISP_PUSH_BATCH_SIZE`` env var when set — lets ops
+                dial the batch size down without a code change if MISP is
+                choking on large pushes (e.g. the 22% HTTP 500 failure rate
+                observed on the 730-day NVD baseline).
 
         Returns:
             Tuple of (successful_count, failed_count)
@@ -1118,6 +1126,20 @@ class MISPWriter:
             return 0, 0
 
         total_items = len(items)
+
+        # Env override wins over caller default so ops can tune without redeploying.
+        _env_batch = os.environ.get("EDGEGUARD_MISP_PUSH_BATCH_SIZE")
+        if _env_batch:
+            try:
+                env_val = int(_env_batch)
+                if env_val > 0:
+                    batch_size = env_val
+            except (ValueError, TypeError):
+                logger.warning(
+                    "Ignoring invalid EDGEGUARD_MISP_PUSH_BATCH_SIZE=%r; using %d",
+                    _env_batch,
+                    batch_size,
+                )
 
         # Guard against invalid batch_size (0 would crash range())
         batch_size = max(1, batch_size)
@@ -1318,6 +1340,15 @@ class MISPWriter:
                     detail,
                 )
                 self.stats["errors"] += 1
+                # 5xx is usually transient (MISP under memory pressure on large
+                # NVD events); raise so @retry_with_backoff can give it another
+                # shot with exponential delay. 4xx is permanent validation
+                # failure — don't retry, just report what failed.
+                if response.status_code >= 500:
+                    raise requests.exceptions.HTTPError(
+                        f"MISP {response.status_code} pushing batch to event {event_id}",
+                        response=response,
+                    )
                 return 0, len(attributes)
 
         except _TRANSIENT_HTTP_ERRORS as e:

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -22,7 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 import urllib3
 
-from collectors.collector_utils import retry_with_backoff
+from collectors.collector_utils import TransientServerError, retry_with_backoff
 from config import (
     DEFAULT_SECTOR,
     MISP_API_KEY,
@@ -55,16 +55,19 @@ def _resolve_vulnerability_cve_id_for_misp(item: Dict) -> Optional[str]:
     return None
 
 
-class MispTransientError(requests.exceptions.HTTPError):
+class MispTransientError(TransientServerError):
     """Raised manually for HTTP 5xx from MISP so @retry_with_backoff can catch
-    it selectively. Subclassing HTTPError means any future call to
-    ``response.raise_for_status()`` on a 4xx will NOT accidentally be retried
-    through this path — only code that explicitly raises MispTransientError
-    opts in to the transient-error contract."""
+    it selectively. Inheriting from ``collector_utils.TransientServerError``
+    (a subclass of ``requests.exceptions.HTTPError``) means the shared retry
+    decorator in ``collector_utils.py`` retries this class by name, without
+    having to widen its catch clause to all ``HTTPError`` values. 4xx errors
+    and any other ``HTTPError`` raised by ``response.raise_for_status()``
+    stay permanent."""
 
 
 # Let @retry_with_backoff on _get_or_create_event / _push_batch retry these (must re-raise, not swallow).
-# The subclass above is the only HTTPError we retry; 4xx stays permanent.
+# MispTransientError is a TransientServerError subclass, which is also in the
+# decorator's catch tuple in collector_utils.retry_with_backoff.
 _TRANSIENT_HTTP_ERRORS = (
     requests.exceptions.ConnectionError,
     requests.exceptions.Timeout,

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1269,7 +1269,25 @@ class MISPWriter:
                     f"[PUSH] Pushing batch {processed_batches}/{total_batches} ({progress_pct:.1f}%) - {elapsed:.1f}s elapsed, {eta_str}"
                 )
 
-                success, failed = self._push_batch(event_id, batch)
+                # After @retry_with_backoff exhausts its attempts on a
+                # persistent 5xx, _push_batch re-raises MispTransientError.
+                # Without this try/except the exception would crash out of
+                # push_items and skip every remaining batch and event in the
+                # push queue — strictly worse than the pre-fix behaviour
+                # where 5xx returned (0, len(attributes)) and the loop
+                # continued. Count the batch as failed and move on so one
+                # bad event doesn't destroy a whole NVD push.
+                try:
+                    success, failed = self._push_batch(event_id, batch)
+                except MispTransientError as exc:
+                    logger.error(
+                        "Batch %s for event %s failed after retries (%s) — counting batch as failed and continuing",
+                        processed_batches,
+                        event_id,
+                        exc,
+                    )
+                    success, failed = 0, len(batch)
+                    self.stats["errors"] += 1
                 total_success += success
                 total_failed += failed
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -3260,12 +3260,20 @@ class MISPToNeo4jSync:
                             )
                             total_errors += 1
                             self.stats["events_failed"] += 1
-                        # Track Neo4j connection failures across this loop too.
+                        # Track Neo4j connection failures across this loop
+                        # too. The main event loop above resets the counter
+                        # on non-connection errors via an `else:` branch;
+                        # mirror that here so a transient MISP 5xx followed
+                        # by an unrelated error doesn't leave the counter
+                        # stuck and prematurely trigger the 3-strike
+                        # Neo4j-dead bail-out.
                         _exc_str = str(exc).lower()
                         if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
                             self._consecutive_conn_failures = (
                                 getattr(self, "_consecutive_conn_failures", 0) + 1
                             )
+                        else:
+                            self._consecutive_conn_failures = 0
                         # Free memory after failed large-event fetch (OOM recovery)
                         import gc
 
@@ -3343,11 +3351,17 @@ class MISPToNeo4jSync:
                         )
                         total_errors += 1
                         self.stats["events_failed"] += 1
+                        # Same symmetry as the main and skipped_large loops:
+                        # increment on connection errors, reset on everything
+                        # else so non-consecutive connection errors don't
+                        # accumulate and trigger the 3-strike bail-out.
                         _exc_str = str(exc).lower()
                         if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
                             self._consecutive_conn_failures = (
                                 getattr(self, "_consecutive_conn_failures", 0) + 1
                             )
+                        else:
+                            self._consecutive_conn_failures = 0
                         import gc
 
                         gc.collect()

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -3274,9 +3274,7 @@ class MISPToNeo4jSync:
                         # Neo4j-dead bail-out.
                         _exc_str = str(exc).lower()
                         if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
-                            self._consecutive_conn_failures = (
-                                getattr(self, "_consecutive_conn_failures", 0) + 1
-                            )
+                            self._consecutive_conn_failures = getattr(self, "_consecutive_conn_failures", 0) + 1
                         else:
                             self._consecutive_conn_failures = 0
                         # Free memory after failed large-event fetch (OOM recovery)
@@ -3362,9 +3360,7 @@ class MISPToNeo4jSync:
                         # accumulate and trigger the 3-strike bail-out.
                         _exc_str = str(exc).lower()
                         if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
-                            self._consecutive_conn_failures = (
-                                getattr(self, "_consecutive_conn_failures", 0) + 1
-                            )
+                            self._consecutive_conn_failures = getattr(self, "_consecutive_conn_failures", 0) + 1
                         else:
                             self._consecutive_conn_failures = 0
                         import gc

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -416,6 +416,10 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
                     requests.exceptions.Timeout,
                     requests.exceptions.ReadTimeout,
                     requests.exceptions.ChunkedEncodingError,
+                    # HTTPError is only raised by our code for 5xx server errors
+                    # (see fetch_event_details). 4xx paths return None instead so
+                    # they never reach this handler.
+                    requests.exceptions.HTTPError,
                 ) as e:
                     last_exception = e
                     if attempt >= max_retries:
@@ -997,6 +1001,22 @@ class MISPToNeo4jSync:
                 )
                 return None
 
+            # 5xx responses are retriable — raise HTTPError so @retry_with_backoff
+            # gets another shot. Silently returning None here used to cause large
+            # events (e.g. NVD ~99K CVEs) to be permanently skipped after a single
+            # transient MISP 500, leaving the graph missing entire feeds.
+            if response.status_code >= 500:
+                logger.warning(
+                    "MISP returned HTTP %s for event %s — will retry via backoff",
+                    response.status_code,
+                    event_id,
+                )
+                raise requests.exceptions.HTTPError(
+                    f"MISP {response.status_code} fetching event {event_id}",
+                    response=response,
+                )
+
+            # 4xx: permanent failure, don't retry
             logger.error(f"Failed to fetch event {event_id}: HTTP {response.status_code}")
             return None
 
@@ -1005,6 +1025,7 @@ class MISPToNeo4jSync:
             requests.exceptions.Timeout,
             requests.exceptions.ReadTimeout,
             requests.exceptions.ChunkedEncodingError,
+            requests.exceptions.HTTPError,
         ):
             raise  # let @retry_with_backoff handle transient errors
         except Exception as e:
@@ -3051,6 +3072,12 @@ class MISPToNeo4jSync:
             except (ValueError, TypeError):
                 max_event_attrs = 50000
             skipped_large: List[Dict] = []
+            # Events that raised a transient error on the first pass. They get
+            # one retry after the initial sweep finishes — gives MISP time to
+            # recover from memory pressure / transient 5xx without losing the
+            # entire feed (see event-4 regression: 99K NVD CVEs lost because a
+            # single 500 skipped the event permanently).
+            failed_events: List[Dict] = []
 
             # ── Sort events: smallest first ──────────────────────────
             # Process small events (MITRE, CISA) before large ones (NVD, OTX)
@@ -3105,13 +3132,11 @@ class MISPToNeo4jSync:
                     self._consecutive_conn_failures = 0  # Reset on successful processing
                 except Exception as exc:
                     logger.error(
-                        "Event %s failed (%s: %s) — skipping, continuing with remaining events",
+                        "Event %s failed on first pass (%s: %s) — deferring for retry",
                         event_id,
                         type(exc).__name__,
                         str(exc)[:200],
                     )
-                    total_errors += 1
-                    self.stats["events_failed"] += 1
 
                     # If this looks like a connection failure, try to reconnect
                     _exc_str = str(exc).lower()
@@ -3123,6 +3148,10 @@ class MISPToNeo4jSync:
                                 "3+ consecutive Neo4j connection failures — aborting sync. "
                                 "Check: docker compose ps neo4j / docker compose logs neo4j"
                             )
+                            # Record the already-accumulated failures; the retry
+                            # pass below will bail out because _consecutive_conn_failures >= 3.
+                            total_errors += 1
+                            self.stats["events_failed"] += 1
                             break  # Stop burning through events with a dead Neo4j
                         logger.warning("Attempting Neo4j reconnect after connection failure...")
                         try:
@@ -3132,6 +3161,11 @@ class MISPToNeo4jSync:
                             logger.error("Neo4j reconnect failed")
                     else:
                         self._consecutive_conn_failures = 0  # Reset on non-connection errors
+
+                    # Queue for a retry pass instead of giving up permanently.
+                    # Accounting (total_errors / events_failed) happens in the
+                    # retry loop below so we don't double-count recoveries.
+                    failed_events.append(event)
 
                     # Free memory after failed event (OOM recovery)
                     import gc
@@ -3175,6 +3209,69 @@ class MISPToNeo4jSync:
                         total_errors += 1
                         self.stats["events_failed"] += 1
                         # Free memory after failed large-event fetch (OOM recovery)
+                        import gc
+
+                        gc.collect()
+
+            # ── Retry events that raised on the first pass ──────────────
+            # Separate from skipped_large: those were deferred *proactively*
+            # by size; these are events that hit a transient error (MISP 5xx,
+            # timeout, OOM, …). Give each a single second chance before
+            # counting it as a permanent failure. Fixes the regression where
+            # a single MISP 500 on a large NVD event caused 99K CVEs to be
+            # silently dropped from the graph.
+            _conn_failures = getattr(self, "_consecutive_conn_failures", 0)
+            if failed_events and _conn_failures >= 3:
+                logger.error(
+                    "Skipping %s event retry(s) — Neo4j connection failed (%s consecutive errors)",
+                    len(failed_events),
+                    _conn_failures,
+                )
+                for _ev in failed_events:
+                    total_errors += 1
+                    self.stats["events_failed"] += 1
+                failed_events = []
+
+            if failed_events:
+                # Short cooldown before retrying: lets MISP memory settle and
+                # any broken connection pools recycle. Reuses the existing
+                # batch-throttle knob so ops can tune both together.
+                try:
+                    retry_cooldown = float(os.environ.get("EDGEGUARD_MISP_RETRY_COOLDOWN_SEC", "15.0"))
+                except (ValueError, TypeError):
+                    retry_cooldown = 15.0
+                if retry_cooldown > 0:
+                    logger.info(
+                        "Cooling down %.1fs before retrying %s failed event(s)...",
+                        retry_cooldown,
+                        len(failed_events),
+                    )
+                    time.sleep(retry_cooldown)
+
+                logger.info(
+                    "Retrying %s event(s) that failed on the first pass...",
+                    len(failed_events),
+                )
+                for event in failed_events:
+                    event_id = event.get("id")
+                    event_info = event.get("info", "")
+                    if event_fetch_throttle > 0:
+                        time.sleep(event_fetch_throttle)
+                    try:
+                        ep, ecr, ee = self._process_single_event(str(event_id), event_info)
+                        total_parsed_items += ep
+                        total_cross_rels_built += ecr
+                        total_errors += ee
+                        logger.info("Event %s recovered on retry", event_id)
+                    except Exception as exc:
+                        logger.error(
+                            "Event %s still failed on retry (%s: %s) — skipping permanently",
+                            event_id,
+                            type(exc).__name__,
+                            str(exc)[:200],
+                        )
+                        total_errors += 1
+                        self.stats["events_failed"] += 1
                         import gc
 
                         gc.collect()

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -32,6 +32,8 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import requests
 import urllib3
 
+# Import resilience utilities
+from collectors.collector_utils import TransientServerError
 from config import (
     MISP_API_KEY,
     MISP_URL,
@@ -47,8 +49,6 @@ from neo4j_client import (
     normalize_cve_id_for_graph,
     resolve_vulnerability_cve_id,
 )
-
-# Import resilience utilities
 from resilience import check_service_health, get_circuit_breaker, record_collection_failure, record_collection_success
 
 try:
@@ -389,12 +389,13 @@ _RELATIONSHIP_BATCH_DEFAULT = 500
 _MAX_RETRY_FAILED_EVENTS = 20
 
 
-class MispTransientServerError(requests.exceptions.HTTPError):
+class MispTransientServerError(TransientServerError):
     """Raised manually for HTTP 5xx from MISP so @retry_with_backoff can catch
-    it selectively. Subclassing HTTPError means any future call to
-    ``response.raise_for_status()`` on a 4xx will NOT accidentally be retried
-    through this path — only code that explicitly raises
-    MispTransientServerError opts in to the transient-error contract."""
+    it selectively. Inherits from ``collector_utils.TransientServerError`` so
+    both the local ``retry_with_backoff`` in this module and the shared one
+    in ``collector_utils`` (used by ``MISPWriter._push_batch``) retry it.
+    Other ``HTTPError`` paths — e.g. 4xx raised via
+    ``response.raise_for_status()`` — remain permanent failures."""
 
 
 def _neo4j_sync_item_sort_rank(item: Dict) -> int:

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -3214,16 +3214,21 @@ class MISPToNeo4jSync:
                     len(skipped_large),
                     max_event_attrs,
                 )
-                for event in skipped_large:
+                for retry_idx, event in enumerate(skipped_large):
                     # Mid-loop bail-out: if Neo4j died while we were processing
                     # earlier events, stop burning through remaining ones.
+                    # Uses enumerate rather than list.index(event) because
+                    # list.index() returns the FIRST equal element — if two
+                    # event dicts ever shared identical content (e.g. a MISP
+                    # API quirk returning duplicate rows) the slice would
+                    # include already-processed events and double-count them.
                     if getattr(self, "_consecutive_conn_failures", 0) >= 3:
+                        remaining = len(skipped_large) - retry_idx
                         logger.error(
                             "Neo4j dead mid-retry — counting remaining %s deferred event(s) as failed",
-                            len(skipped_large) - skipped_large.index(event),
+                            remaining,
                         )
-                        remaining = skipped_large[skipped_large.index(event) :]
-                        for _rem in remaining:
+                        for _rem in skipped_large[retry_idx:]:
                             total_errors += 1
                             self.stats["events_failed"] += 1
                         break

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -382,6 +382,20 @@ def _dedupe_parsed_items(items: List[Dict]) -> List[Dict]:
 # 500 rows per UNWIND batch — smaller batches reduce lock contention on shared nodes.
 _RELATIONSHIP_BATCH_DEFAULT = 500
 
+# Cap how many exception-failed events we retry. Beyond this, MISP is almost
+# certainly broken and retrying more events just burns wall-clock against the
+# Airflow execution_timeout (NVD sync DAG = 2h). The remaining events are
+# counted as failed immediately so operators see the real damage.
+_MAX_RETRY_FAILED_EVENTS = 20
+
+
+class MispTransientServerError(requests.exceptions.HTTPError):
+    """Raised manually for HTTP 5xx from MISP so @retry_with_backoff can catch
+    it selectively. Subclassing HTTPError means any future call to
+    ``response.raise_for_status()`` on a 4xx will NOT accidentally be retried
+    through this path — only code that explicitly raises
+    MispTransientServerError opts in to the transient-error contract."""
+
 
 def _neo4j_sync_item_sort_rank(item: Dict) -> int:
     """Order items so tactics/techniques/malware/actors land before vulns/indicators when chunking."""
@@ -416,10 +430,11 @@ def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY
                     requests.exceptions.Timeout,
                     requests.exceptions.ReadTimeout,
                     requests.exceptions.ChunkedEncodingError,
-                    # HTTPError is only raised by our code for 5xx server errors
-                    # (see fetch_event_details). 4xx paths return None instead so
-                    # they never reach this handler.
-                    requests.exceptions.HTTPError,
+                    # Our own subclass for MISP 5xx. Subclassing HTTPError
+                    # means future raise_for_status() calls on 4xx are NOT
+                    # accidentally retried — only code that explicitly opts
+                    # in by raising MispTransientServerError is retried.
+                    MispTransientServerError,
                 ) as e:
                     last_exception = e
                     if attempt >= max_retries:
@@ -1001,7 +1016,7 @@ class MISPToNeo4jSync:
                 )
                 return None
 
-            # 5xx responses are retriable — raise HTTPError so @retry_with_backoff
+            # 5xx responses are retriable — raise so @retry_with_backoff
             # gets another shot. Silently returning None here used to cause large
             # events (e.g. NVD ~99K CVEs) to be permanently skipped after a single
             # transient MISP 500, leaving the graph missing entire feeds.
@@ -1011,7 +1026,7 @@ class MISPToNeo4jSync:
                     response.status_code,
                     event_id,
                 )
-                raise requests.exceptions.HTTPError(
+                raise MispTransientServerError(
                     f"MISP {response.status_code} fetching event {event_id}",
                     response=response,
                 )
@@ -1025,7 +1040,7 @@ class MISPToNeo4jSync:
             requests.exceptions.Timeout,
             requests.exceptions.ReadTimeout,
             requests.exceptions.ChunkedEncodingError,
-            requests.exceptions.HTTPError,
+            MispTransientServerError,
         ):
             raise  # let @retry_with_backoff handle transient errors
         except Exception as e:
@@ -3138,6 +3153,22 @@ class MISPToNeo4jSync:
                         str(exc)[:200],
                     )
 
+                    # Queue for retry pass unconditionally. Accounting (total_errors
+                    # / events_failed) happens in the retry loop below so we don't
+                    # double-count recoveries. If the cap is exceeded, count as
+                    # failed immediately — retrying 50+ events against a broken
+                    # MISP will blow the Airflow execution_timeout.
+                    if len(failed_events) < _MAX_RETRY_FAILED_EVENTS:
+                        failed_events.append(event)
+                    else:
+                        logger.error(
+                            "failed_events cap (%s) reached — counting event %s as permanent failure",
+                            _MAX_RETRY_FAILED_EVENTS,
+                            event_id,
+                        )
+                        total_errors += 1
+                        self.stats["events_failed"] += 1
+
                     # If this looks like a connection failure, try to reconnect
                     _exc_str = str(exc).lower()
                     if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
@@ -3148,10 +3179,8 @@ class MISPToNeo4jSync:
                                 "3+ consecutive Neo4j connection failures — aborting sync. "
                                 "Check: docker compose ps neo4j / docker compose logs neo4j"
                             )
-                            # Record the already-accumulated failures; the retry
-                            # pass below will bail out because _consecutive_conn_failures >= 3.
-                            total_errors += 1
-                            self.stats["events_failed"] += 1
+                            # The retry-pass bail-out below will count everything
+                            # in failed_events once and only once. Don't count here.
                             break  # Stop burning through events with a dead Neo4j
                         logger.warning("Attempting Neo4j reconnect after connection failure...")
                         try:
@@ -3161,11 +3190,6 @@ class MISPToNeo4jSync:
                             logger.error("Neo4j reconnect failed")
                     else:
                         self._consecutive_conn_failures = 0  # Reset on non-connection errors
-
-                    # Queue for a retry pass instead of giving up permanently.
-                    # Accounting (total_errors / events_failed) happens in the
-                    # retry loop below so we don't double-count recoveries.
-                    failed_events.append(event)
 
                     # Free memory after failed event (OOM recovery)
                     import gc
@@ -3190,6 +3214,18 @@ class MISPToNeo4jSync:
                     max_event_attrs,
                 )
                 for event in skipped_large:
+                    # Mid-loop bail-out: if Neo4j died while we were processing
+                    # earlier events, stop burning through remaining ones.
+                    if getattr(self, "_consecutive_conn_failures", 0) >= 3:
+                        logger.error(
+                            "Neo4j dead mid-retry — counting remaining %s deferred event(s) as failed",
+                            len(skipped_large) - skipped_large.index(event),
+                        )
+                        remaining = skipped_large[skipped_large.index(event) :]
+                        for _rem in remaining:
+                            total_errors += 1
+                            self.stats["events_failed"] += 1
+                        break
                     event_id = event.get("id")
                     event_info = event.get("info", "")
                     if event_fetch_throttle > 0:
@@ -3199,15 +3235,36 @@ class MISPToNeo4jSync:
                         total_parsed_items += ep
                         total_cross_rels_built += ecr
                         total_errors += ee
+                        self._consecutive_conn_failures = 0
                     except Exception as exc:
-                        logger.error(
-                            "Deferred event %s still failed (%s: %s) — skipping permanently",
+                        # Defer to the failed_events retry pass below (with
+                        # cooldown) instead of burying it here. NVD lives in
+                        # skipped_large because it's the largest event — the
+                        # whole regression was its single-shot retry, so we
+                        # give it the same cooldown+retry as exception-failed
+                        # events, subject to the same cap.
+                        logger.warning(
+                            "Deferred event %s failed on first retry (%s: %s) — re-queueing with cooldown",
                             event_id,
                             type(exc).__name__,
                             str(exc)[:200],
                         )
-                        total_errors += 1
-                        self.stats["events_failed"] += 1
+                        if len(failed_events) < _MAX_RETRY_FAILED_EVENTS:
+                            failed_events.append(event)
+                        else:
+                            logger.error(
+                                "failed_events cap (%s) reached — counting deferred event %s as permanent failure",
+                                _MAX_RETRY_FAILED_EVENTS,
+                                event_id,
+                            )
+                            total_errors += 1
+                            self.stats["events_failed"] += 1
+                        # Track Neo4j connection failures across this loop too.
+                        _exc_str = str(exc).lower()
+                        if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
+                            self._consecutive_conn_failures = (
+                                getattr(self, "_consecutive_conn_failures", 0) + 1
+                            )
                         # Free memory after failed large-event fetch (OOM recovery)
                         import gc
 
@@ -3252,7 +3309,19 @@ class MISPToNeo4jSync:
                     "Retrying %s event(s) that failed on the first pass...",
                     len(failed_events),
                 )
-                for event in failed_events:
+                for retry_idx, event in enumerate(failed_events):
+                    # Mid-loop bail-out: if a prior retry just killed Neo4j,
+                    # stop and count the remaining events without thrashing.
+                    if getattr(self, "_consecutive_conn_failures", 0) >= 3:
+                        remaining = len(failed_events) - retry_idx
+                        logger.error(
+                            "Neo4j dead mid-retry — counting remaining %s event(s) as failed",
+                            remaining,
+                        )
+                        for _rem in failed_events[retry_idx:]:
+                            total_errors += 1
+                            self.stats["events_failed"] += 1
+                        break
                     event_id = event.get("id")
                     event_info = event.get("info", "")
                     if event_fetch_throttle > 0:
@@ -3262,16 +3331,22 @@ class MISPToNeo4jSync:
                         total_parsed_items += ep
                         total_cross_rels_built += ecr
                         total_errors += ee
+                        self._consecutive_conn_failures = 0
                         logger.info("Event %s recovered on retry", event_id)
                     except Exception as exc:
                         logger.error(
-                            "Event %s still failed on retry (%s: %s) — skipping permanently",
+                            "Event %s still failed on retry (%s: %s) — skipping until next sync run",
                             event_id,
                             type(exc).__name__,
                             str(exc)[:200],
                         )
                         total_errors += 1
                         self.stats["events_failed"] += 1
+                        _exc_str = str(exc).lower()
+                        if "connection" in _exc_str or "refused" in _exc_str or "unavailable" in _exc_str:
+                            self._consecutive_conn_failures = (
+                                getattr(self, "_consecutive_conn_failures", 0) + 1
+                            )
                         import gc
 
                         gc.collect()

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -3206,6 +3206,14 @@ class MISPToNeo4jSync:
                     len(skipped_large),
                     _conn_failures,
                 )
+                # Count the abandoned events as failures so operators (and
+                # the Prometheus coverage-gap alert) see the real damage.
+                # Every other bail-out path in this function increments
+                # total_errors + events_failed; this pre-loop one was the
+                # outlier that silently dropped the events from accounting.
+                for _rem in skipped_large:
+                    total_errors += 1
+                    self.stats["events_failed"] += 1
                 skipped_large = []  # Don't retry with a dead Neo4j
 
             if skipped_large:


### PR DESCRIPTION
## Summary

Fixes the root cause of the NVD event-4 regression on the 730-day baseline run (2026-04-14), where ~99K CVEs were silently dropped from the Neo4j graph after MISP returned HTTP 500 on a corrupted event.

The colleague's post-mortem found that event 4 got exactly one attempt before being permanently skipped, while events 5/6 hit the same 500s but recovered. This PR closes that asymmetry across **four** layers where HTTP 5xx was being dropped on the floor.

## Root cause chain

1. **`fetch_event_details`** ([run_misp_to_neo4j.py:1000](src/run_misp_to_neo4j.py#L1000)) — returned `None` on any non-200 status, so `@retry_with_backoff` never saw the error.
2. **`retry_with_backoff`** ([run_misp_to_neo4j.py:414](src/run_misp_to_neo4j.py#L414)) — only caught `ConnectionError`/`Timeout`, not `HTTPError`. Even a proper raise on 5xx wouldn't have been retried.
3. **Main sync loop** ([run_misp_to_neo4j.py:3106](src/run_misp_to_neo4j.py#L3106)) — only retried size-deferred events (`skipped_large`). Events that raised mid-pass were marked failed and skipped permanently.
4. **`MISPWriter._push_batch`** ([misp_writer.py:1310](src/collectors/misp_writer.py#L1310)) — returned `(0, failed)` on 5xx, so the 22% NVD push failure rate never triggered exponential-backoff retries either.

## Changes

**`src/run_misp_to_neo4j.py`**
- `retry_with_backoff` now recognizes `HTTPError` as transient (we only raise it for 5xx from our own code).
- `fetch_event_details` raises `HTTPError` on 5xx; 4xx still returns `None` (no retry-spin on permanent validation errors).
- Main loop queues exception-failed events into a new `failed_events` list and retries each once after a configurable cooldown, mirroring the existing `skipped_large` retry pattern. Accounting moved into the retry loop so recoveries aren't double-counted as failures.
- Aborts the retry pass cleanly if Neo4j is dead (3+ consecutive connection failures), without losing the failure count.

**`src/collectors/misp_writer.py`**
- `_push_batch` raises `HTTPError` on 5xx so its own `@retry_with_backoff` decorator retries with exponential delay. 4xx continues to return `(0, failed)`.
- `_TRANSIENT_HTTP_ERRORS` tuple now includes `HTTPError` (only raised by our own 5xx path, so 4xx doesn't leak in).
- `push_items` honours `EDGEGUARD_MISP_PUSH_BATCH_SIZE` env var so ops can dial batches down without a redeploy when MISP is under memory pressure.

## New env vars

| Var | Default | Purpose |
|---|---|---|
| `EDGEGUARD_MISP_PUSH_BATCH_SIZE` | caller-supplied (500) | Override batch size for all `push_items` calls — lets ops shrink batches if MISP is 500-ing on large pushes |
| `EDGEGUARD_MISP_RETRY_COOLDOWN_SEC` | `15.0` | Cooldown between the first pass and the failed-events retry pass |

## Test plan

- [x] `ruff check` clean on both files
- [x] `python -m pytest tests/ -k "misp or sync or retry"` — 65 passed, 1 skipped
- [x] `python -m pytest tests/test_misp_writer_event_exact_match.py tests/test_status_after_misp_push.py` — 7 passed
- [ ] **Manual re-run needed:** after deleting the corrupted MISP event 4 and re-running the NVD collector, verify CVE count in Neo4j lands in the ~99K range (currently 980 from CISA KEV leftovers only)
- [ ] Follow-up: add a unit test that mocks `fetch_event_details` against a 500 response and asserts it raises + is retried by `@retry_with_backoff`. Intentionally excluded from this PR to keep the diff focused on the fix.

## Related

- Baseline run ID: `manual__2026-04-14T22:05:14+00:00`
- NVD push failure rate: 22% (6,500 OK / 22,232 FAILED with HTTP 500)
- OTX collector hit the same MISP-500 pattern — also covered by the `_push_batch` fix.
- Corrupted MISP event 4 still needs to be deleted out-of-band before the re-run; this PR only fixes the code path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes retry and failure-handling paths in the MISP→Neo4j pipeline and MISP writer; mistakes could cause over-retrying or altered failure accounting, but scope is limited to resilience around transient 5xx/network errors.
> 
> **Overview**
> **Improves resilience to transient MISP failures (HTTP 5xx).** Introduces a shared `TransientServerError` base and expands `retry_with_backoff` to retry only explicit 5xx opt-in exceptions, avoiding accidental retries of permanent 4xx validation errors.
> 
> **MISP push path now retries 5xx and won’t abort the whole push.** `MISPWriter._push_batch` raises `MispTransientError` on 5xx so backoff retries run, `push_items` catches terminal failures to count the batch as failed and continue, and batch size can be overridden via `EDGEGUARD_MISP_PUSH_BATCH_SIZE`.
> 
> **MISP→Neo4j sync now retries transiently failed events.** `fetch_event_details` raises a `MispTransientServerError` on 5xx so backoff applies, the main loop queues exception-failed events for a single post-pass retry with configurable cooldown (`EDGEGUARD_MISP_RETRY_COOLDOWN_SEC`) and a cap, and bail-out paths (e.g. Neo4j connection death) now consistently count remaining deferred events as failures.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ff4c90c8490831f81a15345273ae1a749da2292f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->