### PR TITLE
fix: sync-invariant gap + env var docs + migration runbook

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -138,6 +138,19 @@ AIRFLOW_CONN_NEO4J_DEFAULT=
 # Events exceeding this attribute count are deferred to end of sync (small events first).
 # Set to 0 to disable. Default 50000.
 # EDGEGUARD_MAX_EVENT_ATTRIBUTES=50000
+# MISP attribute-push batch size. Lower this on memory-constrained MISP hosts that
+# 500 on large batches. Default 1000.
+# EDGEGUARD_MISP_PUSH_BATCH_SIZE=1000
+# Seconds to wait between failed-event retry passes — gives MISP time to recover
+# from memory pressure / transient 5xx before re-issuing the fetch. Default 15.0.
+# EDGEGUARD_MISP_RETRY_COOLDOWN_SEC=15.0
+
+# Cross-process baseline mutex — prevents a manual `edgeguard baseline` run from
+# racing the scheduled incremental DAG. Both honor the same sentinel file.
+# Default: checkpoints/baseline_in_progress.lock under EDGEGUARD_BASE_DIR.
+# EDGEGUARD_BASELINE_LOCK_PATH=/absolute/path/to/baseline_in_progress.lock
+# Max age (seconds) before a stale lock is auto-cleared. Default 86400 (24h).
+# EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC=86400
 
 # IMPORTANT — ResilMesh deployment port conflict:
 # ResilMesh runs Temporal workflow orchestration on port 8080 (the same default

