### PR TITLE
tune: MISP mem_limit 4g → 8g, Airflow 3h timeouts → 5h

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1528,7 +1528,8 @@ def run_build_relationships(**context):
         ["python3", os.path.join(BASE_DIR, "src", "build_relationships.py")],
         capture_output=True,
         text=True,
-        timeout=10800,  # 3 hours — aligned with execution_timeout
+        timeout=18000,  # 5 hours — aligned with execution_timeout (bumped from 3h
+        # after baseline re-runs hit the ceiling on the merged #20/#22/#24 scope)
     )
     if result.returncode != 0:
         logger.error(f"build_relationships failed:\n{result.stderr}")
@@ -1556,14 +1557,14 @@ def run_enrichment_jobs(**context):
 build_relationships_task = PythonOperator(
     task_id="build_relationships",
     python_callable=run_build_relationships,
-    execution_timeout=timedelta(hours=3),
+    execution_timeout=timedelta(hours=5),
     dag=neo4j_sync_dag,
 )
 
 enrichment_task = PythonOperator(
     task_id="run_enrichment_jobs",
     python_callable=run_enrichment_jobs,
-    execution_timeout=timedelta(hours=3),
+    execution_timeout=timedelta(hours=5),
     dag=neo4j_sync_dag,
 )
 
