### PR TITLE
proposal: STIX 2.1 graph exporter for ResilMesh integration

### DIFF
--- a/docs/STIX21_EXPORTER_PROPOSAL.md
+++ b/docs/STIX21_EXPORTER_PROPOSAL.md
@@ -1,0 +1,273 @@
+# Proposal: STIX 2.1 graph exporter for ResilMesh integration
+
+Status: DRAFT — prototype implementation in `src/stix_exporter.py` and
+`GET /stix/export/{object_type}/{identifier}` in `src/query_api.py`.
+
+Depends on: PR #24 (`refactor/specialize-uses-technique-relationships`),
+which introduced the specialised rel types used below.
+
+## 1. Problem
+
+EdgeGuard and ResilMesh share a Neo4j instance. ResilMesh owns the
+asset/vulnerability layer (Host, Device, IP, Mission, Component,
+Vulnerability, CVE, CVSSv*). EdgeGuard owns the threat-intel layer
+(Indicator, Malware, ThreatActor, Technique, Tool, Campaign). The
+layers meet at `CVE` and the bridging edges `REFERS_TO` / `HAS_CVSS_v*`.
+
+ResilMesh partners want to pull our threat-intel as **STIX 2.1**
+programmatically, so their analysts can enrich an asset with "what do
+we know about this indicator / actor / technique / CVE?" Today,
+EdgeGuard only converts MISP → STIX on the *input* side
+(`run_misp_to_neo4j.py::convert_to_stix21`). There is no graph → STIX
+exporter. This proposal fills that gap.
+
+Out of scope (see §10):
+
+- Full-graph bulk export
+- TAXII 2.1 collection service
+- Push updates (webhooks / NATS-to-STIX relay)
+- Authenticated multi-tenancy
+
+## 2. Shape of the API
+
+Prototype endpoint:
+
+```
+GET /stix/export/{object_type}/{identifier}
+Accept: application/stix+json;version=2.1
+```
+
+| object_type | identifier         | Returns                                           |
+|-------------|--------------------|---------------------------------------------------|
+| `indicator` | raw value          | Indicator + 1-hop (Malware, CVE, Technique, Sector) |
+| `actor`     | name or alias      | Actor + Malware + Techniques + Campaigns (depth 2) |
+| `technique` | MITRE ATT&CK ID    | Technique + Actors/Malware/Tools/Indicators using it |
+| `cve`       | CVE ID             | CVE + Indicators that exploit it + Sectors         |
+
+Response body is a STIX 2.1 `bundle` SDO, JSON-encoded. The media type
+is `application/stix+json;version=2.1` (OASIS section 3.1). Bundle ID
+is random UUIDv4 per request; every object inside the bundle has a
+**deterministic** UUIDv5 ID (see §6).
+
+Example:
+
+```bash
+curl -H 'X-API-Key: ...' \
+  https://edgeguard/stix/export/indicator/1.2.3.4
+```
+
+## 3. Architecture
+
+```
+ ┌────────────────┐       ┌───────────────────┐       ┌─────────────────┐
+ │  ResilMesh     │──────▶│  /stix/export/*   │──────▶│  StixExporter   │
+ │  (enrichment)  │ HTTPS │  query_api.py     │  call │  stix_exporter  │
+ └────────────────┘       └───────────────────┘       └────────┬────────┘
+                                                               │ Cypher
+                                                               ▼
+                                                       ┌───────────────┐
+                                                       │    Neo4j      │
+                                                       │ (shared graph)│
+                                                       └───────────────┘
+```
+
+- `StixExporter` is a thin class that wraps a `Neo4jClient` (only needs
+  `.driver`). Four public methods: `export_indicator`,
+  `export_threat_actor`, `export_technique`, `export_cve`.
+- Each method runs a single Cypher query that fetches the seed node and
+  its neighbourhood in one round-trip, then walks the rows to build SDOs
+  and SROs.
+- SDO/SRO construction goes through the `stix2` SDK (pinned to `~=3.0`
+  in `pyproject.toml`) so the library enforces schema and timestamps.
+  Final serialisation is `json.loads(obj.serialize())` → plain dict.
+- Pattern strings for `indicator` SDOs reuse the existing helper
+  `MISPToNeo4jSync._value_to_stix_pattern` (lazy import, no
+  duplication). Zone metadata helpers (`apply_edgeguard_zone_metadata_to_stix_dict`)
+  are available for future use but not wired in for the prototype (see
+  §10).
+
+## 4. Node → SDO mapping
+
+| Graph node    | STIX 2.1 SDO                                 | Notes                                                    |
+|---------------|----------------------------------------------|----------------------------------------------------------|
+| `Indicator`   | `indicator`                                  | Pattern built from `indicator_type` + `value`            |
+| `Malware`     | `malware`                                    | `is_family=true` if `malware_types` contains "family"    |
+| `ThreatActor` | `intrusion-set`                              | Default — MITRE convention for actor groups              |
+| `Technique`   | `attack-pattern` + `kill_chain_phases` + `external_references[mitre-attack]` | Tactics become phases, not SDOs |
+| `Tactic`      | *(not emitted)*                              | Represented only as `kill_chain_phases` on attack-pattern |
+| `Tool`        | `tool`                                       |                                                          |
+| `Campaign`    | `campaign`                                   |                                                          |
+| `CVE`         | `vulnerability` + `external_references[cve]` |                                                          |
+| `Vulnerability` | `vulnerability`                            | Deduplicated with CVE by `cve_id`                        |
+| `Sector`      | `identity` with `identity_class:"class"`     | `sectors:[<name>]`                                       |
+
+Decision: use `intrusion-set` rather than `threat-actor` by default.
+MITRE ATT&CK models named groups (APT28, FIN7, ...) as `intrusion-set`
+and reserves `threat-actor` for individuals. None of our current
+collectors ingest individual actors. A follow-up can introspect a
+boolean property on the node if that changes.
+
+## 5. Relationship mapping
+
+| Graph edge                                         | STIX 2.1 SRO                                                           | Rationale                                                                                                            |
+|----------------------------------------------------|------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------|
+| `(ThreatActor)-[:EMPLOYS_TECHNIQUE]->(Technique)` | `relationship(uses)` src=intrusion-set tgt=attack-pattern              | Matches STIX 2.1 `intrusion-set → attack-pattern` vocab entry.                                                        |
+| `(Malware)-[:IMPLEMENTS_TECHNIQUE]->(Technique)`  | `relationship(uses)` src=malware tgt=attack-pattern                    | STIX 2.1 `malware → attack-pattern` vocab.                                                                            |
+| `(Tool)-[:IMPLEMENTS_TECHNIQUE]->(Technique)`     | `relationship(uses)` src=tool tgt=attack-pattern                       | STIX 2.1 `tool → attack-pattern` vocab.                                                                               |
+| `(Indicator)-[:USES_TECHNIQUE]->(Technique)`      | `relationship(indicates)` src=indicator tgt=attack-pattern             | STIX 2.1 only defines `indicator → attack-pattern = indicates`; there is no `uses` vocab entry with indicator src.    |
+| `(Indicator)-[:INDICATES]->(Malware)`             | `relationship(indicates)`                                              | Direct vocabulary match.                                                                                              |
+| `(Indicator)-[:EXPLOITS]->(CVE\|Vulnerability)`   | `relationship(indicates)`                                              | STIX has no `exploits` predicate. `indicates` is the closest vocabulary term — see §7.                                |
+| `(Malware)-[:ATTRIBUTED_TO]->(ThreatActor)`       | `relationship(attributed-to)` src=malware tgt=intrusion-set            |                                                                                                                      |
+| `(Campaign)-[:ATTRIBUTED_TO]->(ThreatActor)`      | `relationship(attributed-to)` src=campaign tgt=intrusion-set           |                                                                                                                      |
+| `(Technique)-[:IN_TACTIC]->(Tactic)`              | *(no SRO)* — emitted as `kill_chain_phases` property on attack-pattern | STIX 2.1 ATT&CK convention.                                                                                           |
+| `(Indicator)-[:TARGETS]->(Sector)`                | `relationship(targets)` src=indicator tgt=identity                     |                                                                                                                      |
+| `(Vulnerability\|CVE)-[:TARGETS]->(Sector)`       | `relationship(targets)` src=vulnerability tgt=identity                 |                                                                                                                      |
+
+**Backward compatibility.** All Cypher queries also match the legacy
+`USES` rel type via `[:EMPLOYS_TECHNIQUE|USES]` /
+`[:IMPLEMENTS_TECHNIQUE|USES]` / `[:USES_TECHNIQUE|USES]`. This lets
+the exporter run against graphs that have not yet been re-built under
+PR #24. Remove the legacy branch once the full baseline rebuild lands.
+
+References:
+
+- STIX 2.1 Relationship vocabulary: https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_p5ra8a8xrap4
+- `uses` definition: https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_i9uyt2tokbtz
+- `indicates` definition: https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_9mjnj16e1t6p
+- ATT&CK kill-chain-phases convention: https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_i4tjv75ce50h
+
+## 6. Deterministic IDs
+
+Every SDO/SRO gets a `type--<UUIDv5>` ID, computed as:
+
+```
+uuid.uuid5(EDGEGUARD_STIX_NAMESPACE, f"{type}:{natural_key}".lower())
+```
+
+where `EDGEGUARD_STIX_NAMESPACE` is a fixed UUIDv4 constant hard-coded
+in `stix_exporter.py`. Natural keys per type:
+
+| SDO type            | Natural key                  |
+|---------------------|------------------------------|
+| `indicator`         | `{indicator_type}|{value}`   |
+| `malware`           | `{name}`                     |
+| `intrusion-set`     | `{name}`                     |
+| `attack-pattern`    | `{mitre_id}`                 |
+| `tool`              | `{name}`                     |
+| `campaign`          | `{name}`                     |
+| `vulnerability`     | `{cve_id}`                   |
+| `identity` (sector) | `sector|{name}`              |
+| `relationship`      | `{source_ref}|{rel}|{target_ref}` |
+
+Consequences:
+
+- Re-exporting the same graph state produces byte-identical object IDs
+  → ResilMesh can diff bundles and cache.
+- Two different EdgeGuard environments (dev vs prod) emit the **same**
+  IDs for the same entities. If that turns out to be a problem, we
+  namespace per environment by hashing `ENV` into the namespace UUID.
+- The bundle envelope ID is a random UUIDv4 per request — bundles
+  themselves are not deterministic; only the objects inside them are.
+
+## 7. Open semantic questions (confirm with ResilMesh before merge)
+
+1. **`EXPLOITS` → `indicates` vs `related-to`.** We picked `indicates`
+   because it is a defined vocab term for `indicator → vulnerability`
+   and it preserves the "this is a sign of" semantics. The alternative
+   is the generic `related-to`, which is schema-valid but carries less
+   meaning. ResilMesh should confirm whichever matches their downstream
+   scoring logic.
+2. **`Indicator → Technique` as `indicates` (not `uses`).** STIX 2.1
+   does not define `uses` with `indicator` source_ref. Filing this as
+   `indicates` is the only vocabulary-correct option.
+3. **`intrusion-set` vs `threat-actor`.** Default to `intrusion-set`.
+   Partners that expect `threat-actor` will need to map the type on
+   their side.
+4. **Zone/sector metadata.** The EdgeGuard zone system uses tags
+   (`healthcare`, `energy`, `finance`, `global`). We do not currently
+   emit these as `x_edgeguard_zones` custom properties. Should we? The
+   helper `apply_edgeguard_zone_metadata_to_stix_dict` exists and could
+   be invoked per object if yes.
+5. **CVSS bridging.** ResilMesh stores CVSSv* as separate nodes linked
+   to CVE via `HAS_CVSS_v*`. STIX has no first-class CVSS SDO. For now
+   we flatten nothing — CVSS stays on the ResilMesh side. Confirm this
+   matches their enrichment path.
+
+## 8. Pagination
+
+The four prototype endpoints all return **bounded** neighbourhoods
+(indicator 1-hop, actor depth 2 with capped fan-out via DISTINCT, etc.)
+so no pagination is required in the prototype. Hot spots:
+
+- `export_technique("T1059")` → "Command and Scripting Interpreter"
+  will link to many malware families. If a response exceeds a size
+  threshold (say 5 MB) we will introduce a `?limit=` query parameter
+  and a continuation token keyed by object ID.
+- Full-graph or time-range bulk export is explicitly out of scope; that
+  is a TAXII endpoint, not this one (see §10).
+
+## 9. Authentication
+
+**The prototype reuses the existing `X-API-Key` header** (dependency
+`_verify_api_key`). This is not suitable for partner integration long
+term. TODO before production:
+
+1. Issue per-partner API keys (separate from the internal read key) and
+   record the partner in the audit log.
+2. Consider mTLS for ResilMesh ↔ EdgeGuard traffic if they share a
+   private network.
+3. Add a rate-limit bucket scoped per partner key (the prototype uses
+   the default per-IP read bucket; the endpoint docstring calls this
+   out as a gap).
+
+## 10. Explicit non-goals / follow-ups
+
+Tracked as separate tickets; do **not** expand this PR:
+
+- **FU-1: TAXII 2.1 collection service.** Wrap the exporter in a TAXII
+  server exposing `Collection`, `Manifest`, `Objects` endpoints. This
+  is what partners really want long-term.
+- **FU-2: Bulk / full-graph export.** A background job that writes a
+  full STIX bundle to object storage, then a signed-URL endpoint. Huge
+  memory footprint — needs streaming JSON.
+- **FU-3: Push updates.** Subscribe to the EdgeGuard NATS bus and emit
+  delta STIX bundles over webhooks / TAXII `added_after`.
+- **FU-4: Zone metadata export.** Decide on and wire custom property
+  namespace (`x_edgeguard_*`) for zone tags, confidence, decay score.
+- **FU-5: Per-partner API keys & audit log.** See §9.
+- **FU-6: Bundle signing / provenance.** Sign bundles with a JWS so
+  ResilMesh can verify EdgeGuard as the origin.
+- **FU-7: Pattern coverage.** `_value_to_stix_pattern` only handles a
+  subset of MISP types. Add coverage for file names, user accounts,
+  registry keys, x509, etc.
+- **FU-8: Relationship metadata.** Carry `confidence_score`,
+  `match_type`, `created_at` from Neo4j onto the SRO as custom
+  properties.
+
+## 11. Testing
+
+Unit tests live in `tests/test_stix_exporter.py` and mock the Neo4j
+driver with `MagicMock`. They verify:
+
+- Actor with two techniques → 1 `intrusion-set`, 2 `attack-pattern`,
+  2 `uses` SROs
+- Actor with attributed malware → `attributed-to` SRO
+- Indicator `INDICATES` malware → `indicates` SRO
+- Deterministic IDs stable across exporter instances
+- Technique `kill_chain_phases` emitted as property, not as SRO
+- Legacy `USES` rel type still matched (backward compat)
+- `edgeguard_managed` filter present in Cypher (no ResilMesh leakage)
+- Empty bundle when seed is not found
+
+Integration against a real Neo4j is a follow-up — the prototype
+intentionally does not add Docker fixtures.
+
+## 12. Rollout
+
+1. Merge PR #24 (USES specialisation) — dependency.
+2. Merge this PR (prototype + doc) as DRAFT. Stays behind the
+   default read API key.
+3. ResilMesh tries the four endpoints against staging. Capture
+   feedback on §7 decisions.
+4. Promote decisions to final, add per-partner auth (FU-5), then flip
+   from DRAFT → production.

