### PR TITLE
feat(doctor/validate): version capture + drift warnings + Neo4j 2026.x pin bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 <p align="center">
   <a href="https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/actions/workflows/ci.yml"><img src="https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/actions/workflows/ci.yml/badge.svg" alt="CI"></a>
   <img src="https://img.shields.io/badge/python-3.12+-blue.svg" alt="Python 3.12+">
-  <img src="https://img.shields.io/badge/neo4j-5.27-green.svg" alt="Neo4j 5.27">
+  <img src="https://img.shields.io/badge/neo4j-2026.03-green.svg" alt="Neo4j 2026.03">
   <img src="https://img.shields.io/badge/license-MIT-brightgreen.svg" alt="MIT License">
   <img src="https://img.shields.io/badge/version-2026.4.4-orange.svg" alt="Version">
 </p>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,15 @@ services:
   # Neo4j — graph database
   # ─────────────────────────────────────────────────────────────────────────────
   neo4j:
-    image: neo4j:5.26.23-community
+    # Neo4j moved to CalVer with the 2026.x release line (was 5.x). The
+    # Python driver pinned in requirements*.txt is still on the 5.x line
+    # and is wire-compat with 2026.x server per Neo4j's official matrix
+    # (https://neo4j.com/developer/kb/neo4j-supported-versions/) — driver
+    # bump to 6.x is a separate PR.
+    # See ``src/version_compatibility.py::RECOMMENDED_VERSIONS`` for the
+    # canonical pin table; ``edgeguard doctor`` warns if the running
+    # server drifts from this tag.
+    image: neo4j:2026.03.1-community
     container_name: edgeguard_neo4j
     restart: unless-stopped
     ports:

--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -32,7 +32,7 @@ graph TB
         COLL[Collectors<br/>11 sources]
         MISP[(MISP 2.4.x<br/>Single Source of Truth<br/>port 8443)]
         SYNC[MISP-to-Neo4j Sync<br/>Paged streaming<br/>OOM-safe chunking]
-        NEO4J[(Neo4j 5.27<br/>Knowledge Graph<br/>ports 7474 / 7687)]
+        NEO4J[(Neo4j 2026.03<br/>Knowledge Graph<br/>ports 7474 / 7687)]
         BREL[build_relationships<br/>11 relationship types]
         ENRICH[Enrichment Jobs<br/>Decay / Campaigns /<br/>Calibration / CVE Bridge]
     end
@@ -290,9 +290,9 @@ flowchart LR
 
 | Layer | Technology | Version |
 |-------|-----------|---------|
-| Graph Database | Neo4j Community | 5.27 |
+| Graph Database | Neo4j Community | 2026.03 |
 | Threat Intel Platform | MISP | 2.4.x |
-| Orchestration | Apache Airflow | 2.11 |
+| Orchestration | Apache Airflow | 3.2 |
 | REST API | FastAPI + Uvicorn | latest |
 | GraphQL API | Strawberry | latest |
 | Messaging | NATS | latest |

--- a/docs/ENVIRONMENTS.md
+++ b/docs/ENVIRONMENTS.md
@@ -39,6 +39,18 @@ To keep dependencies clean and reproducible, use a dedicated environment per pro
 
 **Version:** EdgeGuard requires **Python 3.12+** (`requires-python` in `pyproject.toml`, CI, and `Dockerfile`). Apache Airflow **3.2** (upgraded from 2.11 in April 2026 — see [AIRFLOW_DAGS.md § Airflow 2 to 3 upgrade](AIRFLOW_DAGS.md)) supports Python 3.10–3.14 upstream; this repository standardizes on 3.12 for a single supported interpreter line.
 