@@ -1881,13 +1882,13 @@ with TaskGroup("tier1_core", dag=baseline_dag, default_args={"trigger_rule": Tri
     bl_otx = PythonOperator(
         task_id="collect_otx",
         python_callable=run_baseline_otx,
-        execution_timeout=timedelta(hours=3),
+        execution_timeout=timedelta(hours=5),
         dag=baseline_dag,
     )
     bl_nvd = PythonOperator(
         task_id="collect_nvd",
         python_callable=run_baseline_nvd,
-        execution_timeout=timedelta(hours=3),
+        execution_timeout=timedelta(hours=5),
         dag=baseline_dag,
     )
     bl_cisa = PythonOperator(
@@ -1966,7 +1967,7 @@ baseline_build_rels_task = PythonOperator(
 baseline_enrichment_task = PythonOperator(
     task_id="run_enrichment_jobs",
     python_callable=run_baseline_enrichment,
-    execution_timeout=timedelta(hours=3),
+    execution_timeout=timedelta(hours=5),
     dag=baseline_dag,
 )
 

--- a/docs/AIRFLOW_DAGS.md
+++ b/docs/AIRFLOW_DAGS.md
@@ -536,7 +536,7 @@ docker compose build airflow && docker compose up -d airflow
 **NVD (`collect_nvd`) — baseline**
 
 - With **`BASELINE_DAYS`** set to **90** (or **730**), NVD walks many **120-day** API windows and **pages** (0.7 s between pages with an API key). Then it **processes** all CVEs and **pushes** to MISP in bulk — this can take **hours**.
-- **`execution_timeout`** for baseline NVD is **3 hours** in `dags/edgeguard_pipeline.py`. If you need more wall-clock time, increase that timeout (and ensure the scheduler/worker is not restarted mid-run).
+- **`execution_timeout`** for baseline NVD is **5 hours** in `dags/edgeguard_pipeline.py` (bumped from 3h in 2026-04 after baseline re-runs on the merged #20/#22/#24 scope repeatedly hit the 3h ceiling and Airflow retried — the retry was real work, not a zombie). If you need more wall-clock time, increase that timeout (and ensure the scheduler/worker is not restarted mid-run).
 - A **“zombie”** message usually means the scheduler lost the task heartbeat (scheduler/worker restart, heavy CPU blocking, OOM, or platform kill) — check **`docker compose logs airflow`**, host **memory**, and whether the task process was killed. It is **not** always the same as hitting `execution_timeout`.
 
 **Smoke test (recommended before a full baseline)**

--- a/docs/AIRFLOW_DAG_DESIGN.md
+++ b/docs/AIRFLOW_DAG_DESIGN.md
@@ -77,14 +77,19 @@ All tasks have explicit `execution_timeout` values to prevent hung workers from 
 |-----------|---------|
 | Fast collectors (OTX, CISA, VirusTotal) | 1 hour |
 | Slow collectors (MITRE, AbuseIPDB, ThreatFox, etc.) | 2 hours |
-| Baseline collectors (all sources, unlimited) | 2–3 hours each |
+| Baseline collectors OTX / NVD (unlimited)            | 5 hours each |
+| Baseline collectors CISA / MITRE / Tier 2 feeds      | 2 hours each |
 | Neo4j sync (incremental) | 4 hours |
 | Neo4j full sync (baseline) | 6 hours |
-| build_relationships | 3 hours |
-| run_enrichment_jobs | 1 hour |
+| build_relationships | 5 hours |
+| run_enrichment_jobs | 5 hours |
 | Neo4j quality check | 15 minutes |
 | Log/summary tasks | 2–5 minutes |
 | Metrics server task | 24 hours (long-lived) |
+
+_Baseline OTX/NVD, `build_relationships`, and `run_enrichment_jobs` were
+bumped from 3h → 5h in 2026-04 after baseline re-runs on the merged
+#20/#22/#24 scope repeatedly hit the 3h ceiling._
 
 ---
 

--- a/docs/sources/MISP/docker-compose.yml
+++ b/docs/sources/MISP/docker-compose.yml
@@ -3,6 +3,13 @@ services:
     image: coolacid/misp-docker:latest
     container_name: misp_misp_1
     restart: unless-stopped
+    # Memory limit bumped to 8g (from the 4g default) because a full
+    # EdgeGuard baseline pushes 95K+ attributes per event (NVD feed),
+    # and PHP loads the full event context on every POST /attributes/add.
+    # On a 4g cap the MISP container OOM-kills mid-baseline and the
+    # Airflow task has to retry. See docs/DOCKER_SETUP_GUIDE.md §
+    # "MISP memory pressure" for the symptoms.
+    mem_limit: 8g
     ports:
       - "127.0.0.1:8443:443"
       - "127.0.0.1:5000:80"
@@ -22,6 +29,10 @@ services:
     image: mysql:8.0
     container_name: misp_db_1
     restart: unless-stopped
+    # Matches the misp service bump — a 95K-row insert needs working
+    # memory for InnoDB buffer pool and query cache. 4g is the old
+    # default and was OOM-prone during baseline.
+    mem_limit: 8g
     environment:
       - MYSQL_ROOT_PASSWORD=misp
       - MYSQL_DATABASE=misp


### PR DESCRIPTION
## Summary

Two operational bumps surfaced by today's baseline re-runs. Both are reactions to observed failure modes — not preventative.

### 1. MISP container + MISP DB → 8g

`docs/sources/MISP/docker-compose.yml` — the upstream `coolacid/misp-docker` image runs on Docker's default (~4g on a typical dev Mac), which OOM-kills the MISP container mid-baseline when the NVD feed pushes ~95K attributes into a single event. PHP loads the full event context per `POST /attributes/add`, and the MySQL buffer pool / query cache needs breathing room for a 95K-row insert.

Added explicit `mem_limit: 8g` to both `misp` and `misp_db`. Inline comments explain the baseline symptom.

### 2. Airflow `execution_timeout`: 3h → 5h

`dags/edgeguard_pipeline.py` — five `execution_timeout` bumps + the matching `subprocess.run` timeout:

| # | Task | Was | Now |
|---|---|---|---|
| 1 | `build_relationships` subprocess timeout | `10800` | `18000` |
| 2 | `build_relationships_task` (incremental sync) | 3h | 5h |
| 3 | `enrichment_task` (incremental sync) | 3h | 5h |
| 4 | `bl_otx` (baseline tier 1) | 3h | 5h |
| 5 | `bl_nvd` (baseline tier 1) | 3h | 5h |
| 6 | `baseline_enrichment_task` (baseline) | 3h | 5h |

The 2h baseline tier 2 collectors (CISA, MITRE, AbuseIPDB, …) are **unchanged** — they've never hit their ceiling.

**Why:** after the #20/#22/#24/#28 scope landed, baseline re-runs against a populated graph started hitting the 3h ceiling — Airflow marked it as a zombie kill and retried from scratch, burning a lot of MISP roundtrips on an already-healthy run.

**Headroom:** surrounding `dagrun_timeout` values (22h on `neo4j_sync_dag`, 32h on `baseline_dag`) leave plenty of space — no need to bump them.

### 3. Doc updates
- `docs/AIRFLOW_DAGS.md` § baseline NVD timeout section — notes the bump with the reason
- `docs/AIRFLOW_DAG_DESIGN.md` timeout table — split "Baseline collectors OTX/NVD" (5h) vs "CISA/MITRE/Tier 2" (2h); bumped `build_relationships` and `run_enrichment_jobs` to 5h

## Test plan

- [ ] CI green (lint / mypy / pytest / docker build / dep scan)
- [ ] Colleagues rebuild Docker images and restart
- [ ] Next baseline run logs the new 5h `execution_timeout` in task logs
- [ ] `docker stats` on the MISP container shows RSS staying under 8g during the NVD push (the whole point of the bump)
- [ ] No `OOMKilled: true` on `docker inspect misp_misp_1` after a baseline

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Configuration/documentation-only changes (timeouts and container memory limits) with no functional logic changes, but they can increase resource consumption and longer-running tasks in production.
> 
> **Overview**
> **Increases operational headroom for baseline and sync workflows.** Airflow timeouts for `build_relationships`, `run_enrichment_jobs`, and baseline Tier 1 `collect_otx`/`collect_nvd` are bumped from 3h → 5h (including the underlying `subprocess.run` timeout) to avoid premature Airflow kills/retries on larger merged baseline scope.
> 
> Docs are updated to reflect the new timeout guidance, and the example MISP stack compose file sets `mem_limit: 8g` for both `misp` and `misp_db` to reduce OOMs during large baseline NVD pushes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit efd74cad277401f37bac1ca9913de7db07cdd54a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->