### PR TITLE
fix: collectors no longer silently succeed on network outages

### DIFF
--- a/src/collectors/abuseipdb_collector.py
+++ b/src/collectors/abuseipdb_collector.py
@@ -190,7 +190,14 @@ class AbuseIPDBCollector:
             max_age_days: Maximum age of reports to include (default 90)
 
         Returns:
-            IP reputation data dict or None on error
+            IP reputation data dict or None on error / network failure.
+
+        ``_make_request`` is now decorated with ``@retry_with_backoff`` and
+        propagates ``RequestException`` after retries are exhausted.
+        Per-IP enrichment callers still expect ``None`` on error, so we
+        catch here and keep the interface backward-compatible. The
+        collect() → get_blacklist() path does NOT catch — it wants
+        the real failure status so the DAG task fails loudly.
         """
         if not self.api_key:
             logger.warning("AbuseIPDB: No API key configured")
@@ -202,7 +209,11 @@ class AbuseIPDBCollector:
             "verbose": "true",  # Must be lowercase string; Python True → "True" which the API ignores
         }
 
-        data = self._make_request(self.CHECK_ENDPOINT, params)
+        try:
+            data = self._make_request(self.CHECK_ENDPOINT, params)
+        except requests.exceptions.RequestException as exc:
+            logger.warning("AbuseIPDB check_ip(%s) network failure after retries: %s", ip_address, exc)
+            return None
 
         if data and "data" in data:
             return self._format_ip_result(data["data"])
@@ -220,7 +231,9 @@ class AbuseIPDBCollector:
             max_age_days: Maximum age of reports to include
 
         Returns:
-            List of IP reputation data dicts
+            List of IP reputation data dicts. Returns ``[]`` on network
+            failure after retries are exhausted (same backward-compat
+            reason as ``check_ip`` above).
         """
         if not self.api_key:
             logger.warning("AbuseIPDB: No API key configured")
@@ -228,7 +241,11 @@ class AbuseIPDBCollector:
 
         params = {"network": cidr, "maxAgeInDays": max_age_days}
 
-        data = self._make_request(self.CHECK_BLOCK_ENDPOINT, params)
+        try:
+            data = self._make_request(self.CHECK_BLOCK_ENDPOINT, params)
+        except requests.exceptions.RequestException as exc:
+            logger.warning("AbuseIPDB check_cidr_block(%s) network failure after retries: %s", cidr, exc)
+            return []
 
         results = []
         if data and "data" in data:

--- a/src/collectors/abuseipdb_collector.py
+++ b/src/collectors/abuseipdb_collector.py
@@ -28,6 +28,7 @@ from collectors.collector_utils import (
     make_status,
     optional_api_key_effective,
     request_with_rate_limit_retries,
+    retry_with_backoff,
     status_after_misp_push,
 )
 from collectors.misp_writer import MISPWriter
@@ -121,59 +122,63 @@ class AbuseIPDBCollector:
 
         return True
 
