### PR TITLE
fix: cross-process mutex between CLI baseline and scheduled DAGs

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -630,6 +630,38 @@ def run_collector_with_metrics(
 
     task_start = time.time()
 
+    # Baseline mutex: if a CLI baseline run is holding the sentinel lock,
+    # skip this scheduled run instead of racing against it for MISP/Neo4j
+    # writes. The baseline is treated as authoritative — it's a long,
+    # expensive, operator-driven run that shouldn't be undermined by
+    # interleaved partial writes from the incremental DAGs.
+    try:
+        from baseline_lock import baseline_skip_reason
+
+        _baseline_skip = baseline_skip_reason()
+    except Exception:
+        # If the module can't load for any reason, fail-open (run as
+        # before). Import errors must not break the whole DAG.
+        logger.debug("baseline_lock import failed — proceeding without baseline mutex", exc_info=True)
+        _baseline_skip = None
+
+    if _baseline_skip is not None:
+        from collectors.collector_utils import make_skipped_optional_source
+
+        logger.warning("%s: %s", collector_name.upper(), _baseline_skip)
+        result = make_skipped_optional_source(
+            collector_name,
+            skip_reason=_baseline_skip,
+            skip_reason_class="baseline_in_progress",
+        )
+        duration = time.time() - start_time
+        record_dag_run("edgeguard_pipeline", "success")
+        if METRICS_SERVER_AVAILABLE:
+            record_collection(collector_name, "global", 0, "skipped")
+            record_collection_duration(collector_name, "global", duration)
+            record_collector_skip(collector_name, "baseline_in_progress")
+        return result
+
     if not is_collector_enabled_by_allowlist(collector_name):
         from collectors.collector_utils import make_skipped_optional_source
 
@@ -919,6 +951,21 @@ def get_state_file() -> str:
 def should_run_neo4j_sync():
     """Determine if Neo4j sync should run based on interval."""
     import json
+
+    # Baseline mutex: the scheduled Neo4j sync must never run concurrently
+    # with a CLI baseline. The baseline runs its own MISP->Neo4j sync in
+    # the same Python process and a parallel Airflow sync would read
+    # MISP mid-push, producing partial data in Neo4j. ShortCircuit skips
+    # the whole sync DAG run downstream.
+    try:
+        from baseline_lock import baseline_skip_reason
+
+        _baseline_skip = baseline_skip_reason()
+    except Exception:
+        _baseline_skip = None
+    if _baseline_skip is not None:
+        logger.warning("Neo4j sync ShortCircuit: %s", _baseline_skip)
+        return False
 
     state_file = get_state_file()
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -956,12 +956,15 @@ def should_run_neo4j_sync():
     # with a CLI baseline. The baseline runs its own MISP->Neo4j sync in
     # the same Python process and a parallel Airflow sync would read
     # MISP mid-push, producing partial data in Neo4j. ShortCircuit skips
-    # the whole sync DAG run downstream.
+    # the whole sync DAG run downstream. Fail-open: if baseline_lock
+    # fails to import (e.g. module not on PYTHONPATH during a test),
+    # log the error and proceed rather than blocking the sync.
     try:
         from baseline_lock import baseline_skip_reason
 
         _baseline_skip = baseline_skip_reason()
     except Exception:
+        logger.debug("baseline_lock import failed — proceeding without baseline mutex", exc_info=True)
         _baseline_skip = None
     if _baseline_skip is not None:
         logger.warning("Neo4j sync ShortCircuit: %s", _baseline_skip)

--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -128,7 +128,13 @@ def is_baseline_running() -> Optional[Dict[str, Any]]:
     except (TypeError, ValueError):
         pid_int = 0
 
-    # Same-host liveness check.
+    # Same-host liveness check: if the sentinel was written by this host
+    # we can ask the kernel directly whether the PID is still alive.
+    # A live same-host PID is authoritative — do NOT fall through to the
+    # cross-host age check, or a baseline running longer than
+    # EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC (default 24h) would have its
+    # sentinel pruned out from under a still-running process and re-open
+    # the exact race the mutex is designed to prevent.
     local_host = socket.gethostname()
     if host == local_host:
         if not _pid_alive(pid_int):
@@ -139,8 +145,11 @@ def is_baseline_running() -> Optional[Dict[str, Any]]:
             )
             _safe_remove(path)
             return None
+        return data  # live same-host PID — authoritative, skip age check
 