+**Pinned component versions** (PR #36 — Vanko's request to make these explicit and verifiable at runtime):
+
+| Component | Pinned in | Recommended | Verified by |
+|---|---|---|---|
+| Neo4j server | `docker-compose.yml` `neo4j:` image | `2026.03.x-community` (CalVer; was 5.26.x before April 2026) | `edgeguard doctor` |
+| Neo4j Python driver | `requirements.txt`, `requirements-airflow-docker.txt` | `~=5.27` (5.x driver is wire-compat with 2026.x server per [Neo4j compat matrix](https://neo4j.com/developer/kb/neo4j-supported-versions/)) | `edgeguard doctor` |
+| Apache Airflow | `Dockerfile.airflow` `FROM apache/airflow:` | `3.2.0-python3.12` | `edgeguard doctor` |
+| PyMISP | `requirements.txt`, `requirements-airflow-docker.txt` | `~=2.4` | `edgeguard doctor` |
+| MISP server | (operator-controlled deploy) | `2.4.x` | `edgeguard doctor` |
+
+The single source of truth for the comparison logic is `src/version_compatibility.py::RECOMMENDED_VERSIONS`. `edgeguard doctor` and `edgeguard validate` capture the actual running versions and warn on drift. A regression test (`tests/test_version_compatibility.py::test_recommended_*_matches_*_pin`) fails CI if anyone bumps a pin file without updating the recommended-versions table.
+
 #### 2.1 Create a conda environment (recommended)
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,6 +12,12 @@
 # =============================================================================
 
 # ── Core ─────────────────────────────────────────────────────────────────────
+# neo4j driver: pinned to 5.x. The Neo4j SERVER (docker-compose.yml ``neo4j:``
+# image tag) is on the 2026.x CalVer release line; the 5.x Python driver is
+# wire-compat with 2026.x servers per https://neo4j.com/developer/kb/neo4j-supported-versions/
+# A driver bump to 6.x is a separate PR with its own testing pass.
+# ``edgeguard doctor`` warns if running driver/server drift from this pin —
+# see src/version_compatibility.py::RECOMMENDED_VERSIONS.
 neo4j~=5.27
 requests~=2.32
 pandas~=2.2

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -262,6 +262,9 @@ def cmd_doctor(args):
             pass  # Non-critical diagnostic
 
     # Check MISP version compatibility
+    # PR #36 commit X (bugbot LOW): captured here once and threaded to
+    # ``compare_pinned_vs_running`` below to avoid a second MISP round-trip.
+    _captured_misp_version: Optional[str] = None
     if ok_flag:
         info("Checking MISP/PyMISP version compatibility...")
         try:
@@ -279,6 +282,10 @@ def cmd_doctor(args):
                 warn("This may cause Airflow DAG parser to hang. Use 'python3 src/run_pipeline.py' as workaround.")
             else:
                 ok(f"MISP server {version} compatible with PyMISP")
+            # Capture for the version-compat report below — skips the redundant probe
+            # (only "unknown" / falsy values fall through to a fresh capture).
+            if version and version != "unknown":
+                _captured_misp_version = version
         except Exception as e:
             warn(f"Could not check MISP version compatibility: {e}")
 
@@ -497,7 +504,9 @@ def cmd_doctor(args):
     try:
         from version_compatibility import compare_pinned_vs_running
 
-        rows = compare_pinned_vs_running()
+        # Pass the MISP version captured earlier (line ~272) to skip a
+        # redundant network round-trip — bugbot LOW finding on PR #36.
+        rows = compare_pinned_vs_running(misp_server_version=_captured_misp_version)
         for _component, status, message in rows:
             if status == "ok":
                 ok(message)

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -1056,21 +1056,25 @@ def cmd_validate(args):
         from version_compatibility import compare_pinned_vs_running
 
         rows = compare_pinned_vs_running()
-        warn_count = 0
         for _component, status, message in rows:
             if status == "ok":
                 ok(message)
             elif status == "warn":
                 warn(message)
-                warn_count += 1
             else:
                 info(message)
-        if warn_count:
-            # Track in issues list for the validate-exit-code summary, but
-            # only as warnings — version drift doesn't block deployment if
-            # the operator made a deliberate choice to run on a different
-            # line. The signal is informational.
-            issues.append(f"{warn_count} version pin(s) drift from running components")
+        # PR #36 commit 8425380 (bugbot MED): version-drift warnings are
+        # NOT appended to ``issues``. Two reasons:
+        #   1. The previous code appended a synthetic "N pins drifted"
+        #      string AND printed an apologetic comment claiming the
+        #      check "doesn't block deployment" — but ``cmd_validate``
+        #      returns exit 1 when ``issues`` is non-empty, so it
+        #      DID block. Self-contradicting.
+        #   2. Inconsistent with ``cmd_doctor`` which already treats
+        #      version drift as informational (never bumps ``all_ok``).
+        # If a future operator wants version drift to gate deploys, add
+        # an opt-in env var (e.g. ``EDGEGUARD_VALIDATE_FAIL_ON_DRIFT=1``)
+        # rather than reverting the default.
     except Exception as e:
         warn(f"Version compatibility check failed: {e}")
 

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -485,6 +485,29 @@ def cmd_doctor(args):
     ok_flag, msg = check_circuit_breakers()
     ok(msg)
 
+    # Check version compatibility (PR #36 — Vanko's request: capture
+    # actual running versions of Neo4j server/driver, Airflow, MISP,
+    # PyMISP and warn on drift from the pinned recommendations in
+    # docker-compose.yml / requirements*.txt). Best-effort: every
+    # capture function in version_compatibility returns ``None`` on
+    # failure rather than raising, so a missing optional dep can NEVER
+    # crash doctor (Vanko's stale-checkout NameError class of bug —
+    # also pinned structurally by ``test_edgeguard_doctor_audit.py``).
+    info("Checking version compatibility...")
+    try:
+        from version_compatibility import compare_pinned_vs_running
+
+        rows = compare_pinned_vs_running()
+        for _component, status, message in rows:
+            if status == "ok":
+                ok(message)
+            elif status == "warn":
+                warn(message)
+            else:
+                info(message)
+    except Exception as e:
+        warn(f"Version compatibility check failed: {e}")
+
     section("Diagnosis Complete")
     if all_ok:
         ok("EdgeGuard is healthy")
@@ -1022,6 +1045,34 @@ def cmd_validate(args):
             warn("Neo4j not connected — schema check skipped")
     except Exception as e:
         warn(f"Neo4j schema check failed: {e}")
+
+    # Check version compatibility (PR #36 — Vanko's request). Validate's
+    # role is config validation, but version drift IS a configuration
+    # issue: a 2026.x Neo4j server pinned at the 5.26 docker tag will be
+    # silently downgraded on the next ``docker-compose up``. Surface it
+    # here so it shows up in the operator's pre-deploy validation pass.
+    info("Checking version compatibility...")
+    try:
+        from version_compatibility import compare_pinned_vs_running
+
+        rows = compare_pinned_vs_running()
+        warn_count = 0
+        for _component, status, message in rows:
+            if status == "ok":
+                ok(message)
+            elif status == "warn":
+                warn(message)
+                warn_count += 1
+            else:
+                info(message)
+        if warn_count:
+            # Track in issues list for the validate-exit-code summary, but
+            # only as warnings — version drift doesn't block deployment if
+            # the operator made a deliberate choice to run on a different
+            # line. The signal is informational.
+            issues.append(f"{warn_count} version pin(s) drift from running components")
+    except Exception as e:
+        warn(f"Version compatibility check failed: {e}")
 
     section("Validation Complete")
     if issues:

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -175,9 +175,7 @@ def get_neo4j_server_version(neo4j_client_factory=None) -> Optional[str]:
         # accident (would falsely report server as e.g. "5" instead of
         # "2026.03.1"). Same Cypher as in ``_get_neo4j_server_version_fast``
         # — keep them in lockstep.
-        rows = client.run(
-            "CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN versions"
-        )
+        rows = client.run("CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN versions")
         if not rows:
             return None
         versions = rows[0].get("versions") if isinstance(rows[0], dict) else None
@@ -241,9 +239,7 @@ def _get_neo4j_server_version_fast() -> Optional[str]:
             # that don't expose the canonical "Neo4j Kernel" component
             # name; the caller already handles None gracefully.
             result = session.run(
-                "CALL dbms.components() YIELD name, versions "
-                "WHERE name = 'Neo4j Kernel' "
-                "RETURN versions"
+                "CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN versions"
             )
             rows = list(result)
         if rows:

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -407,6 +407,7 @@ def compare_version(component: str, running: Optional[str]) -> Tuple[str, str]:
 def compare_pinned_vs_running(
     *,
     neo4j_client_factory=None,
+    misp_server_version: Optional[str] = None,
 ) -> List[Tuple[str, str, str]]:
     """Capture every component's running version + compare to its pin.
 
@@ -414,16 +415,33 @@ def compare_pinned_vs_running(
     deterministic order. Doctor / validate iterate this list and route
     each row by status to ``ok()`` / ``warn()`` / ``info()``.
 
-    The ``neo4j_client_factory`` parameter is plumbed only through to
-    ``get_neo4j_server_version`` — every other capture is process-local.
-    Tests use it to inject a stub client without a live Neo4j.
+    Parameters
+    ----------
+    neo4j_client_factory:
+        Optional factory for a Neo4j client. When provided, used by
+        ``get_neo4j_server_version`` instead of constructing a fresh
+        ``Neo4jClient`` (which would pay the
+        ``@retry_with_backoff`` cost). Tests inject mocks here.
+    misp_server_version:
+        Optional pre-captured MISP server version string. When provided,
+        skips the internal ``get_misp_server_version()`` call (which
+        otherwise instantiates ``MISPHealthCheck`` and makes a
+        round-trip to MISP).
+
+        PR #36 commit X (bugbot LOW): ``cmd_doctor`` already calls
+        ``MISPHealthCheck().check_health()`` earlier in the doctor
+        flow for the MISP/PyMISP version-compat check. Without this
+        parameter, ``compare_pinned_vs_running`` would do a SECOND
+        round-trip via ``get_misp_server_version`` → duplicate
+        network call on every doctor run. Caller passes the version
+        string from the earlier call to skip the redundant probe.
     """
     captures: Dict[str, Optional[str]] = {
         "neo4j_driver": get_neo4j_driver_version(),
         "neo4j_server": get_neo4j_server_version(neo4j_client_factory=neo4j_client_factory),
         "airflow": get_airflow_version(),
         "pymisp": get_pymisp_version(),
-        "misp_server": get_misp_server_version(),
+        "misp_server": misp_server_version if misp_server_version is not None else get_misp_server_version(),
     }
     # Stable ordering for predictable output
     order = ("neo4j_server", "neo4j_driver", "airflow", "pymisp", "misp_server")

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -169,7 +169,15 @@ def get_neo4j_server_version(neo4j_client_factory=None) -> Optional[str]:
         # Some test factories return an instance directly without needing connect()
         if hasattr(client, "connect") and not client.connect():
             return None
-        rows = client.run("CALL dbms.components() YIELD versions RETURN versions")
+        # PR #36 commit X (bugbot MED): Neo4j 2025.05+ added a "Cypher" row
+        # to ``CALL dbms.components()`` output. Filter to ``Neo4j Kernel``
+        # explicitly so we never pick the Cypher-language version row by
+        # accident (would falsely report server as e.g. "5" instead of
+        # "2026.03.1"). Same Cypher as in ``_get_neo4j_server_version_fast``
+        # — keep them in lockstep.
+        rows = client.run(
+            "CALL dbms.components() YIELD name, versions WHERE name = 'Neo4j Kernel' RETURN versions"
+        )
         if not rows:
             return None
         versions = rows[0].get("versions") if isinstance(rows[0], dict) else None
@@ -219,7 +227,24 @@ def _get_neo4j_server_version_fast() -> Optional[str]:
             max_connection_lifetime=10,
         )
         with driver.session(default_access_mode="READ") as session:
-            result = session.run("CALL dbms.components() YIELD versions RETURN versions")
+            # PR #36 commit X (bugbot MED): Neo4j 2025.05+ added a "Cypher"
+            # row to ``CALL dbms.components()`` output (with ``versions:
+            # ["5", "25"]`` — the Cypher language version). Without an
+            # explicit ``WHERE name = 'Neo4j Kernel'`` filter, ``rows[0]``
+            # may pick up the Cypher row instead of the kernel row →
+            # we'd report the server version as ``"5"`` and the doctor
+            # check would falsely scream MAJOR drift on the new
+            # ``neo4j:2026.03.1-community`` image.
+            #
+            # Filter at the Cypher layer so we never have to guess from
+            # row order. The query still returns ``[]`` on Neo4j forks
+            # that don't expose the canonical "Neo4j Kernel" component
+            # name; the caller already handles None gracefully.
+            result = session.run(
+                "CALL dbms.components() YIELD name, versions "
+                "WHERE name = 'Neo4j Kernel' "
+                "RETURN versions"
+            )
             rows = list(result)
         if rows:
             row = rows[0]

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -139,19 +139,29 @@ def get_neo4j_server_version(neo4j_client_factory=None) -> Optional[str]:
     ``[{"versions": ["5.27.0"]}]`` (list-of-strings inside the row).
 
     ``neo4j_client_factory`` lets tests inject a mock client without
-    needing a live Neo4j. In production it defaults to ``Neo4jClient()``.
+    needing a live Neo4j. In production it defaults to a FAST one-shot
+    driver session (see below).
+
     Best-effort; returns ``None`` on any error including connection
     failure (we'd rather degrade silently in doctor than block on Neo4j
     being down — there are other doctor checks that already report that).
+
+    PR #36 commit X (bugbot MED): when no factory is provided, this
+    function used to instantiate ``Neo4jClient()`` and call ``connect()``,
+    which is decorated with ``@retry_with_backoff(max_retries=5,
+    base_delay=2)`` → up to ~62s of exponential backoff when Neo4j is
+    unreachable. Both ``cmd_doctor`` and ``cmd_validate`` already run
+    their own Neo4j connection check earlier in the flow with the same
+    retry behavior, so version capture added a SECOND full retry cycle
+    — wall-clock roughly doubled on a Neo4j outage for zero diagnostic
+    value. The default-factory path now uses the Neo4j driver
+    DIRECTLY with a tight ``connection_timeout`` so the version probe
+    fails fast (a few seconds) instead of retrying. Test paths still go
+    through the factory hook — the contract for ``test_get_neo4j_server_version_*``
+    is unchanged.
     """
     if neo4j_client_factory is None:
-        try:
-            from neo4j_client import Neo4jClient
-
-            neo4j_client_factory = Neo4jClient
-        except Exception as e:  # noqa: BLE001
-            logger.debug(f"Neo4jClient import failed: {e}")
-            return None
+        return _get_neo4j_server_version_fast()
 
     client = None
     try:
@@ -173,6 +183,58 @@ def get_neo4j_server_version(neo4j_client_factory=None) -> Optional[str]:
         if client is not None and hasattr(client, "close"):
             try:
                 client.close()
+            except Exception:
+                pass
+
+
+def _get_neo4j_server_version_fast() -> Optional[str]:
+    """Production path for ``get_neo4j_server_version``: bypass
+    ``Neo4jClient.connect()``'s retry decorator.
+
+    Uses the official Neo4j Python driver directly with a 2-second
+    ``connection_timeout`` so a probe against a down Neo4j fails in
+    seconds rather than the ~62 seconds that the retry-decorated
+    ``Neo4jClient.connect()`` takes.
+
+    Test paths must call ``get_neo4j_server_version(neo4j_client_factory=...)``
+    instead — that branch keeps the existing test contract.
+    """
+    try:
+        from config import NEO4J_PASSWORD, NEO4J_URI, NEO4J_USER  # noqa: WPS433
+        from neo4j import GraphDatabase  # noqa: WPS433
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"neo4j driver / config import failed: {e}")
+        return None
+
+    driver = None
+    try:
+        # ``connection_timeout`` is the per-connection acquisition timeout;
+        # ``max_connection_lifetime`` keeps the pooled connection short-lived
+        # since this driver is single-shot. Both keep us from hanging on a
+        # half-up Neo4j (TCP accept but no Bolt response).
+        driver = GraphDatabase.driver(
+            NEO4J_URI,
+            auth=(NEO4J_USER, NEO4J_PASSWORD),
+            connection_timeout=2.0,
+            max_connection_lifetime=10,
+        )
+        with driver.session(default_access_mode="READ") as session:
+            result = session.run("CALL dbms.components() YIELD versions RETURN versions")
+            rows = list(result)
+        if rows:
+            row = rows[0]
+            versions = row.get("versions") if hasattr(row, "get") else None
+            if isinstance(versions, list) and versions:
+                return str(versions[0])
+        return None
+    except Exception as e:  # noqa: BLE001
+        # Includes ServiceUnavailable, AuthError, etc. — all best-effort failures.
+        logger.debug(f"neo4j server version fast probe failed: {e}")
+        return None
+    finally:
+        if driver is not None:
+            try:
+                driver.close()
             except Exception:
                 pass
 

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -72,9 +72,21 @@ logger = logging.getLogger(__name__)
 # ``test_recommended_versions_match_pin_files`` regression test fails
 # loudly if the two drift apart.
 #
-# Format: each value is the MINIMUM acceptable major.minor. The compat
-# check warns if running version is older (drift from the deployment
-# baseline) or newer by a major version (likely a breaking change).
+# Format: each value is the EXACT recommended major.minor. The compat
+# check is "ok" only on an exact major.minor match (patch drift is
+# silently fine — that's what the project's ``~=N.M`` SemVer policy
+# in ``requirements.txt`` already documents as non-breaking). ANY
+# minor drift in either direction is "warn":
+#   * older running version → operator hasn't upgraded yet
+#   * newer running minor   → someone bypassed the ``~=`` pin (manual
+#     install, container override, custom build) and the documented
+#     baseline no longer matches the deployed env
+# Major drift additionally calls out likely breaking changes —
+# operators should verify Cypher / API call sites before deploying.
+# (PR #36 bugbot MED — was previously labeled "MINIMUM" which conflicted
+# with the actual exact-match-on-major.minor behavior; the label
+# created a trap for future developers reading the comment in
+# isolation.)
 RECOMMENDED_VERSIONS: Dict[str, str] = {
     # Neo4j server: we run the 2026.x community edition. Server release
     # line moved from 5.x → 2026.x in early 2026 (CalVer rebrand). The 5.x

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -466,8 +466,15 @@ def read_requirements_pin(req_file: str, package: str) -> Optional[str]:
                 # Skip comments / blanks
                 if not stripped or stripped.startswith("#"):
                     continue
-                # Match ``<package>~=<version>`` allowing optional whitespace + extras
-                pattern = rf"^{re.escape(package)}\s*~=\s*([\d.]+)\s*$"
+                # PR #36 commit X (bugbot MED): the previous regex claimed to
+                # allow "optional whitespace + extras" but never had an
+                # optional bracket group, so ``apache-airflow[postgres]~=3.2``
+                # silently returned None — the only RECOMMENDED_VERSIONS
+                # entry without pin-file sync coverage. Now the bracketed
+                # extras form (``<package>[<extras>]~=<version>``) is
+                # explicitly tolerated. Extras content itself is uninspected
+                # — we only care about the package name + the version pin.
+                pattern = rf"^{re.escape(package)}(?:\[[^\]]*\])?\s*~=\s*([\d.]+)\s*$"
                 m = re.match(pattern, stripped)
                 if m:
                     return m.group(1)

--- a/src/version_compatibility.py
+++ b/src/version_compatibility.py
@@ -1,0 +1,402 @@
+"""Runtime version capture + recommended-version comparison for EdgeGuard.
+
+Why this module exists
+----------------------
+Vanko's PR #36 audit (CyberCure follow-up) caught two adjacent gaps:
+
+1. The pinned Neo4j docker image (``neo4j:5.26.23-community``) drifted from
+   what was actually running locally (Neo4j 2026.03.x). When a server has
+   moved to a new release line (5.x → 2026.x) but the docker-compose pin
+   is stale, ``docker-compose up`` happily recreates the container at the
+   pinned (older) version, silently rolling back the operator's data layer
+   on the next ``down``/``up`` cycle. By the time someone notices, the
+   APOC procedures and call signatures may have shifted under them.
+
+2. Neither ``edgeguard doctor`` nor ``edgeguard validate`` reported the
+   ACTUAL running version of any dependency. The operator had no
+   visibility into "what version is actually on this host vs. what the
+   project expects." A mismatch only surfaced via mysterious runtime
+   errors (the Cypher query that failed because a syntax shifted; the
+   PyMISP method that no longer existed; etc.).
+
+This module closes both gaps with a single primitive: a small set of
+``get_*_version()`` capture functions plus a ``RECOMMENDED_VERSIONS``
+table sourced from ``requirements.txt`` / ``docker-compose.yml`` /
+``Dockerfile.airflow``. ``compare_pinned_vs_running()`` produces a
+structured report that ``cmd_doctor`` + ``cmd_validate`` render.
+
+Design notes
+------------
+* All ``get_*_version()`` functions are best-effort and NEVER raise — they
+  return ``None`` on any failure. Doctor/validate must never crash because
+  the version capture failed; that defeats the user-visible benefit.
+* Comparison is permissive on the patch component (``5.27.0`` matches
+  ``~=5.27`` even though the running driver is ``5.27.1``). We only
+  warn on minor/major drift because patch upgrades are by definition
+  non-breaking under the project's ``~=`` SemVer policy (see the comment
+  block in ``requirements.txt`` documenting why we use ``~=``).
+* Server vs. driver are reported separately for Neo4j because they upgrade
+  on independent cycles — the operator may pin the server line but allow
+  driver patch-level upgrades.
+* We deliberately do NOT block on version mismatches (no ``return 1``
+  from doctor on a mismatch alone). The signal is informational; if the
+  operator KNOWS they're on a newer line that's OK with our driver,
+  forcing them to bump the pin would be friction without value.
+
+Recommended versions are kept in this module rather than parsed from
+``requirements.txt`` at runtime. Two reasons:
+* The ``~=N.M`` form is hard to compare meaningfully without bringing
+  in ``packaging.specifiers`` (extra dep just for a doctor check).
+* Source-of-truth here is the bumped pin from PR #36 itself; if a
+  future PR forgets to update both this table AND the pin file, the new
+  ``test_recommended_versions_match_pin_files`` test catches it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import re
+import subprocess
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Recommended pins — source of truth for the version-compat report
+# ---------------------------------------------------------------------------
+#
+# When you bump a pin in ``docker-compose.yml`` / ``requirements.txt`` /
+# ``Dockerfile.airflow``, ALSO bump it here. The
+# ``test_recommended_versions_match_pin_files`` regression test fails
+# loudly if the two drift apart.
+#
+# Format: each value is the MINIMUM acceptable major.minor. The compat
+# check warns if running version is older (drift from the deployment
+# baseline) or newer by a major version (likely a breaking change).
+RECOMMENDED_VERSIONS: Dict[str, str] = {
+    # Neo4j server: we run the 2026.x community edition. Server release
+    # line moved from 5.x → 2026.x in early 2026 (CalVer rebrand). The 5.x
+    # Python driver is still wire-compat per Neo4j's official matrix —
+    # see https://neo4j.com/developer/kb/neo4j-supported-versions/ — so
+    # we don't force a driver bump in the same PR.
+    "neo4j_server": "2026.03",
+    # Neo4j Python driver: still on the 5.x line. Bumping to 6.x is a
+    # major version change — separate PR with explicit testing.
+    "neo4j_driver": "5.27",
+    # Apache Airflow: 3.2.x baked into the custom image (Dockerfile.airflow
+    # ``FROM apache/airflow:3.2.0-python3.12``).
+    "airflow": "3.2",
+    # PyMISP — talks to MISP 2.4.x.
+    "pymisp": "2.4",
+    # MISP server. We don't bump aggressively; 2.4.x is the long-running
+    # line that's compatible with current PyMISP.
+    "misp_server": "2.4",
+}
+
+
+# ---------------------------------------------------------------------------
+# Version capture — every function MUST be best-effort + never raise
+# ---------------------------------------------------------------------------
+
+
+def get_neo4j_driver_version() -> Optional[str]:
+    """Read ``neo4j.__version__`` if the package is importable.
+
+    The driver always exposes this attribute on the top-level module
+    (https://neo4j.com/docs/api/python-driver/). Returns ``None`` if the
+    driver isn't installed (e.g. running ``edgeguard doctor`` from a slim
+    container without Neo4j integration).
+    """
+    try:
+        import neo4j  # noqa: WPS433 — runtime import is intentional
+
+        v = getattr(neo4j, "__version__", None)
+        return str(v) if v else None
+    except Exception as e:  # noqa: BLE001 — best-effort; doctor must not crash
+        logger.debug(f"neo4j driver version capture failed: {e}")
+        return None
+
+
+def get_neo4j_server_version(neo4j_client_factory=None) -> Optional[str]:
+    """Query the running Neo4j server for its version string.
+
+    Uses ``CALL dbms.components() YIELD versions`` which has been the
+    canonical version-discovery procedure since 3.x. Result format:
+    ``[{"versions": ["5.27.0"]}]`` (list-of-strings inside the row).
+
+    ``neo4j_client_factory`` lets tests inject a mock client without
+    needing a live Neo4j. In production it defaults to ``Neo4jClient()``.
+    Best-effort; returns ``None`` on any error including connection
+    failure (we'd rather degrade silently in doctor than block on Neo4j
+    being down — there are other doctor checks that already report that).
+    """
+    if neo4j_client_factory is None:
+        try:
+            from neo4j_client import Neo4jClient
+
+            neo4j_client_factory = Neo4jClient
+        except Exception as e:  # noqa: BLE001
+            logger.debug(f"Neo4jClient import failed: {e}")
+            return None
+
+    client = None
+    try:
+        client = neo4j_client_factory()
+        # Some test factories return an instance directly without needing connect()
+        if hasattr(client, "connect") and not client.connect():
+            return None
+        rows = client.run("CALL dbms.components() YIELD versions RETURN versions")
+        if not rows:
+            return None
+        versions = rows[0].get("versions") if isinstance(rows[0], dict) else None
+        if isinstance(versions, list) and versions:
+            return str(versions[0])
+        return None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"neo4j server version capture failed: {e}")
+        return None
+    finally:
+        if client is not None and hasattr(client, "close"):
+            try:
+                client.close()
+            except Exception:
+                pass
+
+
+def get_airflow_version() -> Optional[str]:
+    """Read Airflow's version.
+
+    Two probes, in order of cost:
+    1. ``import airflow; airflow.__version__`` — instant if installed in
+       the same Python env (Airflow worker / scheduler containers).
+    2. ``airflow version`` subprocess — fallback for when EdgeGuard CLI
+       is invoked from a host shell that has the ``airflow`` binary on
+       ``$PATH`` but the import would fail (different venv).
+
+    Subprocess output format: a banner followed by the version on its
+    own line (e.g. ``3.2.0``). We strip and grab the first line that
+    matches ``^\\d+\\.\\d+(\\.\\d+)?$``.
+    """
+    # Probe 1: import path
+    try:
+        import airflow  # noqa: WPS433
+
+        v = getattr(airflow, "__version__", None)
+        if v:
+            return str(v)
+    except Exception:
+        pass
+
+    # Probe 2: subprocess fallback
+    try:
+        result = subprocess.run(
+            ["airflow", "version"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+            check=False,
+        )
+        if result.returncode == 0:
+            for line in result.stdout.splitlines():
+                line = line.strip()
+                if re.match(r"^\d+\.\d+(\.\d+)?$", line):
+                    return line
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"airflow subprocess version probe failed: {e}")
+
+    return None
+
+
+def get_pymisp_version() -> Optional[str]:
+    """Read ``pymisp.__version__`` if installed.
+
+    Same shape as ``get_neo4j_driver_version`` — pymisp surfaces a
+    top-level ``__version__`` since 2.4.x.
+    """
+    try:
+        import pymisp  # noqa: WPS433
+
+        v = getattr(pymisp, "__version__", None)
+        return str(v) if v else None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"pymisp version capture failed: {e}")
+        return None
+
+
+def get_misp_server_version() -> Optional[str]:
+    """Read the connected MISP server's version via ``MISPHealthCheck``.
+
+    Reuses the existing health check rather than duplicating the API
+    call — keeps a single code path for talking to MISP. Best-effort;
+    returns ``None`` if MISP is unreachable, unconfigured, or the health
+    check raised. ``MISPHealthCheck`` already wraps its own errors so
+    this rarely fires the outer except.
+    """
+    try:
+        from misp_health import MISPHealthCheck  # noqa: WPS433
+
+        result = MISPHealthCheck().check_health()
+        v = result.details.get("version") if hasattr(result, "details") else None
+        return str(v) if v else None
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"MISP server version capture failed: {e}")
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Comparison
+# ---------------------------------------------------------------------------
+
+
+_VERSION_RE = re.compile(r"^(\d+)\.(\d+)(?:\.(\d+))?")
+
+
+def _parse_major_minor(version: str) -> Optional[Tuple[int, int]]:
+    """Extract ``(major, minor)`` from a version string.
+
+    Tolerant of suffixes (``5.27.0-rc1``, ``2026.03.1``, ``3.2.0+local``).
+    Returns ``None`` if the string doesn't start with at least two
+    dot-separated integers — caller treats that as "can't compare,
+    don't warn."
+    """
+    if not version:
+        return None
+    m = _VERSION_RE.match(version.strip())
+    if not m:
+        return None
+    return int(m.group(1)), int(m.group(2))
+
+
+def compare_version(component: str, running: Optional[str]) -> Tuple[str, str]:
+    """Compare a single component's running version against the recommended pin.
+
+    Returns ``(status, message)`` where status is one of:
+      * ``"ok"`` — matches the major.minor pin (patch drift is fine)
+      * ``"warn"`` — minor or major drift (operator needs to know)
+      * ``"unknown"`` — couldn't capture the running version OR couldn't
+        parse it (no pin/running comparison possible). Doctor renders
+        this as info, NOT warn — silence on a missing optional dep is
+        the right user experience.
+    """
+    recommended = RECOMMENDED_VERSIONS.get(component)
+    if not recommended:
+        return ("unknown", f"{component}: no recommended version registered (bug in version_compatibility?)")
+    if not running:
+        return ("unknown", f"{component}: running version not detected (component may not be installed/reachable)")
+
+    rec_parsed = _parse_major_minor(recommended)
+    run_parsed = _parse_major_minor(running)
+    if not rec_parsed or not run_parsed:
+        return ("unknown", f"{component}: cannot compare running={running!r} to recommended={recommended!r}")
+
+    if rec_parsed == run_parsed:
+        return ("ok", f"{component}: {running} matches recommended ~={recommended}")
+
+    rec_major, rec_minor = rec_parsed
+    run_major, run_minor = run_parsed
+    if run_major != rec_major:
+        return (
+            "warn",
+            f"{component}: MAJOR drift — running {running}, recommended ~={recommended}. "
+            f"Likely breaking changes; verify Cypher/API call sites before deploying.",
+        )
+    return (
+        "warn",
+        f"{component}: minor drift — running {running}, recommended ~={recommended}. "
+        f"Update the pin in requirements/docker-compose if this is intentional.",
+    )
+
+
+def compare_pinned_vs_running(
+    *,
+    neo4j_client_factory=None,
+) -> List[Tuple[str, str, str]]:
+    """Capture every component's running version + compare to its pin.
+
+    Returns a list of ``(component, status, message)`` tuples in
+    deterministic order. Doctor / validate iterate this list and route
+    each row by status to ``ok()`` / ``warn()`` / ``info()``.
+
+    The ``neo4j_client_factory`` parameter is plumbed only through to
+    ``get_neo4j_server_version`` — every other capture is process-local.
+    Tests use it to inject a stub client without a live Neo4j.
+    """
+    captures: Dict[str, Optional[str]] = {
+        "neo4j_driver": get_neo4j_driver_version(),
+        "neo4j_server": get_neo4j_server_version(neo4j_client_factory=neo4j_client_factory),
+        "airflow": get_airflow_version(),
+        "pymisp": get_pymisp_version(),
+        "misp_server": get_misp_server_version(),
+    }
+    # Stable ordering for predictable output
+    order = ("neo4j_server", "neo4j_driver", "airflow", "pymisp", "misp_server")
+    rows = []
+    for component in order:
+        running = captures.get(component)
+        status, message = compare_version(component, running)
+        rows.append((component, status, message))
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Pin-file source-of-truth helpers (for the regression test that pins
+# RECOMMENDED_VERSIONS to actual files)
+# ---------------------------------------------------------------------------
+
+
+_REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def read_docker_compose_neo4j_image() -> Optional[str]:
+    """Extract the ``neo4j:<tag>`` image pin from ``docker-compose.yml``.
+
+    Returns the tag portion (e.g. ``"2026.03.1-community"``) or ``None``
+    if the file is missing or doesn't contain the expected line. The
+    regression test uses this to verify ``RECOMMENDED_VERSIONS["neo4j_server"]``
+    is a prefix of what's actually pinned in compose.
+    """
+    path = os.path.join(_REPO_ROOT, "docker-compose.yml")
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as fh:
+            for line in fh:
+                stripped = line.strip()
+                # Match ``image: neo4j:<tag>`` precisely — don't false-match other
+                # services that happen to mention neo4j (e.g. comments, env vars)
+                m = re.match(r"^image:\s*neo4j:(\S+)\s*$", stripped)
+                if m:
+                    return m.group(1)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"docker-compose neo4j image read failed: {e}")
+    return None
+
+
+def read_requirements_pin(req_file: str, package: str) -> Optional[str]:
+    """Extract a ``package~=N.M`` pin from a requirements file.
+
+    ``req_file`` is a relative path under repo root (e.g.
+    ``requirements.txt``). Returns the version portion after ``~=`` or
+    ``None`` if not found. Used by the regression test to verify the
+    Python pins match ``RECOMMENDED_VERSIONS``.
+    """
+    path = os.path.join(_REPO_ROOT, req_file)
+    if not os.path.exists(path):
+        return None
+    try:
+        with open(path) as fh:
+            for line in fh:
+                stripped = line.strip()
+                # Skip comments / blanks
+                if not stripped or stripped.startswith("#"):
+                    continue
+                # Match ``<package>~=<version>`` allowing optional whitespace + extras
+                pattern = rf"^{re.escape(package)}\s*~=\s*([\d.]+)\s*$"
+                m = re.match(pattern, stripped)
+                if m:
+                    return m.group(1)
+    except Exception as e:  # noqa: BLE001
+        logger.debug(f"requirements pin read failed for {package} in {req_file}: {e}")
+    return None

