### PR TITLE
fix: raise PHP memory_limit inside MISP container to 8G

### DIFF
--- a/docs/DOCKER_SETUP_GUIDE.md
+++ b/docs/DOCKER_SETUP_GUIDE.md
@@ -165,12 +165,19 @@ EDGEGUARD_MISP_EVENT_FETCH_THROTTLE_SEC=5
 
 Docker's `mem_limit: 8g` sets the *container* ceiling — Docker kills the container if total RSS exceeds 8 GB. But PHP has its own `memory_limit` in `php.ini`, defaulting to **2 GB** on the `coolacid/misp-docker` image. When MISP's `JSONConverterTool.php` loads a 95K-attribute event, it can exceed 2 GB of PHP heap *before Docker notices*, and PHP kills the process internally with `Fatal Error: Allowed memory size exhausted`.
 
-Fix: the `docs/sources/MISP/docker-compose.yml` mounts `php-overrides.ini` at `/usr/local/etc/php/conf.d/99-edgeguard.ini`, which sets `memory_limit = 8G` to match the container ceiling. If your MISP image uses a different PHP config path, adjust the mount target:
+Fix: the `docs/sources/MISP/docker-compose.yml` mounts `php-overrides.ini` at `/etc/php/7.4/fpm/conf.d/99-edgeguard.ini`, which sets `memory_limit = 8G` to match the container ceiling. That path matches `coolacid/misp-docker` (debian:bullseye-slim base, PHP 7.4 + php-fpm) — the conf.d location PHP scans on Debian-based images is `/etc/php/<version>/<sapi>/conf.d/`, NOT the `/usr/local/etc/php/conf.d/` used by the official `php:*` images.
+
+If your MISP image ships a different PHP version (e.g. a future coolacid release on PHP 8.x), update the mount path in `docker-compose.yml` to match. **Always verify the override actually took effect:**
 
 ```bash
-# Verify the override took effect:
+# 1. Find the PHP version your MISP image uses:
+docker exec misp_misp_1 php -v
+# 2. Verify the override loaded:
 docker exec misp_misp_1 php -i | grep memory_limit
 # Should show: memory_limit => 8G => 8G
+# 3. If it still shows 2G, find the actual conf.d path PHP scans:
+docker exec misp_misp_1 php -i | grep "Scan this dir"
+# Then update the mount target in docker-compose.yml accordingly.
 ```
 
 **4. Retry backoff:** MISP-facing operations use `retry_with_backoff(max_retries=4, base_delay=10.0)` — retries at **10s → 20s → 40s → 80s**. This gives MISP time to recover from memory pressure between retries. Read timeouts are set to **300s** (5 minutes) to accommodate large event processing.