+    @retry_with_backoff(max_retries=3, base_delay=5.0)
     def _make_request(self, endpoint: str, params: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         """
         Make a rate-limited request to AbuseIPDB API.
 
-        Args:
-            endpoint: API endpoint URL
-            params: Query parameters
+        Transient network errors (ConnectionError/Timeout/ReadTimeout/
+        ChunkedEncodingError) are retried with exponential backoff via the
+        decorator — up to 4 total attempts (first + 3 retries) with 5s / 10s /
+        20s delays. Before this fix a single connection hiccup (e.g. DNS
+        glitch or 60s ISP outage) caused ``collect()`` to return
+        ``status=True count=0`` and the day's blacklist was silently lost.
+
+        After all retries are exhausted, the underlying exception propagates
+        to ``collect()`` which catches it and returns ``success=False``, so
+        Airflow retries the task and Prometheus records the failure.
 
         Returns:
-            Response JSON dict or None on error
+            Response JSON dict on success, or None for auth/rate-limit
+            failures (401/403/429) where retrying won't help.
         """
         if not self._check_rate_limit():
             return None
 
-        try:
-            response = request_with_rate_limit_retries(
-                "GET",
-                endpoint,
-                session=self.session,
-                params=params,
-                timeout=30,
-                verify=SSL_VERIFY,
-                max_rate_limit_retries=3,
-                fallback_delay_sec=60.0,
-                retry_on_403=False,
-                context="AbuseIPDB",
-            )
+        # Do NOT wrap in a broad try/except — transient exceptions must
+        # propagate to @retry_with_backoff. Only the shape-of-response
+        # error branches return None (permanent failures: auth, parse).
+        response = request_with_rate_limit_retries(
+            "GET",
+            endpoint,
+            session=self.session,
+            params=params,
+            timeout=(15, 30),  # tuple: connect=15s, read=30s; prevents hangs on DNS/connect glitches
+            verify=SSL_VERIFY,
+            max_rate_limit_retries=3,
+            fallback_delay_sec=60.0,
+            retry_on_403=False,
+            context="AbuseIPDB",
+        )
 
-            self.last_request_time = time.time()
-            self.requests_today += 1
-            self._last_http_status = response.status_code
+        self.last_request_time = time.time()
+        self.requests_today += 1
+        self._last_http_status = response.status_code
 
-            if response.status_code == 200:
-                try:
-                    return response.json()
-                except (ValueError, TypeError):
-                    logger.error("AbuseIPDB: Malformed JSON in 200 response")
-                    return None
-            elif response.status_code == 429:
-                logger.warning("AbuseIPDB: Rate limit exceeded (429) after retries")
+        if response.status_code == 200:
+            try:
+                return response.json()
+            except (ValueError, TypeError):
+                logger.error("AbuseIPDB: Malformed JSON in 200 response")
                 return None
-            elif response.status_code == 401:
-                logger.error("AbuseIPDB: Authentication failed - check API key")
-                return None
-            else:
-                logger.warning(f"AbuseIPDB API error: {response.status_code} - {response.text[:200]}")
-                return None
-
-        except requests.exceptions.Timeout:
-            logger.error("AbuseIPDB request timed out")
+        elif response.status_code == 429:
+            logger.warning("AbuseIPDB: Rate limit exceeded (429) after retries")
             return None
-        except requests.exceptions.RequestException as e:
-            logger.error(f"AbuseIPDB request error: {e}")
+        elif response.status_code == 401:
+            logger.error("AbuseIPDB: Authentication failed - check API key")
+            return None
+        else:
+            logger.warning(f"AbuseIPDB API error: {response.status_code} - {response.text[:200]}")
             return None
 
     def check_ip(self, ip_address: str, max_age_days: int = 90) -> Optional[Dict[str, Any]]:
@@ -432,8 +437,24 @@ class AbuseIPDBCollector:
                 )
             return []
 
-        # Fetch blacklist
-        results = self.get_blacklist(confidence_minimum=confidence_minimum, limit=limit, baseline=baseline)
+        # Fetch blacklist. Network exceptions (after @retry_with_backoff in
+        # _make_request has exhausted its retries) propagate here — catch
+        # them so the collector returns a PROPER failure status instead of
+        # silent success. Before this fix, a connection error returned
+        # success=True count=0 and Airflow never retried the task.
+        try:
+            results = self.get_blacklist(confidence_minimum=confidence_minimum, limit=limit, baseline=baseline)
+        except requests.exceptions.RequestException as exc:
+            logger.error(
+                "AbuseIPDB: network failure after retries (%s: %s) — reporting as collector failure",
+                type(exc).__name__,
+                exc,
+            )
+            if push_to_misp:
+                return self._return_status(False, 0, error=f"{type(exc).__name__}: {exc}", failed=0)
+            # Non-MISP caller expects a list; returning an empty list would
+            # be indistinguishable from "no data today" so raise instead.
+            raise
 
         if baseline and not results:
             logger.warning("AbuseIPDB baseline returned 0 items — verify API key")

--- a/src/collectors/global_feed_collector.py
+++ b/src/collectors/global_feed_collector.py
@@ -352,13 +352,16 @@ class URLhausCollector:
         self.misp_writer = misp_writer or MISPWriter()
 
     @retry_with_backoff(max_retries=3, base_delay=5.0)
+    @retry_with_backoff(max_retries=3, base_delay=5.0)
     def _fetch_feed(self, url: str) -> str:
