### PR TITLE
observability: sync event accounting + per-label drop alerts

### DIFF
--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -212,6 +212,77 @@ groups:
           description: "{{ $labels.name }} has restarted {{ $value }} times in the last hour."
 
   # ================================================================================
+  # Sync integrity — catches silent event drops in MISP->Neo4j sync.
+  # Added after the 2026-04-14 NVD regression: a single MISP 500 on a
+  # corrupted event caused ~99K CVEs to vanish from Neo4j and no alert
+  # fired, because the existing rules only watch for total counts going
+  # below a global floor (sum < 100) and had no signal for per-run
+  # coverage gaps or per-label drops.
+  # ================================================================================
+  - name: edgeguard_sync_integrity
+    rules:
+      - alert: EdgeGuardSyncEventsFailed
+        expr: edgeguard_sync_events_failed > 0
+        for: 5m
+        labels:
+          severity: critical
+          component: sync
+        annotations:
+          summary: "MISP->Neo4j sync had {{ $value }} failed event(s)"
+          description: |
+            The most recent MISP->Neo4j sync permanently failed to process
+            {{ $value }} event(s) after all retries. Check pipeline logs for
+            the event IDs and the underlying error (usually MISP 5xx on a
+            corrupted event, or Neo4j connection loss).
+
+      - alert: EdgeGuardSyncCoverageGap
+        expr: |
+          (
+            edgeguard_sync_events_index_total
+            - edgeguard_sync_events_processed
+            - edgeguard_sync_events_failed
+          ) != 0
+        for: 5m
+        labels:
+          severity: critical
+          component: sync
+        annotations:
+          summary: "MISP->Neo4j sync accounting gap: {{ $value }} unaccounted event(s)"
+          description: |
+            MISP index returned {{ with query "edgeguard_sync_events_index_total" }}{{ . | first | value }}{{ end }}
+            events, but processed + failed does not equal that total. This
+            means events were SILENTLY SKIPPED — the exact failure pattern
+            of the 2026-04-14 NVD regression. Investigate immediately.
+
+      - alert: EdgeGuardNeo4jLabelDropBig
+        # Per-label 1-day drop > 50% of yesterday's value. Uses offset so
+        # the comparison is against the same time yesterday — robust to
+        # normal daily fluctuation but catches catastrophic loss like
+        # CVE count 99K -> 980 (the NVD regression).
+        # Minimum floor of 100 nodes to avoid noise on small labels.
+        expr: |
+          (
+            (edgeguard_neo4j_nodes offset 1d) > 100
+            and
+            edgeguard_neo4j_nodes
+            <
+            0.5 * (edgeguard_neo4j_nodes offset 1d)
+          )
+        for: 15m
+        labels:
+          severity: critical
+          component: neo4j
+        annotations:
+          summary: "Neo4j {{ $labels.label }} count dropped >50% in 24h"
+          description: |
+            {{ $labels.label }} (zone={{ $labels.zone }}) went from
+            {{ with printf "edgeguard_neo4j_nodes{label=\"%s\",zone=\"%s\"} offset 1d" $labels.label $labels.zone | query }}
+            {{ . | first | value }}{{ end }} to {{ $value }} in the last 24h.
+            This usually indicates a silent skip in MISP->Neo4j sync or a
+            truncated feed push. Cross-check edgeguard_sync_events_failed
+            and MISP event health.
+
+  # ================================================================================
   # Neo4j Alerts
   # ================================================================================
   - name: edgeguard_neo4j

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -260,14 +260,18 @@ groups:
         # normal daily fluctuation but catches catastrophic loss like
         # CVE count 99K -> 980 (the NVD regression).
         # Minimum floor of 100 nodes to avoid noise on small labels.
+        #
+        # PromQL `and` returns the LHS vector filtered by the RHS label set,
+        # so the current (today's) value must be on the left — otherwise
+        # $value in the annotation would be yesterday's count, not today's.
         expr: |
           (
-            (edgeguard_neo4j_nodes offset 1d) > 100
-            and
             edgeguard_neo4j_nodes
             <
             0.5 * (edgeguard_neo4j_nodes offset 1d)
           )