--- a/migrations/2026_04_specialize_uses_technique.cypher
+++ b/migrations/2026_04_specialize_uses_technique.cypher
@@ -1,0 +1,126 @@
+// ============================================================================
+// Migration: specialize USES → {EMPLOYS_TECHNIQUE, IMPLEMENTS_TECHNIQUE}
+// ============================================================================
+//
+// Context
+// -------
+// Prior to 2026-04, every X→Technique edge from MITRE ATT&CK was a single
+// generic USES. That conflated three semantically distinct claims:
+//
+//   - ThreatActor USES Technique  = attribution (who is observed doing this TTP)
+//   - Malware     USES Technique  = capability  (what the code can do)
+//   - Tool        USES Technique  = capability  (what the tool can do)
+//
+// Indicator→Technique was already specialized as USES_TECHNIQUE (OTX
+// attack_ids), so USES was the odd one out. The mixed semantics hurt:
+//   1. GraphRAG retrieval quality — the rel type is part of the LLM prompt
+//      and "uses" tells the model much less than "employs"/"implements".
+//   2. Cypher clarity — every query had to add endpoint-label filters.
+//   3. Analyst interpretation — attribution and capability mean different
+//      things operationally.
+//
+// This migration splits USES→Technique into two specialized types while
+// leaving USES_TECHNIQUE (Indicator side) untouched. All non-Technique
+// target USES edges — if any exist from legacy imports — are left alone.
+//
+// Safety
+// ------
+// - Uses apoc.periodic.iterate for batching so the transaction log never
+//   grows unbounded on large graphs (81K USES edges were observed after
+//   the 730-day NVD baseline).
+// - Each block copies all properties (SET r2 = properties(r)) before
+//   deleting the old edge. If the ingest code is rerun mid-migration it
+//   will MERGE into the new type cleanly.
+// - Parallel:false keeps lock contention predictable.
+// - Each block is idempotent: running it again against an already-
+//   migrated graph matches 0 rows and does nothing.
+//
+// Pre-migration sanity check (run manually first):
+//
+//   MATCH ()-[r:USES]->(t:Technique) RETURN count(r) AS before_count;
+//
+// Post-migration sanity check:
+//
+//   MATCH ()-[r:USES]->(t:Technique) RETURN count(r) AS remaining_uses;
+//   // expected: 0
+//
+//   MATCH (a:ThreatActor)-[r:EMPLOYS_TECHNIQUE]->(:Technique)
+//   RETURN count(r) AS employs_count;
+//
+//   MATCH (m:Malware)-[r:IMPLEMENTS_TECHNIQUE]->(:Technique)
+//   RETURN count(r) AS malware_implements_count;
+//
+//   MATCH (tool:Tool)-[r:IMPLEMENTS_TECHNIQUE]->(:Technique)
+//   RETURN count(r) AS tool_implements_count;
+//
+// before_count should equal employs_count + malware_implements_count +
+// tool_implements_count (± any Campaign→Technique edges if you have them).
+//
+// Requires APOC. If APOC is unavailable, see the non-APOC variants at the
+// bottom of this file.
+// ============================================================================
+
+
+// ----------------------------------------------------------------------------
+// 1. ThreatActor → Technique  ⇒  EMPLOYS_TECHNIQUE  (attribution)
+// ----------------------------------------------------------------------------
+CALL apoc.periodic.iterate(
+  "MATCH (a:ThreatActor)-[r:USES]->(t:Technique) RETURN a, r, t",
+  "MERGE (a)-[r2:EMPLOYS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r",
+  {batchSize: 1000, parallel: false}
+);
+
+
+// ----------------------------------------------------------------------------
+// 2. Campaign → Technique  ⇒  EMPLOYS_TECHNIQUE  (attribution)
+//
+// Included for forward-compat — no Campaign→USES→Technique edges are
+// created by current code, but if any exist from a manual import they
+// get the same attribution treatment as ThreatActor.
+// ----------------------------------------------------------------------------
+CALL apoc.periodic.iterate(
+  "MATCH (c:Campaign)-[r:USES]->(t:Technique) RETURN c, r, t",
+  "MERGE (c)-[r2:EMPLOYS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r",
+  {batchSize: 1000, parallel: false}
+);
+
+
+// ----------------------------------------------------------------------------
+// 3. Malware → Technique  ⇒  IMPLEMENTS_TECHNIQUE  (capability)
+// ----------------------------------------------------------------------------
+CALL apoc.periodic.iterate(
+  "MATCH (m:Malware)-[r:USES]->(t:Technique) RETURN m, r, t",
+  "MERGE (m)-[r2:IMPLEMENTS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r",
+  {batchSize: 1000, parallel: false}
+);
+
+
+// ----------------------------------------------------------------------------
+// 4. Tool → Technique  ⇒  IMPLEMENTS_TECHNIQUE  (capability)
+// ----------------------------------------------------------------------------
+CALL apoc.periodic.iterate(
+  "MATCH (tool:Tool)-[r:USES]->(t:Technique) RETURN tool, r, t",
+  "MERGE (tool)-[r2:IMPLEMENTS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r",
+  {batchSize: 1000, parallel: false}
+);
+
+
+// ============================================================================
+// Non-APOC variants (uncomment if APOC is not installed)
+// ============================================================================
+//
+// These are single-transaction versions — safe on small graphs (<10K edges
+// total) but will blow up the transaction log at the 80K+ scale seen in
+// production. Prefer the APOC versions above.
+//
+// MATCH (a:ThreatActor)-[r:USES]->(t:Technique)
+// MERGE (a)-[r2:EMPLOYS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r;
+//
+// MATCH (c:Campaign)-[r:USES]->(t:Technique)
+// MERGE (c)-[r2:EMPLOYS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r;
+//
+// MATCH (m:Malware)-[r:USES]->(t:Technique)
+// MERGE (m)-[r2:IMPLEMENTS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r;
+//
+// MATCH (tool:Tool)-[r:USES]->(t:Technique)
+// MERGE (tool)-[r2:IMPLEMENTS_TECHNIQUE]->(t) SET r2 += properties(r) DELETE r;

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -172,7 +172,8 @@ class AlertProcessor:
       - (Asset)-[:HAS_IP]->(Indicator)
       - (Indicator)-[:INDICATES]->(Malware)
       - (Malware)-[:ATTRIBUTED_TO]->(ThreatActor)
-      - (ThreatActor)-[:USES]->(Technique)
+      - (ThreatActor)-[:EMPLOYS_TECHNIQUE]->(Technique)
+      - (Malware)-[:IMPLEMENTS_TECHNIQUE]->(Technique)
       - (Indicator)-[:INDICATES]->(Vulnerability)
     """
 
@@ -254,9 +255,9 @@ class AlertProcessor:
 
         Query strategy:
         1. Find the Indicator node
-        2. Find related Malware (via ATTRIBUTED_TO)
-        3. Find related ThreatActors (via USES from Malware)
-        4. Find Techniques (via USES from Actor)
+        2. Find related Malware (via INDICATES)
+        3. Find related ThreatActors (via ATTRIBUTED_TO from Malware)
+        4. Find Techniques (via EMPLOYS_TECHNIQUE from Actor)
         5. Find CVEs (if mentioned in alert or linked to indicator)
         6. Find related Assets and Users from Alert context
         """
@@ -353,7 +354,7 @@ class AlertProcessor:
                     MATCH (i:Indicator {value: $indicator})
                     OPTIONAL MATCH (i)-[:INDICATES]->(m:Malware)
                     OPTIONAL MATCH (m)-[:ATTRIBUTED_TO]->(a:ThreatActor)
-                    OPTIONAL MATCH (a)-[:USES]->(t:Technique)
+                    OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE]->(t:Technique)
                     RETURN collect(DISTINCT a {
                         .name, .aliases, .description
                     }) as actors,

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -160,22 +160,26 @@ def build_relationships():
             failures += 1
         time.sleep(_INTER_QUERY_PAUSE)
 
-        # 5. ThreatActor → Technique (USES) — explicit ATT&CK uses_techniques list
+        # 5. ThreatActor → Technique (EMPLOYS_TECHNIQUE) — explicit ATT&CK
+        # uses_techniques list. Attribution semantics: "who uses this TTP".
+        # Split from a previously-generic USES in 2026-04 to improve GraphRAG
+        # retrieval — see migrations/2026_04_specialize_uses_technique.cypher.
         logger.info("[LINK] 5/11 ThreatActor → Technique (ATT&CK explicit)...")
         _outer = "MATCH (a:ThreatActor) WHERE size(coalesce(a.uses_techniques, [])) > 0 RETURN a"
-        _inner = 'WITH $a AS a UNWIND a.uses_techniques AS tid WITH a, tid MATCH (t:Technique {mitre_id: tid}) MERGE (a)-[r:USES]->(t) ON CREATE SET r.confidence_score = 0.95, r.match_type = "mitre_explicit", r.created_at = datetime() SET r.updated_at = datetime()'
+        _inner = 'WITH $a AS a UNWIND a.uses_techniques AS tid WITH a, tid MATCH (t:Technique {mitre_id: tid}) MERGE (a)-[r:EMPLOYS_TECHNIQUE]->(t) ON CREATE SET r.confidence_score = 0.95, r.match_type = "mitre_explicit", r.created_at = datetime() SET r.updated_at = datetime()'
         if not _safe_run_batched(
-            client, "ThreatActor → Technique (ATT&CK explicit)", _outer, _inner, stats, "uses_explicit"
+            client, "ThreatActor → Technique (ATT&CK explicit)", _outer, _inner, stats, "employs_technique_explicit"
         ):
             failures += 1
         time.sleep(_INTER_QUERY_PAUSE)
 
-        # 6. Malware → Technique (USES) — MITRE STIX uses relationships
+        # 6. Malware → Technique (IMPLEMENTS_TECHNIQUE) — MITRE STIX uses
+        # relationships. Capability semantics: "what the code can do".
         logger.info("[LINK] 6/11 Malware → Technique (MITRE explicit)...")
         _outer = "MATCH (m:Malware) WHERE size(coalesce(m.uses_techniques, [])) > 0 RETURN m"
-        _inner = 'WITH $m AS m UNWIND m.uses_techniques AS tid WITH m, tid MATCH (t:Technique {mitre_id: tid}) MERGE (m)-[r:USES]->(t) ON CREATE SET r.confidence_score = 0.95, r.match_type = "mitre_explicit", r.created_at = datetime() SET r.updated_at = datetime()'
+        _inner = 'WITH $m AS m UNWIND m.uses_techniques AS tid WITH m, tid MATCH (t:Technique {mitre_id: tid}) MERGE (m)-[r:IMPLEMENTS_TECHNIQUE]->(t) ON CREATE SET r.confidence_score = 0.95, r.match_type = "mitre_explicit", r.created_at = datetime() SET r.updated_at = datetime()'
         if not _safe_run_batched(
-            client, "Malware → Technique (MITRE explicit)", _outer, _inner, stats, "malware_uses_technique"
+            client, "Malware → Technique (MITRE explicit)", _outer, _inner, stats, "malware_implements_technique"
         ):
             failures += 1
         time.sleep(_INTER_QUERY_PAUSE)
@@ -232,12 +236,14 @@ def build_relationships():
             failures += 1
         time.sleep(_INTER_QUERY_PAUSE)
 
-        # 10. Tool → Technique (USES) — MITRE uses_techniques
+        # 10. Tool → Technique (IMPLEMENTS_TECHNIQUE) — MITRE uses_techniques.
+        # Same capability semantics as Malware above; both are "code/tool can
+        # execute this TTP".
         logger.info("[LINK] 10/11 Tool → Technique (MITRE explicit)...")
         _outer = "MATCH (tool:Tool) WHERE size(coalesce(tool.uses_techniques, [])) > 0 RETURN tool"
-        _inner = 'WITH $tool AS tool UNWIND tool.uses_techniques AS tid WITH tool, tid MATCH (t:Technique {mitre_id: tid}) MERGE (tool)-[r:USES]->(t) ON CREATE SET r.confidence_score = 0.95, r.match_type = "mitre_explicit", r.created_at = datetime() SET r.updated_at = datetime()'
+        _inner = 'WITH $tool AS tool UNWIND tool.uses_techniques AS tid WITH tool, tid MATCH (t:Technique {mitre_id: tid}) MERGE (tool)-[r:IMPLEMENTS_TECHNIQUE]->(t) ON CREATE SET r.confidence_score = 0.95, r.match_type = "mitre_explicit", r.created_at = datetime() SET r.updated_at = datetime()'
         if not _safe_run_batched(
-            client, "Tool → Technique (MITRE explicit)", _outer, _inner, stats, "tool_uses_technique"
+            client, "Tool → Technique (MITRE explicit)", _outer, _inner, stats, "tool_implements_technique"
         ):
             failures += 1
         time.sleep(_INTER_QUERY_PAUSE)

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1601,11 +1601,16 @@ class Neo4jClient:
     def create_actor_technique_relationship(
         self, actor_name: str, technique_mitre_id: str, source_id: str = "mitre_attck"
     ) -> bool:
-        """Create USES relationship: ThreatActor -> Technique.
+        """Create EMPLOYS_TECHNIQUE relationship: ThreatActor -> Technique.
 
         Matches actors by name or alias and techniques by mitre_id, cross-source
         (no tag filter) so that enrichment links work regardless of which collector
         ingested each node.
+
+        Semantic note: ``EMPLOYS_TECHNIQUE`` is the attribution edge ("who uses
+        this TTP"), distinct from ``IMPLEMENTS_TECHNIQUE`` (the capability edge
+        on Malware/Tool). Split from a previously-generic ``USES`` in the
+        2026-04 refactor to improve GraphRAG retrieval and Cypher clarity.
         """
         if not self.driver:
             return False
@@ -1622,7 +1627,7 @@ class Neo4jClient:
         MATCH (a:ThreatActor)
         WHERE a.name = $actor_name OR $actor_name IN coalesce(a.aliases, [])
         MATCH (t:Technique {mitre_id: $technique_mitre_id})
-        MERGE (a)-[r:USES]->(t)
+        MERGE (a)-[r:EMPLOYS_TECHNIQUE]->(t)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [$source_id]),
             r.source_id = $source_id,
             r.confidence_score = 0.7,
@@ -1905,7 +1910,12 @@ class Neo4jClient:
         if not self.driver or not relationships:
             return 0
 
-        uses_rows: List[Dict[str, Any]] = []
+        # Split from a previously-generic "USES" bucket in the 2026-04 refactor:
+        # EMPLOYS_TECHNIQUE = attribution  (ThreatActor/Campaign → Technique)
+        # IMPLEMENTS_TECHNIQUE = capability (Malware/Tool → Technique)
+        # USES_TECHNIQUE already existed for Indicator → Technique (OTX attack_ids)
+        employs_rows: List[Dict[str, Any]] = []
+        implements_rows: List[Dict[str, Any]] = []
         attr_rows: List[Dict[str, Any]] = []
         ind_mal_rows: List[Dict[str, Any]] = []
         tgt_ind_rows: List[Dict[str, Any]] = []
@@ -1918,11 +1928,36 @@ class Neo4jClient:
             fk = rel.get("from_key") or {}
             tk = rel.get("to_key") or {}
             conf = rel.get("confidence", 0.5)
-            if rt == "USES":
-                an = nonempty_graph_string(fk.get("name"))
+            # Backward-compat: accept legacy "USES" rel_type from callers that
+            # haven't been migrated yet, and route based on from_type. New
+            # code should emit the specialized rel_type directly.
+            if rt in ("EMPLOYS_TECHNIQUE", "IMPLEMENTS_TECHNIQUE") or (
+                rt == "USES" and rel.get("to_type") == "Technique"
+            ):
+                from_type = rel.get("from_type", "ThreatActor")
                 mid = nonempty_graph_string(tk.get("mitre_id"))
-                if an and mid:
-                    uses_rows.append({"actor": an, "mitre_id": mid, "source_id": source_id, "confidence": conf})
+                if from_type in ("ThreatActor", "Campaign"):
+                    an = nonempty_graph_string(fk.get("name"))
+                    if an and mid:
+                        employs_rows.append(
+                            {"actor": an, "mitre_id": mid, "source_id": source_id, "confidence": conf}
+                        )
+                    else:
+                        _dropped_rels += 1
+                elif from_type in ("Malware", "Tool"):
+                    nm = nonempty_graph_string(fk.get("name"))
+                    if nm and mid:
+                        implements_rows.append(
+                            {
+                                "entity": nm,
+                                "entity_label": from_type,
+                                "mitre_id": mid,
+                                "source_id": source_id,
+                                "confidence": conf,
+                            }
+                        )
+                    else:
+                        _dropped_rels += 1
                 else:
                     _dropped_rels += 1
             elif rt == "ATTRIBUTED_TO":
@@ -1974,12 +2009,41 @@ class Neo4jClient:
 
         total = 0
 
-        q_uses = """
+        # Attribution edge: ThreatActor (or Campaign) → Technique
+        q_employs = """
         UNWIND $rows AS row
         MATCH (a:ThreatActor)
         WHERE a.name = row.actor OR row.actor IN coalesce(a.aliases, [])
         MATCH (t:Technique {mitre_id: row.mitre_id})
-        MERGE (a)-[r:USES]->(t)
+        MERGE (a)-[r:EMPLOYS_TECHNIQUE]->(t)
+        SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
+            r.confidence_score = row.confidence,
+            r.imported_at = coalesce(r.imported_at, datetime()),
+            r.updated_at = datetime()
+        """
+        # Capability edge: Malware or Tool → Technique. Single query handles
+        # both labels via CALL ... apoc.do.case-style branching; we run one
+        # UNWIND per from_type inside the caller so planner can use label
+        # lookups efficiently (see _run_rows calls below).
+        q_malware_implements = """
+        UNWIND $rows AS row
+        MATCH (m:Malware)
+        WHERE (m.name = row.entity OR row.entity IN coalesce(m.aliases, []))
+        MATCH (t:Technique {mitre_id: row.mitre_id})
+        MERGE (m)-[r:IMPLEMENTS_TECHNIQUE]->(t)
+        SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
+            r.source_id = row.source_id,
+            r.confidence_score = row.confidence,
+            r.imported_at = coalesce(r.imported_at, datetime()),
+            r.updated_at = datetime()
+        """
+        q_tool_implements = """
+        UNWIND $rows AS row
+        MATCH (tool:Tool)
+        WHERE (tool.name = row.entity OR row.entity IN coalesce(tool.aliases, []))
+        MATCH (t:Technique {mitre_id: row.mitre_id})
+        MERGE (tool)-[r:IMPLEMENTS_TECHNIQUE]->(t)
         SET r.sources = apoc.coll.toSet(coalesce(r.sources, []) + [row.source_id]),
             r.source_id = row.source_id,
             r.confidence_score = row.confidence,
@@ -2090,8 +2154,18 @@ class Neo4jClient:
                 logger.warning("MISP relationship batch %s failed (%s rows): %s", label, len(rows), e)
 
         with self.driver.session() as session:
-            _run_rows(session, "USES", q_uses, uses_rows)
-            if uses_rows:
+            _run_rows(session, "EMPLOYS_TECHNIQUE", q_employs, employs_rows)
+            if employs_rows:
+                time.sleep(1)
+            # Split IMPLEMENTS_TECHNIQUE rows by entity_label so each UNWIND
+            # hits a single label index instead of a union scan.
+            mal_impl_rows = [r for r in implements_rows if r.get("entity_label") == "Malware"]
+            tool_impl_rows = [r for r in implements_rows if r.get("entity_label") == "Tool"]
+            _run_rows(session, "IMPLEMENTS_TECHNIQUE_malware", q_malware_implements, mal_impl_rows)
+            if mal_impl_rows:
+                time.sleep(1)
+            _run_rows(session, "IMPLEMENTS_TECHNIQUE_tool", q_tool_implements, tool_impl_rows)
+            if tool_impl_rows:
                 time.sleep(1)
             _run_rows(session, "ATTRIBUTED_TO", q_attr, attr_rows)
             if attr_rows:

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -633,18 +633,24 @@ async def graph_explore(
                 if zone:
                     zone_ind = "AND $zone IN coalesce(i.zone, [])"
 
+                # Malware → Indicator edges are INDICATES (dropped/observed
+                # artifact) or DROPS (file drop). The legacy filter included
+                # "USES" which was incorrect — USES here was previously
+                # (Actor/Malware)→Technique, not Malware→Indicator, so any
+                # match was unreachable. Kept the two valid types.
                 cypher = f"""
                     MATCH (m:Malware)-[r]->(i:Indicator)
-                    WHERE type(r) IN ['INDICATES', 'USES', 'DROPS'] AND m.edgeguard_managed = true
+                    WHERE type(r) IN ['INDICATES', 'DROPS'] AND m.edgeguard_managed = true
                     {zone_ind}
-                    WITH m, i
+                    WITH m, i, type(r) AS rel_type
                     LIMIT $limit
                     RETURN m.name AS malware_name, m.family AS malware_family,
                            i.value AS ind_value, i.indicator_type AS ind_type,
                            coalesce(i.zone, ['global']) AS ind_zones,
                            i.confidence_score AS ind_confidence,
                            i.indicator_role AS ind_role,
-                           i.threat_label AS ind_threat_label
+                           i.threat_label AS ind_threat_label,
+                           rel_type
                 """
                 result = session.run(cypher, limit=limit, **zone_param, timeout=_NEO4J_QUERY_TIMEOUT)
                 for r in result:
@@ -663,7 +669,7 @@ async def graph_explore(
                             "threat_label": r.get("ind_threat_label", ""),
                         },
                     )
-                    _add_edge(mid, iid, "USES")
+                    _add_edge(mid, iid, r.get("rel_type", "INDICATES"))
                     for z in r.get("ind_zones", []):
                         sid = f"sector:{z}"
                         _add_node(sid, z.title(), "sector", {"sector": z})
@@ -676,7 +682,7 @@ async def graph_explore(
                     zone_act = "AND $zone IN coalesce(a.zone, [])"
 
                 cypher = f"""
-                    MATCH (a:ThreatActor)-[:USES]->(t:Technique)
+                    MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t:Technique)
                     WHERE t.mitre_id IS NOT NULL AND a.edgeguard_managed = true
                     {zone_act}
                     WITH a, t
@@ -703,7 +709,7 @@ async def graph_explore(
                         "technique",
                         {"name": r.get("technique_name", ""), "tactics": r.get("tactics", [])},
                     )