--- a/docs/DOCKER_SETUP_GUIDE.md
+++ b/docs/DOCKER_SETUP_GUIDE.md
@@ -161,9 +161,21 @@ EDGEGUARD_MISP_BATCH_THROTTLE_SEC=10
 EDGEGUARD_MISP_EVENT_FETCH_THROTTLE_SEC=5
 ```
 
-**3. Retry backoff:** MISP-facing operations use `retry_with_backoff(max_retries=4, base_delay=10.0)` — retries at **10s → 20s → 40s → 80s**. This gives MISP time to recover from memory pressure between retries. Read timeouts are set to **300s** (5 minutes) to accommodate large event processing.
+**3. PHP `memory_limit` inside the container** (critical — distinct from Docker `mem_limit`):
 
-**4. Signs of MISP memory pressure:**
+Docker's `mem_limit: 8g` sets the *container* ceiling — Docker kills the container if total RSS exceeds 8 GB. But PHP has its own `memory_limit` in `php.ini`, defaulting to **2 GB** on the `coolacid/misp-docker` image. When MISP's `JSONConverterTool.php` loads a 95K-attribute event, it can exceed 2 GB of PHP heap *before Docker notices*, and PHP kills the process internally with `Fatal Error: Allowed memory size exhausted`.
+
+Fix: the `docs/sources/MISP/docker-compose.yml` mounts `php-overrides.ini` at `/usr/local/etc/php/conf.d/99-edgeguard.ini`, which sets `memory_limit = 8G` to match the container ceiling. If your MISP image uses a different PHP config path, adjust the mount target:
+
+```bash
+# Verify the override took effect:
+docker exec misp_misp_1 php -i | grep memory_limit
+# Should show: memory_limit => 8G => 8G
+```
+
+**4. Retry backoff:** MISP-facing operations use `retry_with_backoff(max_retries=4, base_delay=10.0)` — retries at **10s → 20s → 40s → 80s**. This gives MISP time to recover from memory pressure between retries. Read timeouts are set to **300s** (5 minutes) to accommodate large event processing.
+
+**5. Signs of MISP memory pressure:**
 - `ReadTimeout` or `ConnectionError` in pipeline logs
 - Circuit breaker opening after 4 failed retries
 - MISP container OOM-killed (check `docker inspect <container> | grep OOMKilled`)

--- a/docs/sources/MISP/docker-compose.yml
+++ b/docs/sources/MISP/docker-compose.yml
@@ -22,6 +22,11 @@ services:
       - misp_data:/var/www/MISP
       - misp_redis:/var/www/MISP/App/files
       - /etc/localtime:/etc/localtime:ro
+      # PHP process memory_limit override — the Docker mem_limit (8g) is the
+      # container ceiling; this .ini raises the PHP-internal ceiling from 2g
+      # to match. Without it, PHP OOM-kills on the NVD 95K-attribute event
+      # even though the container has 6g of headroom.
+      - ./php-overrides.ini:/usr/local/etc/php/conf.d/99-edgeguard.ini:ro
     networks:
       - misp_network
 

--- a/docs/sources/MISP/docker-compose.yml
+++ b/docs/sources/MISP/docker-compose.yml
@@ -26,7 +26,16 @@ services:
       # container ceiling; this .ini raises the PHP-internal ceiling from 2g
       # to match. Without it, PHP OOM-kills on the NVD 95K-attribute event
       # even though the container has 6g of headroom.
-      - ./php-overrides.ini:/usr/local/etc/php/conf.d/99-edgeguard.ini:ro
+      #
+      # Mount path matches coolacid/misp-docker (debian:bullseye-slim base,
+      # PHP 7.4 via php-fpm). The conf.d location PHP scans is
+      # /etc/php/<version>/<sapi>/conf.d/ on Debian-based images — NOT the
+      # /usr/local/etc/php/conf.d/ used by the official php:* images. If your
+      # MISP image ships a different PHP version (e.g. coolacid future PHP
+      # 8.x), update the path. Verify it took effect:
+      #     docker exec misp_misp_1 php -i | grep memory_limit
+      #     # Should show: memory_limit => 8G => 8G
+      - ./php-overrides.ini:/etc/php/7.4/fpm/conf.d/99-edgeguard.ini:ro
     networks:
       - misp_network
 

--- a/docs/sources/MISP/php-overrides.ini
+++ b/docs/sources/MISP/php-overrides.ini
@@ -1,0 +1,30 @@
+; EdgeGuard PHP overrides for the MISP container.
+;
+; Mounted into the container at /usr/local/etc/php/conf.d/99-edgeguard.ini
+; via docker-compose.yml. Loaded AFTER the base php.ini so these values
+; take precedence.
+;
+; Why 8G:
+; MISP's JSONConverterTool.php (line ~99) loads the full event JSON into
+; memory during POST /attributes/add. The NVD baseline event pushes 95K+
+; attributes, producing a ~300MB JSON blob that PHP parses into an object
+; graph requiring ~2-3GB of heap. The upstream default memory_limit (2G =
+; 2147483648 bytes) OOM-kills the PHP process at exactly that threshold,
+; crashing the CyberCure collector on try #2 and forcing Airflow retries.
+;
+; Docker mem_limit (8g) is the *container* ceiling; this is the *process*
+; ceiling inside PHP. Both must be raised together or PHP dies before the
+; container does.
+
+memory_limit = 8G
+
+; Large POST bodies (bulk attribute creation) hit the default 8M post_max_size.
+; MISP's own .htaccess raises it, but some image builds miss it.
+post_max_size = 512M
+upload_max_filesize = 512M
+
+; Request timeout: the NVD 95K-attribute event can take 10+ minutes to
+; process server-side. The default max_execution_time (30s or 300s depending
+; on the image build) silently kills the PHP process mid-write.
+max_execution_time = 3600
+max_input_time = 3600

--- a/docs/sources/MISP/php-overrides.ini
+++ b/docs/sources/MISP/php-overrides.ini
@@ -1,8 +1,14 @@
 ; EdgeGuard PHP overrides for the MISP container.
 ;
-; Mounted into the container at /usr/local/etc/php/conf.d/99-edgeguard.ini
-; via docker-compose.yml. Loaded AFTER the base php.ini so these values
-; take precedence.
+; Mounted into the container at /etc/php/7.4/fpm/conf.d/99-edgeguard.ini
+; via docker-compose.yml — that path matches the coolacid/misp-docker image
+; (debian:bullseye-slim base, PHP 7.4 + php-fpm). PHP scans this conf.d
+; AFTER the base php.ini so these values take precedence.
+;
+; If your MISP image uses a different PHP version (newer images may ship
+; PHP 8.x), update the docker-compose.yml mount target accordingly. Verify:
+;     docker exec misp_misp_1 php -i | grep memory_limit
+;     # Should show: memory_limit => 8G => 8G
 ;
 ; Why 8G:
 ; MISP's JSONConverterTool.php (line ~99) loads the full event JSON into


### PR DESCRIPTION
## Problem

Docker `mem_limit: 8g` (PR #30) is the **container ceiling**. PHP has its own `memory_limit` in `php.ini`, still set to **2G** on the `coolacid/misp-docker` image. When MISP's `JSONConverterTool.php` loads a 95K-attribute event (NVD baseline), PHP exceeds 2G of internal heap and kills itself with:

```
Fatal Error: Allowed memory size of 2147483648 bytes exhausted
at JSONConverterTool.php line 99
```

The container has 6G of headroom but PHP refuses to use it. This is the root cause of the CyberCure OOM crash on the 2026-04-15 baseline run (try #2 at 02:53:59 UTC).

## Fix

New `docs/sources/MISP/php-overrides.ini` mounted into the container at `/usr/local/etc/php/conf.d/99-edgeguard.ini`:

```ini
memory_limit = 8G
post_max_size = 512M
upload_max_filesize = 512M
max_execution_time = 3600
max_input_time = 3600
```

### Why each setting

| Setting | Default | New | Why |
|---|---|---|---|
| `memory_limit` | 2G | 8G | Match the Docker container ceiling — PHP must be allowed to use the memory Docker allocated |
| `post_max_size` | 8M | 512M | Bulk attribute creation POSTs exceed 8M easily |
| `upload_max_filesize` | 8M | 512M | Matches post_max_size |
| `max_execution_time` | 30s–300s | 3600s | The NVD 95K-attribute event takes 10+ minutes to process server-side |
| `max_input_time` | 60s | 3600s | Matches max_execution_time for large POST parsing |

Also adds a new subsection to `docs/DOCKER_SETUP_GUIDE.md` § MISP performance tuning explaining the distinction between Docker `mem_limit` and PHP `memory_limit`, with a verification command.

## Verification

After pulling and restarting the MISP container:

```bash
docker compose -f docs/sources/MISP/docker-compose.yml down
docker compose -f docs/sources/MISP/docker-compose.yml up -d