--- a/tests/test_edgeguard_doctor_audit.py
+++ b/tests/test_edgeguard_doctor_audit.py
@@ -1,0 +1,227 @@
+"""PR #36 — structural pin for the class of bug Vanko reported (NameError
+in cmd_doctor / cmd_validate) plus a smoke test for the new
+``version_compatibility`` module wiring.
+
+Background
+----------
+Vanko's report (2026-04-18): ``edgeguard doctor`` and ``edgeguard validate``
+crashed with ``NameError`` partway through because a config-module name
+they referenced was not in scope at the call site. The current main does
+not exhibit the crash because ``_ensure_runtime_imports()`` (in
+``src/edgeguard.py``) injects every name listed in ``_CFG_EXPORTS`` onto
+the module before the dispatch.
+
+The fragility, however, is real: if a future PR adds ``MISP_PASSWORD`` (or
+any other ``ALL_CAPS`` config name) inside ``cmd_doctor`` and forgets to
+add it to ``_CFG_EXPORTS``, the bug returns and only surfaces in
+production. This file pins the contract structurally with an AST scan
+that auto-discovers references and asserts each is either locally
+defined or runtime-injected.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+def _load_edgeguard_ast() -> ast.Module:
+    path = os.path.join(_SRC, "edgeguard.py")
+    with open(path) as fh:
+        return ast.parse(fh.read())
+
+
+def _function_node(tree: ast.Module, name: str) -> ast.FunctionDef:
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"function {name!r} not found in src/edgeguard.py")
+
+
+def _module_level_names(tree: ast.Module) -> set:
+    """Names defined at module top level (functions, classes, top-level
+    assignments, imported aliases). These are the "available" names a
+    function body can reference without injection."""
+    names: set = set()
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) or isinstance(node, ast.AsyncFunctionDef):
+            names.add(node.name)
+        elif isinstance(node, ast.ClassDef):
+            names.add(node.name)
+        elif isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    names.add(tgt.id)
+                elif isinstance(tgt, ast.Tuple):
+                    for elt in tgt.elts:
+                        if isinstance(elt, ast.Name):
+                            names.add(elt.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            names.add(node.target.id)
+        elif isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.asname or alias.name.split(".")[0])
+        elif isinstance(node, ast.ImportFrom):
+            for alias in node.names:
+                names.add(alias.asname or alias.name)
+    return names
+
+
+def _all_caps_names_referenced(func: ast.FunctionDef) -> set:
+    """All ALL_CAPS Name references (Load context) inside the function
+    body. These are the candidate names that need to come from
+    ``_CFG_EXPORTS`` injection or the runtime-imports path."""
+    names: set = set()
+    locally_assigned: set = set()
+
+    # Track local assignments inside the function so we don't flag
+    # ``X = "..."`` followed by a reference as an external dep.
+    for node in ast.walk(func):
+        if isinstance(node, ast.Assign):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    locally_assigned.add(tgt.id)
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.target, ast.Name):
+            locally_assigned.add(node.target.id)
+
+    for node in ast.walk(func):
+        if isinstance(node, ast.Name) and isinstance(node.ctx, ast.Load):
+            n = node.id
+            # Heuristic for "looks like a config constant"
+            if n.isupper() and len(n) >= 4 and not n.startswith("_") and n not in locally_assigned:
+                names.add(n)
+    return names
+
+
+def _runtime_injected_names() -> set:
+    """The names that ``_ensure_runtime_imports`` puts onto the module.
+
+    This MUST mirror ``_CFG_EXPORTS`` plus the explicit module-attribute
+    sets at the bottom of that helper (``MISPHealthCheck``,
+    ``PROMETHEUS_AVAILABLE``). Hard-coded here intentionally — if a future
+    PR changes ``_ensure_runtime_imports`` we want this test to fail
+    loudly so the contract is re-verified.
+    """
+    import edgeguard
+
+    return set(edgeguard._CFG_EXPORTS) | {"MISPHealthCheck", "PROMETHEUS_AVAILABLE"}
+
+
+# ---------------------------------------------------------------------------
+# Vanko's class-of-bug pin
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_doctor_references_no_uninjected_config_name():
+    """Every ALL_CAPS reference in cmd_doctor must be either:
+      * defined at module top level (a constant in edgeguard.py itself), OR
+      * registered in ``_CFG_EXPORTS`` for runtime injection, OR
+      * one of the explicitly-injected attrs (MISPHealthCheck etc.)
+
+    A regression in this test means a future PR added a config-module
+    reference (e.g. ``MISP_PASSWORD``) without registering it for
+    injection. In production that would crash with NameError partway
+    through doctor — exactly what Vanko reported.
+    """
+    tree = _load_edgeguard_ast()
+    func = _function_node(tree, "cmd_doctor")
+    referenced = _all_caps_names_referenced(func)
+    available = _module_level_names(tree) | _runtime_injected_names()
+    missing = referenced - available
+    assert not missing, (
+        f"cmd_doctor references ALL_CAPS name(s) not in the module top-level "
+        f"namespace AND not registered for runtime injection: {sorted(missing)}. "
+        f"Add them to ``_CFG_EXPORTS`` in src/edgeguard.py (or define them as "
+        f"module constants), or this will crash with NameError in production."
+    )
+
+
+def test_cmd_validate_references_no_uninjected_config_name():
+    """Same contract as cmd_doctor. Vanko's report named both functions."""
+    tree = _load_edgeguard_ast()
+    func = _function_node(tree, "cmd_validate")
+    referenced = _all_caps_names_referenced(func)
+    available = _module_level_names(tree) | _runtime_injected_names()
+    missing = referenced - available
+    assert not missing, (
+        f"cmd_validate references ALL_CAPS name(s) not in the module namespace "
+        f"AND not registered for runtime injection: {sorted(missing)}. "
+        f"Add them to ``_CFG_EXPORTS`` in src/edgeguard.py."
+    )
+
+
+def test_runtime_injection_names_actually_exist_on_config_module():
+    """Negative pin on the OTHER side of the contract: every name in
+    ``_CFG_EXPORTS`` must actually be defined in ``src/config.py``.
+
+    Otherwise ``_ensure_runtime_imports`` raises ``AttributeError`` at
+    startup — different bug, same root cause (drift between the export
+    list and reality). Catches the case where someone removes a config
+    constant without removing it from ``_CFG_EXPORTS``."""
+    import edgeguard
+
+    # Re-import config fresh so we see the actual module attrs (config.py
+    # raises at import time on missing required env vars; we tolerate
+    # that by skipping the test if config can't load — the doctor
+    # itself fails the same way and that's the right behavior).
+    try:
+        cfg = __import__("config", fromlist=["*"])
+    except Exception:
+        import pytest
+
+        pytest.skip("config.py requires real env vars to import — skipping injection-list audit")
+
+    missing = [n for n in edgeguard._CFG_EXPORTS if not hasattr(cfg, n)]
+    assert not missing, (
+        f"_CFG_EXPORTS lists name(s) that don't exist on src/config.py: "
+        f"{missing}. Either add them to config.py or remove from _CFG_EXPORTS."
+    )
+
+
+# ---------------------------------------------------------------------------
+# Smoke test for the new version_compatibility wiring
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_doctor_calls_version_compatibility_check():
+    """Source-grep pin: PR #36 wires ``compare_pinned_vs_running()`` into
+    cmd_doctor. If a future refactor accidentally drops the call,
+    operators lose the version-drift warning that's the whole point of
+    this PR. Pin structurally so the regression catches it."""
+    path = os.path.join(_SRC, "edgeguard.py")
+    with open(path) as fh:
+        src = fh.read()
+    # Locate cmd_doctor body and check the new section is present
+    start = src.find("def cmd_doctor(")
+    assert start > 0, "cmd_doctor not found"
+    # Find the boundary to next top-level def
+    end = src.find("\ndef ", start + 1)
+    body = src[start:end]
+    assert "version_compatibility" in body, (
+        "cmd_doctor must import + call version_compatibility.compare_pinned_vs_running — "
+        "Vanko's PR #36 explicit ask. Don't drop the wiring."
+    )
+    assert "Checking version compatibility" in body, (
+        "cmd_doctor must emit the operator-facing 'Checking version compatibility...' line"
+    )
+
+
+def test_cmd_validate_calls_version_compatibility_check():
+    """Same contract as cmd_doctor. Validate is the operator's pre-deploy
+    pass — it MUST surface version drift before the operator clicks
+    deploy."""
+    path = os.path.join(_SRC, "edgeguard.py")
+    with open(path) as fh:
+        src = fh.read()
+    start = src.find("def cmd_validate(")
+    assert start > 0, "cmd_validate not found"
+    end = src.find("\ndef ", start + 1)
+    body = src[start:end]
+    assert "version_compatibility" in body, (
+        "cmd_validate must import + call version_compatibility.compare_pinned_vs_running"
+    )