+          and
+          (edgeguard_neo4j_nodes offset 1d) > 100
         for: 15m
         labels:
           severity: critical

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -110,6 +110,28 @@ NEO4J_SYNC_DURATION = Histogram(
     buckets=[1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0],
 )
 
+# Per-run sync accounting. Gauges (not counters) so they reset each run
+# and alerts can fire on the CURRENT run's damage, not cumulative history.
+# Added after the 2026-04-14 NVD regression where a single MISP 500 dropped
+# ~99K CVEs silently: events_failed stayed 0 because the accounting bug
+# never recorded the skipped event, so no alert fired. Exporting these
+# three invariants (processed + failed + index_total) lets a coverage-gap
+# alert catch that exact silent-skip pattern.
+SYNC_EVENTS_PROCESSED = Gauge(
+    "edgeguard_sync_events_processed",
+    "Events successfully processed in the most recent MISP->Neo4j sync run",
+)
+
+SYNC_EVENTS_FAILED = Gauge(
+    "edgeguard_sync_events_failed",
+    "Events that failed in the most recent MISP->Neo4j sync run (after all retries)",
+)
+
+SYNC_EVENTS_INDEX_TOTAL = Gauge(
+    "edgeguard_sync_events_index_total",
+    "Total events returned by MISP events index for the most recent sync run",
+)
+
 NEO4J_QUERIES = Counter("edgeguard_neo4j_queries_total", "Total Neo4j queries executed", ["query_type", "status"])
 
 NEO4J_QUERY_DURATION = Histogram(
@@ -232,6 +254,23 @@ def record_neo4j_sync(node_counts: Dict[str, int], duration: float):
         if ":" in label:
             label, zone = label.split(":", 1)
         NEO4J_NODES.labels(label=label, zone=zone).set(count)
+
+
+def record_sync_event_accounting(
+    events_index_total: int,
+    events_processed: int,
+    events_failed: int,
+) -> None:
+    """Export the per-run event accounting so alerts can catch silent skips.
+
+    The invariant ``events_index_total == events_processed + events_failed``
+    is what would have caught the 2026-04-14 NVD regression (event 4 was
+    neither processed nor failed — it was silently dropped, and the counter
+    gap stayed hidden because nothing exported the numbers).
+    """
+    SYNC_EVENTS_INDEX_TOTAL.set(max(events_index_total, 0))
+    SYNC_EVENTS_PROCESSED.set(max(events_processed, 0))
+    SYNC_EVENTS_FAILED.set(max(events_failed, 0))
 
 
 def record_neo4j_relationships(rel_counts: Dict[str, int]):

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2860,10 +2860,12 @@ class MISPToNeo4jSync:
                 if rels:
                     event_embedded_rels.extend(rels)
 
-        self.stats["events_processed"] += 1
-
         if not event_items:
             logger.debug("Event %s: no parsed items, skipping Neo4j writes", event_id)
+            # Count empty-but-valid events so the invariant
+            # `events_index_total == events_processed + events_failed`
+            # holds for the coverage-gap alert.
+            self.stats["events_processed"] += 1
             return 0, 0, 0
 
         unique_event_items = _dedupe_parsed_items(event_items)
@@ -2881,6 +2883,13 @@ class MISPToNeo4jSync:
         )
 
         _s, ev_errors, _u = self.sync_to_neo4j(unique_event_items)
+        # Increment events_processed only AFTER sync_to_neo4j returns. If
+        # sync_to_neo4j raises, the outer run() loop will append the event
+        # to failed_events and count it as events_failed — without this
+        # ordering we'd double-count events that fail during sync (both
+        # processed and failed), violating the coverage-gap invariant and
+        # making `EdgeGuardSyncCoverageGap` fire with a negative value.
+        self.stats["events_processed"] += 1
 
         if event_embedded_rels:
             rels_created = self._create_relationships(event_embedded_rels, "misp")
