### PR TITLE
release: calver 2026.4.15 + audit-driven followups

### DIFF
--- a/README.md
+++ b/README.md
@@ -548,6 +548,7 @@ This README stays the **short** entry (quick start, ports, env vars). Deep onboa
 | [docs/HEARTBEAT.md](docs/HEARTBEAT.md) | Airflow zombie tasks, OOM/SIGKILL, heartbeat timeout |
 | [docs/PROMETHEUS_SETUP.md](docs/PROMETHEUS_SETUP.md) | Prometheus + Grafana monitoring stack |
 | [docs/MISP_SOURCES.md](docs/MISP_SOURCES.md) | MISP as single source of truth, event discovery, metadata prefixes |
+| [docs/MIGRATIONS.md](docs/MIGRATIONS.md) | Neo4j schema migrations — pre-flight, backup, execute, rollback runbook for hand-applied Cypher rewrites |
 | [docs/RESILIENCE_CONFIG.md](docs/RESILIENCE_CONFIG.md) | Circuit breakers, retry logic, timeout tuning |
 | [docs/SECRETS_MANAGEMENT.md](docs/SECRETS_MANAGEMENT.md) | Credential handling, env vars, key rotation |
 
@@ -557,6 +558,8 @@ This README stays the **short** entry (quick start, ports, env vars). Deep onboa
 | [docs/RESILMESH_INTEROPERABILITY.md](docs/RESILMESH_INTEROPERABILITY.md) | Integration contract — what EdgeGuard produces, what ResilMesh consumes |
 | [docs/RESILMESH_INTEGRATION_GUIDE.md](docs/RESILMESH_INTEGRATION_GUIDE.md) | NATS messaging, Neo4j bridging, alert enrichment flow |
 | [docs/RESILMESH_INTEGRATION_TESTING.md](docs/RESILMESH_INTEGRATION_TESTING.md) | Integration verification and test procedures |
+| [docs/RESILMESH_QUICKSTART_STIX.md](docs/RESILMESH_QUICKSTART_STIX.md) | **STIX 2.1 exporter quickstart** — curl examples, `/stix/types` discovery, `scripts/resilmesh_stix_smoke.sh` |
+| [docs/STIX21_EXPORTER_PROPOSAL.md](docs/STIX21_EXPORTER_PROPOSAL.md) | Design doc for the graph → STIX 2.1 exporter (mappings, open questions, follow-ups) |
 
 ### Tooling & Visualization
 | Document | Description |