--- a/tests/test_version_compatibility.py
+++ b/tests/test_version_compatibility.py
@@ -412,3 +412,61 @@ def test_recommended_pymisp_matches_requirements_pin():
     assert pin, "requirements.txt must pin pymisp"
     recommended = RECOMMENDED_VERSIONS["pymisp"]
     assert pin.startswith(recommended)
+
+
+def test_recommended_airflow_matches_requirements_pin():
+    """PR #36 commit X (bugbot MED) regression pin.
+
+    Was previously blocked because ``read_requirements_pin``'s regex
+    didn't tolerate pip extras syntax — ``apache-airflow[postgres]~=3.2``
+    returned None and the test couldn't be written. With the regex
+    fix, this test now closes the only remaining gap in the
+    ``RECOMMENDED_VERSIONS`` ↔ pin-files sync coverage.
+    """
+    from version_compatibility import RECOMMENDED_VERSIONS, read_requirements_pin
+
+    pin = read_requirements_pin("requirements.txt", "apache-airflow")
+    assert pin, (
+        "requirements.txt must pin apache-airflow (with [postgres] extras) — "
+        "if this fails, either the pin was removed OR the extras-syntax regex regressed"
+    )
+    recommended = RECOMMENDED_VERSIONS["airflow"]
+    assert pin.startswith(recommended), (
+        f"requirements.txt pins apache-airflow~={pin}, but RECOMMENDED_VERSIONS['airflow']={recommended!r}. "
+        "Bump both together or doctor's drift warning lies."
+    )
+
+
+def test_read_requirements_pin_handles_pip_extras_syntax():
+    """Pure-function pin: ``read_requirements_pin`` MUST recognize
+    ``<package>[<extras>]~=<version>`` (pip extras form). Was a Tier-S
+    bugbot finding because the previous regex silently returned None
+    on any package with extras (apache-airflow being the most common
+    example). Includes a synthetic temp-file fixture so the test
+    doesn't depend on the real requirements.txt always pinning
+    apache-airflow with extras.
+    """
+    import tempfile
+    from pathlib import Path
+
+    import version_compatibility
+
+    with tempfile.TemporaryDirectory() as td:
+        # Place a fake requirements file under a temporary repo root.
+        # The function reads relative to ``_REPO_ROOT``, so monkeypatch via
+        # the module attribute.
+        fake_req = Path(td) / "fake-requirements.txt"
+        fake_req.write_text(
+            "# header\napache-airflow[postgres]~=3.2\nneo4j~=5.27\nstuff[a,b,c]  ~=  1.2\nno-extras~=9.9\n"
+        )
+        original_root = version_compatibility._REPO_ROOT
+        version_compatibility._REPO_ROOT = td
+        try:
+            assert version_compatibility.read_requirements_pin("fake-requirements.txt", "apache-airflow") == "3.2"
+            assert version_compatibility.read_requirements_pin("fake-requirements.txt", "stuff") == "1.2"
+            # No-extras form still works (regression: the new (?:\[...\])?
+            # group is optional, not required)
+            assert version_compatibility.read_requirements_pin("fake-requirements.txt", "no-extras") == "9.9"
+            assert version_compatibility.read_requirements_pin("fake-requirements.txt", "neo4j") == "5.27"
+        finally:
+            version_compatibility._REPO_ROOT = original_root