-        """Download a URLhaus feed CSV with retry."""
+        """Download a URLhaus feed CSV with retry. Matches the CyberCure
+        pattern — transient network errors retry 4x with backoff before the
+        exception propagates."""
         response = request_with_rate_limit_retries(
             "GET",
             url,
             session=None,
-            timeout=30,
+            timeout=(15, 30),  # tuple: connect=15s, read=30s
             verify=SSL_VERIFY,
             max_rate_limit_retries=3,
             fallback_delay_sec=30.0,
@@ -398,6 +401,13 @@ class URLhausCollector:
 
         limit = resolve_collection_limit(limit, "urlhaus", baseline=baseline)
         results = []
+        # Track per-URL failures so we can distinguish "all mirrors failed"
+        # (real outage — report FAILURE to Airflow/Prometheus) from "first
+        # mirror succeeded, others skipped" (success). Before this change
+        # an all-mirrors-down run returned count=0 success=True and was
+        # invisible to monitoring.
+        mirror_failures = 0
+        mirror_success = False
 
         for url in self.urls:
             # Rate limiting
@@ -456,11 +466,13 @@ class URLhausCollector:
 
                 logger.info(f"[OK] URLhaus: Collected from {url.split('/')[-2]}")
                 URLHAUS_CIRCUIT_BREAKER.record_success()
+                mirror_success = True
                 break  # Got data, no need to try other URLs
 
             except Exception as e:
                 logger.warning(f"URLhaus {url}: {e}")
                 URLHAUS_CIRCUIT_BREAKER.record_failure()
+                mirror_failures += 1
                 continue
 
         # Deduplicate by value
@@ -474,6 +486,17 @@ class URLhausCollector:
         logger.info(f"[OK] URLhaus: {len(unique)} unique URLs")
         if not unique:
             logger.warning("URLhaus returned 0 URLs — check feed availability")
+
+        # If every mirror failed, report collector FAILURE instead of
+        # success-with-zero-count. This is the fix for the silent-data-loss
+        # pattern where an all-mirrors-down outage showed up as a successful
+        # Airflow task with zero indicators and never triggered an alert.
+        if not mirror_success and mirror_failures >= len(self.urls) and self.urls:
+            err = f"URLhaus: all {mirror_failures} mirror(s) failed"
+            logger.error(err)
+            if push_to_misp:
+                return make_status("urlhaus", False, count=0, failed=0, error=err)
+            return []
 
         out = unique if limit is None else unique[:limit]
         if push_to_misp:
@@ -517,7 +540,7 @@ class CyberCureCollector:
             "GET",
             url,
             session=None,
-            timeout=30,
+            timeout=(15, 30),  # tuple: connect=15s, read=30s
             verify=SSL_VERIFY,
             max_rate_limit_retries=3,
             fallback_delay_sec=30.0,
@@ -555,6 +578,11 @@ class CyberCureCollector:
 
         limit = resolve_collection_limit(limit, "cybercure", baseline=baseline)
         results = []
+        # Track per-feed failures so an all-feeds-down outage reports as
+        # a collector failure rather than silent-zero-success. Same
+        # rationale as URLhaus above.
+        feed_failures = 0
+        feed_success_count = 0
 
         for feed_type, url in self.feeds.items():
             # Rate limiting
@@ -628,15 +656,26 @@ class CyberCureCollector:
                         )
 
                 CYBERCURE_CIRCUIT_BREAKER.record_success()
+                feed_success_count += 1
 
             except Exception as e:
                 logger.warning(f"CyberCure {feed_type}: {e}")
                 CYBERCURE_CIRCUIT_BREAKER.record_failure()
+                feed_failures += 1
                 continue
 
         logger.info(f"[OK] CyberCure: Collected {len(results)} indicators")
         if not results:
             logger.warning("CyberCure returned 0 indicators — check feed availability")
+
+        # All feeds failed → report collector failure instead of silent
+        # zero-count success.
+        if feed_success_count == 0 and feed_failures >= len(self.feeds) and self.feeds:
+            err = f"CyberCure: all {feed_failures} feed(s) failed"
+            logger.error(err)
+            if push_to_misp:
+                return make_status("cybercure", False, count=0, failed=0, error=err)
+            return []
 
         if push_to_misp:
             if not results:

--- a/src/collectors/global_feed_collector.py
+++ b/src/collectors/global_feed_collector.py
@@ -490,12 +490,17 @@ class URLhausCollector:
         # success-with-zero-count. This is the fix for the silent-data-loss
         # pattern where an all-mirrors-down outage showed up as a successful
         # Airflow task with zero indicators and never triggered an alert.