--- a/docs/DEPLOYMENT_READINESS_CHECKLIST.md
+++ b/docs/DEPLOYMENT_READINESS_CHECKLIST.md
@@ -79,6 +79,7 @@ Execute from the **same network context** as Airflow tasks (e.g. `docker exec` i
 | [ ] | Collector tasks | Logs for `collect_*` | Status dict; skips show `skipped` + reason class; real failures → task failed as designed |
 | [ ] | Neo4j sync gate | Observe `full_neo4j_sync` / short-circuit | Matches [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) |
 | [ ] | Baseline smoke (recommended) | [BASELINE_SMOKE_TEST.md](BASELINE_SMOKE_TEST.md) | Short window + cap; logs show effective limits |
+| [ ] | Schema migrations applied (if upgrading from a pre-2026-04 graph) | [MIGRATIONS.md](MIGRATIONS.md) | Run the hand-applied Cypher scripts in `migrations/` per the runbook — pause DAGs, backup, execute, verify post-flight counts, resume. The 2026-04 `specialize_uses_technique` migration splits `USES→Technique` into `EMPLOYS_TECHNIQUE` / `IMPLEMENTS_TECHNIQUE` and MUST run once before the first sync after the upgrade. |
 
 ---
 

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -37,7 +37,7 @@ print(EDGEGUARD_ENV)
 
 To keep dependencies clean and reproducible, use a dedicated environment per project/deployment.
 
-**Version:** EdgeGuard requires **Python 3.12+** (`requires-python` in `pyproject.toml`, CI, and `Dockerfile`). Apache Airflow **2.11** supports **Python 3.11+** upstream; this repository does not test or support 3.11.
+**Version:** EdgeGuard requires **Python 3.12+** (`requires-python` in `pyproject.toml`, CI, and `Dockerfile`). Apache Airflow **3.2** (upgraded from 2.11 in April 2026 — see [AIRFLOW_DAGS.md § Airflow 2 to 3 upgrade](AIRFLOW_DAGS.md)) supports Python 3.10–3.14 upstream; this repository standardizes on 3.12 for a single supported interpreter line.
 
 #### 2.1 Create a conda environment (recommended)
 
@@ -134,7 +134,25 @@ EdgeGuard does **not** require Docker. The same Python code paths read **`NEO4J_
 
 ---
 
-### 5. Summary checklist
+### 5. MISP sync tuning + baseline mutex (added 2026-04)
+
+These four env vars were introduced with PRs #20, #23, and #28. They are
+off-by-default — the code uses sensible fallbacks — but operators tuning
+a slow MISP host or running parallel baselines should know they exist.
+All four are also in `.env.example`.
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `EDGEGUARD_MISP_PUSH_BATCH_SIZE` | `1000` | Attributes per MISP POST. Lower on memory-constrained MISP hosts that 500 on large batches. |
+| `EDGEGUARD_MISP_RETRY_COOLDOWN_SEC` | `15.0` | Seconds between failed-event retry passes. Gives MISP time to recover from transient 5xx. |
+| `EDGEGUARD_BASELINE_LOCK_PATH` | `checkpoints/baseline_in_progress.lock` | Cross-process sentinel that blocks a manual `edgeguard baseline` run from racing the scheduled incremental DAG. |
+| `EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC` | `86400` (24h) | Max age before a stale lock is auto-cleared (e.g. after a crash on a different host — the PID-liveness check only works on the same host). |
+
+See [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) for the wider set of Airflow-related
+variables introduced with the 3.2 upgrade, and [MIGRATIONS.md](MIGRATIONS.md)
+for the operator runbook that references the baseline lock.
+
+### 6. Summary checklist
 
 - [ ] `EDGEGUARD_ENV` set appropriately (`dev`, `stage`, `prod`, `edge`, …).
 - [ ] Dedicated Python/conda environment created for EdgeGuard.
@@ -144,4 +162,4 @@ EdgeGuard does **not** require Docker. The same Python code paths read **`NEO4J_
 
 ---
 
-_Last updated: 2026-04-06 — Airflow container **`AIRFLOW_MEMORY_LIMIT`** note for sync OOM/SIGKILL._
+_Last updated: 2026-04-15 — added MISP sync tuning + baseline mutex env vars; noted Airflow 3.2 upgrade._

--- a/docs/PROMETHEUS_SETUP.md
+++ b/docs/PROMETHEUS_SETUP.md
@@ -165,6 +165,18 @@ To import manually:
 | `edgeguard_dag_runs_total` | Counter | `dag_id`, `status`, `run_type` | DAG run count |
 | `edgeguard_dag_run_duration_seconds` | Histogram | `dag_id` | DAG run duration |
 
+### MISP Sync Event Accounting
+
+Added in 2026-04 after the NVD silent-skip regression (see [AIRFLOW_DAGS.md](AIRFLOW_DAGS.md)).
+These gauges enforce the invariant `events_index_total == events_processed + events_failed`
+for every sync run — the `EdgeGuardSyncCoverageGap` alert fires when it breaks.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `edgeguard_sync_events_index_total` | Gauge | - | Events returned from the MISP index on the last sync |
+| `edgeguard_sync_events_processed` | Gauge | - | Events whose `sync_to_neo4j` completed successfully |
+| `edgeguard_sync_events_failed` | Gauge | - | Events that failed permanently (first pass + retry pass + cap exhaustion) |
+
 ## Using Metrics in Code
 
 ### Recording Collection
@@ -300,6 +312,25 @@ The following alerts are pre-configured in `prometheus/alerts.yml`:
 | `EdgeGuardDAGRunStuck` | DAG run running >1 hour without completing | critical |
 | `EdgeGuardDAGLastSuccessStale` | No successful DAG run in >6 hours | warning |
 | `EdgeGuardContainerRestartLoop` | >3 container restarts in 1 hour (requires cAdvisor) | critical |
+| `EdgeGuardSyncEventsFailed` | Any MISP event in the last sync landed in `events_failed` | warning |
+| `EdgeGuardSyncCoverageGap` | `events_index_total ≠ events_processed + events_failed` — silent skip detected | critical |
+| `EdgeGuardNeo4jLabelDropBig` | Per-label node count dropped >50% vs previous scrape | critical |
+
+The last three were added in 2026-04 to catch the silent-skip regression where a single MISP 5xx lost ~99K NVD CVEs from the graph. See [docs/AIRFLOW_DAGS.md](AIRFLOW_DAGS.md) § sync-event accounting for the invariant the `EdgeGuardSyncCoverageGap` alert guards.
+
+### Reloading Prometheus after editing `alerts.yml`
+
+Prometheus loads alert rules at startup. After you edit `prometheus/alerts.yml`:
+
+```bash
+# Validate the rules first (syntax + expression).
+docker compose exec prometheus promtool check rules /etc/prometheus/alerts.yml
+
+# Hot-reload without restarting Prometheus (requires --web.enable-lifecycle).
+curl -X POST http://localhost:9090/-/reload
+```
+
+If `--web.enable-lifecycle` is not set, restart the container: `docker compose restart prometheus`.
 
 ### Custom Alerts
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "edgeguard"
 # CalVer: release date YYYY.M.D (PEP 440). Bump when you tag/publish a release — not on every commit.
-version = "2026.4.4"
+version = "2026.4.15"
 description = "Threat Intelligence Pipeline - Sources to MISP to Neo4j"
 authors = [
     {name = "EdgeGuard Team"}

--- a/src/collectors/abuseipdb_collector.py
+++ b/src/collectors/abuseipdb_collector.py
@@ -177,6 +177,20 @@ class AbuseIPDBCollector:
         elif response.status_code == 401:
             logger.error("AbuseIPDB: Authentication failed - check API key")
             return None
+        elif response.status_code >= 500:
+            # A 5xx that survives the inner ``request_with_rate_limit_retries``
+            # budget (4 attempts with exponential backoff) is a real outage —
+            # not "no data today". Raise so ``collect()`` reports the task as
+            # failed and Airflow retries it, rather than silently returning
+            # ``count=0 success=True``. Matches the surface-failure contract
+            # of virustotal_collector.py and global_feed_collector.py, which
+            # both call ``response.raise_for_status()`` in the equivalent
+            # code path.
+            logger.warning(f"AbuseIPDB API error: {response.status_code} - {response.text[:200]}")
+            raise requests.exceptions.HTTPError(
+                f"AbuseIPDB {response.status_code} after inner retries",
+                response=response,
+            )
         else:
             logger.warning(f"AbuseIPDB API error: {response.status_code} - {response.text[:200]}")
             return None

--- a/tests/test_baseline_lock.py
+++ b/tests/test_baseline_lock.py
@@ -1,0 +1,165 @@
+"""Unit tests for src/baseline_lock.py.
+
+Covers the three load-bearing behaviors of the cross-process mutex
+between CLI baseline runs and scheduled Airflow DAGs:
+
+1. Acquire / release lifecycle — both the write and the idempotent
+   release path.
+2. Stale-lock detection — a same-host PID that is no longer alive must
+   be pruned. This is the security-critical path; if it breaks, a
+   crashed baseline leaves a permanent lock and every scheduled
+   collector skips forever.
+3. Same-host liveness takes precedence over age — a long-running
+   baseline (>24h) must not be pruned out from under a still-alive
+   PID. Before the round-1 bugbot fix on PR #23 the age check ran
+   unconditionally and re-opened the exact race the mutex prevents.
+
+Tests use a per-test temporary lock path via the
+EDGEGUARD_BASELINE_LOCK_PATH env var so they don't touch the real
+`checkpoints/` directory.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import baseline_lock
+
+
+@pytest.fixture
+def lock_path(tmp_path, monkeypatch):
+    """Point baseline_lock at a throwaway path for this test only."""
+    path = tmp_path / "baseline_in_progress.lock"
+    monkeypatch.setenv("EDGEGUARD_BASELINE_LOCK_PATH", str(path))
+    # Also clear any stale max-age override so tests are deterministic
+    monkeypatch.delenv("EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC", raising=False)
+    return path
+
+
+def test_acquire_release_roundtrip(lock_path):
+    """Happy path: acquire, observe, release, gone."""
+    assert not lock_path.exists()
+    assert baseline_lock.acquire_baseline_lock() is True
+    assert lock_path.exists()
+
+    data = baseline_lock.is_baseline_running()
+    assert data is not None
+    assert int(data["pid"]) == os.getpid()
+    assert data["host"] == socket.gethostname()
+
+    baseline_lock.release_baseline_lock()
+    assert not lock_path.exists()
+    assert baseline_lock.is_baseline_running() is None
+
+
+def test_double_acquire_is_rejected(lock_path):
+    """A second acquire while the first is still live must fail."""
+    assert baseline_lock.acquire_baseline_lock() is True
+    try:
+        # Same process, same PID — is_baseline_running returns the live
+        # sentinel, and acquire_baseline_lock short-circuits.
+        assert baseline_lock.acquire_baseline_lock() is False
+    finally:
+        baseline_lock.release_baseline_lock()
+
+
+def test_stale_sentinel_with_dead_pid_is_pruned(lock_path):
+    """A same-host sentinel pointing at a PID that no longer exists
+    must be cleared on the next is_baseline_running() call. PID 1 is
+    always alive on POSIX, so we use a PID that can't exist (very
+    high number well past any plausible live process)."""
+    sentinel = {
+        "pid": 2**30,  # effectively guaranteed dead
+        "host": socket.gethostname(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    lock_path.write_text(json.dumps(sentinel))
+    assert lock_path.exists()
+
+    assert baseline_lock.is_baseline_running() is None
+    assert not lock_path.exists(), "stale sentinel should have been removed"
+
+
+def test_same_host_alive_pid_is_not_aged_out(lock_path, monkeypatch):
+    """Regression test for a round-1 bugbot finding on PR #23: a
+    long-running baseline whose sentinel is older than
+    EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC must NOT be pruned if the
+    same-host PID is still alive. The age check is for cross-host
+    stale detection only."""
+    # Make the max age very small so the sentinel looks ancient.
+    monkeypatch.setenv("EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC", "1")
+
+    ancient = (datetime.now(timezone.utc) - timedelta(days=365)).isoformat()
+    sentinel = {
+        "pid": os.getpid(),  # definitely alive — it's us
+        "host": socket.gethostname(),
+        "started_at": ancient,
+    }
+    lock_path.write_text(json.dumps(sentinel))
+
+    result = baseline_lock.is_baseline_running()
+    assert result is not None, "live same-host PID must survive the age check"
+    assert int(result["pid"]) == os.getpid()
+    assert lock_path.exists(), "sentinel must not be removed"
+
+
+def test_cross_host_age_check_prunes_old_sentinel(lock_path, monkeypatch):
+    """The age check is load-bearing for cross-host clusters: if the
+    baseline crashed on another host we can't kill -0 its PID from
+    here, so we fall back to a configurable max age."""
+    monkeypatch.setenv("EDGEGUARD_BASELINE_LOCK_MAX_AGE_SEC", "1")
+
+    old = (datetime.now(timezone.utc) - timedelta(seconds=10)).isoformat()
+    sentinel = {
+        "pid": 1,  # real pid on a different host — not locally verifiable
+        "host": "definitely-not-this-host-" + socket.gethostname() + "-xyz",
+        "started_at": old,
+    }
+    lock_path.write_text(json.dumps(sentinel))
+
+    assert baseline_lock.is_baseline_running() is None
+    assert not lock_path.exists(), "stale cross-host sentinel should be removed"
+
+
+def test_release_is_idempotent_when_no_sentinel(lock_path):
+    """Calling release when no lock is held must be a no-op, not an
+    exception — the `finally` block in the baseline pipeline runs
+    unconditionally."""
+    assert not lock_path.exists()
+    baseline_lock.release_baseline_lock()  # must not raise
+
+
+def test_release_refuses_to_delete_foreign_sentinel(lock_path):
+    """Crash-restart race: a new baseline process must not delete a
+    sentinel owned by a different PID. Otherwise a fresh crashed-and-
+    restarted baseline could wipe a still-running one on the same host."""
+    foreign_sentinel = {
+        "pid": os.getpid() + 1,  # not us
+        "host": socket.gethostname(),
+        "started_at": datetime.now(timezone.utc).isoformat(),
+    }
+    lock_path.write_text(json.dumps(foreign_sentinel))
+
+    baseline_lock.release_baseline_lock()
+    assert lock_path.exists(), "must refuse to remove another process's lock"
+
+
+def test_baseline_skip_reason_matches_running_state(lock_path):
+    """The human-readable skip reason used by DAG collector tasks."""
+    assert baseline_lock.baseline_skip_reason() is None
+
+    assert baseline_lock.acquire_baseline_lock() is True
+    try:
+        reason = baseline_lock.baseline_skip_reason()
+        assert reason is not None
+        assert "baseline is running" in reason
+        assert str(os.getpid()) in reason
+    finally:
+        baseline_lock.release_baseline_lock()
+
+    assert baseline_lock.baseline_skip_reason() is None


### PR DESCRIPTION
## Summary

Synthesized fixes from 4 parallel post-merge audit agents that ran against main after 8 PRs landed today (#20, #21, #22, #23, #24, #26, #27, #28). This is the followup — calver bump, one real code fix, doc updates, and the missing test coverage for `src/baseline_lock.py`.

## What's in this PR

### 🏷️ Release
- **`pyproject.toml`** — CalVer bump `2026.4.4` → `2026.4.15`. Today included #26 (Airflow 2.11 → 3.2 upgrade) and #27 (STIX exporter — ResilMesh handoff feature), plus 6 smaller fixes. Release-worthy.

### 🐛 Real code fix
- **`src/collectors/abuseipdb_collector.py`** — `_make_request` was returning `None` for 5xx responses after the inner rate-limit retries exhausted, which `collect()` then reported as "success with 0 indicators". A sustained AbuseIPDB outage could silently lose a day's blacklist feed with Airflow marking the task green.
  - `virustotal_collector.py` and `global_feed_collector.py` both already call `response.raise_for_status()` in the equivalent code path — only abuseipdb was missing it.
  - Fix raises `requests.exceptions.HTTPError` on 5xx so `collect()` catches it and reports the task as failed.

### 📚 Documentation
- **`docs/PROMETHEUS_SETUP.md`** — 3 new alert rules from #21 added to the "Built-in Alert Rules" table. New "MISP Sync Event Accounting" subsection for the 3 new gauges. New "Reloading Prometheus after editing `alerts.yml`" subsection with `promtool` + hot-reload.
- **`docs/ENVIRONMENTS.md`** — Airflow 2.11 → 3.2. New section documenting the 4 env vars from #20/#23/#28 with defaults matching the code.
- **`README.md`** — Added `docs/MIGRATIONS.md` to Operations table. Added STIX quickstart + proposal to ResilMesh table.
- **`docs/DEPLOYMENT_READINESS_CHECKLIST.md`** — New Layer 4 row pointing operators at `MIGRATIONS.md`. Before this an operator upgrading from a pre-2026-04 graph would miss the `specialize_uses_technique` migration.

### 🧪 Tests
- **`tests/test_baseline_lock.py`** (NEW, 8 tests) — Agent 2 flagged `src/baseline_lock.py` as 🔴 security-critical with zero tests. Covers acquire/release, double-acquire rejection, stale PID pruning, the round-1 bugbot regression (same-host alive PID must NOT be aged out), cross-host age check, idempotent release, foreign-sentinel safety, and `baseline_skip_reason`.

## Audit findings verified as FALSE POSITIVES (not fixed)

Before committing to any Agent 1 claims I traced each one:

- **`run_misp_to_neo4j.py` skipped_large double-count** — Agent 1 claimed a large event failing on retry could double-count. Traced the loop carefully: `skipped_large[retry_idx+1:]` (line 3268) and `failed_events` (line 3336) are disjoint sets. No double-count.
- **Airflow 3.2 Variable.get rejects positional defaults** — Verified against the Airflow 3.2 SDK source: signature is `get(cls, key, default=NOTSET, deserialize_json=False)`. Positional second argument is accepted. All 7 `Variable.get` calls in `dags/edgeguard_pipeline.py` are correct.

## Deferred (tracked as follow-ups)

- Integration-level regression test for the #28 `event_id=None` fix — requires mocking ~500 lines of `sync_to_neo4j`, too much scope for this followup.
- Neo4j 5.26.23 vs pyproject 5.27 minor skew in `docker-compose.yml` — Agent 4 LOW.
- Coverage `omit` list in `pyproject.toml` — Agent 2 🔴; dropping these would require adding integration tests for ~5000 LOC that currently have none.
- Retry decorator consolidation (Agent 2 LOW, DRY polish).

## Test plan

- [ ] CI green (ruff, mypy, pytest with 8 new tests)
- [ ] `tests/test_baseline_lock.py` passes locally against real `os.kill(pid, 0)`
- [ ] pip-audit clean on Airflow 3.2 deps
- [ ] After merge, tag `v2026.4.15` + push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collector error-handling so persistent AbuseIPDB 5xx responses now fail tasks (triggering Airflow retries) instead of being reported as successful zero-results; behavior change could increase task failures during vendor outages but prevents silent data loss.
> 
> **Overview**
> **Release + ops docs update.** Bumps CalVer to `2026.4.15` and updates docs to surface new operator runbooks/quickstarts (adds `MIGRATIONS.md` and STIX exporter docs to the README index; adds a deployment checklist gate for applying Neo4j schema migrations; documents Airflow 3.2/Python guidance and new MISP sync/baseline mutex env vars; expands Prometheus docs with MISP sync event-accounting metrics, new alert rules, and reload instructions).
> 
> **Collector reliability fix.** Updates `AbuseIPDBCollector._make_request()` to *raise* on persistent HTTP 5xx after internal retries so `collect()` reports a real failure (enabling Airflow retries) rather than silently returning a successful 0-count.
> 
> **Test coverage.** Adds `tests/test_baseline_lock.py` to cover acquire/release, stale-lock pruning, cross-host max-age behavior, and safety checks for the baseline mutex sentinel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d28c26de62e66bdca2835375e344d4b4b194fe2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->