# Confirm the override took effect:
docker exec misp_misp_1 php -i | grep memory_limit
# Expected: memory_limit => 8G => 8G
```

## Colleague's other findings (for context, not in this PR)

| Finding | Status |
|---|---|
| Bugs #6/#7/#8 | Confirmed fixed (PRs #19, #24) |
| NVD/OTX needed 2 tries | Expected — retry logging already in place from PR #20; first-try failure cause is in the Airflow task logs |
| `full_neo4j_sync` at 63 min | Plausible for 251K attributes across 8 events |
| `build_relationships` at 38 sec | Likely correct — the new specialized queries (#24) are much faster than the old generic USES scan |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs and Docker configuration-only changes; main risk is mis-targeting the PHP `conf.d` path for different MISP image/PHP versions, which would leave defaults in effect.
> 
> **Overview**
> Prevents MISP baseline ingestion from failing on very large events by mounting a new `php-overrides.ini` into the `coolacid/misp-docker` container to raise PHP-level limits (notably `memory_limit = 8G`, plus larger `post_max_size`/`upload_max_filesize` and longer execution/input timeouts).
> 
> Updates the MISP `docker-compose.yml` and `DOCKER_SETUP_GUIDE.md` to explain the Docker `mem_limit` vs PHP `memory_limit` distinction, document the Debian/PHP 7.4 `conf.d` mount path used, and add commands to verify the override is actually loaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a76f2468c9dd7dc1b3b23e41c85d77c26d977b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->