+        #
+        # For the non-MISP caller (push_to_misp=False), an empty list is
+        # indistinguishable from "feed had no data today" — raise instead so
+        # the failure is visible to enrichment workflows. Matches the
+        # AbuseIPDB pattern in collect().
         if not mirror_success and mirror_failures >= len(self.urls) and self.urls:
             err = f"URLhaus: all {mirror_failures} mirror(s) failed"
             logger.error(err)
             if push_to_misp:
                 return make_status("urlhaus", False, count=0, failed=0, error=err)
-            return []
+            raise RuntimeError(err)
 
         out = unique if limit is None else unique[:limit]
         if push_to_misp:
@@ -668,13 +673,15 @@ class CyberCureCollector:
             logger.warning("CyberCure returned 0 indicators — check feed availability")
 
         # All feeds failed → report collector failure instead of silent
-        # zero-count success.
+        # zero-count success. Raise for the non-MISP caller so failures
+        # are visible to enrichment workflows (same pattern as URLhaus
+        # above and AbuseIPDB in its own collect()).
         if feed_success_count == 0 and feed_failures >= len(self.feeds) and self.feeds:
             err = f"CyberCure: all {feed_failures} feed(s) failed"
             logger.error(err)
             if push_to_misp:
                 return make_status("cybercure", False, count=0, failed=0, error=err)
-            return []
+            raise RuntimeError(err)
 
         if push_to_misp:
             if not results:

--- a/src/collectors/global_feed_collector.py
+++ b/src/collectors/global_feed_collector.py
@@ -352,7 +352,6 @@ class URLhausCollector:
         self.misp_writer = misp_writer or MISPWriter()
 
     @retry_with_backoff(max_retries=3, base_delay=5.0)
-    @retry_with_backoff(max_retries=3, base_delay=5.0)
     def _fetch_feed(self, url: str) -> str:
         """Download a URLhaus feed CSV with retry. Matches the CyberCure
         pattern — transient network errors retry 4x with backoff before the

--- a/src/collectors/virustotal_collector.py
+++ b/src/collectors/virustotal_collector.py
@@ -106,6 +106,8 @@ class VirusTotalCollector:
         try:
             indicators = self._collect_from_files(limit)
         except requests.HTTPError as e:
+            # Auth/access denied → optional-source skip (the source is
+            # wired but the key is expired or low-tier).
             if push_to_misp and is_auth_or_access_denied(e):
                 logger.warning(f"VirusTotal enrich: auth/access denied — skipping (optional): {e}")
                 return make_skipped_optional_source(
@@ -113,8 +115,20 @@ class VirusTotalCollector:
                     skip_reason=str(e),
                     skip_reason_class="virustotal_auth_denied",
                 )
-            logger.error(f"VirusTotal collection error: {e}")
-            indicators = self._collect_demo_data(limit)
+            # Any other HTTPError (5xx after retry exhaustion, 4xx that
+            # isn't auth) → report as collector failure. Do NOT fall back
+            # to demo data — the pre-round-1 behaviour pushed fake hashes
+            # to MISP tagged as real VT enrichment on any error.
+            logger.error(f"VirusTotal HTTP error: {e}")
+            if push_to_misp:
+                return make_status(
+                    "virustotal_enrich",
+                    False,
+                    count=0,
+                    failed=0,
+                    error=f"{type(e).__name__}: {e}",
+                )
+            raise
         except (
             requests.exceptions.ConnectionError,
             requests.exceptions.Timeout,
@@ -124,8 +138,7 @@ class VirusTotalCollector:
             # Network outage after @retry_with_backoff exhausted. Do NOT
             # silently fall back to demo data — return a proper failure
             # status so Airflow retries the task and Prometheus records
-            # the failure. (Pre-fix behaviour pushed demo data to MISP
-            # tagged as real VT enrichment during any outage.)
+            # the failure.
             logger.error(
                 "VirusTotal: network failure after retries (%s: %s) — reporting as collector failure",
                 type(net_exc).__name__,
@@ -141,6 +154,14 @@ class VirusTotalCollector:
                 )
             raise
         except Exception as e:
+            # Any remaining exception (JSONDecodeError on a malformed VT
+            # 200 response, KeyError / TypeError on unexpected schema,
+            # etc.) — report as a hard collector failure, NOT a fall-back
+            # to demo data. Round 1 removed the internal try/except from
+            # _collect_from_files without fixing this handler, so parse
+            # errors were silently pushing fake hashes to MISP — bugbot
+            # caught it on round 3. Auth/access-denied exceptions still
+            # route through the optional-source skip path.
             if push_to_misp and is_auth_or_access_denied(e):
                 logger.warning(f"VirusTotal enrich: auth/access denied — skipping (optional): {e}")
                 return make_skipped_optional_source(
@@ -148,8 +169,20 @@ class VirusTotalCollector:
                     skip_reason=str(e),
                     skip_reason_class="virustotal_auth_denied",
                 )
-            logger.error(f"VirusTotal collection error: {e}")
-            indicators = self._collect_demo_data(limit)
+            logger.error(
+                "VirusTotal collection error (parse/schema/other): %s: %s",
+                type(e).__name__,
+                e,
+            )
+            if push_to_misp:
+                return make_status(
+                    "virustotal_enrich",
+                    False,
+                    count=0,
+                    failed=0,
+                    error=f"{type(e).__name__}: {e}",
+                )
+            raise
 
         if push_to_misp:
             if not self.misp_writer:

--- a/src/collectors/virustotal_collector.py
+++ b/src/collectors/virustotal_collector.py
@@ -161,7 +161,6 @@ class VirusTotalCollector:
 
         return indicators
 
-    @retry_with_backoff(max_retries=3, base_delay=5.0)
     def _collect_from_files(self, limit):
         """Collect recent malware files from VT.
 