-    # Age check (works across hosts).
+    # Age check — ONLY for cross-host sentinels, where we can't verify the
+    # PID from here. If a baseline ran on another host and crashed without
+    # cleaning up, this reaps the sentinel after the configured max age.
     try:
         started_dt = datetime.fromisoformat(started_at)
         age_sec = (datetime.now(timezone.utc) - started_dt).total_seconds()

--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -1,0 +1,258 @@
+"""
+EdgeGuard baseline lock — cross-process mutex between CLI baseline runs
+and scheduled Airflow collector DAG tasks.
+
+Problem this solves
+-------------------
+
+Before this module existed, there was no serialization between a CLI
+baseline run (`python run_pipeline.py --baseline`) and the regularly
+scheduled Airflow collector DAGs (edgeguard_pipeline, edgeguard_daily,
+edgeguard_low_freq, etc.). Both could target MISP and Neo4j at the same
+time, racing on MISP event writes and Neo4j MERGE operations.
+
+Existing locks did not cover this:
+- `checkpoints/pipeline.lock` (set in run_pipeline.py) only prevents
+  concurrent CLI invocations.
+- `max_active_runs=1` on each DAG only prevents overlap *within* that DAG.
+
+Neither knew about the other.
+
+Design
+------
+
+A sentinel file at `checkpoints/baseline_in_progress.lock` that CLI
+baseline runs write on entry and remove on exit. Every scheduled DAG
+collector task checks the sentinel before doing work and short-circuits
+(returns a skipped status) if a baseline is holding it.
+
+The sentinel stores `{"pid": int, "started_at": ISO-8601, "host": str}`
+so stale entries (process died without cleanup) can be pruned safely by
+checking whether the PID is still alive on the same host. Cross-host
+stale detection uses a configurable max-age (default 24h).
+
+Why not Airflow pools / ExternalTaskSensor
+------------------------------------------
+
+Airflow pools require API plumbing from the CLI side to take the slot,
+which is more invasive. ExternalTaskSensor only works if the baseline
+also runs inside Airflow. The sentinel file is the cheapest approach
+that handles both the CLI→Airflow and Airflow→Airflow directions, and
+it matches the existing `pipeline.lock` idiom.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import socket
+import time
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Max age before a sentinel is considered stale on cross-host setups.
+# PID-check covers local same-host stale detection; this catches the case
+# where the process holding the lock crashed on a different host.
+_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 24 * 3600
+
+
+def _repo_root() -> str:
+    """Repo root — src/../ — without depending on any other module."""
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def baseline_lock_path() -> str:
+    """Absolute path to the sentinel file. Matches the `checkpoints/` dir
+    convention already used by `pipeline.lock` and baseline checkpoints."""
+    override = os.environ.get("EDGEGUARD_BASELINE_LOCK_PATH")
+    if override:
+        return override
+    return os.path.join(_repo_root(), "checkpoints", "baseline_in_progress.lock")
+
+
+def _read_sentinel(path: str) -> Optional[Dict[str, Any]]:
+    try:
+        with open(path) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError, OSError):
+        return None
+
+
+def _pid_alive(pid: int) -> bool:
+    if pid <= 0:
+        return False
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        # PID exists but owned by another user — treat as alive.
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError:
+        return False
+
+
+def _max_age_sec() -> float:
+    raw = os.environ.get("EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC")
+    if not raw:
+        return float(_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT)
+    try:
+        return max(1.0, float(raw))
+    except (TypeError, ValueError):
+        return float(_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT)
+
+
+def is_baseline_running() -> Optional[Dict[str, Any]]:
+    """
+    Return the sentinel dict if a baseline is currently holding the lock,
+    else None. Transparently prunes stale sentinels (dead PID on same host,
+    or exceeded max-age on any host).
+
+    Callers: treat a non-None return as "do not run, baseline has priority".
+    """
+    path = baseline_lock_path()
+    data = _read_sentinel(path)
+    if data is None:
+        return None
+
+    # Validate fields — tolerate missing/garbled state by treating as stale.
+    pid = data.get("pid")
+    host = data.get("host", "")
+    started_at = data.get("started_at", "")
+    try:
+        pid_int = int(pid) if pid is not None else 0
+    except (TypeError, ValueError):
+        pid_int = 0
+
+    # Same-host liveness check.
+    local_host = socket.gethostname()
+    if host == local_host:
+        if not _pid_alive(pid_int):
+            logger.warning(
+                "Stale baseline lock (PID %s on this host is gone) — removing %s",
+                pid_int,
+                path,
+            )
+            _safe_remove(path)
+            return None
+
+    # Age check (works across hosts).
+    try:
+        started_dt = datetime.fromisoformat(started_at)
+        age_sec = (datetime.now(timezone.utc) - started_dt).total_seconds()
+    except (TypeError, ValueError):
+        age_sec = float("inf")
+
+    if age_sec > _max_age_sec():
+        logger.warning(
+            "Stale baseline lock (age %.0fs > max %.0fs) — removing %s",
+            age_sec,
+            _max_age_sec(),
+            path,
+        )
+        _safe_remove(path)
+        return None
+
+    return data
+
+
+def _safe_remove(path: str) -> None:
+    try:
+        os.remove(path)
+    except FileNotFoundError:
+        pass
+    except OSError as exc:
+        logger.warning("Failed to remove baseline lock %s: %s", path, exc)
+
+
+def acquire_baseline_lock() -> bool:
+    """
+    Write the sentinel file. Returns True on success, False if another
+    live baseline already holds the lock (caller should not proceed).
+
+    The caller is responsible for calling `release_baseline_lock()` on
+    exit — both success and failure paths. `_run_pipeline_inner` wraps
+    this in a try/finally alongside the existing pipeline.lock cleanup.
+    """
+    path = baseline_lock_path()
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+
+    existing = is_baseline_running()
+    if existing is not None:
+        logger.error(
+            "Refusing to start baseline: another baseline is already running "
+            "(pid=%s host=%s started_at=%s). "
+            "If this is stale, delete %s and retry.",
+            existing.get("pid"),
+            existing.get("host"),
+            existing.get("started_at"),
+            path,
+        )
+        return False
+
+    payload = {
+        "pid": os.getpid(),
+        "host": socket.gethostname(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+        "monotonic_started": time.monotonic(),
+    }
+    try:
+        # Atomic-ish write: write to tmp then rename so a reader never sees
+        # a half-written JSON blob.
+        tmp_path = f"{path}.tmp.{os.getpid()}"
+        with open(tmp_path, "w") as f:
+            json.dump(payload, f)
+        os.replace(tmp_path, path)
+    except OSError as exc:
+        logger.error("Failed to acquire baseline lock at %s: %s", path, exc)
+        return False
+
+    logger.info(
+        "Acquired baseline lock at %s (pid=%s host=%s)",
+        path,
+        payload["pid"],
+        payload["host"],
+    )
+    return True
+
+
+def release_baseline_lock() -> None:
+    """Remove the sentinel. Safe to call even if never acquired (idempotent)."""
+    path = baseline_lock_path()
+    # Only remove if the sentinel belongs to this process — prevents a
+    # crash-and-restart race where we'd delete someone else's lock.
+    data = _read_sentinel(path)
+    if data is None:
+        return
+    try:
+        pid_val = int(data.get("pid", 0))
+    except (TypeError, ValueError):
+        pid_val = 0
+    if pid_val != os.getpid():
+        logger.warning(
+            "Not removing baseline lock: sentinel pid=%s != current pid=%s",
+            pid_val,
+            os.getpid(),
+        )
+        return
+    _safe_remove(path)
+    logger.info("Released baseline lock at %s", path)
+
+
+def baseline_skip_reason() -> Optional[str]:
+    """
+    Human-readable reason for an Airflow task to skip if a baseline is
+    running. Returns None if no baseline is holding the lock.
+    """
+    data = is_baseline_running()
+    if data is None:
+        return None
+    return (
+        f"EdgeGuard baseline is running (pid={data.get('pid')}, "
+        f"host={data.get('host')}, started_at={data.get('started_at')}) — "
+        "skipping scheduled collector run to avoid racing MISP/Neo4j writes"
+    )

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -877,12 +877,37 @@ class EdgeGuardPipeline:
         import atexit
         import signal
 
+        # Baseline runs also take an additional cross-process sentinel that
+        # scheduled Airflow collector DAGs check before running. This
+        # prevents a CLI baseline and a regularly-scheduled DAG task from
+        # racing on MISP/Neo4j writes. Non-baseline runs do NOT take this
+        # lock — they're expected to share the pipeline with Airflow.
+        baseline_lock_held = False
+        if baseline:
+            from baseline_lock import acquire_baseline_lock
+
+            if not acquire_baseline_lock():
+                # Another baseline is already running — refuse to start.
+                try:
+                    os.remove(lock_path)
+                except OSError:
+                    pass
+                return False
+            baseline_lock_held = True
+
         def _cleanup_lock(*_args):
             try:
                 if os.path.exists(lock_path):
                     os.remove(lock_path)
             except OSError:
                 pass
+            if baseline_lock_held:
+                try:
+                    from baseline_lock import release_baseline_lock as _release
+
+                    _release()
+                except Exception:
+                    logger.debug("Baseline lock release failed", exc_info=True)
 
         atexit.register(_cleanup_lock)
 


### PR DESCRIPTION
## Summary

Fixes a cross-process serialization gap that let CLI baseline runs race against scheduled Airflow collector DAGs.

**Context on user's suspicion:** The user reported that \`--baseline\` appears to start regular collectors. An audit confirmed this is NOT what's happening: the CLI never programmatically unpauses any Airflow DAG. The real problem is that **there is no mutex** between:
- A CLI baseline run (holds \`checkpoints/pipeline.lock\`, but that only guards other CLI invocations)
- Scheduled Airflow collector DAGs (guarded by \`max_active_runs=1\`, which only prevents overlap *within* that DAG)

Neither lock knew about the other, so both sides could target MISP and Neo4j simultaneously — racing on MISP event writes and Neo4j MERGE operations.

\`--fresh-baseline\` *appeared* to work correctly only because it wipes MISP and Neo4j clean before starting, masking the race.

## Changes

### New module \`src/baseline_lock.py\`

Sentinel file at \`checkpoints/baseline_in_progress.lock\`. JSON payload with PID, host, started_at, so stale entries can be pruned via same-host PID check or cross-host max-age (\`EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC\`, default 24h). Atomic-ish write via tmp+rename.

API: \`acquire_baseline_lock\`, \`release_baseline_lock\`, \`is_baseline_running\`, \`baseline_skip_reason\`.

### \`src/run_pipeline.py\`

When \`baseline=True\`, acquires the sentinel alongside the existing pipeline.lock. Releases both on atexit / SIGTERM / normal exit. Refuses to start if another live baseline already holds the lock.

### \`dags/edgeguard_pipeline.py\`

Two chokepoints guarded:

1. **\`run_collector_with_metrics()\`** — the helper every scheduled collector task routes through. If a baseline is running, returns a skipped status with \`skip_reason_class=\"baseline_in_progress\"\`; Prometheus records the skip; task succeeds (no false failures).

2. **\`should_run_neo4j_sync()\`** — ShortCircuit guard. The baseline runs its own MISP→Neo4j sync in-process; a parallel scheduled sync would read MISP mid-push.

**Fail-open:** if \`baseline_lock\` can't import for any reason, DAGs run as before.

## Test plan

- [x] \`ruff check\` clean
- [x] Smoke test: acquire → check → double-acquire-fails → release → check cycle passes against real filesystem path
- [x] 73 existing tests pass
- [ ] Manual: start a CLI baseline; confirm scheduled collector DAGs skip with \"baseline_in_progress\" reason
- [ ] Manual: kill baseline process without cleanup; confirm next scheduled DAG prunes the stale sentinel via PID check
- [ ] Operator docs update: document the new sentinel path and env vars

## Stacks on

Independent of [#20](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/20), [#21](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/21), [#22](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/22) — no conflicts, can be merged in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new cross-process locking that can cause scheduled collectors/Neo4j syncs to skip while a baseline is running; incorrect lock/staleness handling could delay ingestion or leave stale locks blocking runs.
> 
> **Overview**
> Adds a **cross-process mutex** between CLI `--baseline` runs and scheduled Airflow DAG tasks to prevent concurrent MISP/Neo4j writes.
> 
> Introduces `src/baseline_lock.py`, which manages a `checkpoints/baseline_in_progress.lock` sentinel (PID/host/start time, stale detection, env overrides) and exposes `acquire_baseline_lock`/`release_baseline_lock` plus `baseline_skip_reason()` for Airflow.
> 
> Updates `run_pipeline.py` to acquire/release this sentinel for baseline CLI runs (and refuse to start if another baseline holds it), and updates `edgeguard_pipeline.py` to **skip scheduled collectors** (returning a skipped status + metrics) and **ShortCircuit Neo4j sync** when a baseline is in progress, with fail-open behavior if `baseline_lock` can’t be imported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3a61aba5f47059b625eec1df8bac97026662e619. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->