--- a/docs/MIGRATIONS.md
+++ b/docs/MIGRATIONS.md
@@ -1,0 +1,145 @@
+# Neo4j Schema Migrations
+
+Hand-applied Cypher migrations that evolve the EdgeGuard graph schema in place.
+They are **not** auto-applied by any pipeline run — an operator must execute
+them against a running Neo4j once, after the corresponding code has been
+deployed.
+
+Migrations live in [`migrations/`](../migrations/) and are named
+`YYYY_MM_<slug>.cypher`. Each file is **idempotent**: re-running it against an
+already-migrated graph matches 0 rows and leaves the graph unchanged.
+
+---
+
+## How to run a migration
+
+All migrations assume:
+
+- Neo4j is reachable from wherever you run `cypher-shell` (laptop, Airflow
+  worker, or the Neo4j container itself).
+- APOC is installed (`CALL apoc.help("periodic")` returns rows). The 2026-04
+  migration falls back to a non-APOC variant for small graphs — see the file
+  comments.
+
+### 1. Pre-flight
+
+```bash
+# From the repo root, verify target Neo4j and credentials match the graph you mean to migrate.
+echo "$NEO4J_URI  $NEO4J_USER"
+
+# Snapshot edge counts that the migration will touch. Save the output.
+cypher-shell -a "$NEO4J_URI" -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" \
+  "MATCH ()-[r:USES]->(t:Technique) RETURN count(r) AS before_count;"
+```
+
+Record `before_count` — the post-flight sum must match it.
+
+### 2. Back up the graph
+
+Migrations rewrite edges in place. There is **no automatic rollback**. Before
+running any migration against production:
+
+```bash
+# Inside the Neo4j container
+docker compose exec neo4j neo4j-admin database dump neo4j \
+    --to-path=/backups --overwrite-destination
+docker compose cp neo4j:/backups/neo4j.dump ./backups/pre-$(date +%F).dump
+```
+
+If something goes wrong, restore with `neo4j-admin database load` after
+stopping Neo4j. Keep the dump until you've verified the post-flight counts.
+
+### 3. Pause ingest
+
+Stop the DAGs that write to Neo4j so the migration runs against a stable graph:
+
+```bash
+# Airflow UI → Pause: edgeguard_pipeline, edgeguard_baseline
+# OR: edgeguard doctor --pause-dags   (if the helper is available)
+```
+
+Wait for any in-flight task to finish (`edgeguard doctor` or check the Airflow
+UI). A concurrent sync writing the old rel type will produce a few edges the
+migration won't see — harmless, but you'll want to re-run the migration once
+more afterward.
+
+### 4. Execute
+
+```bash
+cypher-shell -a "$NEO4J_URI" -u "$NEO4J_USER" -p "$NEO4J_PASSWORD" \
+    -f migrations/2026_04_specialize_uses_technique.cypher
+```
+
+`apoc.periodic.iterate` prints one row per block with
+`batches`, `total`, `committedOperations`, `failedOperations`. All blocks
+should report `failedOperations: 0`.
+
+### 5. Post-flight
+
+```bash
+# Must be 0 — all USES→Technique edges rewritten.
+cypher-shell ... "MATCH ()-[r:USES]->(t:Technique) RETURN count(r) AS remaining_uses;"
+
+# These should sum to before_count (± any Campaign→Technique edges).
+cypher-shell ... "
+MATCH (a:ThreatActor)-[r:EMPLOYS_TECHNIQUE]->(:Technique)   RETURN count(r) AS actor_employs;
+MATCH (c:Campaign)-[r:EMPLOYS_TECHNIQUE]->(:Technique)      RETURN count(r) AS campaign_employs;
+MATCH (m:Malware)-[r:IMPLEMENTS_TECHNIQUE]->(:Technique)    RETURN count(r) AS malware_implements;
+MATCH (tool:Tool)-[r:IMPLEMENTS_TECHNIQUE]->(:Technique)    RETURN count(r) AS tool_implements;
+"
+```
+
+### 6. Resume ingest
+
+Unpause the DAGs. The first scheduled run will MERGE directly into the new
+rel types — the Python code has already been switched over in
+[src/build_relationships.py](../src/build_relationships.py) and
+[src/neo4j_client.py](../src/neo4j_client.py).
+
+---
+
+## Rollback
+
+Migrations are forward-only. If you need to reverse `2026_04_specialize_uses_technique.cypher`:
+
+1. **Preferred:** restore the dump taken in step 2 above.
+2. **Manual reverse migration** (graph is small, no dump available):
+
+    ```cypher
+    CALL apoc.periodic.iterate(
+      "MATCH (a:ThreatActor)-[r:EMPLOYS_TECHNIQUE]->(t:Technique) RETURN a, r, t",
+      "MERGE (a)-[r2:USES]->(t) SET r2 += properties(r) DELETE r",
+      {batchSize: 1000, parallel: false}
+    );
+    CALL apoc.periodic.iterate(
+      "MATCH (c:Campaign)-[r:EMPLOYS_TECHNIQUE]->(t:Technique) RETURN c, r, t",
+      "MERGE (c)-[r2:USES]->(t) SET r2 += properties(r) DELETE r",
+      {batchSize: 1000, parallel: false}
+    );
+    CALL apoc.periodic.iterate(
+      "MATCH (m:Malware)-[r:IMPLEMENTS_TECHNIQUE]->(t:Technique) RETURN m, r, t",
+      "MERGE (m)-[r2:USES]->(t) SET r2 += properties(r) DELETE r",
+      {batchSize: 1000, parallel: false}
+    );
+    CALL apoc.periodic.iterate(
+      "MATCH (tool:Tool)-[r:IMPLEMENTS_TECHNIQUE]->(t:Technique) RETURN tool, r, t",
+      "MERGE (tool)-[r2:USES]->(t) SET r2 += properties(r) DELETE r",
+      {batchSize: 1000, parallel: false}
+    );
+    ```
+
+    Note: after a manual reverse you must also redeploy a code build from
+    before the 2026-04 specialization, otherwise the next sync will re-write
+    the new rel types and undo the reverse.
+
+---
+
+## Migration index
+
+| File | Applied | Purpose |
+|------|---------|---------|
+| [2026_04_specialize_uses_technique.cypher](../migrations/2026_04_specialize_uses_technique.cypher) | _pending_ | Split generic `USES→Technique` into `EMPLOYS_TECHNIQUE` (attribution) and `IMPLEMENTS_TECHNIQUE` (capability). Run once after deploying the PR that merged the specialization. |
+
+Update the **Applied** column with a date once a migration has been run in
+production — that's the single source of truth for whether the migration
+still needs to be applied to a new environment.

--- a/migrations/2026_04_specialize_uses_technique.cypher
+++ b/migrations/2026_04_specialize_uses_technique.cypher
@@ -58,6 +58,9 @@
 //
 // Requires APOC. If APOC is unavailable, see the non-APOC variants at the
 // bottom of this file.
+//
+// Operator runbook: docs/MIGRATIONS.md (pre-flight, backup, execute,
+// post-flight, rollback instructions).
 // ============================================================================
 
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -3138,10 +3138,17 @@ class MISPToNeo4jSync:
                 event_info = event.get("info", "")
 
                 if event_id is None:
+                    # Count as failed so the coverage-gap invariant holds:
+                    # events_index_total == events_processed + events_failed.
+                    # Otherwise the EdgeGuardSyncCoverageGap Prometheus alert
+                    # fires false positives on every baseline run that hits
+                    # a malformed MISP index row.
                     logger.warning(
                         "Skipping MISP row with no event id (info=%r) — check index/search response shape",
                         (event_info or "")[:120],
                     )
+                    total_errors += 1
+                    self.stats["events_failed"] += 1
                     continue
 
                 # Check attribute count from index metadata before fetching


### PR DESCRIPTION
## Summary

Closes the three blockers the pre-production audit flagged before the NVD baseline re-run. Small, self-contained, addresses pipeline observability + operator docs only.

### 1. 🔴 Sync invariant violation (`src/run_misp_to_neo4j.py`)

MISP index rows with `event_id=None` were silently `continue`-d inside the main sync loop — counted in `events_index_total` but never in `events_processed` or `events_failed`. This breaks the invariant the `EdgeGuardSyncCoverageGap` Prometheus alert relies on:

```
events_index_total == events_processed + events_failed
```

The first malformed row in a baseline feed would fire a false-positive `EdgeGuardSyncCoverageGap` alert. Now the skip path increments `total_errors` + `self.stats["events_failed"]` so the invariant holds. Same semantics the post-retry terminal-failure paths already use.

### 2. 🟡 Missing env vars in `.env.example`

Four knobs ship in the recently-merged PRs but had no example entry. Operators would only find them by grepping the source:

| Var | Default | Shipped in |
|---|---|---|
| `EDGEGUARD_MISP_PUSH_BATCH_SIZE` | `1000` | PR #20 |
| `EDGEGUARD_MISP_RETRY_COOLDOWN_SEC` | `15.0` | PR #20 |
| `EDGEGUARD_BASELINE_LOCK_PATH` | `checkpoints/baseline_in_progress.lock` | PR #23 |
| `EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC` | `86400` (24h) | PR #23 |

Defaults in `.env.example` match the code defaults exactly — verified against `src/collectors/misp_writer.py`, `src/baseline_lock.py`, and `src/run_misp_to_neo4j.py`.

### 3. 🔴 Cypher migration has no operator runbook

`migrations/2026_04_specialize_uses_technique.cypher` has great inline context but no instructions an operator can follow. New `docs/MIGRATIONS.md` covers:

- Pre-flight (record `before_count`)
- Backup (`neo4j-admin database dump`)
- Pause ingest (stop `edgeguard_pipeline`, `edgeguard_baseline`)
- Execute (`cypher-shell -f …`)
- Post-flight (counts per new rel type must sum to `before_count`)
- **Rollback** — preferred path is dump restore, plus a manual reverse-migration Cypher snippet for small graphs
- Migration index table (single source of truth for which migrations have been applied in prod)

The migration file header now points at the runbook.

## What's still open (follow-up PR)

Per the synthesized audit, these are 🟡 and don't block the baseline re-run:

- `baseline_lock` doesn't cover the Airflow `edgeguard_baseline` DAG (UI-triggered run can still race scheduled DAGs)
- New Prometheus alerts not yet documented in `docs/PROMETHEUS_SETUP.md`
- Prometheus `curl -X POST /-/reload` procedure not documented

## Test plan

- [ ] CI green (ruff + mypy + pytest)
- [ ] `pip-audit` still green (no dep changes)
- [ ] Manual: grep a test MISP index row with null id through `sync_to_neo4j` → confirm `events_failed` increments
- [ ] Post-merge: eyeball `docs/MIGRATIONS.md` renders on GitHub
- [ ] Post-merge: when the Airflow 3.2 PR #26 rolls out, the 4 new env vars are already discoverable in `.env.example`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core MISP→Neo4j sync loop by changing failure accounting, which can affect alerting and run success criteria, but the functional change is narrowly scoped. Remaining changes are documentation-only.
> 
> **Overview**
> Prevents false-positive `EdgeGuardSyncCoverageGap` alerts by counting MISP index rows missing an `event_id` as failures (`events_failed`/`total_errors`) instead of silently skipping them.
> 
> Adds missing `.env.example` entries for recently introduced MISP batching/retry knobs and baseline lock settings.
> 
> Introduces an operator runbook in `docs/MIGRATIONS.md` for hand-applied Neo4j Cypher migrations and links it from `migrations/2026_04_specialize_uses_technique.cypher`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 215cdcdcdae566d353f83f41b69630cc9c70f6c1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->