@@ -169,29 +168,24 @@ class VirusTotalCollector:
         an empty list, which meant the outer ``collect()`` silently fell
         back to DEMO DATA on any network error and pushed fake hashes to
         MISP tagged as real VT intelligence. Now transient network errors
-        propagate to ``@retry_with_backoff`` (4 total attempts at 5/10/20s)
-        and, on final exhaustion, bubble up to ``collect()`` which routes
-        them to a proper failure status instead of the demo fallback.
+        propagate to ``@retry_with_backoff`` (applied on the inner
+        ``_fetch_recent_files_raw`` helper, not this method) and, on
+        final exhaustion, bubble up to ``collect()`` which routes them
+        to a proper failure status instead of the demo fallback.
+
+        Rate limiting is handled HERE, not inside the retried helper,
+        because the VT rate limiter is a 4 req/min sliding window —
+        retrying inside the rate-limited scope would burn the full
+        per-minute quota on a single failing call. Matches the
+        URLhaus/CyberCure pattern (rate limiter outside, retry inside).
         """
         indicators = []
 
-        # Rate limit check
+        # Rate limit check — outside the retried helper so a single failing
+        # call doesn't exhaust the VT 4/minute sliding window on its retries.
         self.rate_limiter.wait_if_needed()
 
-        # Get recent files analyzed by VT. Do NOT catch generic Exception
-        # here — let transient network errors reach the retry decorator,
-        # and let terminal errors reach collect() for failure reporting.
-        response = request_with_rate_limit_retries(
-            "GET",
-            f"{self.base_url}/files",
-            session=self.session,
-            params={"limit": min(limit, 10)},  # API has strict limits
-            timeout=(15, 30),  # tuple: connect=15s, read=30s
-            max_rate_limit_retries=3,
-            fallback_delay_sec=60.0,
-            retry_on_403=False,
-            context="VirusTotal",
-        )
+        response = self._fetch_recent_files_raw(limit)
 
         if response.status_code == 200:
             data = response.json()
@@ -228,6 +222,32 @@ class VirusTotalCollector:
             )
 
         return indicators[:limit]
+
+    @retry_with_backoff(max_retries=3, base_delay=5.0)
+    def _fetch_recent_files_raw(self, limit):
+        """HTTP fetch for ``/files`` with retry but NO rate limiting.
+
+        Split out of ``_collect_from_files`` so each retry attempt does
+        not re-enter ``self.rate_limiter.wait_if_needed()`` — the VT
+        free-tier limiter is a 4 req/min sliding window, and a single
+        failing call inside the retried scope would have burned the
+        whole per-minute quota on its 4 attempts.
+
+        The caller (``_collect_from_files``) handles rate limiting
+        once, before this helper runs. Matches the URLhaus/CyberCure
+        split in ``global_feed_collector.py``.
+        """
+        return request_with_rate_limit_retries(
+            "GET",
+            f"{self.base_url}/files",
+            session=self.session,
+            params={"limit": min(limit, 10)},  # API has strict limits
+            timeout=(15, 30),  # tuple: connect=15s, read=30s
+            max_rate_limit_retries=3,
+            fallback_delay_sec=60.0,
+            retry_on_403=False,
+            context="VirusTotal",
+        )
 
     def _detect_zones_from_names(self, attrs):
         """Detect ALL sectors from file names/paths using common zone detection.