--- a/tests/test_version_compatibility.py
+++ b/tests/test_version_compatibility.py
@@ -89,6 +89,15 @@ def test_get_neo4j_server_version_calls_dbms_components():
     cypher = fake_client.run.call_args[0][0]
     assert "dbms.components()" in cypher
     assert "versions" in cypher
+    # PR #36 commit X (bugbot MED): Neo4j 2025.05+ adds a "Cypher" row
+    # to dbms.components() output. We MUST filter to Neo4j Kernel so we
+    # never pick up the Cypher-language version (e.g. "5") as the server
+    # version. Pin the WHERE filter at the source-grep level — without
+    # it, doctor reports falsely on every 2026.x deploy.
+    assert "Neo4j Kernel" in cypher, (
+        "Cypher MUST filter to component name 'Neo4j Kernel' — Neo4j 2025.05+ adds a "
+        "'Cypher' row that would otherwise be picked up as the server version"
+    )
     fake_client.close.assert_called_once(), "client must be closed even on success"
 
 

--- a/tests/test_version_compatibility.py
+++ b/tests/test_version_compatibility.py
@@ -98,7 +98,13 @@ def test_get_neo4j_server_version_calls_dbms_components():
         "Cypher MUST filter to component name 'Neo4j Kernel' — Neo4j 2025.05+ adds a "
         "'Cypher' row that would otherwise be picked up as the server version"
     )