-                    _add_edge(aid, tid, "USES")
+                    _add_edge(aid, tid, "EMPLOYS_TECHNIQUE")
                     for tac in r.get("tactics") or []:
                         tacid = f"tactic:{tac}"
                         _add_node(tacid, tac, "tactic")

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -835,7 +835,7 @@ async def graph_explore(
         raise HTTPException(status_code=500, detail="Internal error — see server logs")
 
 
-@app.get("/stix/export/{object_type}/{identifier}", dependencies=[Depends(_verify_api_key)])
+@app.get("/stix/export/{object_type}/{identifier:path}", dependencies=[Depends(_verify_api_key)])
 @limiter.limit(_RATE_LIMIT_READ)
 async def stix_export(
     request: Request,
@@ -854,6 +854,12 @@ async def stix_export(
       Returns the technique + everything that uses it.
     - ``cve`` — ``identifier`` is a CVE ID (e.g. ``CVE-2021-44228``).
       Returns the CVE + indicators that exploit it + affected sectors.
+
+    The ``identifier`` segment uses the FastAPI ``:path`` converter so it
+    can capture values containing slashes (e.g. URL indicators like
+    ``http://evil.com/malware``). The default converter only matches a
+    single path segment and would 404 on any URL with a slash after the
+    host — not viable for the documented indicator types.
 
     Response Content-Type: ``application/stix+json;version=2.1``.
 

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -880,10 +880,14 @@ async def stix_export(
         elif ot == "cve":
             bundle = exporter.export_cve(identifier)
         else:
+            # Static error string (no f-string interpolation of the URL
+            # path parameter). Every other HTTPException in this file uses
+            # a fixed generic message; bugbot caught this as the only
+            # f-string `detail` and flagged it for consistency with the
+            # project convention.
             raise HTTPException(
                 status_code=400,
-                detail=f"Unsupported object_type '{object_type}'. "
-                "Use one of: indicator, actor, technique, cve.",
+                detail="Unsupported object_type. Use one of: indicator, actor, technique, cve.",
             )
     except HTTPException:
         raise

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -835,6 +835,68 @@ async def graph_explore(
         raise HTTPException(status_code=500, detail="Internal error — see server logs")
 
 
+@app.get("/stix/export/{object_type}/{identifier}", dependencies=[Depends(_verify_api_key)])
+@limiter.limit(_RATE_LIMIT_READ)
+async def stix_export(
+    request: Request,
+    object_type: str,
+    identifier: str,
+):
+    """Export a STIX 2.1 bundle centred on a threat-intel object.
+
+    Supported ``object_type`` values:
+
+    - ``indicator`` — ``identifier`` is the indicator value (IP, domain,
+      hash, URL, …). Returns the indicator + its 1-hop neighbourhood.
+    - ``actor`` — ``identifier`` is a ThreatActor name or alias. Returns
+      actor + attributed malware + employed techniques + campaigns.
+    - ``technique`` — ``identifier`` is a MITRE ATT&CK ID (e.g. ``T1055``).
+      Returns the technique + everything that uses it.
+    - ``cve`` — ``identifier`` is a CVE ID (e.g. ``CVE-2021-44228``).
+      Returns the CVE + indicators that exploit it + affected sectors.
+
+    Response Content-Type: ``application/stix+json;version=2.1``.
+
+    Prototype — see ``docs/STIX21_EXPORTER_PROPOSAL.md`` for auth,
+    pagination, and rate-limit notes (no custom rate-limit middleware is
+    added yet; the endpoint is subject to the default read rate limit).
+    """
+    from fastapi.responses import JSONResponse as _JSON
+
+    from stix_exporter import StixExporter
+
+    if not neo4j_client or not neo4j_client.is_connected():
+        raise HTTPException(status_code=503, detail="Neo4j not connected")
+
+    exporter = StixExporter(neo4j_client)
+    try:
+        ot = object_type.lower()
+        if ot == "indicator":
+            bundle = exporter.export_indicator(identifier)
+        elif ot == "actor":
+            bundle = exporter.export_threat_actor(identifier)
+        elif ot == "technique":
+            bundle = exporter.export_technique(identifier)
+        elif ot == "cve":
+            bundle = exporter.export_cve(identifier)
+        else:
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported object_type '{object_type}'. "
+                "Use one of: indicator, actor, technique, cve.",
+            )
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("STIX export failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal error — see server logs")
+
+    return _JSON(
+        content=bundle,
+        media_type=StixExporter.MEDIA_TYPE,
+    )
+
+
 @app.post("/admin/query", dependencies=[Depends(_verify_api_key)])
 @limiter.limit(_RATE_LIMIT_ADMIN)
 async def admin_query(

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1631,7 +1631,7 @@ class MISPToNeo4jSync:
         one event's attribute set.
 
         Relationship kinds produced:
-        - ThreatActor -> USES -> Technique
+        - ThreatActor -> EMPLOYS_TECHNIQUE -> Technique
         - Malware -> ATTRIBUTED_TO -> ThreatActor
         - Indicator -> INDICATES -> Malware
         - Indicator/Vulnerability -> TARGETS -> Sector
@@ -1736,13 +1736,15 @@ class MISPToNeo4jSync:
             except Exception:
                 logger.debug("Metrics recording failed", exc_info=True)
 
-        # Build actor -> technique relationships (USES)
-        # When an event has both actors and techniques, assume the actors use those techniques
+        # Build actor -> technique relationships (EMPLOYS_TECHNIQUE).
+        # Attribution semantics: "actor uses this TTP". Split from a
+        # previously-generic USES in 2026-04 to disambiguate from
+        # IMPLEMENTS_TECHNIQUE (Malware/Tool capability).
         for actor in actors:
             for technique in techniques:
                 relationships.append(
                     {
-                        "rel_type": "USES",
+                        "rel_type": "EMPLOYS_TECHNIQUE",
                         "from_type": "ThreatActor",
                         "from_key": {"name": actor["name"]},
                         "to_type": "Technique",
@@ -2053,11 +2055,13 @@ class MISPToNeo4jSync:
                 except (ValueError, IndexError):
                     actor_description = raw_comment
 
-            # Build USES relationships to techniques
+            # Build EMPLOYS_TECHNIQUE relationships to techniques.
+            # Attribution edge (who uses the TTP). See 2026-04 refactor note
+            # in src/neo4j_client.py create_actor_technique_relationship.
             for technique in techniques:
                 relationships.append(
                     {
-                        "rel_type": "USES",
+                        "rel_type": "EMPLOYS_TECHNIQUE",
                         "from_type": "ThreatActor",
                         "from_key": {"name": actor_name},
                         "to_type": "Technique",

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -613,13 +613,18 @@ class EdgeGuardPipeline:
                             self.neo4j.create_malware_actor_relationship(src["name"], tgt["name"])
                             stats["relationships_attributed_to"] += 1
 
-                    # Handle USES (Actor/Malware -> Technique)
+                    # Handle STIX "uses" predicate → EMPLOYS_TECHNIQUE (Actor)
+                    # or IMPLEMENTS_TECHNIQUE (Malware/Tool). The STIX SRO
+                    # type stays "uses" on input; we route to the right
+                    # specialized edge based on the source type at write
+                    # time. See 2026-04 refactor note in neo4j_client.py.
                     elif rel_type == "uses":
                         if src["type"] in ["actor", "malware"] and tgt["type"] == "technique":
                             if src["type"] == "actor":
                                 self.neo4j.create_actor_technique_relationship(src["name"], tgt["mitre_id"])
-                            # Note: malware-technique relationship would need a separate method
-                            # For now, we skip malware->technique via STIX relationships
+                            # Malware→Technique (IMPLEMENTS_TECHNIQUE) is
+                            # created post-sync by build_relationships.py
+                            # from the uses_techniques property, not here.
 
                 # Handle STIX Report objects (containers)
                 elif obj_type == "report":
@@ -1295,7 +1300,10 @@ class EdgeGuardPipeline:
         indicates_created = self._create_indicates_relationships()
         logger.info(f"   [OK] Created {indicates_created} INDICATES relationships")
 
-        logger.info(f"   [OK] Created {rel_stats['uses']} USES relationships")
+        logger.info(
+            f"   [OK] Created {rel_stats['uses']} EMPLOYS_TECHNIQUE relationships "
+            "(Actor→Technique)"
+        )
         logger.info(f"   [OK] Created {rel_stats['attributed_to']} ATTRIBUTED_TO relationships")
 
         # Step 5: Enrich existing indicators from multiple sources
@@ -1342,7 +1350,7 @@ class EdgeGuardPipeline:
         total_uses = rel_stats.get("uses", 0)
 
         logger.info("\n[STATS] Relationships created:")
-        logger.info(f"   - USES (Actor/Malware → Technique): {total_uses}")
+        logger.info(f"   - EMPLOYS_TECHNIQUE / IMPLEMENTS_TECHNIQUE (→ Technique): {total_uses}")
         logger.info(f"   - ATTRIBUTED_TO (Malware → Actor): {total_attributed_to}")
         logger.info(f"   - INDICATES (Indicator → Malware): {total_indicates}")
 

--- a/src/run_pipeline_misp_spt.py
+++ b/src/run_pipeline_misp_spt.py
@@ -218,7 +218,10 @@ class EdgeGuardPipelineMISPSPT:
                 except Exception:
                     pass  # Skip failed relationships
 
-            logger.info(f"   [OK] Created {rel_stats['uses']} USES relationships")
+            logger.info(
+                f"   [OK] Created {rel_stats['uses']} EMPLOYS_TECHNIQUE relationships "
+                "(Actor→Technique)"
+            )
             logger.info(f"   [OK] Created {rel_stats['attributed_to']} ATTRIBUTED_TO relationships")
 
         finally:

--- a/src/stix_exporter.py
+++ b/src/stix_exporter.py
@@ -15,8 +15,12 @@ Key design decisions (see proposal doc for justification):
 - STIX IDs are **deterministic** (UUIDv5 over the node's natural key) so
   re-exports of the same graph state produce the same bundle — ResilMesh
   can diff bundles safely.
-- All Cypher queries filter on ``edgeguard_managed = true`` so we never
-  leak ResilMesh-owned asset/vulnerability nodes into an outbound bundle.
+- All Cypher queries filter on ``x.edgeguard_managed = true`` (strict
+  equality — null fails) so we never leak ResilMesh-owned
+  asset/vulnerability nodes into an outbound bundle. Originally written
+  as ``coalesce(x.edgeguard_managed, true) = true``, which defaulted
+  missing properties to ``true`` and let ResilMesh-owned nodes pass the
+  filter — fixed in the bugbot pass on PR #25.
 - Backward compatibility with the legacy ``USES`` relationship type is
   preserved alongside the new ``EMPLOYS_TECHNIQUE`` /
   ``IMPLEMENTS_TECHNIQUE`` edges introduced by PR #24.
@@ -133,16 +137,16 @@ class StixExporter:
         rows = self._run(
             """
             MATCH (i:Indicator {value: $value})
-            WHERE coalesce(i.edgeguard_managed, true) = true
+            WHERE i.edgeguard_managed = true
             OPTIONAL MATCH (i)-[rim:INDICATES]->(m:Malware)
-              WHERE coalesce(m.edgeguard_managed, true) = true
+              WHERE m.edgeguard_managed = true
             OPTIONAL MATCH (i)-[rie:EXPLOITS]->(v)
               WHERE (v:CVE OR v:Vulnerability)
-                AND coalesce(v.edgeguard_managed, true) = true
+                AND v.edgeguard_managed = true
             OPTIONAL MATCH (i)-[rit:USES_TECHNIQUE|USES]->(t:Technique)
-              WHERE coalesce(t.edgeguard_managed, true) = true
+              WHERE t.edgeguard_managed = true
             OPTIONAL MATCH (i)-[ris:TARGETS]->(s:Sector)
-              WHERE coalesce(s.edgeguard_managed, true) = true
+              WHERE s.edgeguard_managed = true
             RETURN i AS seed,
                    collect(DISTINCT m) AS malware,
                    collect(DISTINCT v) AS vulns,
@@ -204,15 +208,15 @@ class StixExporter:
             """
             MATCH (a:ThreatActor)
             WHERE (a.name = $name OR $name IN coalesce(a.aliases, []))
-              AND coalesce(a.edgeguard_managed, true) = true
+              AND a.edgeguard_managed = true
             OPTIONAL MATCH (m:Malware)-[ram:ATTRIBUTED_TO]->(a)
-              WHERE coalesce(m.edgeguard_managed, true) = true
+              WHERE m.edgeguard_managed = true
             OPTIONAL MATCH (a)-[rat:EMPLOYS_TECHNIQUE|USES]->(t:Technique)
-              WHERE coalesce(t.edgeguard_managed, true) = true
+              WHERE t.edgeguard_managed = true
             OPTIONAL MATCH (m)-[rmt:IMPLEMENTS_TECHNIQUE|USES]->(mt:Technique)
-              WHERE coalesce(mt.edgeguard_managed, true) = true
+              WHERE mt.edgeguard_managed = true
             OPTIONAL MATCH (c:Campaign)-[rca:ATTRIBUTED_TO]->(a)
-              WHERE coalesce(c.edgeguard_managed, true) = true
+              WHERE c.edgeguard_managed = true
             RETURN a AS seed,
                    collect(DISTINCT m) AS malware,
                    collect(DISTINCT t) AS actor_tech,
@@ -281,15 +285,15 @@ class StixExporter:
         rows = self._run(
             """
             MATCH (t:Technique {mitre_id: $mid})
-            WHERE coalesce(t.edgeguard_managed, true) = true
+            WHERE t.edgeguard_managed = true
             OPTIONAL MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE|USES]->(t)
-              WHERE coalesce(a.edgeguard_managed, true) = true
+              WHERE a.edgeguard_managed = true
             OPTIONAL MATCH (m:Malware)-[:IMPLEMENTS_TECHNIQUE|USES]->(t)
-              WHERE coalesce(m.edgeguard_managed, true) = true
+              WHERE m.edgeguard_managed = true
             OPTIONAL MATCH (tool:Tool)-[:IMPLEMENTS_TECHNIQUE|USES]->(t)
-              WHERE coalesce(tool.edgeguard_managed, true) = true
+              WHERE tool.edgeguard_managed = true
             OPTIONAL MATCH (i:Indicator)-[:USES_TECHNIQUE|USES]->(t)
-              WHERE coalesce(i.edgeguard_managed, true) = true
+              WHERE i.edgeguard_managed = true
             RETURN t AS seed,
                    collect(DISTINCT a) AS actors,
                    collect(DISTINCT m) AS malware,
@@ -335,11 +339,11 @@ class StixExporter:
             MATCH (v)
             WHERE (v:CVE OR v:Vulnerability)
               AND v.cve_id = $cve_id
-              AND coalesce(v.edgeguard_managed, true) = true
+              AND v.edgeguard_managed = true
             OPTIONAL MATCH (i:Indicator)-[:EXPLOITS]->(v)
-              WHERE coalesce(i.edgeguard_managed, true) = true
-            OPTIONAL MATCH (v)-[:TARGETS]->(s:Sector)
-              WHERE coalesce(s.edgeguard_managed, true) = true
+              WHERE i.edgeguard_managed = true
+            OPTIONAL MATCH (v)-[:AFFECTS]->(s:Sector)
+              WHERE s.edgeguard_managed = true
             RETURN v AS seed,
                    collect(DISTINCT i) AS indicators,
                    collect(DISTINCT s) AS sectors
@@ -602,12 +606,21 @@ class StixExporter:
     # ------------------------------------------------------------------
 
     def _run(self, cypher: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
-        """Run a Cypher query, returning a list of row dicts."""
+        """Run a Cypher query, returning a list of row dicts.
+
+        Sessions are opened with ``default_access_mode="READ"`` so Neo4j
+        itself rejects any accidental write from this API surface — the
+        same defense-in-depth pattern used by the graph-explore and
+        admin-query endpoints in ``query_api.py``. The STIX exporter is a
+        strictly read-only consumer; a bug that produced a MERGE/CREATE
+        here should fail at the driver rather than silently mutate the
+        shared graph that ResilMesh also writes to.
+        """
         driver = getattr(self.client, "driver", None)
         if driver is None:
             logger.warning("StixExporter: Neo4j driver not connected")
             return []
-        with driver.session() as session:
+        with driver.session(default_access_mode="READ") as session:
             result = session.run(cypher, **params)
             return [dict(record) for record in result]
 

--- a/src/stix_exporter.py
+++ b/src/stix_exporter.py
@@ -1,0 +1,640 @@
+"""Graph → STIX 2.1 exporter for ResilMesh integration.
+
+This module is a **prototype** proposal implementation — see
+``docs/STIX21_EXPORTER_PROPOSAL.md`` for design notes, open questions and
+the list of follow-ups. It builds STIX 2.1 bundles centred on a single
+seed object (indicator / threat actor / technique / CVE) plus the
+immediate threat-intel neighbourhood, so ResilMesh can enrich an asset
+with "what do we know about this indicator/actor/etc." without pulling
+the whole graph.
+
+Key design decisions (see proposal doc for justification):
+- Uses the ``stix2`` SDK (already pinned in ``pyproject.toml``) for object
+  construction so we get ID generation, timestamp formatting and schema
+  validation for free.
+- STIX IDs are **deterministic** (UUIDv5 over the node's natural key) so
+  re-exports of the same graph state produce the same bundle — ResilMesh
+  can diff bundles safely.
+- All Cypher queries filter on ``edgeguard_managed = true`` so we never
+  leak ResilMesh-owned asset/vulnerability nodes into an outbound bundle.
+- Backward compatibility with the legacy ``USES`` relationship type is
+  preserved alongside the new ``EMPLOYS_TECHNIQUE`` /
+  ``IMPLEMENTS_TECHNIQUE`` edges introduced by PR #24.
+- ATT&CK tactics are emitted as ``kill_chain_phases`` on the
+  ``attack-pattern`` SDO, not as standalone objects (per STIX 2.1 ATT&CK
+  convention).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from typing import Any, Dict, Iterable, List, Optional
+
+import stix2
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Deterministic IDs
+# ---------------------------------------------------------------------------
+
+# Fixed namespace so UUIDv5 is stable across processes/machines. This
+# value is arbitrary but MUST NOT change — doing so would break ID
+# stability for ResilMesh consumers that cache by STIX ID.
+EDGEGUARD_STIX_NAMESPACE = uuid.UUID("5f2e1f9a-6a1b-5e0f-9b25-ed9ea2d574cb")
+
+
+def _deterministic_id(obj_type: str, natural_key: str) -> str:
+    """Return a deterministic STIX 2.1 ID for ``obj_type`` + ``natural_key``.
+
+    STIX IDs look like ``indicator--<uuid>``; we use UUIDv5 with a fixed
+    namespace so the same (type, key) pair always yields the same ID.
+    """
+    if not natural_key:
+        natural_key = f"__missing__:{obj_type}"
+    name = f"{obj_type}:{natural_key}".lower()
+    return f"{obj_type}--{uuid.uuid5(EDGEGUARD_STIX_NAMESPACE, name)}"
+
+
+# ---------------------------------------------------------------------------
+# Pattern helper — reuse the escape + type mapping from MISPToNeo4jSync
+# instead of re-implementing it. We instantiate the class lazily with
+# ``__new__`` to avoid triggering its heavy ``__init__`` (which would try
+# to connect to MISP).
+# ---------------------------------------------------------------------------
+
+_pattern_helper: Any = None
+
+
+def _get_pattern_helper() -> Any:
+    """Return a bare instance of MISPToNeo4jSync for pattern helpers.
+
+    We only need ``_value_to_stix_pattern``/``_escape_stix_value``; both
+    are pure and do not touch ``self``'s network state, so skipping
+    ``__init__`` is safe.
+    """
+    global _pattern_helper
+    if _pattern_helper is None:
+        from run_misp_to_neo4j import MISPToNeo4jSync
+
+        _pattern_helper = MISPToNeo4jSync.__new__(MISPToNeo4jSync)
+    return _pattern_helper
+
+
+def _build_pattern(indicator_type: Optional[str], value: str) -> str:
+    """Build a STIX 2.1 pattern literal for an indicator row.
+
+    Falls back to a generic ``artifact`` match if the MISP type is not
+    recognised — that way we never drop an indicator just because its
+    type is exotic; the proposal lists pattern coverage as a follow-up.
+    """
+    helper = _get_pattern_helper()
+    pattern = helper._value_to_stix_pattern(indicator_type or "", value)
+    if pattern:
+        return pattern
+    # Fallback: emit a valid but coarse pattern. STIX requires a pattern
+    # on indicator SDOs so we must not return None here.
+    safe = helper._escape_stix_value(value)
+    return f"[artifact:payload_bin = '{safe}']"
+
+
+# ---------------------------------------------------------------------------
+# Main exporter
+# ---------------------------------------------------------------------------
+
+
+class StixExporter:
+    """Build STIX 2.1 bundles from the EdgeGuard threat-intel graph.
+
+    Each ``export_*`` method returns a ``dict`` (the serialised bundle)
+    ready to be handed to a FastAPI response. Returning a dict rather
+    than a ``stix2.Bundle`` instance keeps the API layer free of a hard
+    dependency on the SDK's object classes.
+    """
+
+    # MIME type ResilMesh expects for STIX 2.1 payloads.
+    MEDIA_TYPE = "application/stix+json;version=2.1"
+
+    def __init__(self, neo4j_client: Any) -> None:
+        """Wrap a connected Neo4jClient (or any object exposing ``.driver``)."""
+        self.client = neo4j_client
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def export_indicator(self, value: str) -> Dict[str, Any]:
+        """Bundle one indicator + its 1-hop neighbourhood.
+
+        Neighbourhood: INDICATES→Malware, EXPLOITS→CVE/Vulnerability,
+        USES_TECHNIQUE→Technique, TARGETS→Sector.
+        """
+        rows = self._run(
+            """
+            MATCH (i:Indicator {value: $value})
+            WHERE coalesce(i.edgeguard_managed, true) = true
+            OPTIONAL MATCH (i)-[rim:INDICATES]->(m:Malware)
+              WHERE coalesce(m.edgeguard_managed, true) = true
+            OPTIONAL MATCH (i)-[rie:EXPLOITS]->(v)
+              WHERE (v:CVE OR v:Vulnerability)
+                AND coalesce(v.edgeguard_managed, true) = true
+            OPTIONAL MATCH (i)-[rit:USES_TECHNIQUE|USES]->(t:Technique)
+              WHERE coalesce(t.edgeguard_managed, true) = true
+            OPTIONAL MATCH (i)-[ris:TARGETS]->(s:Sector)
+              WHERE coalesce(s.edgeguard_managed, true) = true
+            RETURN i AS seed,
+                   collect(DISTINCT m) AS malware,
+                   collect(DISTINCT v) AS vulns,
+                   collect(DISTINCT t) AS techniques,
+                   collect(DISTINCT s) AS sectors
+            """,
+            {"value": value},
+        )
+        if not rows:
+            return self._empty_bundle()
+        row = rows[0]
+        seed = row["seed"]
+        if seed is None:
+            return self._empty_bundle()
+
+        objects: Dict[str, Dict[str, Any]] = {}
+        seed_sdo = self._node_to_sdo("Indicator", dict(seed))
+        self._add(objects, seed_sdo)
+
+        for m in _nonnull(row["malware"]):
+            m_sdo = self._node_to_sdo("Malware", dict(m))
+            self._add(objects, m_sdo)
+            self._add(
+                objects,
+                self._edge_to_sro("indicates", seed_sdo["id"], m_sdo["id"]),
+            )
+        for v in _nonnull(row["vulns"]):
+            v_sdo = self._node_to_sdo("Vulnerability", dict(v))
+            self._add(objects, v_sdo)
+            # STIX has no "exploits" vocab term; "indicates" is the closest
+            # defined value and matches the Indicator→Vulnerability semantics.
+            self._add(
+                objects,
+                self._edge_to_sro("indicates", seed_sdo["id"], v_sdo["id"]),
+            )
+        for t in _nonnull(row["techniques"]):
+            t_sdo = self._node_to_sdo("Technique", dict(t))
+            self._add(objects, t_sdo)
+            # Indicator→Technique: STIX 2.1 vocabulary for indicator
+            # source_ref allows "indicates". We use "indicates" here
+            # (not "uses") — see proposal doc §5.
+            self._add(
+                objects,
+                self._edge_to_sro("indicates", seed_sdo["id"], t_sdo["id"]),
+            )
+        for s in _nonnull(row["sectors"]):
+            s_sdo = self._node_to_sdo("Sector", dict(s))
+            self._add(objects, s_sdo)
+            self._add(
+                objects,
+                self._edge_to_sro("targets", seed_sdo["id"], s_sdo["id"]),
+            )
+
+        return self._bundle(objects.values())
+
+    def export_threat_actor(self, name: str) -> Dict[str, Any]:
+        """Bundle centred on a ThreatActor + attributed malware + TTPs + campaigns."""
+        rows = self._run(
+            """
+            MATCH (a:ThreatActor)
+            WHERE (a.name = $name OR $name IN coalesce(a.aliases, []))
+              AND coalesce(a.edgeguard_managed, true) = true
+            OPTIONAL MATCH (m:Malware)-[ram:ATTRIBUTED_TO]->(a)
+              WHERE coalesce(m.edgeguard_managed, true) = true
+            OPTIONAL MATCH (a)-[rat:EMPLOYS_TECHNIQUE|USES]->(t:Technique)
+              WHERE coalesce(t.edgeguard_managed, true) = true
+            OPTIONAL MATCH (m)-[rmt:IMPLEMENTS_TECHNIQUE|USES]->(mt:Technique)
+              WHERE coalesce(mt.edgeguard_managed, true) = true
+            OPTIONAL MATCH (c:Campaign)-[rca:ATTRIBUTED_TO]->(a)
+              WHERE coalesce(c.edgeguard_managed, true) = true
+            RETURN a AS seed,
+                   collect(DISTINCT m) AS malware,
+                   collect(DISTINCT t) AS actor_tech,
+                   collect(DISTINCT {m: m, t: mt}) AS mal_tech,
+                   collect(DISTINCT c) AS campaigns
+            """,
+            {"name": name},
+        )
+        if not rows:
+            return self._empty_bundle()
+        row = rows[0]
+        seed = row["seed"]
+        if seed is None:
+            return self._empty_bundle()
+
+        objects: Dict[str, Dict[str, Any]] = {}
+        seed_sdo = self._node_to_sdo("ThreatActor", dict(seed))
+        self._add(objects, seed_sdo)
+
+        mal_ids: Dict[str, str] = {}
+        for m in _nonnull(row["malware"]):
+            md = dict(m)
+            m_sdo = self._node_to_sdo("Malware", md)
+            self._add(objects, m_sdo)
+            mal_ids[md.get("name", "")] = m_sdo["id"]
+            self._add(
+                objects,
+                self._edge_to_sro("attributed-to", m_sdo["id"], seed_sdo["id"]),
+            )
+
+        for t in _nonnull(row["actor_tech"]):
+            t_sdo = self._node_to_sdo("Technique", dict(t))
+            self._add(objects, t_sdo)
+            self._add(
+                objects,
+                self._edge_to_sro("uses", seed_sdo["id"], t_sdo["id"]),
+            )
+        for pair in row["mal_tech"] or []:
+            m = pair.get("m") if isinstance(pair, dict) else None
+            t = pair.get("t") if isinstance(pair, dict) else None
+            if not m or not t:
+                continue
+            md = dict(m)
+            td = dict(t)
+            m_sdo_id = mal_ids.get(md.get("name", "")) or self._add(
+                objects, self._node_to_sdo("Malware", md)
+            )
+            t_sdo = self._node_to_sdo("Technique", td)
+            self._add(objects, t_sdo)
+            self._add(
+                objects,
+                self._edge_to_sro("uses", m_sdo_id, t_sdo["id"]),
+            )
+        for c in _nonnull(row["campaigns"]):
+            c_sdo = self._node_to_sdo("Campaign", dict(c))
+            self._add(objects, c_sdo)
+            self._add(
+                objects,
+                self._edge_to_sro("attributed-to", c_sdo["id"], seed_sdo["id"]),
+            )
+
+        return self._bundle(objects.values())
+
+    def export_technique(self, mitre_id: str) -> Dict[str, Any]:
+        """Bundle centred on a Technique + everything that uses it."""
+        rows = self._run(
+            """
+            MATCH (t:Technique {mitre_id: $mid})
+            WHERE coalesce(t.edgeguard_managed, true) = true
+            OPTIONAL MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE|USES]->(t)
+              WHERE coalesce(a.edgeguard_managed, true) = true
+            OPTIONAL MATCH (m:Malware)-[:IMPLEMENTS_TECHNIQUE|USES]->(t)
+              WHERE coalesce(m.edgeguard_managed, true) = true
+            OPTIONAL MATCH (tool:Tool)-[:IMPLEMENTS_TECHNIQUE|USES]->(t)
+              WHERE coalesce(tool.edgeguard_managed, true) = true
+            OPTIONAL MATCH (i:Indicator)-[:USES_TECHNIQUE|USES]->(t)
+              WHERE coalesce(i.edgeguard_managed, true) = true
+            RETURN t AS seed,
+                   collect(DISTINCT a) AS actors,
+                   collect(DISTINCT m) AS malware,
+                   collect(DISTINCT tool) AS tools,
+                   collect(DISTINCT i) AS indicators
+            """,
+            {"mid": mitre_id},
+        )
+        if not rows:
+            return self._empty_bundle()
+        row = rows[0]
+        seed = row["seed"]
+        if seed is None:
+            return self._empty_bundle()
+
+        objects: Dict[str, Dict[str, Any]] = {}
+        seed_sdo = self._node_to_sdo("Technique", dict(seed))
+        self._add(objects, seed_sdo)
+
+        for a in _nonnull(row["actors"]):
+            a_sdo = self._node_to_sdo("ThreatActor", dict(a))
+            self._add(objects, a_sdo)
+            self._add(objects, self._edge_to_sro("uses", a_sdo["id"], seed_sdo["id"]))
+        for m in _nonnull(row["malware"]):
+            m_sdo = self._node_to_sdo("Malware", dict(m))
+            self._add(objects, m_sdo)
+            self._add(objects, self._edge_to_sro("uses", m_sdo["id"], seed_sdo["id"]))
+        for tool in _nonnull(row["tools"]):
+            tool_sdo = self._node_to_sdo("Tool", dict(tool))
+            self._add(objects, tool_sdo)
+            self._add(objects, self._edge_to_sro("uses", tool_sdo["id"], seed_sdo["id"]))
+        for i in _nonnull(row["indicators"]):
+            i_sdo = self._node_to_sdo("Indicator", dict(i))
+            self._add(objects, i_sdo)
+            self._add(objects, self._edge_to_sro("indicates", i_sdo["id"], seed_sdo["id"]))
+
+        return self._bundle(objects.values())
+
+    def export_cve(self, cve_id: str) -> Dict[str, Any]:
+        """Bundle centred on a CVE/Vulnerability + exploiting indicators + affected sectors."""
+        rows = self._run(
+            """
+            MATCH (v)
+            WHERE (v:CVE OR v:Vulnerability)
+              AND v.cve_id = $cve_id
+              AND coalesce(v.edgeguard_managed, true) = true
+            OPTIONAL MATCH (i:Indicator)-[:EXPLOITS]->(v)
+              WHERE coalesce(i.edgeguard_managed, true) = true
+            OPTIONAL MATCH (v)-[:TARGETS]->(s:Sector)
+              WHERE coalesce(s.edgeguard_managed, true) = true
+            RETURN v AS seed,
+                   collect(DISTINCT i) AS indicators,
+                   collect(DISTINCT s) AS sectors
+            """,
+            {"cve_id": cve_id},
+        )
+        if not rows:
+            return self._empty_bundle()
+        row = rows[0]
+        seed = row["seed"]
+        if seed is None:
+            return self._empty_bundle()
+
+        objects: Dict[str, Dict[str, Any]] = {}
+        seed_sdo = self._node_to_sdo("Vulnerability", dict(seed))
+        self._add(objects, seed_sdo)
+
+        for i in _nonnull(row["indicators"]):
+            i_sdo = self._node_to_sdo("Indicator", dict(i))
+            self._add(objects, i_sdo)
+            self._add(objects, self._edge_to_sro("indicates", i_sdo["id"], seed_sdo["id"]))
+        for s in _nonnull(row["sectors"]):
+            s_sdo = self._node_to_sdo("Sector", dict(s))
+            self._add(objects, s_sdo)
+            self._add(objects, self._edge_to_sro("targets", seed_sdo["id"], s_sdo["id"]))
+
+        return self._bundle(objects.values())
+
+    # ------------------------------------------------------------------
+    # Node → SDO mapping
+    # ------------------------------------------------------------------
+
+    def _node_to_sdo(self, label: str, props: Dict[str, Any]) -> Dict[str, Any]:
+        """Turn a Neo4j node dict into a STIX 2.1 SDO dict.
+
+        We build objects through the stix2 SDK so the library enforces
+        schema and emits correct timestamps, then serialise back to a
+        plain dict for the bundle (``stix2.parsing.dict_to_stix2`` would
+        round-trip but the dict form is what FastAPI serialises anyway).
+        """
+        label = label.lower()
+        if label == "indicator":
+            return self._indicator_sdo(props)
+        if label == "malware":
+            return self._malware_sdo(props)
+        if label == "threatactor":
+            return self._actor_sdo(props)
+        if label == "technique":
+            return self._technique_sdo(props)
+        if label == "tool":
+            return self._tool_sdo(props)
+        if label == "campaign":
+            return self._campaign_sdo(props)
+        if label in ("cve", "vulnerability"):
+            return self._vulnerability_sdo(props)
+        if label == "sector":
+            return self._sector_sdo(props)
+        # Unknown — never happens with well-formed graph, but fail soft.
+        return {
+            "type": "x-edgeguard-unknown",
+            "id": _deterministic_id("x-edgeguard-unknown", str(props)),
+            "spec_version": "2.1",
+        }
+
+    # ---- per-type constructors ----------------------------------------
+
+    def _indicator_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        value = props.get("value", "")
+        ind_type = props.get("indicator_type", "")
+        pattern = _build_pattern(ind_type, value)
+        stix_id = _deterministic_id("indicator", f"{ind_type}|{value}")
+        obj = stix2.Indicator(
+            id=stix_id,
+            pattern=pattern,
+            pattern_type="stix",
+            valid_from=props.get("first_seen") or "1970-01-01T00:00:00Z",
+            name=props.get("name") or f"{ind_type}:{value}",
+            indicator_types=_listify(props.get("indicator_classification") or ["malicious-activity"]),
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    def _malware_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        name = props.get("name", "")
+        stix_id = _deterministic_id("malware", name)
+        malware_types = _listify(props.get("malware_types") or ["unknown"])
+        is_family = any(
+            "family" in (mt or "").lower() for mt in malware_types
+        ) or bool(props.get("is_family"))
+        obj = stix2.Malware(
+            id=stix_id,
+            name=name,
+            is_family=is_family,
+            malware_types=malware_types,
+            aliases=_listify(props.get("aliases")),
+            description=props.get("description"),
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    def _actor_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        name = props.get("name", "")
+        # Default to intrusion-set (group convention, matches MITRE ATT&CK).
+        stix_id = _deterministic_id("intrusion-set", name)
+        obj = stix2.IntrusionSet(
+            id=stix_id,
+            name=name,
+            aliases=_listify(props.get("aliases")),
+            description=props.get("description"),
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    def _technique_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        mitre_id = props.get("mitre_id") or props.get("external_id") or ""
+        name = props.get("name", mitre_id)
+        stix_id = _deterministic_id("attack-pattern", mitre_id or name)
+
+        kcp: List[Dict[str, str]] = []
+        # Tactic → kill_chain_phases. We accept either a list of phases
+        # stored on the node or the legacy ``tactic_phases`` property.
+        phases = props.get("tactic_phases") or props.get("kill_chain_phases") or []
+        for phase in phases:
+            if isinstance(phase, dict):
+                name_ = phase.get("phase_name") or phase.get("name")
+            else:
+                name_ = str(phase)
+            if name_:
+                kcp.append({"kill_chain_name": "mitre-attack", "phase_name": str(name_).lower()})
+
+        ext_refs = []
+        if mitre_id:
+            ext_refs.append(
+                {
+                    "source_name": "mitre-attack",
+                    "external_id": mitre_id,
+                    "url": f"https://attack.mitre.org/techniques/{mitre_id.replace('.', '/')}",
+                }
+            )
+
+        kwargs: Dict[str, Any] = {
+            "id": stix_id,
+            "name": name,
+            "description": props.get("description"),
+            "allow_custom": True,
+        }
+        if kcp:
+            kwargs["kill_chain_phases"] = kcp
+        if ext_refs:
+            kwargs["external_references"] = ext_refs
+        obj = stix2.AttackPattern(**kwargs)
+        return _to_dict(obj)
+
+    def _tool_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        name = props.get("name", "")
+        stix_id = _deterministic_id("tool", name)
+        obj = stix2.Tool(
+            id=stix_id,
+            name=name,
+            tool_types=_listify(props.get("tool_types") or ["unknown"]),
+            description=props.get("description"),
+            aliases=_listify(props.get("aliases")),
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    def _campaign_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        name = props.get("name", "")
+        stix_id = _deterministic_id("campaign", name)
+        obj = stix2.Campaign(
+            id=stix_id,
+            name=name,
+            description=props.get("description"),
+            aliases=_listify(props.get("aliases")),
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    def _vulnerability_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        cve_id = props.get("cve_id") or props.get("name") or ""
+        stix_id = _deterministic_id("vulnerability", cve_id)
+        ext_refs = []
+        if cve_id:
+            ext_refs.append(
+                {
+                    "source_name": "cve",
+                    "external_id": cve_id,
+                    "url": f"https://nvd.nist.gov/vuln/detail/{cve_id}",
+                }
+            )
+        kwargs: Dict[str, Any] = {
+            "id": stix_id,
+            "name": cve_id,
+            "description": props.get("description"),
+            "allow_custom": True,
+        }
+        if ext_refs:
+            kwargs["external_references"] = ext_refs
+        obj = stix2.Vulnerability(**kwargs)
+        return _to_dict(obj)
+
+    def _sector_sdo(self, props: Dict[str, Any]) -> Dict[str, Any]:
+        name = props.get("name") or props.get("sector") or ""
+        stix_id = _deterministic_id("identity", f"sector|{name}")
+        obj = stix2.Identity(
+            id=stix_id,
+            name=name,
+            identity_class="class",
+            sectors=[name] if name else None,
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    # ------------------------------------------------------------------
+    # Edge → SRO
+    # ------------------------------------------------------------------
+
+    def _edge_to_sro(
+        self, relationship_type: str, source_ref: str, target_ref: str
+    ) -> Dict[str, Any]:
+        """Build a deterministic Relationship SRO between two SDOs."""
+        stix_id = _deterministic_id(
+            "relationship", f"{source_ref}|{relationship_type}|{target_ref}"
+        )
+        obj = stix2.Relationship(
+            id=stix_id,
+            relationship_type=relationship_type,
+            source_ref=source_ref,
+            target_ref=target_ref,
+            allow_custom=True,
+        )
+        return _to_dict(obj)
+
+    # ------------------------------------------------------------------
+    # Bundle assembly
+    # ------------------------------------------------------------------
+
+    def _add(
+        self, objects: Dict[str, Dict[str, Any]], sdo: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        """Insert a SDO/SRO into the bundle dict, keyed by its STIX id."""
+        if not sdo:
+            return None
+        objects.setdefault(sdo["id"], sdo)
+        return sdo["id"]
+
+    def _bundle(self, objects: Iterable[Dict[str, Any]]) -> Dict[str, Any]:
+        bundle_id = "bundle--" + str(uuid.uuid4())
+        return {
+            "type": "bundle",
+            "id": bundle_id,
+            "objects": list(objects),
+        }
+
+    def _empty_bundle(self) -> Dict[str, Any]:
+        return self._bundle([])
+
+    # ------------------------------------------------------------------
+    # Neo4j helper
+    # ------------------------------------------------------------------
+
+    def _run(self, cypher: str, params: Dict[str, Any]) -> List[Dict[str, Any]]:
+        """Run a Cypher query, returning a list of row dicts."""
+        driver = getattr(self.client, "driver", None)
+        if driver is None:
+            logger.warning("StixExporter: Neo4j driver not connected")
+            return []
+        with driver.session() as session:
+            result = session.run(cypher, **params)
+            return [dict(record) for record in result]
+
+
+# ---------------------------------------------------------------------------
+# Module helpers
+# ---------------------------------------------------------------------------
+
+
+def _listify(value: Any) -> Optional[List[str]]:
+    if value is None:
+        return None
+    if isinstance(value, (list, tuple)):
+        out = [str(v) for v in value if v is not None]
+        return out or None
+    return [str(value)]
+
+
+def _nonnull(items: Any) -> List[Any]:
+    """Drop None entries from a collect() result."""
+    return [x for x in (items or []) if x is not None]
+
+
+def _to_dict(stix_obj: Any) -> Dict[str, Any]:
+    """Serialise a stix2 SDO/SRO to a plain dict."""
+    # stix2 objects expose ``serialize`` (json) and ``.get`` on __dict__.
+    # The simplest stable round-trip is ``json.loads(obj.serialize())``.
+    import json
+
+    return json.loads(stix_obj.serialize())

--- a/src/stix_exporter.py
+++ b/src/stix_exporter.py
@@ -203,24 +203,44 @@ class StixExporter:
         return self._bundle(objects.values())
 
     def export_threat_actor(self, name: str) -> Dict[str, Any]:
-        """Bundle centred on a ThreatActor + attributed malware + TTPs + campaigns."""
+        """Bundle centred on a ThreatActor + attributed malware + TTPs + campaigns.
+
+        The query uses a ``WITH ... collect(DISTINCT ...)`` step between
+        every ``OPTIONAL MATCH`` to avoid the Cartesian product that
+        would otherwise arise from chaining 5 optional matches. Without
+        the intermediate aggregation, Neo4j produces
+        O(malware × actor_tech × mal_tech × campaigns) intermediate
+        rows before the final ``DISTINCT`` collapses them — a
+        well-connected actor group (e.g. APT28) would generate
+        thousands of throwaway rows, materially impacting query
+        latency. Aggregating at each step keeps the row count bounded
+        by the size of one collection at a time.
+        """
         rows = self._run(
             """
             MATCH (a:ThreatActor)
             WHERE (a.name = $name OR $name IN coalesce(a.aliases, []))
               AND a.edgeguard_managed = true
-            OPTIONAL MATCH (m:Malware)-[ram:ATTRIBUTED_TO]->(a)
+            WITH a
+            OPTIONAL MATCH (m:Malware)-[:ATTRIBUTED_TO]->(a)
               WHERE m.edgeguard_managed = true
-            OPTIONAL MATCH (a)-[rat:EMPLOYS_TECHNIQUE|USES]->(t:Technique)
+            WITH a, collect(DISTINCT m) AS malware
+            OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE|USES]->(t:Technique)
               WHERE t.edgeguard_managed = true
-            OPTIONAL MATCH (m)-[rmt:IMPLEMENTS_TECHNIQUE|USES]->(mt:Technique)
-              WHERE mt.edgeguard_managed = true
-            OPTIONAL MATCH (c:Campaign)-[rca:ATTRIBUTED_TO]->(a)
+            WITH a, malware, collect(DISTINCT t) AS actor_tech
+            UNWIND (CASE WHEN size(malware) = 0 THEN [null] ELSE malware END) AS m_each
+            OPTIONAL MATCH (m_each)-[:IMPLEMENTS_TECHNIQUE|USES]->(mt:Technique)
+              WHERE m_each IS NOT NULL AND mt.edgeguard_managed = true
+            WITH a, malware, actor_tech,
+                 collect(DISTINCT CASE WHEN mt IS NULL THEN null ELSE {m: m_each, t: mt} END) AS mal_tech_raw
+            WITH a, malware, actor_tech,
+                 [pair IN mal_tech_raw WHERE pair IS NOT NULL] AS mal_tech
+            OPTIONAL MATCH (c:Campaign)-[:ATTRIBUTED_TO]->(a)
               WHERE c.edgeguard_managed = true
             RETURN a AS seed,
-                   collect(DISTINCT m) AS malware,
-                   collect(DISTINCT t) AS actor_tech,
-                   collect(DISTINCT {m: m, t: mt}) AS mal_tech,
+                   malware,
+                   actor_tech,
+                   mal_tech,
                    collect(DISTINCT c) AS campaigns
             """,
             {"name": name},

--- a/src/stix_exporter.py
+++ b/src/stix_exporter.py
@@ -235,7 +235,7 @@ class StixExporter:
                  collect(DISTINCT CASE WHEN mt IS NULL THEN null ELSE {m: m_each, t: mt} END) AS mal_tech_raw
             WITH a, malware, actor_tech,
                  [pair IN mal_tech_raw WHERE pair IS NOT NULL] AS mal_tech
-            OPTIONAL MATCH (c:Campaign)-[:ATTRIBUTED_TO]->(a)
+            OPTIONAL MATCH (a)-[:RUNS]->(c:Campaign)
               WHERE c.edgeguard_managed = true
             RETURN a AS seed,
                    malware,
@@ -281,9 +281,7 @@ class StixExporter:
                 continue
             md = dict(m)
             td = dict(t)
-            m_sdo_id = mal_ids.get(md.get("name", "")) or self._add(
-                objects, self._node_to_sdo("Malware", md)
-            )
+            m_sdo_id = mal_ids.get(md.get("name", "")) or self._add(objects, self._node_to_sdo("Malware", md))
             t_sdo = self._node_to_sdo("Technique", td)
             self._add(objects, t_sdo)
             self._add(
@@ -293,6 +291,11 @@ class StixExporter:
         for c in _nonnull(row["campaigns"]):
             c_sdo = self._node_to_sdo("Campaign", dict(c))
             self._add(objects, c_sdo)
+            # The graph edge is (ThreatActor)-[:RUNS]->(Campaign) — the
+            # actor owns/operates the campaign. STIX 2.1 expresses this
+            # as `relationship_type: attributed-to` with source_ref on
+            # the campaign and target_ref on the intrusion-set. See
+            # https://docs.oasis-open.org/cti/stix/v2.1/os/stix-v2.1-os.html#_i4tjv75ce50h
             self._add(
                 objects,
                 self._edge_to_sro("attributed-to", c_sdo["id"], seed_sdo["id"]),
@@ -301,23 +304,39 @@ class StixExporter:
         return self._bundle(objects.values())
 
     def export_technique(self, mitre_id: str) -> Dict[str, Any]:
-        """Bundle centred on a Technique + everything that uses it."""
+        """Bundle centred on a Technique + everything that uses it.
+
+        Uses ``WITH ... collect(DISTINCT ...) AS ...`` between every
+        ``OPTIONAL MATCH`` for the same reason as ``export_threat_actor``:
+        chaining four optional matches without aggregation produces a
+        Cartesian product of O(actors × malware × tools × indicators)
+        intermediate rows that a final ``DISTINCT`` collapses. A
+        well-connected technique (T1059 command-and-scripting is the
+        hotspot called out in the proposal doc) would generate thousands
+        of throwaway rows under the naive query shape. Aggregating at
+        each step bounds the row count by the size of one collection at
+        a time.
+        """
         rows = self._run(
             """
             MATCH (t:Technique {mitre_id: $mid})
             WHERE t.edgeguard_managed = true
+            WITH t
             OPTIONAL MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE|USES]->(t)
               WHERE a.edgeguard_managed = true
+            WITH t, collect(DISTINCT a) AS actors
             OPTIONAL MATCH (m:Malware)-[:IMPLEMENTS_TECHNIQUE|USES]->(t)
               WHERE m.edgeguard_managed = true
+            WITH t, actors, collect(DISTINCT m) AS malware
             OPTIONAL MATCH (tool:Tool)-[:IMPLEMENTS_TECHNIQUE|USES]->(t)
               WHERE tool.edgeguard_managed = true
+            WITH t, actors, malware, collect(DISTINCT tool) AS tools
             OPTIONAL MATCH (i:Indicator)-[:USES_TECHNIQUE|USES]->(t)
               WHERE i.edgeguard_managed = true
             RETURN t AS seed,
-                   collect(DISTINCT a) AS actors,
-                   collect(DISTINCT m) AS malware,
-                   collect(DISTINCT tool) AS tools,
+                   actors,
+                   malware,
+                   tools,
                    collect(DISTINCT i) AS indicators
             """,
             {"mid": mitre_id},
@@ -450,9 +469,7 @@ class StixExporter:
         name = props.get("name", "")
         stix_id = _deterministic_id("malware", name)
         malware_types = _listify(props.get("malware_types") or ["unknown"])
-        is_family = any(
-            "family" in (mt or "").lower() for mt in malware_types
-        ) or bool(props.get("is_family"))
+        is_family = any("family" in (mt or "").lower() for mt in malware_types) or bool(props.get("is_family"))
         obj = stix2.Malware(
             id=stix_id,
             name=name,
@@ -581,13 +598,9 @@ class StixExporter:
     # Edge → SRO
     # ------------------------------------------------------------------
 
-    def _edge_to_sro(
-        self, relationship_type: str, source_ref: str, target_ref: str
-    ) -> Dict[str, Any]:
+    def _edge_to_sro(self, relationship_type: str, source_ref: str, target_ref: str) -> Dict[str, Any]:
         """Build a deterministic Relationship SRO between two SDOs."""
-        stix_id = _deterministic_id(
-            "relationship", f"{source_ref}|{relationship_type}|{target_ref}"
-        )
+        stix_id = _deterministic_id("relationship", f"{source_ref}|{relationship_type}|{target_ref}")
         obj = stix2.Relationship(
             id=stix_id,
             relationship_type=relationship_type,
@@ -601,9 +614,7 @@ class StixExporter:
     # Bundle assembly
     # ------------------------------------------------------------------
 
-    def _add(
-        self, objects: Dict[str, Dict[str, Any]], sdo: Optional[Dict[str, Any]]
-    ) -> Optional[str]:
+    def _add(self, objects: Dict[str, Dict[str, Any]], sdo: Optional[Dict[str, Any]]) -> Optional[str]:
         """Insert a SDO/SRO into the bundle dict, keyed by its STIX id."""
         if not sdo:
             return None

--- a/tests/test_merge_key_dedup.py
+++ b/tests/test_merge_key_dedup.py
@@ -223,18 +223,20 @@ class TestCrossItemRelKeys:
         syncer = MISPToNeo4jSync.__new__(MISPToNeo4jSync)
         return syncer._build_cross_item_relationships(items)
 
-    def test_actor_technique_uses_no_tag(self):
+    def test_actor_technique_employs_no_tag(self):
         items = [
             {"type": "actor", "name": "APT28", "tag": "mitre_attck"},
             {"type": "technique", "mitre_id": "T1059", "name": "CLI", "tag": "mitre_attck"},
         ]
         rels = self._build_rels(items)
-        uses = [r for r in rels if r["rel_type"] == "USES"]
-        assert len(uses) == 1
-        assert "tag" not in uses[0]["from_key"], f"USES from_key has tag: {uses[0]['from_key']}"
-        assert "tag" not in uses[0]["to_key"], f"USES to_key has tag: {uses[0]['to_key']}"
-        assert uses[0]["from_key"] == {"name": "APT28"}
-        assert uses[0]["to_key"] == {"mitre_id": "T1059"}
+        # Actor→Technique is EMPLOYS_TECHNIQUE (attribution) since the
+        # 2026-04 split of the generic USES bucket.
+        employs = [r for r in rels if r["rel_type"] == "EMPLOYS_TECHNIQUE"]
+        assert len(employs) == 1
+        assert "tag" not in employs[0]["from_key"], f"from_key has tag: {employs[0]['from_key']}"
+        assert "tag" not in employs[0]["to_key"], f"to_key has tag: {employs[0]['to_key']}"
+        assert employs[0]["from_key"] == {"name": "APT28"}
+        assert employs[0]["to_key"] == {"mitre_id": "T1059"}
 
     def test_malware_actor_attributed_to_no_tag(self):
         items = [

--- a/tests/test_misp_cross_item_event_scope.py
+++ b/tests/test_misp_cross_item_event_scope.py
@@ -30,7 +30,7 @@ def syncer() -> MISPToNeo4jSync:
 
 
 def test_per_event_cross_item_fewer_edges_than_global_pool(syncer: MISPToNeo4jSync):
-    """Two actors and two techniques in separate events → 2 USES total, not 2×2."""
+    """Two actors and two techniques in separate events → 2 EMPLOYS_TECHNIQUE total, not 2×2."""
     actor_a = {"type": "actor", "name": "ActorA", "tag": "misp"}
     actor_b = {"type": "actor", "name": "ActorB", "tag": "misp"}
     t1 = {"type": "technique", "mitre_id": "T1059", "tag": "misp", "name": "Scripting"}
@@ -55,6 +55,9 @@ def test_dedupe_parsed_items_keeps_one_row_per_key(syncer: MISPToNeo4jSync):
     ]
     u = _dedupe_parsed_items(dup_indicators)
     assert len(u) == 1
-    # Single indicator, no malware/vuln in pool → no pairwise INDICATES / USES / ATTRIBUTED_TO
+    # Single indicator, no malware/vuln in pool → no pairwise
+    # INDICATES / EMPLOYS_TECHNIQUE / ATTRIBUTED_TO
     cross = syncer._build_cross_item_relationships(u)
-    assert not any(r.get("rel_type") in ("INDICATES", "USES", "ATTRIBUTED_TO") for r in cross)
+    assert not any(
+        r.get("rel_type") in ("INDICATES", "EMPLOYS_TECHNIQUE", "ATTRIBUTED_TO") for r in cross
+    )

--- a/tests/test_stix_exporter.py
+++ b/tests/test_stix_exporter.py
@@ -1,0 +1,294 @@
+"""Unit tests for src/stix_exporter.py.
+
+We mock the Neo4j driver so these run without a live DB. The goal is to
+validate the shape of the emitted STIX 2.1 bundles and the deterministic
+ID behaviour, not to exercise real Cypher.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+from stix_exporter import StixExporter, _deterministic_id
+
+# ---------------------------------------------------------------------------
+# Fake Neo4j driver
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, rows: List[Dict[str, Any]]):
+        self._rows = rows
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, rows: List[Dict[str, Any]]):
+        self._rows = rows
+        self.last_cypher: str = ""
+        self.last_params: Dict[str, Any] = {}
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_exc):
+        return False
+
+    def run(self, cypher: str, **params: Any) -> _FakeResult:
+        self.last_cypher = cypher
+        self.last_params = params
+        return _FakeResult(self._rows)
+
+
+class _FakeDriver:
+    def __init__(self, rows: List[Dict[str, Any]]):
+        self._session = _FakeSession(rows)
+
+    def session(self):
+        return self._session
+
+
+def _mk_client(rows: List[Dict[str, Any]]) -> Any:
+    client = MagicMock()
+    client.driver = _FakeDriver(rows)
+    client.is_connected.return_value = True
+    return client
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _by_type(bundle: Dict[str, Any], stix_type: str) -> List[Dict[str, Any]]:
+    return [o for o in bundle["objects"] if o["type"] == stix_type]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+def test_actor_with_two_techniques_yields_intrusion_set_and_uses_sros():
+    rows = [
+        {
+            "seed": {"name": "APT28", "aliases": ["Fancy Bear"]},
+            "malware": [],
+            "actor_tech": [
+                {"mitre_id": "T1055", "name": "Process Injection"},
+                {"mitre_id": "T1059", "name": "Command and Scripting Interpreter"},
+            ],
+            "mal_tech": [],
+            "campaigns": [],
+        }
+    ]
+    exporter = StixExporter(_mk_client(rows))
+    bundle = exporter.export_threat_actor("APT28")
+
+    intrusion_sets = _by_type(bundle, "intrusion-set")
+    attack_patterns = _by_type(bundle, "attack-pattern")
+    relationships = _by_type(bundle, "relationship")
+
+    assert len(intrusion_sets) == 1
+    assert intrusion_sets[0]["name"] == "APT28"
+    assert len(attack_patterns) == 2
+    # Two "uses" SROs from the intrusion-set to each attack-pattern.
+    uses = [r for r in relationships if r["relationship_type"] == "uses"]
+    assert len(uses) == 2
+    assert all(r["source_ref"] == intrusion_sets[0]["id"] for r in uses)
+
+
+def test_actor_with_attributed_malware_emits_attributed_to_sro():
+    rows = [
+        {
+            "seed": {"name": "APT28"},
+            "malware": [{"name": "X-Agent", "malware_types": ["trojan"]}],
+            "actor_tech": [],
+            "mal_tech": [],
+            "campaigns": [],
+        }
+    ]
+    exporter = StixExporter(_mk_client(rows))
+    bundle = exporter.export_threat_actor("APT28")
+
+    malware = _by_type(bundle, "malware")
+    rels = _by_type(bundle, "relationship")
+    assert len(malware) == 1 and malware[0]["name"] == "X-Agent"
+    attributed = [r for r in rels if r["relationship_type"] == "attributed-to"]
+    assert len(attributed) == 1
+    assert attributed[0]["source_ref"] == malware[0]["id"]
+    assert attributed[0]["target_ref"].startswith("intrusion-set--")
+
+
+def test_indicator_indicates_malware_bundle():
+    rows = [
+        {
+            "seed": {
+                "value": "1.2.3.4",
+                "indicator_type": "ipv4",
+                "first_seen": "2024-01-01T00:00:00Z",
+            },
+            "malware": [{"name": "Emotet", "malware_types": ["trojan"]}],
+            "vulns": [],
+            "techniques": [],
+            "sectors": [],
+        }
+    ]
+    exporter = StixExporter(_mk_client(rows))
+    bundle = exporter.export_indicator("1.2.3.4")
+
+    assert len(_by_type(bundle, "indicator")) == 1
+    assert len(_by_type(bundle, "malware")) == 1
+    rels = _by_type(bundle, "relationship")
+    indicates = [r for r in rels if r["relationship_type"] == "indicates"]
+    assert len(indicates) == 1
+    assert indicates[0]["target_ref"].startswith("malware--")
+
+
+def test_deterministic_ids_stable_across_calls():
+    rows = [
+        {
+            "seed": {"value": "1.2.3.4", "indicator_type": "ipv4"},
+            "malware": [],
+            "vulns": [],
+            "techniques": [],
+            "sectors": [],
+        }
+    ]
+    e1 = StixExporter(_mk_client(rows))
+    e2 = StixExporter(_mk_client(rows))
+    b1 = e1.export_indicator("1.2.3.4")
+    b2 = e2.export_indicator("1.2.3.4")
+    # Bundle IDs differ (random), but object IDs must be identical.
+    ids1 = sorted(o["id"] for o in b1["objects"])
+    ids2 = sorted(o["id"] for o in b2["objects"])
+    assert ids1 == ids2
+    assert ids1  # not empty
+
+
+def test_deterministic_id_helper_uses_uuid5():
+    a = _deterministic_id("indicator", "ipv4|1.2.3.4")
+    b = _deterministic_id("indicator", "ipv4|1.2.3.4")
+    c = _deterministic_id("indicator", "ipv4|9.9.9.9")
+    assert a == b
+    assert a != c
+    assert a.startswith("indicator--")
+
+
+def test_technique_kill_chain_phases_emitted_as_property_not_sro():
+    rows = [
+        {
+            "seed": {
+                "mitre_id": "T1055",
+                "name": "Process Injection",
+                "tactic_phases": ["defense-evasion", "privilege-escalation"],
+            },
+            "actors": [],
+            "malware": [],
+            "tools": [],
+            "indicators": [],
+        }
+    ]
+    exporter = StixExporter(_mk_client(rows))
+    bundle = exporter.export_technique("T1055")
+
+    ap = _by_type(bundle, "attack-pattern")
+    assert len(ap) == 1
+    kcp = ap[0].get("kill_chain_phases") or []
+    assert {"kill_chain_name": "mitre-attack", "phase_name": "defense-evasion"} in kcp
+    assert {"kill_chain_name": "mitre-attack", "phase_name": "privilege-escalation"} in kcp
+    # No Tactic SDO and no in_tactic/IN_TACTIC SRO
+    assert _by_type(bundle, "x-mitre-tactic") == []
+    rels = _by_type(bundle, "relationship")
+    assert not any(r["relationship_type"] in ("in-tactic", "IN_TACTIC") for r in rels)
+    # External reference to MITRE ATT&CK
+    assert ap[0]["external_references"][0]["source_name"] == "mitre-attack"
+    assert ap[0]["external_references"][0]["external_id"] == "T1055"
+
+
+def test_legacy_uses_rel_type_is_queried_for_backward_compat():
+    """The Cypher for actor/technique export must still match the legacy
+    ``USES`` rel type alongside the new EMPLOYS_/IMPLEMENTS_TECHNIQUE ones.
+    We assert this by inspecting the query string the exporter ran.
+    """
+    rows = [
+        {
+            "seed": {"name": "APT29"},
+            "malware": [],
+            "actor_tech": [],
+            "mal_tech": [],
+            "campaigns": [],
+        }
+    ]
+    client = _mk_client(rows)
+    exporter = StixExporter(client)
+    exporter.export_threat_actor("APT29")
+    q = client.driver._session.last_cypher
+    assert "EMPLOYS_TECHNIQUE|USES" in q
+    assert "IMPLEMENTS_TECHNIQUE|USES" in q
+
+    # And the technique-centric export also checks the legacy variant.
+    rows2 = [
+        {
+            "seed": {"mitre_id": "T1059", "name": "CLI", "tactic_phases": []},
+            "actors": [],
+            "malware": [],
+            "tools": [],
+            "indicators": [],
+        }
+    ]
+    client2 = _mk_client(rows2)
+    StixExporter(client2).export_technique("T1059")
+    q2 = client2.driver._session.last_cypher
+    assert "EMPLOYS_TECHNIQUE|USES" in q2
+    assert "IMPLEMENTS_TECHNIQUE|USES" in q2
+    assert "USES_TECHNIQUE|USES" in q2
+
+
+def test_edgeguard_managed_filter_present_in_all_queries():
+    rows = [
+        {
+            "seed": {"value": "evil.com", "indicator_type": "domain"},
+            "malware": [],
+            "vulns": [],
+            "techniques": [],
+            "sectors": [],
+        }
+    ]
+    client = _mk_client(rows)
+    StixExporter(client).export_indicator("evil.com")
+    assert "edgeguard_managed" in client.driver._session.last_cypher
+
+
+def test_cve_export_bundle_contains_vulnerability_and_indicator_indicates_rel():
+    rows = [
+        {
+            "seed": {"cve_id": "CVE-2021-44228", "name": "Log4Shell"},
+            "indicators": [
+                {"value": "evil.com", "indicator_type": "domain"},
+            ],
+            "sectors": [],
+        }
+    ]
+    exporter = StixExporter(_mk_client(rows))
+    bundle = exporter.export_cve("CVE-2021-44228")
+    vulns = _by_type(bundle, "vulnerability")
+    assert len(vulns) == 1
+    assert vulns[0]["external_references"][0]["source_name"] == "cve"
+    assert vulns[0]["external_references"][0]["external_id"] == "CVE-2021-44228"
+    rels = _by_type(bundle, "relationship")
+    assert any(
+        r["relationship_type"] == "indicates"
+        and r["target_ref"] == vulns[0]["id"]
+        for r in rels
+    )
+
+
+def test_empty_bundle_when_seed_not_found():
+    exporter = StixExporter(_mk_client([]))
+    bundle = exporter.export_indicator("nothing-here")
+    assert bundle["type"] == "bundle"
+    assert bundle["objects"] == []

--- a/tests/test_stix_exporter.py
+++ b/tests/test_stix_exporter.py
@@ -106,6 +106,60 @@ def test_actor_with_two_techniques_yields_intrusion_set_and_uses_sros():
     assert all(r["source_ref"] == intrusion_sets[0]["id"] for r in uses)
 
 
+def test_actor_campaign_query_uses_runs_direction():
+    """Regression test for bugbot round-4 finding: the export_threat_actor
+    Cypher was originally ``(c:Campaign)-[:ATTRIBUTED_TO]->(a)`` but the
+    actual graph edge is ``(a:ThreatActor)-[:RUNS]->(c:Campaign)`` —
+    see enrichment_jobs.build_campaign_nodes(). The wrong pattern
+    matched zero campaigns for every actor, silently omitting them
+    from STIX bundles."""
+    rows = [
+        {
+            "seed": {"name": "APT28"},
+            "malware": [],
+            "actor_tech": [],
+            "mal_tech": [],
+            "campaigns": [{"name": "OperationPawnStorm"}],
+        }
+    ]
+    client = _mk_client(rows)
+    StixExporter(client).export_threat_actor("APT28")
+    q = client.driver._session.last_cypher
+    # The query must match (a:ThreatActor)-[:RUNS]->(c:Campaign), not
+    # the reverse. Match on the full pattern so a future refactor that
+    # accidentally flips direction fails loudly here.
+    assert "(a)-[:RUNS]->(c:Campaign)" in q
+    assert "(c:Campaign)-[:ATTRIBUTED_TO]->(a)" not in q
+
+
+def test_export_technique_uses_with_aggregation_to_avoid_cartesian():
+    """Regression test for bugbot round-4 finding: the export_technique
+    Cypher chained four OPTIONAL MATCH clauses without intermediate
+    aggregation, producing a Cartesian product for well-connected
+    techniques. The fix adds ``WITH t, collect(DISTINCT ...) AS ...``
+    between each clause. Assert the WITH aggregation is in the emitted
+    Cypher so a future regression is caught."""
+    rows = [
+        {
+            "seed": {"mitre_id": "T1059", "name": "Command and Scripting Interpreter"},
+            "actors": [],
+            "malware": [],
+            "tools": [],
+            "indicators": [],
+        }
+    ]
+    client = _mk_client(rows)
+    StixExporter(client).export_technique("T1059")
+    q = client.driver._session.last_cypher
+    # Must see the aggregation step between OPTIONAL MATCH clauses.
+    assert "collect(DISTINCT a) AS actors" in q
+    assert "collect(DISTINCT m) AS malware" in q
+    assert "collect(DISTINCT tool) AS tools" in q
+    # And the first WITH must be between the seed match and the first
+    # OPTIONAL MATCH so actors don't multiply the seed row.
+    assert "WITH t\n" in q or "WITH t " in q
+
+
 def test_actor_with_attributed_malware_emits_attributed_to_sro():
     rows = [
         {
@@ -330,11 +384,7 @@ def test_cve_export_bundle_contains_vulnerability_and_indicator_indicates_rel():
     assert vulns[0]["external_references"][0]["source_name"] == "cve"
     assert vulns[0]["external_references"][0]["external_id"] == "CVE-2021-44228"
     rels = _by_type(bundle, "relationship")
-    assert any(
-        r["relationship_type"] == "indicates"
-        and r["target_ref"] == vulns[0]["id"]
-        for r in rels
-    )
+    assert any(r["relationship_type"] == "indicates" and r["target_ref"] == vulns[0]["id"] for r in rels)
 
 
 def test_empty_bundle_when_seed_not_found():

--- a/tests/test_stix_exporter.py
+++ b/tests/test_stix_exporter.py
@@ -46,8 +46,13 @@ class _FakeSession:
 class _FakeDriver:
     def __init__(self, rows: List[Dict[str, Any]]):
         self._session = _FakeSession(rows)
+        self.last_session_kwargs: Dict[str, Any] = {}
 
-    def session(self):
+    def session(self, **kwargs: Any):
+        # Mirrors neo4j.Driver.session(**kwargs). The exporter passes
+        # default_access_mode="READ" so Neo4j rejects accidental writes —
+        # we capture the kwargs here so tests can assert on them.
+        self.last_session_kwargs = kwargs
         return self._session
 
 
@@ -260,7 +265,52 @@ def test_edgeguard_managed_filter_present_in_all_queries():
     ]
     client = _mk_client(rows)
     StixExporter(client).export_indicator("evil.com")
-    assert "edgeguard_managed" in client.driver._session.last_cypher
+    q = client.driver._session.last_cypher
+    # Bugbot regression: the original filter used
+    # `coalesce(x.edgeguard_managed, true) = true`, which defaulted missing
+    # properties to true and let ResilMesh-owned nodes leak through. Enforce
+    # strict equality — `x.edgeguard_managed = true` — so null fails the
+    # check and only EdgeGuard-owned nodes can be exported.
+    assert "edgeguard_managed = true" in q
+    assert "coalesce(" not in q or "coalesce(i.edgeguard_managed" not in q
+
+
+def test_session_opened_with_read_access_mode():
+    """Exporter must open Neo4j sessions with default_access_mode='READ'
+    so the driver rejects any accidental write — matches the defense-
+    in-depth pattern in query_api.py graph-explore and admin-query
+    endpoints. Regression test for a bugbot finding on PR #25."""
+    rows = [
+        {
+            "seed": {"value": "evil.com", "indicator_type": "domain"},
+            "malware": [],
+            "vulns": [],
+            "techniques": [],
+            "sectors": [],
+        }
+    ]
+    client = _mk_client(rows)
+    StixExporter(client).export_indicator("evil.com")
+    assert client.driver.last_session_kwargs.get("default_access_mode") == "READ"
+
+
+def test_cve_export_uses_affects_not_targets_for_sectors():
+    """Vulnerability/CVE→Sector edges are written as AFFECTS by
+    build_relationships.py, not TARGETS (TARGETS is reserved for
+    Indicator→Sector). Regression test for a bugbot finding on PR #25
+    where the Cypher silently returned zero sectors for every CVE."""
+    rows = [
+        {
+            "seed": {"cve_id": "CVE-2021-44228"},
+            "indicators": [],
+            "sectors": [],
+        }
+    ]
+    client = _mk_client(rows)
+    StixExporter(client).export_cve("CVE-2021-44228")
+    q = client.driver._session.last_cypher
+    assert "[:AFFECTS]->(s:Sector)" in q
+    assert "[:TARGETS]->(s:Sector)" not in q
 
 
 def test_cve_export_bundle_contains_vulnerability_and_indicator_indicates_rel():

--- a/tests/test_sync_to_neo4j_chunking.py
+++ b/tests/test_sync_to_neo4j_chunking.py
@@ -120,8 +120,10 @@ def test_create_relationships_respects_rel_batch_size(monkeypatch):
     syncer = MISPToNeo4jSync(neo4j_client=neo)
     rels = [
         {
-            "rel_type": "USES",
+            "rel_type": "EMPLOYS_TECHNIQUE",
+            "from_type": "ThreatActor",
             "from_key": {"name": f"A{i}"},
+            "to_type": "Technique",
             "to_key": {"mitre_id": f"T{i}"},
         }
         for i in range(7)


### PR DESCRIPTION
## Summary

Prototype Neo4j → STIX 2.1 exporter so ResilMesh partners can retrieve our threat-intel bundles centred on a single indicator / actor / technique / CVE. Today EdgeGuard only converts MISP → STIX on the input side; this fills the output-side gap.

**Depends on #24** (USES specialisation). Opened as DRAFT for ResilMesh alignment before promoting.

See [`docs/STIX21_EXPORTER_PROPOSAL.md`](../blob/proposal/stix-exporter-resilmesh/docs/STIX21_EXPORTER_PROPOSAL.md) for the full design — node/rel mapping tables, STIX vocab citations, deterministic ID strategy, auth + pagination notes, and the explicit non-goal list.

## What this PR adds

- `src/stix_exporter.py` — `StixExporter` class with `export_indicator`, `export_threat_actor`, `export_technique`, `export_cve`. Uses the `stix2` SDK for object construction, UUIDv5 for deterministic IDs, reuses `_value_to_stix_pattern` via lazy import (no duplication), filters `edgeguard_managed=true` on every Cypher query, matches legacy `USES` alongside the new `EMPLOYS_/IMPLEMENTS_TECHNIQUE` rel types.
- `src/query_api.py` — `GET /stix/export/{object_type}/{identifier}` returning `application/stix+json;version=2.1`.
- `tests/test_stix_exporter.py` — 10 unit tests against a mocked Neo4j driver.
- `docs/STIX21_EXPORTER_PROPOSAL.md` — the design doc.

## Open questions for ResilMesh (see proposal §7)

1. `EXPLOITS` → STIX `indicates` vs `related-to`?
2. `Indicator → Technique` emitted as `indicates` (no `uses` vocab with indicator src).
3. `intrusion-set` vs `threat-actor` default (we picked `intrusion-set`).
4. Do bundles need zone metadata (`x_edgeguard_zones`)?
5. Does ResilMesh want CVSS flattened onto the `vulnerability` SDO?

## Explicit non-goals (follow-ups)

TAXII 2.1 collection, bulk / full-graph export, push updates, per-partner auth, bundle signing, pattern coverage for exotic MISP types, SRO confidence properties. All listed in the proposal §10.

## Test plan

- [x] `python3 -m pytest tests/test_stix_exporter.py -q` — 10 passed
- [x] `python3 -m ruff check src/stix_exporter.py src/query_api.py tests/test_stix_exporter.py` — clean
- [ ] Manual smoke test against staging Neo4j (deferred — prototype)
- [ ] ResilMesh partner tries the four endpoints and signs off on §7 decisions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new externally-consumable API endpoint that serializes Neo4j threat-intel data into STIX bundles; incorrect Cypher filters or relationship mappings could leak/shared-graph data or misrepresent semantics. Risk is mitigated by strict `edgeguard_managed = true` filtering, read-only Neo4j sessions, and unit tests, but still touches data export surface area.
> 
> **Overview**
> Implements a prototype **graph → STIX 2.1 exporter** so partners can fetch bounded STIX `bundle` payloads centered on a single `indicator`, `actor`, `technique`, or `cve`.
> 
> Adds `GET /stix/export/{object_type}/{identifier}` in `query_api.py` (path-capturing `identifier` for URL indicators) that returns `application/stix+json;version=2.1` and delegates to a new `StixExporter`.
> 
> Introduces `src/stix_exporter.py` with Cypher queries that fetch the seed + neighborhood in one round-trip, build SDOs/SROs via `stix2`, generate **deterministic UUIDv5 IDs**, match both new specialized rel types and legacy `USES`, and enforce `edgeguard_managed = true` plus Neo4j `default_access_mode="READ"`.
> 
> Adds mocked-driver unit tests covering bundle contents/relationships, deterministic IDs, query-shape regressions (aggregation to avoid cartesian products, correct edge directions/types), and empty-bundle behavior, plus a detailed design/proposal doc in `docs/STIX21_EXPORTER_PROPOSAL.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 06928d926247b8393edfc61cf6a32ec901a4e7bd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->