--- a/src/collectors/virustotal_collector.py
+++ b/src/collectors/virustotal_collector.py
@@ -30,6 +30,7 @@ from collectors.collector_utils import (
     make_status,
     optional_api_key_effective,
     request_with_rate_limit_retries,
+    retry_with_backoff,
     status_after_misp_push,
 )
 from config import (
@@ -114,6 +115,31 @@ class VirusTotalCollector:
                 )
             logger.error(f"VirusTotal collection error: {e}")
             indicators = self._collect_demo_data(limit)
+        except (
+            requests.exceptions.ConnectionError,
+            requests.exceptions.Timeout,
+            requests.exceptions.ReadTimeout,
+            requests.exceptions.ChunkedEncodingError,
+        ) as net_exc:
+            # Network outage after @retry_with_backoff exhausted. Do NOT
+            # silently fall back to demo data — return a proper failure
+            # status so Airflow retries the task and Prometheus records
+            # the failure. (Pre-fix behaviour pushed demo data to MISP
+            # tagged as real VT enrichment during any outage.)
+            logger.error(
+                "VirusTotal: network failure after retries (%s: %s) — reporting as collector failure",
+                type(net_exc).__name__,
+                net_exc,
+            )
+            if push_to_misp:
+                return make_status(
+                    "virustotal_enrich",
+                    False,
+                    count=0,
+                    failed=0,
+                    error=f"{type(net_exc).__name__}: {net_exc}",
+                )
+            raise
         except Exception as e:
             if push_to_misp and is_auth_or_access_denied(e):
                 logger.warning(f"VirusTotal enrich: auth/access denied — skipping (optional): {e}")
@@ -135,55 +161,71 @@ class VirusTotalCollector:
 
         return indicators
 
+    @retry_with_backoff(max_retries=3, base_delay=5.0)
     def _collect_from_files(self, limit):
-        """Collect recent malware files from VT"""
+        """Collect recent malware files from VT.
+
+        Previously this method caught ``Exception`` broadly and returned
+        an empty list, which meant the outer ``collect()`` silently fell
+        back to DEMO DATA on any network error and pushed fake hashes to
+        MISP tagged as real VT intelligence. Now transient network errors
+        propagate to ``@retry_with_backoff`` (4 total attempts at 5/10/20s)
+        and, on final exhaustion, bubble up to ``collect()`` which routes
+        them to a proper failure status instead of the demo fallback.
+        """
         indicators = []
 
         # Rate limit check
         self.rate_limiter.wait_if_needed()
 