-    fake_client.close.assert_called_once(), "client must be closed even on success"
+    # PR #36 commit X (bugbot LOW): the previous form was
+    # ``fake_client.close.assert_called_once(), "msg"`` — a bare
+    # tuple expression that discarded the message. assert_called_once()
+    # already raises AssertionError with its own descriptive output;
+    # the trailing message was dead code from a misremembered ``assert
+    # X, "msg"`` pattern.
+    fake_client.close.assert_called_once()
 
 
 def test_get_neo4j_server_version_returns_none_on_connection_failure():
@@ -412,6 +418,53 @@ def test_recommended_neo4j_driver_matches_airflow_image_requirements_pin():
         f"requirements-airflow-docker.txt pins neo4j~={pin}; CLI requirements.txt + "
         f"RECOMMENDED_VERSIONS['neo4j_driver']={recommended!r} — keep them aligned."
     )
+
+
+def test_compare_pinned_vs_running_uses_provided_misp_version_skipping_probe(monkeypatch):
+    """PR #36 commit X (bugbot LOW) regression pin.
+
+    When the caller passes ``misp_server_version=...``, the function
+    MUST use that value and NOT call ``get_misp_server_version()``.
+    Without this, ``cmd_doctor`` makes two MISP round-trips per run.
+    """
+    import version_compatibility
+
+    # Patch the internal MISP probe to bomb if invoked — proves the
+    # caller's pre-captured value is honored, not re-fetched.
+    def _bomb():
+        raise RuntimeError("get_misp_server_version must NOT be called when caller supplies misp_server_version")
+
+    monkeypatch.setattr(version_compatibility, "get_misp_server_version", _bomb)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False  # don't try a real Neo4j
+
+    rows = version_compatibility.compare_pinned_vs_running(
+        neo4j_client_factory=lambda: fake_client,
+        misp_server_version="2.4.180",
+    )
+    misp_row = next(r for r in rows if r[0] == "misp_server")
+    # Status should be "ok" since 2.4.180 matches the pinned major.minor of 2.4
+    assert misp_row[1] == "ok", f"misp_server with 2.4.180 should match pin 2.4; got {misp_row}"
+
+
+def test_compare_pinned_vs_running_falls_back_to_probe_when_no_value_provided(monkeypatch):
+    """Negative pin: caller doesn't pass misp_server_version → function
+    DOES call get_misp_server_version (the existing behavior pre-LOW)."""
+    import version_compatibility
+
+    probe_calls = {"n": 0}
+
+    def _counting_probe():
+        probe_calls["n"] += 1
+        return "2.4.180"
+
+    monkeypatch.setattr(version_compatibility, "get_misp_server_version", _counting_probe)
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False
+    version_compatibility.compare_pinned_vs_running(neo4j_client_factory=lambda: fake_client)
+    assert probe_calls["n"] == 1, "default path must call get_misp_server_version exactly once"
 
 
 def test_recommended_pymisp_matches_requirements_pin():

