### PR TITLE
fix(lock): atomic O_EXCL acquisition for pipeline.lock + baseline sentinel

### DIFF
--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -186,10 +186,32 @@ def acquire_baseline_lock() -> bool:
     The caller is responsible for calling `release_baseline_lock()` on
     exit — both success and failure paths. `_run_pipeline_inner` wraps
     this in a try/finally alongside the existing pipeline.lock cleanup.
+
+    PR #38 (Bug Hunter Tier S S2): the sentinel acquisition is now
+    ATOMIC via ``os.open(path, O_CREAT|O_EXCL|O_WRONLY)``. The previous
+    pattern — ``is_baseline_running()`` (read sentinel) THEN
+    ``os.replace(tmp, path)`` — was non-atomic: two concurrent
+    baselines could both see ``existing is None``, both write to their
+    own tmp file, both rename in (last writer wins), and both proceed
+    thinking they hold the lock. ``release_baseline_lock`` then
+    erroneously deleted the winner's sentinel via the loser's
+    PID-mismatch check. Net: both baselines ran unguarded against
+    scheduled DAGs — the exact race the lock was meant to prevent.
+
+    ``O_EXCL`` is POSIX-defined as atomic create-or-fail: if the
+    sentinel already exists, ``os.open`` raises ``FileExistsError`` AND
+    does not touch the existing file. No window for a racing process.
+    Stale-sentinel pruning (the dead-PID + age-based logic in
+    ``is_baseline_running``) still runs before the atomic acquisition;
+    if THAT detects a stale lock it unlinks first, then we attempt the
+    atomic create.
     """
     path = baseline_lock_path()
     os.makedirs(os.path.dirname(path), exist_ok=True)
 
+    # Stale-pruning: ``is_baseline_running`` will unlink an obviously-stale
+    # sentinel (dead PID, too old) and return None. If it returns a payload,
+    # there's a live baseline.
     existing = is_baseline_running()
     if existing is not None:
         logger.error(
@@ -209,16 +231,43 @@ def acquire_baseline_lock() -> bool:
         "started_at": datetime.now(timezone.utc).isoformat(),
         "monotonic_started": time.monotonic(),
     }
+    serialized = json.dumps(payload).encode("utf-8")
+
+    # Atomic create-or-fail. If FileExistsError fires, a competitor slipped
+    # in between our ``is_baseline_running`` check and this ``os.open`` —
+    # they win, we abort. If ANY other OSError fires, log + abort to be
+    # safe (we'd rather refuse than start a baseline whose lock state is
+    # unknowable).
     try:
-        # Atomic-ish write: write to tmp then rename so a reader never sees
-        # a half-written JSON blob.
-        tmp_path = f"{path}.tmp.{os.getpid()}"
-        with open(tmp_path, "w") as f:
-            json.dump(payload, f)
-        os.replace(tmp_path, path)
+        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+    except FileExistsError:
+        logger.error(
+            "Refusing to start baseline: lost the lock-acquisition race "
+            "to another baseline that started in the gap between the "
+            "stale-pruning check and the atomic create. Path: %s",
+            path,
+        )
+        return False
     except OSError as exc:
         logger.error("Failed to acquire baseline lock at %s: %s", path, exc)
         return False
+
+    try:
+        os.write(fd, serialized)
+    except OSError as exc:
+        logger.error("Failed to write baseline-lock payload to %s: %s", path, exc)
+        # Roll back the empty/partial sentinel so the next attempt isn't blocked.
+        try:
+            os.close(fd)
+            os.unlink(path)
+        except OSError:
+            pass
+        return False
+    finally:
+        try:
+            os.close(fd)
+        except OSError:
+            pass
 
     logger.info(
         "Acquired baseline lock at %s (pid=%s host=%s)",

--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -178,6 +178,39 @@ def _safe_remove(path: str) -> None:
         logger.warning("Failed to remove baseline lock %s: %s", path, exc)
 
 
+def _is_corrupt_sentinel(path: str) -> bool:
+    """Return True iff the sentinel file at ``path`` is empty or unparseable
+    JSON (i.e. a crash-during-write artifact, not a live lock).
+
+    Used by ``acquire_baseline_lock`` to recover from the SIGKILL-between-
+    O_EXCL-and-write race. Distinct from the empty-string check in
+    ``is_baseline_running`` because that one returns None on the SAME
+    condition (with the implicit interpretation "no live lock"); this one
+    explicitly says "this file is junk, safe to unlink".
+
+    Returns False if the file is missing (the caller's prior FileExistsError
+    must have raced with a competitor's ``release_baseline_lock``), or if
+    it parses as a valid JSON object — that's a real live lock and we
+    must NOT delete it.
+    """
+    try:
+        with open(path) as f:
+            content = f.read().strip()
+    except FileNotFoundError:
+        return False
+    except OSError:
+        # Can't read at all — leave it alone; caller will see FileExistsError again.
+        return False
+    if not content:
+        return True
+    try:
+        parsed = json.loads(content)
+    except (ValueError, TypeError):
+        return True
+    # Valid JSON but not a dict → also corrupt
+    return not isinstance(parsed, dict)
+
+
 def acquire_baseline_lock() -> bool:
     """
     Write the sentinel file. Returns True on success, False if another
@@ -235,19 +268,62 @@ def acquire_baseline_lock() -> bool:
 
     # Atomic create-or-fail. If FileExistsError fires, a competitor slipped
     # in between our ``is_baseline_running`` check and this ``os.open`` —
-    # they win, we abort. If ANY other OSError fires, log + abort to be
-    # safe (we'd rather refuse than start a baseline whose lock state is
-    # unknowable).
+    # OR a previous process was killed AFTER O_EXCL created the sentinel
+    # but BEFORE os.write completed (SIGKILL, power loss). In the latter
+    # case, the file exists but is empty/corrupt — ``is_baseline_running``
+    # returns None (its JSON parse fails silently), the dead-PID/age
+    # pruning never fires, and we'd be permanently locked out until
+    # someone manually deletes the sentinel.
+    #
+    # PR #38 commit X (bugbot MED): on FileExistsError, do a SECOND
+    # corrupt-sentinel probe — try to read+parse the file. If it's
+    # genuinely unparseable (zero-byte, truncated JSON), unlink it and
+    # retry the atomic create exactly once. The old ``os.replace``
+    # pattern tolerated this case by silently overwriting; with O_EXCL
+    # we have to handle it explicitly.
+    def _attempt_atomic_create() -> int:
+        """Single atomic create attempt; returns fd on success, raises
+        OSError (including FileExistsError) on failure. Caller MUST handle
+        the exception — there is no None return path."""
+        return os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+
     try:
-        fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+        fd = _attempt_atomic_create()
     except FileExistsError:
-        logger.error(
-            "Refusing to start baseline: lost the lock-acquisition race "
-            "to another baseline that started in the gap between the "
-            "stale-pruning check and the atomic create. Path: %s",
-            path,
-        )
-        return False
+        # Probe whether the existing sentinel is empty/corrupt — if so, treat
+        # as a crash-during-write artifact and retry once.
+        if _is_corrupt_sentinel(path):
+            logger.warning(
+                "Detected empty/corrupt baseline-lock sentinel at %s — "
+                "likely a crash during write; unlinking + retrying once.",
+                path,
+            )
+            try:
+                os.unlink(path)
+            except OSError as unlink_exc:
+                logger.error(
+                    "Failed to unlink corrupt baseline-lock sentinel at %s: %s",
+                    path,
+                    unlink_exc,
+                )
+                return False
+            try:
+                fd = _attempt_atomic_create()
+            except OSError as retry_exc:
+                logger.error(
+                    "Failed to acquire baseline lock at %s after corrupt-sentinel cleanup: %s",
+                    path,
+                    retry_exc,
+                )
+                return False
+        else:
+            logger.error(
+                "Refusing to start baseline: lost the lock-acquisition race "
+                "to another baseline that started in the gap between the "
+                "stale-pruning check and the atomic create. Path: %s",
+                path,
+            )
+            return False
     except OSError as exc:
         logger.error("Failed to acquire baseline lock at %s: %s", path, exc)
         return False

--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -252,22 +252,31 @@ def acquire_baseline_lock() -> bool:
         logger.error("Failed to acquire baseline lock at %s: %s", path, exc)
         return False
 
+    # PR #38 commit X (bugbot MED): close the fd EXACTLY ONCE. The
+    # previous structure had close inside both the except branch AND
+    # the finally, racing to double-close → EBADF on the second close
+    # (silently swallowed, but ugly). The cleaner pattern: close in
+    # finally only; on write failure, the finally still runs, then
+    # we unlink the partial sentinel AFTER the close completes.
+    write_failed = False
     try:
         os.write(fd, serialized)
     except OSError as exc:
         logger.error("Failed to write baseline-lock payload to %s: %s", path, exc)
-        # Roll back the empty/partial sentinel so the next attempt isn't blocked.
-        try:
-            os.close(fd)
-            os.unlink(path)
-        except OSError:
-            pass
-        return False
+        write_failed = True
     finally:
         try:
             os.close(fd)
         except OSError:
             pass
+
+    if write_failed:
+        # Roll back the empty/partial sentinel so the next attempt isn't blocked.
+        try:
+            os.unlink(path)
+        except OSError:
+            pass
+        return False
 
     logger.info(
         "Acquired baseline lock at %s (pid=%s host=%s)",

--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -178,21 +178,62 @@ def _safe_remove(path: str) -> None:
         logger.warning("Failed to remove baseline lock %s: %s", path, exc)
 
 
+# How long a sentinel must be unchanged before we'll treat "empty or
+# unparseable content" as crash debris vs. an active-write-in-progress
+# by a competitor. 5 minutes is MASSIVELY conservative — a legitimate
+# ``os.open(O_EXCL)`` → ``os.write`` window is sub-millisecond — but it
+# eliminates the window where Process B could mistake Process A's
+# mid-write empty file for a crash artifact and unlink it.
+#
+# See ``_is_corrupt_sentinel`` docstring for the race scenario.
+_CRASH_RECOVERY_AGE_SECS = 300
+
+
 def _is_corrupt_sentinel(path: str) -> bool:
-    """Return True iff the sentinel file at ``path`` is empty or unparseable
-    JSON (i.e. a crash-during-write artifact, not a live lock).
+    """Return True iff the sentinel file at ``path`` is BOTH:
+      * empty or contains unparseable-as-dict content, AND
+      * older than ``_CRASH_RECOVERY_AGE_SECS`` (mtime check).
 
-    Used by ``acquire_baseline_lock`` to recover from the SIGKILL-between-
-    O_EXCL-and-write race. Distinct from the empty-string check in
-    ``is_baseline_running`` because that one returns None on the SAME
-    condition (with the implicit interpretation "no live lock"); this one
-    explicitly says "this file is junk, safe to unlink".
+    The mtime check is CRITICAL for correctness (PR #38 bugbot HIGH).
+    Without it, this recovery path re-introduces the TOCTOU race that
+    atomic ``O_EXCL`` was added to eliminate:
 
-    Returns False if the file is missing (the caller's prior FileExistsError
-    must have raced with a competitor's ``release_baseline_lock``), or if
-    it parses as a valid JSON object — that's a real live lock and we
-    must NOT delete it.
+      Process A: os.open(O_EXCL) → succeeds, fd held
+      Process B: os.open(O_EXCL) → FileExistsError
+      Process B: reads file → empty (A hasn't written yet!)
+      Process B: _is_corrupt_sentinel → True (WITHOUT age check)
+      Process B: unlinks file → succeeds
+      Process A: writes to orphaned inode → succeeds
+      Process A: returns True  ┐
+      Process B: os.open(O_EXCL) → succeeds on the re-created file
+      Process B: returns True  ┘  BOTH hold the "lock" — bug returns.
+
+    With the age check, Process B sees file is fresh (mtime seconds ago,
+    not minutes) and refuses rather than unlinking. Only genuinely stale
+    crash debris (5+ minutes old, empty) gets auto-recovered.
+
+    Distinct from the empty-string check in ``is_baseline_running``
+    because that one returns None on the SAME condition (interpretation:
+    "no live lock"); this one explicitly says "this file is junk AND old
+    enough to be safely unlinked".
+
+    Returns False if the file is missing, too young for the age check,
+    or parses as a valid JSON dict (a real live lock — we must NOT
+    delete it).
     """
+    try:
+        stat = os.stat(path)
+    except FileNotFoundError:
+        return False
+    except OSError:
+        return False
+
+    age_secs = time.time() - stat.st_mtime
+    if age_secs < _CRASH_RECOVERY_AGE_SECS:
+        # File is fresh — might be a competitor's mid-write O_EXCL. Refuse
+        # to interpret as crash debris regardless of content.
+        return False
+
     try:
         with open(path) as f:
             content = f.read().strip()

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -937,6 +937,14 @@ class EdgeGuardPipeline:
                 fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
             except FileExistsError:
                 return False
+            except OSError as exc:
+                # PR #38 commit X (bugbot MED): catch the broader OSError too.
+                # PermissionError, ENOSPC (disk full), EROFS (read-only fs) etc.
+                # would otherwise propagate UNCAUGHT through the caller — the
+                # pipeline crashes with a stack trace instead of cleanly
+                # refusing to start. Mirrors the baseline_lock.py pattern.
+                logger.error(f"Failed to acquire pipeline lock at {path}: {exc}")
+                return False
             write_failed = False
             try:
                 os.write(fd, str(os.getpid()).encode("ascii"))

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -921,17 +921,40 @@ class EdgeGuardPipeline:
 
             Returns True iff THIS process now exclusively owns the lock
             file. Returns False on FileExistsError (someone else holds
-            it). Any other OSError propagates to the caller.
+            it). Returns False on write failure too — the partial sentinel
+            is rolled back so a retry can proceed cleanly. Any other
+            OSError on the create itself propagates to the caller.
+
+            PR #38 commit X (bugbot MED): added the write-failure
+            rollback. Previously a write OSError propagated up
+            uncaught while the empty/partial lock file lingered on
+            disk → next CLI invocation would see a "live" lock and
+            refuse to start, even though the prior process never
+            actually held it. Mirrors the baseline_lock.py pattern.
             """
             try:
                 # 0o644 — owner rw, others r (matches the previous open(..., "w") default)
                 fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
             except FileExistsError:
                 return False
+            write_failed = False
             try:
                 os.write(fd, str(os.getpid()).encode("ascii"))
+            except OSError as exc:
+                logger.error(f"Failed to write pipeline-lock PID to {path}: {exc}")
+                write_failed = True
             finally:
-                os.close(fd)
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
+            if write_failed:
+                # Roll back the partial sentinel so the next attempt isn't blocked.
+                try:
+                    os.unlink(path)
+                except OSError:
+                    pass
+                return False
             return True
 
         if not _try_atomic_lock_acquire(lock_path):

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -971,8 +971,34 @@ class EdgeGuardPipeline:
                 with open(lock_path) as f:
                     old_pid = int(f.read().strip())
             except (ValueError, OSError):
-                # Lock file unreadable / malformed — treat as stale and try to clean.
-                logger.warning(f"Lock file {lock_path} unreadable — treating as stale and removing.")
+                # Lock file unreadable / malformed.
+                #
+                # PR #38 commit X (bugbot HIGH): age-gate the auto-recovery
+                # to avoid the same TOCTOU race fixed in baseline_lock.py
+                # (see ``_is_corrupt_sentinel`` docstring there for the
+                # full scenario). Without an age check, Process B could
+                # see Process A's mid-write empty file, unlink it, and
+                # retry — both processes end up "holding" the lock.
+                #
+                # Refuse the auto-recovery if the file is fresh (< 5 min);
+                # operator must manually delete a fresh lock that's
+                # genuinely corrupt.
+                _PIPELINE_LOCK_RECOVERY_AGE_SECS = 300
+                try:
+                    age_secs = time.time() - os.stat(lock_path).st_mtime
+                except OSError:
+                    age_secs = 0  # treat unstat-able as fresh → refuse
+                if age_secs < _PIPELINE_LOCK_RECOVERY_AGE_SECS:
+                    logger.error(
+                        f"Lock file {lock_path} is unreadable BUT only {age_secs:.0f}s old — "
+                        f"refusing to auto-recover (could race a competitor mid-write). "
+                        f"Either wait {(_PIPELINE_LOCK_RECOVERY_AGE_SECS - age_secs):.0f}s or "
+                        f"manually delete the file if you're sure it's stale."
+                    )
+                    return False
+                logger.warning(
+                    f"Lock file {lock_path} unreadable + {age_secs:.0f}s old — treating as stale and removing."
+                )
                 try:
                     os.unlink(lock_path)
                 except OSError:

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -901,10 +901,55 @@ class EdgeGuardPipeline:
         lock_dir = os.path.join(os.path.dirname(__file__), "..", "checkpoints")
         os.makedirs(lock_dir, exist_ok=True)
         lock_path = os.path.join(lock_dir, "pipeline.lock")
-        try:
-            if os.path.exists(lock_path):
+
+        # PR #38 (Bug Hunter Tier S S2): atomic lock acquisition via
+        # ``O_CREAT|O_EXCL|O_WRONLY``. The previous TOCTOU pattern —
+        # ``os.path.exists(lock_path)`` then ``with open(lock_path, "w")`` —
+        # could let two CLI invocations both find no lock and both write
+        # their PID, last writer wins. Two pipelines then ran concurrently,
+        # racing MISP event creation and Neo4j MERGEs (the very condition
+        # the lock was meant to prevent).
+        #
+        # ``O_EXCL`` is POSIX-defined as atomic create-or-fail: if the
+        # file already exists, ``os.open`` raises ``FileExistsError`` AND
+        # does NOT touch the existing file. No window for a racing process
+        # to slip in. Stale-lock recovery (the "PID is gone" case) still
+        # uses the read-then-unlink-then-retry pattern below — but the
+        # final lock acquisition itself is atomic.
+        def _try_atomic_lock_acquire(path: str) -> bool:
+            """Single atomic create-or-fail attempt.
+
+            Returns True iff THIS process now exclusively owns the lock
+            file. Returns False on FileExistsError (someone else holds
+            it). Any other OSError propagates to the caller.
+            """
+            try:
+                # 0o644 — owner rw, others r (matches the previous open(..., "w") default)
+                fd = os.open(path, os.O_CREAT | os.O_EXCL | os.O_WRONLY, 0o644)
+            except FileExistsError:
+                return False
+            try:
+                os.write(fd, str(os.getpid()).encode("ascii"))
+            finally:
+                os.close(fd)
+            return True
+
+        if not _try_atomic_lock_acquire(lock_path):
+            # File exists. Read the PID, decide if it's stale, and possibly retry once.
+            try:
                 with open(lock_path) as f:
                     old_pid = int(f.read().strip())
+            except (ValueError, OSError):
+                # Lock file unreadable / malformed — treat as stale and try to clean.
+                logger.warning(f"Lock file {lock_path} unreadable — treating as stale and removing.")
+                try:
+                    os.unlink(lock_path)
+                except OSError:
+                    pass
+                if not _try_atomic_lock_acquire(lock_path):
+                    logger.error("Lost lock-acquisition race after stale-lock cleanup. Aborting.")
+                    return False
+            else:
                 # Check if the process is still alive
                 try:
                     os.kill(old_pid, 0)
@@ -924,10 +969,17 @@ class EdgeGuardPipeline:
                     return False
                 except ProcessLookupError:
                     logger.info(f"Stale lock file found (PID {old_pid} is gone) — removing.")
-        except (ValueError, IOError):
-            pass
-        with open(lock_path, "w") as f:
-            f.write(str(os.getpid()))
+                    try:
+                        os.unlink(lock_path)
+                    except OSError:
+                        pass
+                    # Single retry; if a competitor grabbed it in the gap, fail loudly.
+                    if not _try_atomic_lock_acquire(lock_path):
+                        logger.error(
+                            "Lost lock-acquisition race after stale-lock cleanup — "
+                            "another process grabbed the lock. Aborting."
+                        )
+                        return False
 
         import atexit
         import signal

--- a/tests/test_lock_atomicity.py
+++ b/tests/test_lock_atomicity.py
@@ -130,6 +130,17 @@ def test_acquire_baseline_lock_is_atomic_under_concurrent_attempts(tmp_path, mon
     for t in threads:
         t.join(timeout=5)
 
+    # PR #38 commit X (bugbot LOW): assert BOTH threads completed before
+    # counting successes. Thread exceptions don't propagate to the main
+    # thread — they print to stderr and the thread silently dies. Without
+    # this length check, a thread that crashed instead of returning False
+    # would skip ``results.append(...)`` and leave ``results`` with one
+    # entry; if THAT entry is True the success count still equals 1 and
+    # the test falsely passes.
+    assert len(results) == 2, (
+        f"Both threads must have completed and recorded a result; got {len(results)} results. "
+        f"A missing result means a thread crashed silently — investigate stderr."
+    )
     successes = sum(1 for r in results if r is True)
     assert successes == 1, (
         f"Exactly ONE thread must acquire the baseline lock; got {successes} successes. "

--- a/tests/test_lock_atomicity.py
+++ b/tests/test_lock_atomicity.py
@@ -1,0 +1,203 @@
+"""PR #38 regression pins for the lock-atomicity TOCTOU fixes.
+
+Bug Hunter (proactive audit) Tier S S2 surfaced two TOCTOU bugs that
+let concurrent baselines both acquire the same "lock":
+
+1. ``src/run_pipeline.py:905`` — pipeline.lock used
+   ``os.path.exists(lock_path)`` then ``with open(lock_path, "w")``.
+   Non-atomic: two CLI invocations both find no lock and both write
+   their PID, last writer wins.
+
+2. ``src/baseline_lock.py:193-218`` — sentinel acquisition used
+   ``is_baseline_running()`` then ``os.replace(tmp, path)``.
+   Non-atomic: two concurrent baselines both see ``existing is None``,
+   both rename their tmp file in (last writer wins), both proceed.
+
+Fix: both sites now use ``os.open(path, O_CREAT|O_EXCL|O_WRONLY)``,
+which is POSIX-defined as atomic create-or-fail. Concurrent attempts
+either succeed exactly once or fail with ``FileExistsError``.
+
+Tests below pin the contract structurally (source-grep for the new
+flag combo) AND behaviorally (concurrent acquisition simulation
+where only one should win).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+import threading
+from typing import List
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+# ---------------------------------------------------------------------------
+# Structural pins — source-grep that the atomic flags are present
+# ---------------------------------------------------------------------------
+
+
+def test_run_pipeline_uses_o_excl_for_lock_file_acquisition():
+    """Pin the contract: the pipeline.lock acquisition MUST use
+    ``O_CREAT | O_EXCL`` so concurrent CLI invocations atomically
+    serialize on the lock. If a future refactor removes O_EXCL the
+    TOCTOU bug returns silently (no test caught it before).
+    """
+    path = os.path.join(_SRC, "run_pipeline.py")
+    with open(path) as fh:
+        src = fh.read()
+    # Find the lock-acquisition function-local helper
+    assert "_try_atomic_lock_acquire" in src, (
+        "run_pipeline.py must define _try_atomic_lock_acquire; "
+        "if this assertion fails, lock acquisition is no longer atomic"
+    )
+    # And it must use O_EXCL
+    assert "O_EXCL" in src, (
+        "run_pipeline.py lock acquisition MUST use os.open(..., O_CREAT|O_EXCL|O_WRONLY) — "
+        "that's the only POSIX-atomic create-or-fail primitive. "
+        "TOCTOU race returns if anyone removes the flag."
+    )
+
+
+def test_baseline_lock_uses_o_excl_for_sentinel_acquisition():
+    """Same contract for the baseline-lock sentinel."""
+    path = os.path.join(_SRC, "baseline_lock.py")
+    with open(path) as fh:
+        src = fh.read()
+    assert "O_EXCL" in src, (
+        "baseline_lock.py acquire_baseline_lock MUST use os.open(..., O_CREAT|O_EXCL|O_WRONLY); "
+        "without it, two concurrent baselines can both acquire the sentinel"
+    )
+    # And it must NOT use the old non-atomic os.replace pattern as the primary acquisition
+    # (the file may still be referenced in comments documenting the historical bug; that's OK)
+    code_lines = [line for line in src.splitlines() if not line.lstrip().startswith("#")]
+    code_only = "\n".join(code_lines)
+    # The acquire function specifically must not use os.replace anymore for the sentinel
+    acquire_start = code_only.find("def acquire_baseline_lock")
+    if acquire_start > 0:
+        # Find end of function — next top-level def
+        next_def = code_only.find("\ndef ", acquire_start + 1)
+        acquire_body = code_only[acquire_start:next_def] if next_def > 0 else code_only[acquire_start:]
+        assert "os.replace(tmp_path, path)" not in acquire_body, (
+            "acquire_baseline_lock must no longer use the os.replace(tmp, path) pattern — "
+            "that was the non-atomic acquisition that PR #38 replaced"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral pin — concurrent acquisition: only one winner
+# ---------------------------------------------------------------------------
+
+
+def test_acquire_baseline_lock_is_atomic_under_concurrent_attempts(tmp_path, monkeypatch):
+    """Two threads both call acquire_baseline_lock simultaneously.
+    Exactly ONE must succeed; the other must return False.
+
+    Note on what this test does + does NOT prove
+    --------------------------------------------
+    PROVES: the FIXED code correctly serializes concurrent attempts
+    via O_EXCL — exactly one winner, deterministically.
+
+    Does NOT (reliably) prove that the OLD code was broken — the
+    TOCTOU window in the pre-fix ``is_baseline_running()`` →
+    ``os.replace(tmp, path)`` pattern is real but small enough that
+    two threads typically don't hit it under benign scheduling. The
+    structural-pin test
+    ``test_baseline_lock_uses_o_excl_for_sentinel_acquisition``
+    above is the actual regression-prevention mechanism: it source-
+    greps for ``O_EXCL`` and fails loudly if the atomic flag is ever
+    removed. This behavioral test complements it by exercising the
+    real concurrency path.
+    """
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    results: List[bool] = []
+    barrier = threading.Barrier(parties=2)
+
+    def attempt() -> None:
+        # Sync both threads to maximize the race window
+        barrier.wait()
+        results.append(baseline_lock.acquire_baseline_lock())
+
+    threads = [threading.Thread(target=attempt) for _ in range(2)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    successes = sum(1 for r in results if r is True)
+    assert successes == 1, (
+        f"Exactly ONE thread must acquire the baseline lock; got {successes} successes. "
+        f"If this fails, the TOCTOU race lets concurrent baselines proceed."
+    )
+
+
+def test_acquire_baseline_lock_then_retry_returns_false(tmp_path, monkeypatch):
+    """After one process acquires the lock, a second attempt MUST return
+    False (the live-lock case). Independent of the concurrent-race
+    test — this is the simpler ordering."""
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    assert baseline_lock.acquire_baseline_lock() is True
+    # Second attempt: ours is the "competitor" — should fail.
+    # is_baseline_running will see our own pid as alive.
+    assert baseline_lock.acquire_baseline_lock() is False
+    # Cleanup: release so other tests don't see a stale sentinel
+    baseline_lock.release_baseline_lock()
+
+
+def test_acquire_baseline_lock_handles_filewrite_failure_cleanly(tmp_path, monkeypatch):
+    """If os.write fails between O_EXCL acquire and write completion,
+    the partial sentinel must be cleaned up so the next attempt isn't
+    permanently blocked. Pins the rollback path."""
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    # Patch os.write to raise OSError on the first call
+    original_write = os.write
+    call_count = {"n": 0}
+
+    def bomb_first_write(fd: int, data: bytes) -> int:
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise OSError("simulated disk full")
+        return original_write(fd, data)
+
+    monkeypatch.setattr(baseline_lock.os, "write", bomb_first_write)
+
+    # First attempt: write fails, sentinel must be rolled back
+    assert baseline_lock.acquire_baseline_lock() is False
+    assert not os.path.exists(sentinel_path), "partial sentinel must be cleaned up after write failure"
+
+    # Second attempt with normal write: must succeed (sentinel was cleaned)
+    assert baseline_lock.acquire_baseline_lock() is True
+    baseline_lock.release_baseline_lock()
+
+
+# ---------------------------------------------------------------------------
+# Documentation pin — ensure the bug-fix narrative is captured
+# ---------------------------------------------------------------------------
+
+
+def test_baseline_lock_docstring_documents_pr38_atomicity_fix():
+    """Make sure future maintainers see the rationale for the O_EXCL
+    pattern in the function docstring. Without this trace, someone
+    "simplifying" the code can re-introduce the TOCTOU bug."""
+    import baseline_lock
+
+    doc = baseline_lock.acquire_baseline_lock.__doc__ or ""
+    assert "PR #38" in doc, (
+        "acquire_baseline_lock docstring must reference PR #38 as the source of "
+        "the atomicity fix so future refactors don't accidentally undo it"
+    )
+    assert "O_EXCL" in doc, "docstring must explain the O_EXCL atomic-create-or-fail mechanism"

--- a/tests/test_lock_atomicity.py
+++ b/tests/test_lock_atomicity.py
@@ -74,16 +74,21 @@ def test_baseline_lock_uses_o_excl_for_sentinel_acquisition():
     # (the file may still be referenced in comments documenting the historical bug; that's OK)
     code_lines = [line for line in src.splitlines() if not line.lstrip().startswith("#")]
     code_only = "\n".join(code_lines)
-    # The acquire function specifically must not use os.replace anymore for the sentinel
+    # The acquire function specifically must not use os.replace anymore for the sentinel.
+    # PR #38 commit X (bugbot LOW): use ``>= 0`` not ``> 0`` — find() returns
+    # -1 when not found and 0 when at the start of the string. The previous
+    # ``> 0`` would silently skip the assertion if the function happened to
+    # be at index 0 (after comment-stripping, that's actually possible if
+    # there are no comments above the def).
     acquire_start = code_only.find("def acquire_baseline_lock")
-    if acquire_start > 0:
-        # Find end of function — next top-level def
-        next_def = code_only.find("\ndef ", acquire_start + 1)
-        acquire_body = code_only[acquire_start:next_def] if next_def > 0 else code_only[acquire_start:]
-        assert "os.replace(tmp_path, path)" not in acquire_body, (
-            "acquire_baseline_lock must no longer use the os.replace(tmp, path) pattern — "
-            "that was the non-atomic acquisition that PR #38 replaced"
-        )
+    assert acquire_start >= 0, "could not locate acquire_baseline_lock in baseline_lock.py source"
+    # Find end of function — next top-level def
+    next_def = code_only.find("\ndef ", acquire_start + 1)
+    acquire_body = code_only[acquire_start:next_def] if next_def >= 0 else code_only[acquire_start:]
+    assert "os.replace(tmp_path, path)" not in acquire_body, (
+        "acquire_baseline_lock must no longer use the os.replace(tmp, path) pattern — "
+        "that was the non-atomic acquisition that PR #38 replaced"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +168,84 @@ def test_acquire_baseline_lock_then_retry_returns_false(tmp_path, monkeypatch):
     assert baseline_lock.acquire_baseline_lock() is False
     # Cleanup: release so other tests don't see a stale sentinel
     baseline_lock.release_baseline_lock()
+
+
+def test_acquire_baseline_lock_recovers_from_corrupt_sentinel(tmp_path, monkeypatch):
+    """PR #38 commit X (bugbot MED) regression pin.
+
+    Background: with O_EXCL atomic create-or-fail, a process killed
+    AFTER ``os.open`` creates the sentinel but BEFORE ``os.write``
+    completes leaves an empty/corrupt file behind. ``is_baseline_running``
+    returns None (its JSON parse silently fails on empty content), the
+    dead-PID/age pruning never fires, and ``os.open`` then hits
+    FileExistsError forever — permanent lock-out until manual cleanup.
+
+    Fix: after FileExistsError, probe the sentinel content via
+    ``_is_corrupt_sentinel``; if it's empty/junk, unlink + retry.
+    """
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    # Simulate a crash artifact: empty sentinel file
+    with open(sentinel_path, "w") as fh:
+        fh.write("")
+
+    # acquire_baseline_lock must detect the corrupt file, unlink it, retry,
+    # and succeed.
+    assert baseline_lock.acquire_baseline_lock() is True, (
+        "Empty sentinel (crash artifact) must be auto-recovered; if this fails the "
+        "operator is permanently locked out until manual deletion."
+    )
+    baseline_lock.release_baseline_lock()
+
+
+def test_acquire_baseline_lock_recovers_from_truncated_json_sentinel(tmp_path, monkeypatch):
+    """Same recovery path for truncated/malformed JSON content (a power-loss
+    artifact that wrote a few bytes before dying)."""
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    with open(sentinel_path, "w") as fh:
+        fh.write('{"pid": 12345, "host":')  # truncated mid-JSON
+
+    assert baseline_lock.acquire_baseline_lock() is True
+    baseline_lock.release_baseline_lock()
+
+
+def test_acquire_baseline_lock_does_NOT_unlink_valid_sentinel(tmp_path, monkeypatch):
+    """Negative pin: a VALID JSON sentinel from a real live lock must NOT
+    be auto-unlinked. ``_is_corrupt_sentinel`` must return False on
+    well-formed JSON dicts so the recovery path can't trash a legitimate
+    lock from another process."""
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    # Write a sentinel that LOOKS like a live lock from a competing process
+    # (with a fake but live PID — this process's own pid will pass os.kill(p, 0))
+    import json as _json
+
+    payload = {
+        "pid": os.getpid(),
+        "host": "competitor.example",
+        "started_at": "2026-04-18T12:00:00+00:00",
+        "monotonic_started": 0.0,
+    }
+    with open(sentinel_path, "w") as fh:
+        _json.dump(payload, fh)
+
+    # is_baseline_running returns the payload (live lock detected); acquire
+    # must REFUSE.
+    assert baseline_lock.acquire_baseline_lock() is False, (
+        "A valid JSON sentinel from a live process must NOT be auto-recovered as 'corrupt'"
+    )
+    # And the sentinel must still exist
+    assert os.path.exists(sentinel_path), "valid sentinel must not be unlinked by recovery path"
 
 
 def test_acquire_baseline_lock_handles_filewrite_failure_cleanly(tmp_path, monkeypatch):

--- a/tests/test_lock_atomicity.py
+++ b/tests/test_lock_atomicity.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import os
 import sys
 import threading
+import time
 from typing import List
 
 _SRC = os.path.join(os.path.dirname(__file__), "..", "src")
@@ -170,40 +171,46 @@ def test_acquire_baseline_lock_then_retry_returns_false(tmp_path, monkeypatch):
     baseline_lock.release_baseline_lock()
 
 
-def test_acquire_baseline_lock_recovers_from_corrupt_sentinel(tmp_path, monkeypatch):
-    """PR #38 commit X (bugbot MED) regression pin.
+def _backdate_mtime(path: str, seconds_ago: int = 600) -> None:
+    """Set the file's mtime to N seconds ago. Used to simulate a stale
+    crash-debris sentinel that's old enough for the auto-recovery path
+    to engage (PR #38 commit X added a 5-minute mtime guard to prevent
+    the TOCTOU race where Process B unlinks Process A's mid-write file)."""
+    target_ts = time.time() - seconds_ago
+    os.utime(path, (target_ts, target_ts))
+
+
+def test_acquire_baseline_lock_recovers_from_aged_corrupt_sentinel(tmp_path, monkeypatch):
+    """PR #38 commit X regression pin.
 
     Background: with O_EXCL atomic create-or-fail, a process killed
     AFTER ``os.open`` creates the sentinel but BEFORE ``os.write``
-    completes leaves an empty/corrupt file behind. ``is_baseline_running``
-    returns None (its JSON parse silently fails on empty content), the
-    dead-PID/age pruning never fires, and ``os.open`` then hits
-    FileExistsError forever — permanent lock-out until manual cleanup.
+    completes leaves an empty/corrupt file behind.
 
-    Fix: after FileExistsError, probe the sentinel content via
-    ``_is_corrupt_sentinel``; if it's empty/junk, unlink + retry.
+    Fix: after FileExistsError, probe via ``_is_corrupt_sentinel``;
+    if it's empty/junk AND OLDER THAN 5 MINUTES, unlink + retry. The
+    age check is critical for correctness — see the
+    ``_is_corrupt_sentinel`` docstring for the TOCTOU race scenario
+    that hits without it (bugbot HIGH).
     """
     import baseline_lock
 
     sentinel_path = str(tmp_path / "baseline.lock")
     monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
 
-    # Simulate a crash artifact: empty sentinel file
+    # Simulate a STALE crash artifact: empty file, mtime 10 minutes ago
     with open(sentinel_path, "w") as fh:
         fh.write("")
+    _backdate_mtime(sentinel_path, seconds_ago=600)
 
-    # acquire_baseline_lock must detect the corrupt file, unlink it, retry,
-    # and succeed.
     assert baseline_lock.acquire_baseline_lock() is True, (
-        "Empty sentinel (crash artifact) must be auto-recovered; if this fails the "
-        "operator is permanently locked out until manual deletion."
+        "Aged empty sentinel (crash debris > 5min old) must be auto-recovered"
     )
     baseline_lock.release_baseline_lock()
 
 
-def test_acquire_baseline_lock_recovers_from_truncated_json_sentinel(tmp_path, monkeypatch):
-    """Same recovery path for truncated/malformed JSON content (a power-loss
-    artifact that wrote a few bytes before dying)."""
+def test_acquire_baseline_lock_recovers_from_aged_truncated_json_sentinel(tmp_path, monkeypatch):
+    """Same recovery path for truncated/malformed JSON, BUT only when aged."""
     import baseline_lock
 
     sentinel_path = str(tmp_path / "baseline.lock")
@@ -211,9 +218,42 @@ def test_acquire_baseline_lock_recovers_from_truncated_json_sentinel(tmp_path, m
 
     with open(sentinel_path, "w") as fh:
         fh.write('{"pid": 12345, "host":')  # truncated mid-JSON
+    _backdate_mtime(sentinel_path, seconds_ago=600)
 
     assert baseline_lock.acquire_baseline_lock() is True
     baseline_lock.release_baseline_lock()
+
+
+def test_acquire_baseline_lock_REFUSES_fresh_empty_sentinel(tmp_path, monkeypatch):
+    """PR #38 commit X (bugbot HIGH) regression pin — the critical
+    NEGATIVE case for the TOCTOU race fix.
+
+    Without the age guard, a competitor's mid-write empty file (just
+    after their O_EXCL succeeded, just before their os.write completes)
+    would be misclassified as crash debris by THIS process and unlinked.
+    Both processes would end up "holding" the lock — re-introducing
+    the very bug PR #38 fixed.
+
+    The age guard requires the empty file to be 5+ minutes old before
+    auto-recovery engages. A fresh empty file (likely active competitor)
+    must REFUSE.
+    """
+    import baseline_lock
+
+    sentinel_path = str(tmp_path / "baseline.lock")
+    monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
+
+    # Fresh empty sentinel (mtime = now) — simulates a competitor who
+    # just did O_EXCL and hasn't yet written their PID.
+    with open(sentinel_path, "w") as fh:
+        fh.write("")
+
+    assert baseline_lock.acquire_baseline_lock() is False, (
+        "A FRESH empty sentinel must NOT be auto-recovered — it might be a "
+        "competitor's mid-write O_EXCL. If this regresses, the TOCTOU race returns."
+    )
+    # Sentinel still exists (we did not unlink it)
+    assert os.path.exists(sentinel_path), "fresh sentinel must NOT be unlinked"
 
 
 def test_acquire_baseline_lock_does_NOT_unlink_valid_sentinel(tmp_path, monkeypatch):
@@ -226,14 +266,23 @@ def test_acquire_baseline_lock_does_NOT_unlink_valid_sentinel(tmp_path, monkeypa
     sentinel_path = str(tmp_path / "baseline.lock")
     monkeypatch.setattr(baseline_lock, "baseline_lock_path", lambda: sentinel_path)
 
-    # Write a sentinel that LOOKS like a live lock from a competing process
-    # (with a fake but live PID — this process's own pid will pass os.kill(p, 0))
+    # PR #38 commit X (bugbot LOW): use a DYNAMIC ``started_at`` instead
+    # of a hardcoded date. The original hardcoded
+    # ``"2026-04-18T12:00:00+00:00"`` would have made this test pass
+    # today but FAIL after that timestamp aged past
+    # ``BASELINE_MAX_CROSS_HOST_AGE_HOURS`` (default 24h) — at which
+    # point ``is_baseline_running`` would prune the sentinel as stale,
+    # ``acquire_baseline_lock`` would succeed, and the assertion would
+    # flip. Using ``datetime.now(timezone.utc)`` keeps the started_at
+    # anchored to "now" relative to test execution.
     import json as _json
+    from datetime import datetime as _dt
+    from datetime import timezone as _tz
 
     payload = {
         "pid": os.getpid(),
         "host": "competitor.example",
-        "started_at": "2026-04-18T12:00:00+00:00",
+        "started_at": _dt.now(_tz.utc).isoformat(),
         "monotonic_started": 0.0,
     }
     with open(sentinel_path, "w") as fh:


### PR DESCRIPTION
## Summary

Two TOCTOU bugs from the proactive audit's Bug Hunter agent (Tier S S2). Both let two concurrent baselines/CLI runs acquire the "lock" simultaneously and proceed to race on MISP/Neo4j writes — the exact condition the locks were supposed to prevent.

| Site | Old pattern | New pattern |
|---|---|---|
| `src/run_pipeline.py:905` | `os.path.exists()` then `open(..., "w")` | `os.open(..., O_CREAT\|O_EXCL\|O_WRONLY)` |
| `src/baseline_lock.py:212-218` | `is_baseline_running()` then `os.replace(tmp, path)` | `os.open(..., O_CREAT\|O_EXCL\|O_WRONLY)` + write + close |

`O_EXCL` is POSIX-defined as atomic create-or-fail: if the file exists, `os.open` raises `FileExistsError` AND does NOT touch the existing file. No window for a racing process.

Stale-lock recovery is preserved (dead-PID liveness check, age-based pruning, single retry after cleanup). Resource hygiene improved — write failures roll back partial sentinels.

## What this does NOT fix (deliberate)

- The Devil's Advocate finding that `baseline_skip_reason()` at task entry is advisory-only (cross-process mutex requires moving baseline into Airflow with a shared pool — separate larger redesign).

## Test plan

- [x] 6 new tests in `tests/test_lock_atomicity.py`
  - 2 source-grep pins for `O_EXCL` in both files (real regression-prevention)
  - 1 source-grep that the old `os.replace(tmp, path)` pattern is gone from `acquire_baseline_lock` executable code
  - 1 behavioral pin: 2 threads with a barrier → exactly 1 winner (proves fix correct)
  - 1 sequential live-lock case
  - 1 write-failure rollback case
  - 1 docstring pin: PR #38 + O_EXCL must remain documented
- [x] All gates green: ruff format/check + mypy
- [ ] Full pytest in CI
- [ ] Bugbot review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches cross-process locking used to prevent concurrent pipeline/baseline runs; mistakes could either reintroduce data races or cause false lockouts, though changes add explicit rollback and age-gated recovery to reduce risk.
> 
> **Overview**
> **Prevents concurrent CLI/baseline runs from both “winning” the same lock** by switching both `pipeline.lock` (in `run_pipeline.py`) and the baseline sentinel (in `baseline_lock.py`) from check-then-write/rename patterns to atomic `os.open(..., O_CREAT|O_EXCL|O_WRONLY)` acquisition.
> 
> Adds *crash-debris handling and rollback*: write failures now clean up partial lock files, and corrupt/empty lock files are only auto-removed after an mtime-based age gate (5 minutes) to avoid deleting a competitor’s in-progress write.
> 
> Introduces `tests/test_lock_atomicity.py` with structural pins (source asserts for `O_EXCL` and removal of the old `os.replace` pattern) plus behavioral concurrency/recovery tests to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6d577aa549f0ce41e3131397f6003ea0cee448c4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->