@@ -3057,6 +3066,11 @@ class MISPToNeo4jSync:
             logger.error("Failed to connect to databases")
             self.stats["end_time"] = datetime.now(timezone.utc).isoformat()
             return False
+
+        # Initialized up-front so the accounting gauges always have a value
+        # to read in the finally block — even on early-return or crash
+        # paths that exit before sorted_events is built.
+        events_index_total = 0
 
         try:
             # Fetch events from MISP
@@ -3399,21 +3413,11 @@ class MISPToNeo4jSync:
                     record_pipeline_duration("misp_to_neo4j", duration)
                 except Exception:
                     logger.debug("Metrics recording failed", exc_info=True)
-                # Export per-run event accounting so Prometheus can alert on
-                # the "processed + failed != total" invariant and on any
-                # failed events at all. Safe fallback if the import failed.
-                try:
-                    # events_index_total is assigned inside the try block
-                    # (line ~3072) before any processing. Defensive fallback
-                    # to 0 just in case this code path is ever reached via
-                    # a different control flow.
-                    record_sync_event_accounting(
-                        events_index_total=locals().get("events_index_total", 0),
-                        events_processed=int(self.stats.get("events_processed", 0)),
-                        events_failed=int(self.stats.get("events_failed", 0)),
-                    )
-                except Exception:
-                    logger.debug("Sync event accounting export failed", exc_info=True)
+                # Per-run event accounting is exported from the `finally`
+                # block below so it fires on every exit path (happy path,
+                # no-events early return, and unhandled exception) — not
+                # only on success. Without that, the gauges retain stale
+                # values from the previous run on crashes.
 
             # Update circuit breaker states in stats
             self.stats["circuit_breaker_states"] = {
@@ -3464,6 +3468,21 @@ class MISPToNeo4jSync:
             return False
 
         finally:
+            # Reset per-run accounting gauges on every exit path (happy,
+            # no-events early return, unhandled exception). Without this,
+            # a run that crashes before the happy-path metrics block would
+            # leave the previous run's values in Prometheus, causing
+            # `EdgeGuardSyncEventsFailed` to keep firing after a clean
+            # rerun or masking a crashing sync entirely.
+            if _METRICS_AVAILABLE:
+                try:
+                    record_sync_event_accounting(
+                        events_index_total=int(locals().get("events_index_total", 0) or 0),
+                        events_processed=int(self.stats.get("events_processed", 0) or 0),
+                        events_failed=int(self.stats.get("events_failed", 0) or 0),
+                    )
+                except Exception:
+                    logger.debug("Sync event accounting export failed", exc_info=True)
             if self.neo4j:
                 self.neo4j.close()
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -52,7 +52,7 @@ from neo4j_client import (
 from resilience import check_service_health, get_circuit_breaker, record_collection_failure, record_collection_success
 
 try:
-    from metrics_server import record_pipeline_duration
+    from metrics_server import record_pipeline_duration, record_sync_event_accounting
 
     _METRICS_AVAILABLE = True
 except ImportError:
@@ -3110,6 +3110,10 @@ class MISPToNeo4jSync:
                 return 0  # unknown size → process first (safe default)
 
             sorted_events = sorted(events, key=_event_sort_key)
+            # Total input size — used by the coverage-gap alert to catch
+            # silently-skipped events (the exact failure mode of the
+            # 2026-04-14 NVD regression).
+            events_index_total = len(sorted_events)
 
             for ev_idx, event in enumerate(sorted_events):
                 event_id = event.get("id")
@@ -3395,6 +3399,21 @@ class MISPToNeo4jSync:
                     record_pipeline_duration("misp_to_neo4j", duration)
                 except Exception:
                     logger.debug("Metrics recording failed", exc_info=True)
+                # Export per-run event accounting so Prometheus can alert on
+                # the "processed + failed != total" invariant and on any
+                # failed events at all. Safe fallback if the import failed.
+                try:
+                    # events_index_total is assigned inside the try block
+                    # (line ~3072) before any processing. Defensive fallback
+                    # to 0 just in case this code path is ever reached via
+                    # a different control flow.
+                    record_sync_event_accounting(
+                        events_index_total=locals().get("events_index_total", 0),
+                        events_processed=int(self.stats.get("events_processed", 0)),
+                        events_failed=int(self.stats.get("events_failed", 0)),
+                    )
+                except Exception:
+                    logger.debug("Sync event accounting export failed", exc_info=True)
 
             # Update circuit breaker states in stats
             self.stats["circuit_breaker_states"] = {


### PR DESCRIPTION
## Summary

Plugs the three monitoring gaps that let the 2026-04-14 NVD regression slip through undetected (99K CVEs dropped from Neo4j without any alert).

**Before this PR**, nothing would catch:
- Silently-skipped events (the exact event-4 pattern — accounting bug meant \`events_failed\` stayed 0)
- Catastrophic per-label drops (global alert was \`sum < 100\`, still satisfied at 980 CVEs)
- The invariant \`events_index_total == events_processed + events_failed\`

## Changes

**\`src/metrics_server.py\`** — three new per-run Prometheus gauges + \`record_sync_event_accounting()\` helper.

**\`src/run_misp_to_neo4j.py\`** — capture \`events_index_total\` and export accounting at end of sync alongside \`record_pipeline_duration\`.

**\`prometheus/alerts.yml\`** — new \`edgeguard_sync_integrity\` group with three alerts:
1. \`EdgeGuardSyncEventsFailed\` — fires immediately on any permanent event failure.
2. \`EdgeGuardSyncCoverageGap\` — fires on the \`index_total - processed - failed != 0\` invariant violation. **This is the alert that would have caught the event-4 incident in 5 minutes.**
3. \`EdgeGuardNeo4jLabelDropBig\` — per-label >50% drop vs 24h ago. Uses \`offset 1d\` so normal daily fluctuation is baseline. Would have fired on CVE 99K → 980.

## Stacks on

Complementary to [#20](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/20) (retry fix). #20 prevents the silent skip from happening; this PR makes sure future silent skips are caught fast.

## Test plan

- [x] \`ruff check\` clean
- [x] YAML parses
- [x] 65 existing tests pass (misp / sync / metric filter)
- [ ] After deploy: confirm the three new metrics appear at \`/metrics\`
- [ ] After deploy: confirm \`promtool check rules prometheus/alerts.yml\` passes in CI
- [ ] Follow-up PR: Grafana dashboard panel for the three new gauges + sudden-drop annotation
- [ ] Follow-up PR: post-sync MISP-vs-Neo4j reconciliation doctor script

## What this does NOT do

- No Grafana dashboard changes (separate concern, needs manual panel design).
- No doctor/validator script yet (needs live MISP access to test end-to-end).
- No rolling-median baseline yet (24h offset catches the catastrophic case).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new critical alerting based on newly exported gauges and changes when `events_processed` is incremented, which could cause unexpected paging/noise if metric values or invariants are off in edge cases.
> 
> **Overview**
> Adds per-run Prometheus gauges for MISP→Neo4j sync event accounting (`edgeguard_sync_events_index_total`, `edgeguard_sync_events_processed`, `edgeguard_sync_events_failed`) and exports them via a new `record_sync_event_accounting()` helper.
> 
> Updates the sync runner to compute the input event total, adjust `events_processed` counting to avoid double-counting on failures (including counting empty-but-valid events), and always publish the accounting gauges from a `finally` block so values don’t go stale on early exits/crashes.
> 
> Extends Prometheus rules with a new `edgeguard_sync_integrity` group that pages on any failed events, on an accounting coverage gap (index_total ≠ processed + failed), and on >50% 24h per-label Neo4j node-count drops using `offset 1d`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40cf5eb1a4b9f2c9f62b52828e082d33a8700231. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->