--- a/tests/test_version_compatibility.py
+++ b/tests/test_version_compatibility.py
@@ -1,0 +1,377 @@
+"""PR #36 — tests for ``src/version_compatibility.py``.
+
+Covers:
+  * Each ``get_*_version()`` is best-effort and returns ``None`` instead
+    of raising on any failure (Vanko's "doctor must not crash" contract)
+  * ``compare_version`` correctly classifies match / minor drift /
+    major drift / unknown
+  * ``compare_pinned_vs_running`` produces the deterministic ordered
+    report doctor + validate iterate
+  * ``RECOMMENDED_VERSIONS`` stays in sync with ``docker-compose.yml``
+    and ``requirements.txt`` (regression: bump the pin without bumping
+    this table → test fails)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+# ---------------------------------------------------------------------------
+# Best-effort capture functions — must NEVER raise
+# ---------------------------------------------------------------------------
+
+
+def test_get_neo4j_driver_version_returns_string_or_none():
+    """If neo4j is installed (it is in dev), we get a string; if not, None.
+    Either way: no exception escapes."""
+    from version_compatibility import get_neo4j_driver_version
+
+    result = get_neo4j_driver_version()
+    assert result is None or isinstance(result, str)
+
+
+def test_get_neo4j_driver_version_swallows_import_error():
+    """Simulate neo4j not installed (slim container scenario) — must
+    return None, NOT raise ImportError up to doctor."""
+    # Patch builtins.__import__ to raise on neo4j specifically
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _bomb_neo4j(name, *args, **kwargs):
+        if name == "neo4j":
+            raise ImportError("simulated: neo4j not installed")
+        return real_import(name, *args, **kwargs)
+
+    with patch("builtins.__import__", side_effect=_bomb_neo4j):
+        # Force a re-evaluation by re-importing
+        import importlib
+
+        import version_compatibility
+
+        importlib.reload(version_compatibility)
+        result = version_compatibility.get_neo4j_driver_version()
+
+    # Reload again to restore the real import
+    import importlib
+
+    import version_compatibility
+
+    importlib.reload(version_compatibility)
+
+    assert result is None, "missing neo4j must yield None, not raise"
+
+
+def test_get_neo4j_server_version_calls_dbms_components():
+    """Verify the canonical Cypher (`CALL dbms.components() YIELD versions`)
+    is what gets executed, and the first version string from the row is
+    returned. Pins the contract so a future refactor doesn't switch to a
+    different procedure that may not exist on older Neo4j."""
+    from version_compatibility import get_neo4j_server_version
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.run.return_value = [{"versions": ["2026.03.1"]}]
+    fake_client.close = MagicMock()
+
+    def factory():
+        return fake_client
+
+    result = get_neo4j_server_version(neo4j_client_factory=factory)
+
+    assert result == "2026.03.1"
+    fake_client.run.assert_called_once()
+    cypher = fake_client.run.call_args[0][0]
+    assert "dbms.components()" in cypher
+    assert "versions" in cypher
+    fake_client.close.assert_called_once(), "client must be closed even on success"
+
+
+def test_get_neo4j_server_version_returns_none_on_connection_failure():
+    """Neo4j down → factory's connect() returns False → must return None,
+    NOT raise. This is the doctor-friendly failure mode: there's already
+    a separate doctor check for "Neo4j connection" — version-capture
+    failure shouldn't double-report."""
+    from version_compatibility import get_neo4j_server_version
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False
+
+    result = get_neo4j_server_version(neo4j_client_factory=lambda: fake_client)
+    assert result is None
+
+
+def test_get_neo4j_server_version_returns_none_when_run_raises():
+    """Cypher execution raises (e.g. `CALL dbms.components()` not
+    available on a non-standard Neo4j fork) → must return None."""
+    from version_compatibility import get_neo4j_server_version
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.run.side_effect = RuntimeError("simulated cypher failure")
+
+    result = get_neo4j_server_version(neo4j_client_factory=lambda: fake_client)
+    assert result is None
+
+
+def test_get_neo4j_server_version_closes_client_even_on_exception():
+    """Resource hygiene: a Cypher exception must not leak the connection."""
+    from version_compatibility import get_neo4j_server_version
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = True
+    fake_client.run.side_effect = RuntimeError("boom")
+
+    get_neo4j_server_version(neo4j_client_factory=lambda: fake_client)
+    fake_client.close.assert_called_once()
+
+
+def test_get_airflow_version_via_subprocess_fallback():
+    """If airflow isn't importable but the binary is on PATH, parse the
+    subprocess output. We do NOT exercise the import path here because
+    it depends on whether airflow is installed in the dev env — which
+    it is in our DAG-test path. This subprocess-only path is what would
+    fire on a CLI host without the airflow package."""
+    from version_compatibility import get_airflow_version
+
+    fake_completed = MagicMock()
+    fake_completed.returncode = 0
+    fake_completed.stdout = "Airflow build banner\n3.2.0\nmore noise\n"
+
+    # Force the import path to fail so we hit the subprocess fallback
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _no_airflow_import(name, *args, **kwargs):
+        if name == "airflow":
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    with (
+        patch("builtins.__import__", side_effect=_no_airflow_import),
+        patch("subprocess.run", return_value=fake_completed),
+    ):
+        result = get_airflow_version()
+
+    assert result == "3.2.0"
+
+
+def test_get_airflow_version_returns_none_when_neither_probe_works():
+    """Neither importable nor binary → None. Doctor renders this as
+    info, not warn."""
+    from version_compatibility import get_airflow_version
+
+    real_import = __builtins__["__import__"] if isinstance(__builtins__, dict) else __builtins__.__import__
+
+    def _no_airflow_import(name, *args, **kwargs):
+        if name == "airflow":
+            raise ImportError("simulated")
+        return real_import(name, *args, **kwargs)
+
+    with (
+        patch("builtins.__import__", side_effect=_no_airflow_import),
+        patch("subprocess.run", side_effect=FileNotFoundError("airflow binary not found")),
+    ):
+        result = get_airflow_version()
+
+    assert result is None
+
+
+def test_get_misp_server_version_uses_misp_health_check():
+    """Reuses ``MISPHealthCheck.check_health()`` rather than duplicating
+    the API call. Patch the health check to return a known version + a
+    matching ``details`` dict shape."""
+    from version_compatibility import get_misp_server_version
+
+    fake_result = MagicMock()
+    fake_result.details = {"version": "2.4.180"}
+
+    fake_check = MagicMock()
+    fake_check.return_value.check_health.return_value = fake_result
+
+    with patch.dict(sys.modules, {"misp_health": MagicMock(MISPHealthCheck=fake_check)}):
+        result = get_misp_server_version()
+
+    assert result == "2.4.180"
+
+
+def test_get_misp_server_version_returns_none_when_check_raises():
+    """MISP unreachable → check_health raises → must return None."""
+    from version_compatibility import get_misp_server_version
+
+    fake_check = MagicMock()
+    fake_check.return_value.check_health.side_effect = ConnectionError("simulated")
+
+    with patch.dict(sys.modules, {"misp_health": MagicMock(MISPHealthCheck=fake_check)}):
+        result = get_misp_server_version()
+
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# compare_version: 4 outcome classes
+# ---------------------------------------------------------------------------
+
+
+def test_compare_version_ok_on_exact_major_minor_match():
+    from version_compatibility import compare_version
+
+    status, msg = compare_version("neo4j_driver", "5.27.1")
+    assert status == "ok", msg
+    assert "matches recommended" in msg
+
+
+def test_compare_version_ok_ignores_patch_drift():
+    """Patch drift is fine — the project's ~= policy explicitly allows it."""
+    from version_compatibility import compare_version
+
+    # Recommended is "5.27"; running "5.27.999" should still be OK
+    status, _ = compare_version("neo4j_driver", "5.27.999")
+    assert status == "ok"
+
+
+def test_compare_version_warn_on_minor_drift():
+    from version_compatibility import compare_version
+
+    # Recommended "5.27", running "5.28" → minor drift
+    status, msg = compare_version("neo4j_driver", "5.28.0")
+    assert status == "warn"
+    assert "minor drift" in msg
+
+
+def test_compare_version_warn_on_major_drift_calls_out_breaking_changes():
+    """Major drift wording must alert the operator to verify call sites —
+    that's the actionable instruction. A bare warning without context
+    fails its purpose."""
+    from version_compatibility import compare_version
+
+    status, msg = compare_version("neo4j_driver", "6.1.0")
+    assert status == "warn"
+    assert "MAJOR" in msg
+    assert "breaking" in msg.lower() or "verify" in msg.lower()
+
+
+def test_compare_version_unknown_when_running_is_none():
+    """Running version not detected (component not installed) → unknown,
+    NOT warn. Slack about a missing optional dep is noise."""
+    from version_compatibility import compare_version
+
+    status, msg = compare_version("neo4j_driver", None)
+    assert status == "unknown"
+    assert "not detected" in msg
+
+
+def test_compare_version_unknown_for_unregistered_component():
+    """Bug guard: if doctor asks about a component we never registered,
+    say so — don't silently 'ok'."""
+    from version_compatibility import compare_version
+
+    status, _ = compare_version("totally_made_up_component", "1.2.3")
+    assert status == "unknown"
+
+
+def test_compare_version_unknown_when_running_unparseable():
+    """Some fork or dev build returns a non-semver string. Don't crash;
+    don't lie about the comparison."""
+    from version_compatibility import compare_version
+
+    status, _ = compare_version("neo4j_driver", "git-snapshot-abc123")
+    assert status == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# compare_pinned_vs_running: full report shape
+# ---------------------------------------------------------------------------
+
+
+def test_compare_pinned_vs_running_returns_one_row_per_recommended_component():
+    """Doctor iterates this list and renders each row. Order matters
+    (we display in ``order`` from the function); count must match the
+    recommended-versions table so nothing is missed."""
+    from version_compatibility import RECOMMENDED_VERSIONS, compare_pinned_vs_running
+
+    # Inject a stub Neo4j factory so server probe doesn't try a real
+    # connection in test env.
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False  # don't bother running cypher
+
+    rows = compare_pinned_vs_running(neo4j_client_factory=lambda: fake_client)
+    components = {r[0] for r in rows}
+    assert components == set(RECOMMENDED_VERSIONS.keys()), (
+        f"every recommended-versions entry must appear exactly once in the report; "
+        f"got {components}, expected {set(RECOMMENDED_VERSIONS.keys())}"
+    )
+
+
+def test_compare_pinned_vs_running_each_row_has_ok_warn_or_unknown_status():
+    from version_compatibility import compare_pinned_vs_running
+
+    fake_client = MagicMock()
+    fake_client.connect.return_value = False
+    rows = compare_pinned_vs_running(neo4j_client_factory=lambda: fake_client)
+    for component, status, message in rows:
+        assert status in {"ok", "warn", "unknown"}, f"{component}: bad status {status!r}"
+        assert isinstance(message, str) and message, f"{component}: empty message"
+
+
+# ---------------------------------------------------------------------------
+# RECOMMENDED_VERSIONS must stay in sync with the actual pin files
+# ---------------------------------------------------------------------------
+
+
+def test_recommended_neo4j_server_matches_docker_compose_pin():
+    """Bumping ``docker-compose.yml`` neo4j image without updating
+    ``RECOMMENDED_VERSIONS["neo4j_server"]`` would silently make the
+    drift warning lie. Pin them together."""
+    from version_compatibility import RECOMMENDED_VERSIONS, read_docker_compose_neo4j_image
+
+    tag = read_docker_compose_neo4j_image()
+    assert tag, "docker-compose.yml must declare a neo4j image — couldn't parse the pin"
+    recommended = RECOMMENDED_VERSIONS["neo4j_server"]
+    assert tag.startswith(recommended), (
+        f"docker-compose.yml pins neo4j:{tag} but RECOMMENDED_VERSIONS['neo4j_server'] is "
+        f"{recommended!r}. They must agree on major.minor — bump both in the same PR."
+    )
+
+
+def test_recommended_neo4j_driver_matches_requirements_pin():
+    from version_compatibility import RECOMMENDED_VERSIONS, read_requirements_pin
+
+    pin = read_requirements_pin("requirements.txt", "neo4j")
+    assert pin, "requirements.txt must declare neo4j ~=N.M"
+    recommended = RECOMMENDED_VERSIONS["neo4j_driver"]
+    assert pin.startswith(recommended), (
+        f"requirements.txt pins neo4j~={pin} but RECOMMENDED_VERSIONS['neo4j_driver']={recommended!r}"
+    )
+
+
+def test_recommended_neo4j_driver_matches_airflow_image_requirements_pin():
+    """Same pin must appear in requirements-airflow-docker.txt (the
+    ones baked into the Airflow image). If they drift, scheduler workers
+    end up on a different driver line than the CLI — silently."""
+    from version_compatibility import RECOMMENDED_VERSIONS, read_requirements_pin
+
+    pin = read_requirements_pin("requirements-airflow-docker.txt", "neo4j")
+    if pin is None:
+        # File optional in some setups; only enforce if it exists.
+        import pytest
+
+        pytest.skip("requirements-airflow-docker.txt not present")
+    recommended = RECOMMENDED_VERSIONS["neo4j_driver"]
+    assert pin.startswith(recommended), (
+        f"requirements-airflow-docker.txt pins neo4j~={pin}; CLI requirements.txt + "
+        f"RECOMMENDED_VERSIONS['neo4j_driver']={recommended!r} — keep them aligned."
+    )
+
+
+def test_recommended_pymisp_matches_requirements_pin():
+    from version_compatibility import RECOMMENDED_VERSIONS, read_requirements_pin
+
+    pin = read_requirements_pin("requirements.txt", "pymisp")
+    assert pin, "requirements.txt must pin pymisp"
+    recommended = RECOMMENDED_VERSIONS["pymisp"]
+    assert pin.startswith(recommended)