-        try:
-            # Get recent files analyzed by VT
-            response = request_with_rate_limit_retries(
-                "GET",
-                f"{self.base_url}/files",
-                session=self.session,
-                params={"limit": min(limit, 10)},  # API has strict limits
-                timeout=30,
-                max_rate_limit_retries=3,
-                fallback_delay_sec=60.0,
-                retry_on_403=False,
-                context="VirusTotal",
+        # Get recent files analyzed by VT. Do NOT catch generic Exception
+        # here — let transient network errors reach the retry decorator,
+        # and let terminal errors reach collect() for failure reporting.
+        response = request_with_rate_limit_retries(
+            "GET",
+            f"{self.base_url}/files",
+            session=self.session,
+            params={"limit": min(limit, 10)},  # API has strict limits
+            timeout=(15, 30),  # tuple: connect=15s, read=30s
+            max_rate_limit_retries=3,
+            fallback_delay_sec=60.0,
+            retry_on_403=False,
+            context="VirusTotal",
+        )
+
+        if response.status_code == 200:
+            data = response.json()
+            for item in data.get("data", []):
+                attrs = item.get("attributes", {})
+                hashes = attrs.get("last_analysis_stats", {})
+
+                # Get the hash with most info
+                if attrs.get("sha256"):
+                    mal_count = hashes.get("malicious", 0)
+                    conf = min(0.5 + (mal_count / 70), 0.95)  # Scale 0.5-0.95
+
+                    zones = self._detect_zones_from_names(attrs)
+
+                    indicators.append(
+                        {
+                            "indicator_type": "hash",
+                            "value": attrs["sha256"],
+                            "zone": zones,  # zone is now an array
+                            "tag": self.tag,
+                            "source": [self.tag],
+                            "first_seen": attrs.get("first_submission_date", ""),
+                            "last_updated": datetime.now(timezone.utc).isoformat(),
+                            "confidence_score": conf,
+                        }
+                    )
+        elif response.status_code in (401, 403):
+            # Surface auth errors so the caller can mark the source skipped.
+            response.raise_for_status()
+        else:
+            logger.warning(
+                "VT files query returned unexpected status %s — treating as empty",
+                response.status_code,
             )
-
-            if response.status_code == 200:
-                data = response.json()
-                for item in data.get("data", []):
-                    attrs = item.get("attributes", {})
-                    hashes = attrs.get("last_analysis_stats", {})
-
-                    # Get the hash with most info
-                    if attrs.get("sha256"):
-                        mal_count = hashes.get("malicious", 0)
-                        conf = min(0.5 + (mal_count / 70), 0.95)  # Scale 0.5-0.95
-
-                        zones = self._detect_zones_from_names(attrs)
-
-                        indicators.append(
-                            {
-                                "indicator_type": "hash",
-                                "value": attrs["sha256"],
-                                "zone": zones,  # zone is now an array
-                                "tag": self.tag,
-                                "source": [self.tag],
-                                "first_seen": attrs.get("first_submission_date", ""),
-                                "last_updated": datetime.now(timezone.utc).isoformat(),
-                                "confidence_score": conf,
-                            }
-                        )
-
-        except Exception as e:
-            logger.warning(f"VT files query: {e}")
 
         return indicators[:limit]
 
@@ -240,7 +282,7 @@ class VirusTotalCollector:
                 "GET",
                 f"{self.base_url}/domains/{domain}",
                 session=self.session,
-                timeout=10,
+                timeout=(15, 30),  # tuple: connect=15s, read=30s — single-value 10s was too tight for DNS glitches
                 max_rate_limit_retries=3,
                 fallback_delay_sec=60.0,
                 retry_on_403=False,
@@ -292,7 +334,7 @@ class VirusTotalCollector:
                 "GET",
                 f"{self.base_url}/files/{hash_value}",
                 session=self.session,
-                timeout=10,
+                timeout=(15, 30),  # tuple: connect=15s, read=30s — single-value 10s was too tight for DNS glitches
                 max_rate_limit_retries=3,
                 fallback_delay_sec=60.0,
                 retry_on_403=False,
@@ -337,7 +379,7 @@ class VirusTotalCollector:
                 "GET",
                 f"{self.base_url}/ip_addresses/{ip}",
                 session=self.session,
-                timeout=10,
+                timeout=(15, 30),  # tuple: connect=15s, read=30s — single-value 10s was too tight for DNS glitches
                 max_rate_limit_retries=3,
                 fallback_delay_sec=60.0,
                 retry_on_403=False,

--- a/src/collectors/virustotal_collector.py
+++ b/src/collectors/virustotal_collector.py
@@ -245,10 +245,13 @@ class VirusTotalCollector:
                             "confidence_score": conf,
                         }
                     )
-        elif response.status_code in (401, 403):
-            # Surface auth errors so the caller can mark the source skipped.
-            response.raise_for_status()
         else:
+            # Any non-200 that reaches this branch is either a 4xx
+            # client error (already surfaced as HTTPError in
+            # _fetch_recent_files_raw below) or an unexpected status.
+            # Treat it as empty and move on; real 5xx failures are
+            # caught by raise_for_status() inside the retried helper
+            # so they never reach here.
             logger.warning(
                 "VT files query returned unexpected status %s — treating as empty",
                 response.status_code,
@@ -268,9 +271,15 @@ class VirusTotalCollector:
 
         The caller (``_collect_from_files``) handles rate limiting
         once, before this helper runs. Matches the URLhaus/CyberCure
-        split in ``global_feed_collector.py``.
+        split in ``global_feed_collector.py``, which includes
+        ``response.raise_for_status()`` at the end to surface HTTP
+        5xx as exceptions that hit the retry decorator (and, on
+        exhaustion, propagate to collect() for proper failure
+        reporting — bugbot round 4 caught that this VT helper was
+        the only one missing that step and 5xx slipped through
+        silently as empty indicators).
         """
-        return request_with_rate_limit_retries(
+        response = request_with_rate_limit_retries(
             "GET",
             f"{self.base_url}/files",
             session=self.session,
@@ -281,6 +290,12 @@ class VirusTotalCollector:
             retry_on_403=False,
             context="VirusTotal",
         )
+        # Raise HTTPError on 4xx/5xx so the retry decorator above gets a
+        # shot at transient 5xx, and terminal failures propagate to
+        # collect() — matches URLhaus/CyberCure. 200 responses pass
+        # through unchanged to the caller for normal parsing.
+        response.raise_for_status()
+        return response
 
     def _detect_zones_from_names(self, attrs):
         """Detect ALL sectors from file names/paths using common zone detection.


### PR DESCRIPTION
## Summary

Independent audit of all 11 collectors found 4 that **silently drop data on any network outage** — they catch broad \`Exception\`, log a warning, return an empty list, and the pipeline reports \`success=True count=0\`. Airflow never retries; Prometheus stays green. An entire day's feed could be lost invisibly.

This fixes the four worst offenders.

## The pattern being fixed

\`\`\`python
try:
    response = request_with_rate_limit_retries(...)
    ...
except Exception as e:
    logger.warning(f\"Feed error: {e}\")  # ← swallowed, no retry, no failure
    return []                              # ← caller treats as \"no data today\"
\`\`\`

Result: \`make_status(\"feed\", True, count=0)\` → Airflow green, Prometheus green, operators blind.

## Changes per collector

### AbuseIPDB
- \`_make_request\` → \`@retry_with_backoff(3, 5.0)\` + removed broad \`except RequestException\`
- Tuple timeout \`(15, 30)\`
- \`collect()\` catches post-retry failures and returns proper failure status

### VirusTotal enrichment
- \`_collect_from_files\` → \`@retry_with_backoff(3, 5.0)\` + removed broad \`Exception\` catch
- \`collect()\` now differentiates network failures (→ failure status) from auth failures (→ optional-source skip). **Previously both fell back to \`_collect_demo_data()\` which pushed FAKE hashes to MISP tagged as real VT enrichment during any outage.**
- Tuple timeouts \`(15, 30)\` replace four hardcoded single-value timeouts

### URLhaus
- \`_fetch_feed\` → \`@retry_with_backoff(3, 5.0)\` (CyberCure already had this; URLhaus was the outlier)
- \`collect()\` tracks mirror_failures / mirror_success. All mirrors down → failure status instead of silent success.

### CyberCure
- Same feed_failures / feed_success_count tracking. All-feeds-down → failure status.
- Tuple timeout \`(15, 30)\`

## What this does NOT do

- Does not touch the other 7 collectors. NVD, OTX, MITRE, CISA, VT primary (\`vt_collector.py\`), Feodo, and SSLBL already raise properly on network errors.
- The \`nvd_collector._fetch_cves_batch\` silent-empty-list bug in **baseline mode** is flagged as a follow-up — the incremental path is safe.
- No shared retry base class (larger refactor, out of scope).

## Stacks on

Complementary to [#20](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/20) (retry) and [#21](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/21) (observability). These three PRs together close the silent-data-loss loop: sync failures retry properly (#20), are exported to Prometheus (#21), and collectors don't mask outages as success (#22).

## Test plan

- [x] \`ruff check\` clean on all three files
- [x] 15 collector tests pass
- [ ] Manual test: revoke network on abuseipdb/vt/urlhaus hosts → verify status=False returned instead of count=0 success
- [ ] After deploy: confirm \`edgeguard_source_health\` gauges flip when these collectors fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collector error-handling semantics so transient network failures now raise/return failure statuses instead of silently producing empty results, which may increase observed task failures but improves reliability and monitoring.
> 
> **Overview**
> Stops several collectors from **silently succeeding with `count=0`** during network outages.
> 
> `AbuseIPDBCollector` now retries transient request failures via `@retry_with_backoff`, uses connect/read tuple timeouts, and ensures post-retry `RequestException`s become **collector failures** (while keeping `check_ip`/`check_cidr_block` returning `None`/`[]` for enrichment compatibility).
> 
> `URLhausCollector` and `CyberCureCollector` add per-mirror/feed success tracking so **all endpoints failing** reports `success=False` (and raises for non-MISP callers), and both switch feed fetch timeouts to `(15, 30)`.
> 
> `VirusTotalCollector` removes demo-data fallback on errors: it splits the `/files` fetch into a retried helper that `raise_for_status()`es, updates timeouts to `(15, 30)`, and makes network/HTTP/parse failures return **failure statuses** (or raise) while still treating auth-denied as optional-source skips.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5751ba3c21297b91315d3f59da6f0a6161bb4be0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->