--- a/tests/test_version_compatibility.py
+++ b/tests/test_version_compatibility.py
@@ -106,6 +106,43 @@ def test_get_neo4j_server_version_returns_none_on_connection_failure():
     assert result is None
 
 
+def test_get_neo4j_server_version_default_path_uses_fast_driver_not_neo4jclient_connect():
+    """PR #36 commit X (bugbot MED) regression pin.
+
+    Background: ``Neo4jClient.connect()`` is decorated with
+    ``@retry_with_backoff(max_retries=5, base_delay=2)`` → up to ~62
+    seconds of exponential backoff when Neo4j is unreachable. When
+    ``get_neo4j_server_version()`` was called WITHOUT a factory (the
+    production path from doctor/validate), it instantiated
+    ``Neo4jClient()`` and called ``connect()``, paying that 62-second
+    retry cycle as a SECOND probe (doctor/validate already did the
+    first probe upstream). Bug report: doctor wall-clock roughly
+    doubled on a Neo4j outage for zero diagnostic value.
+
+    Fix: the default-factory path now goes through
+    ``_get_neo4j_server_version_fast()`` which uses the Neo4j driver
+    DIRECTLY with ``connection_timeout=2.0`` so a probe against a down
+    Neo4j fails in seconds, not minutes.
+
+    Pin: source-grep the production branch routes to the fast helper,
+    and that the fast helper sets a tight ``connection_timeout``.
+    """
+    import inspect
+
+    import version_compatibility
+
+    src = inspect.getsource(version_compatibility.get_neo4j_server_version)
+    assert "_get_neo4j_server_version_fast" in src, (
+        "get_neo4j_server_version's default-factory branch MUST route to the fast driver path "
+        "to avoid the @retry_with_backoff(5, 2) ~62s cycle on a Neo4j outage. "
+        "If this assertion fails, doctor/validate hangs for ~minute on a downed Neo4j."
+    )
+    fast_src = inspect.getsource(version_compatibility._get_neo4j_server_version_fast)
+    assert "connection_timeout" in fast_src, (
+        "_get_neo4j_server_version_fast must set connection_timeout to fail fast on a down Neo4j"
+    )
+
+
 def test_get_neo4j_server_version_returns_none_when_run_raises():
     """Cypher execution raises (e.g. `CALL dbms.components()` not
     available on a non-standard Neo4j fork) → must return None."""


### PR DESCRIPTION
## Summary

Vanko's follow-up to PR #35 raised two adjacent gaps:

1. **Stale Neo4j docker pin.** `docker-compose.yml` pinned `neo4j:5.26.23-community` but operators are running Neo4j 2026.x locally. `docker-compose up` would silently rebuild the container at the older line on the next `down/up` cycle — rolling back the data layer without warning.

2. **No runtime visibility into actual versions.** Neither `edgeguard doctor` nor `edgeguard validate` reported what was actually running. Operators only learned about a mismatch via mysterious runtime errors (PyMISP method gone, Cypher syntax shift, etc.).

Vanko also reported a `NameError` in cmd_doctor / cmd_validate from a stale checkout. Current `main` does not actually crash (`_ensure_runtime_imports()` injects the names), but the fragility is real — the AST scanner test in this PR pins the contract structurally so any future regression is caught at test time, not in production.

## What changed

### New
- **`src/version_compatibility.py`** — `RECOMMENDED_VERSIONS` table + best-effort capture functions for Neo4j server/driver, Airflow, PyMISP, MISP server. `compare_pinned_vs_running()` returns ordered `(component, status, message)` rows for doctor/validate to render. Every capture is best-effort + returns `None` on failure — doctor must NEVER crash because version capture failed.
- **`tests/test_edgeguard_doctor_audit.py`** — AST scanner pin (Vanko's class-of-bug): verifies every ALL_CAPS reference inside `cmd_doctor`/`cmd_validate` is either locally defined or registered in `_CFG_EXPORTS`. Verified by temporary fake `MISP_PASSWORD` injection — fails with actionable message.
- **`tests/test_version_compatibility.py`** — 23 tests covering each capture function's failure modes, the four `compare_version` outcome classes, and pin-table-vs-actual-files sync.

### Modified
- **`src/edgeguard.py`** — `cmd_doctor` + `cmd_validate` get a new "Checking version compatibility..." section.
- **`docker-compose.yml`** — `neo4j:5.26.23-community` → `neo4j:2026.03.1-community`. Header comment cites the [Neo4j compat matrix](https://neo4j.com/developer/kb/neo4j-supported-versions/) confirming 5.x driver is wire-compat with 2026.x server.
- **`requirements.txt`** — header above `neo4j~=5.27` documents the server/driver version split.
- **`docs/ENVIRONMENTS.md`** — new "Pinned component versions" table.

## Out of scope (deliberate)

- Neo4j driver bump to 6.x — major version change, separate PR per the existing `~=` SemVer policy.
- Auto-bumping pins to "latest" — operator decides; this PR only surfaces drift.

## Test plan

- [x] 28 new tests pass
- [x] 470 full pytest pass (was 442; +28 new)
- [x] ruff format/check + mypy clean
- [x] AST scanner verified to catch a fresh uninjected reference (temporary `MISP_PASSWORD` injection → expected failure → restored → green)
- [ ] CI green (Lint, Unit, Docker build, Dep scan, Cursor Bugbot)
- [ ] Bugbot review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the deployed Neo4j Docker image to `2026.03.1-community` and adds new runtime version-capture logic surfaced in `edgeguard doctor/validate`, which could affect operator environments and diagnostics behavior but not core pipeline execution.
> 
> **Overview**
> **Adds runtime dependency drift visibility to ops tooling.** `edgeguard doctor` and `edgeguard validate` now run a best-effort version compatibility report (Neo4j server/driver, Airflow, MISP, PyMISP) and emit `ok/warn/info` messages without ever crashing if a probe fails; doctor also reuses the earlier MISP health check result to avoid an extra network call.
> 
> **Introduces a new version-compatibility module + regression tests.** New `src/version_compatibility.py` defines a `RECOMMENDED_VERSIONS` table, capture helpers, and `compare_pinned_vs_running()`, plus tests that enforce capture failure-safety, correct drift classification, deterministic output ordering, and that recommended versions stay in sync with `docker-compose.yml`/`requirements.txt` pins (including parsing requirement pins with pip extras).
> 
> **Bumps and documents pinned component versions.** `docker-compose.yml` switches Neo4j from `5.26.23-community` to `2026.03.1-community`, and docs/badges/diagrams are updated to reflect Neo4j `2026.03` (and Airflow `3.2` in the architecture docs), with environment docs adding an explicit pinned-version table verified by `edgeguard doctor`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dc9ae96bd357e4e3fac1d947a1de9c32afe21938. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->