### PR TITLE
fix(security): close 7 Tier-S/A auth + API hardening findings (Red Team audit)

### DIFF
--- a/src/collectors/collector_utils.py
+++ b/src/collectors/collector_utils.py
@@ -181,6 +181,20 @@ def request_with_rate_limit_retries(
     Returns:
         Final ``requests.Response`` (may still have status != 200).
     """
+    # PR (security A8) — Red Team Tier A: default ``allow_redirects=False``
+    # for all collector outbound HTTP. Without this, a compromised/hijacked
+    # upstream feed (URLhaus, MITRE, NVD, etc.) can redirect a fetch to:
+    #   * cloud metadata endpoints (169.254.169.254 → AWS/GCP/Azure creds)
+    #   * internal services (127.0.0.1:7474 → Neo4j Browser, 7687 → Bolt)
+    #   * .internal hostnames in private VPC ranges
+    # The redirected response body lands in MISP and ultimately Neo4j, and
+    # may leak via /graph/explore.
+    #
+    # Caller can override per-call by passing ``allow_redirects=True``
+    # explicitly when redirect-following is genuinely needed and the
+    # destination is trusted.
+    kwargs.setdefault("allow_redirects", False)
+
     attempts_allowed = max(1, max_rate_limit_retries + 1)
     rate_limit_hits = 0
     attempt = 0

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -242,10 +242,16 @@ def cmd_doctor(args):
 
             misp_url = os.getenv("MISP_URL", "https://localhost:8443")
             misp_key = os.getenv("MISP_API_KEY", "")
+            # PR (security S7) — Red Team Tier S: was hardcoded ``verify=False``,
+            # which sent the API key over MITM-able TLS regardless of operator
+            # config. Now respects ``SSL_VERIFY`` (the same flag every other
+            # outbound HTTP call in EdgeGuard already honors). An on-path
+            # attacker can no longer silently downgrade this probe to
+            # plaintext-equivalent.
             resp = _req.get(
                 f"{misp_url}/events/index",
                 headers={"Authorization": misp_key, "Accept": "application/json"},
-                verify=False,
+                verify=SSL_VERIFY,
                 timeout=10,
             )
             if resp.status_code == 200:
@@ -360,10 +366,28 @@ def cmd_doctor(args):
         all_ok = False
 
     # Check Airflow DAG state if webserver is reachable
-    if airflow_ok:
+    # PR (security S6) — Red Team Tier S: previously used
+    # ``os.getenv("AIRFLOW_API_PASSWORD", "airflow")`` which silently
+    # used the literal default ``"airflow"`` when unset. Combined with
+    # the equivalent default user ``"airflow"`` already in
+    # airflow_client.py, this exposed the Airflow REST API (DAG triggering,
+    # task-instance reset) to anyone who could reach port 8082 with
+    # ``airflow:airflow``. Now: if no password set, SKIP the deeper API
+    # check (we still know from the /health probe above whether the
+    # webserver is reachable). Operator must set AIRFLOW_API_PASSWORD
+    # explicitly to enable the DAG-list diagnostic.
+    airflow_password = os.getenv("AIRFLOW_API_PASSWORD", "").strip()
+    if airflow_ok and not airflow_password:
+        info(
+            "AIRFLOW_API_PASSWORD not set — skipping DAG state check. "
+            "Set the env var to enable detailed DAG diagnostics."
+        )
+    if airflow_ok and airflow_password:
         try:
             resp = requests.get(
-                f"{airflow_url}/api/v1/dags", timeout=10, auth=("airflow", os.getenv("AIRFLOW_API_PASSWORD", "airflow"))
+                f"{airflow_url}/api/v1/dags",
+                timeout=10,
+                auth=(os.getenv("AIRFLOW_API_USER", "airflow"), airflow_password),
             )
             if resp.status_code == 200:
                 dags = resp.json().get("dags", [])

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -80,7 +80,16 @@ _ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()
 # so the unauthenticated endpoint isn't reachable from the network.
 # Operators who genuinely want public unauth dev access can opt in
 # via the explicit escape hatch ``EDGEGUARD_ALLOW_UNAUTH=1``.
-_BIND_HOST = os.getenv("EDGEGUARD_API_HOST", os.getenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")).strip()
+# PR #40 commit X (bugbot HIGH): the security check MUST read the same
+# env var the server actually binds to. The server at line 725 reads
+# ``EDGEGUARD_GRAPHQL_HOST`` (with "127.0.0.1" default). The previous
+# code here read ``EDGEGUARD_API_HOST`` first (a REST-API var that the
+# GraphQL server never honors) — an operator setting
+# ``EDGEGUARD_API_HOST=127.0.0.1`` (loopback for REST) +
+# ``EDGEGUARD_GRAPHQL_HOST=0.0.0.0`` (all-interfaces for GraphQL)
+# would pass this safety check but the server would actually bind to
+# 0.0.0.0 unauthenticated.
+_BIND_HOST = os.getenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1").strip()
 _ALLOW_UNAUTH = os.getenv("EDGEGUARD_ALLOW_UNAUTH", "").strip().lower() in ("1", "true", "yes", "on")
 
 if _ENV == "prod" and not EDGEGUARD_API_KEY:

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -67,10 +67,34 @@ MISP_URL = os.getenv("MISP_URL", "").rstrip("/")
 EDGEGUARD_API_KEY = os.getenv("EDGEGUARD_API_KEY", "")
 _ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()
 
+# PR (security A6) — Red Team Tier A: previously the API-key requirement
+# only fired when ``EDGEGUARD_ENV=prod``. A staging deployment with the
+# default ``EDGEGUARD_ENV=dev`` (or no env var at all) silently ran with
+# NO authentication — and ``_verify_api_key`` short-circuited the check
+# whenever ``EDGEGUARD_API_KEY`` was empty, making every endpoint
+# anonymously accessible. An internet-exposed staging instance would
+# leak the entire graph via ``/graph/explore?limit=500``.
+#
+# New rule: in non-prod environments, EITHER set ``EDGEGUARD_API_KEY``
+# (auth enforced for everyone) OR bind to loopback only (``127.0.0.1``)
+# so the unauthenticated endpoint isn't reachable from the network.
+# Operators who genuinely want public unauth dev access can opt in
+# via the explicit escape hatch ``EDGEGUARD_ALLOW_UNAUTH=1``.
+_BIND_HOST = os.getenv("EDGEGUARD_API_HOST", os.getenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")).strip()
+_ALLOW_UNAUTH = os.getenv("EDGEGUARD_ALLOW_UNAUTH", "").strip().lower() in ("1", "true", "yes", "on")
+
 if _ENV == "prod" and not EDGEGUARD_API_KEY:
     raise RuntimeError(
         "EDGEGUARD_API_KEY must be set when EDGEGUARD_ENV=prod. "
         "Set a strong random value before starting the GraphQL API in production."
+    )
+
+if not EDGEGUARD_API_KEY and _BIND_HOST not in ("127.0.0.1", "localhost", "::1") and not _ALLOW_UNAUTH:
+    raise RuntimeError(
+        f"EDGEGUARD_API_KEY is unset AND the bind host ({_BIND_HOST!r}) is not loopback. "
+        "Refusing to start an unauthenticated GraphQL endpoint reachable from the network. "
+        "Either set EDGEGUARD_API_KEY (recommended), bind to 127.0.0.1, "
+        "or opt in explicitly with EDGEGUARD_ALLOW_UNAUTH=1 (not recommended)."
     )
 
 
@@ -595,7 +619,36 @@ class Query:
 
 GRAPHQL_PLAYGROUND = os.getenv("EDGEGUARD_GRAPHQL_PLAYGROUND", "false").lower() == "true"
 
-schema = strawberry.Schema(query=Query)
+# PR (security S8 + A7) — Red Team Tier S/A — defense in depth on the
+# GraphQL surface:
+#
+# * ``QueryDepthLimiter(max_depth=8)``: cap nested-field depth so a
+#   malicious request can't fan out into hundreds of OPTIONAL MATCH
+#   joins per resolver and exhaust the Neo4j bolt pool. 8 is generous —
+#   the deepest legitimate query in our schema (CVE → vuln → indicator
+#   → malware → technique → tactic) is 6.
+#
+# * ``DisableIntrospection``: hide the schema in production
+#   (``EDGEGUARD_ENV=prod``) so reconnaissance probes can't enumerate
+#   every queryable field for follow-up complexity attacks. Stays
+#   ON in dev/staging so developers can use GraphiQL/Apollo Studio.
+#
+# Both are extensions, not middleware — they run inside Strawberry's
+# request lifecycle so the limit applies BEFORE the resolver fans out
+# (vs. middleware which would run after parse).
+from graphql.validation import NoSchemaIntrospectionCustomRule  # noqa: E402
+from strawberry.extensions import QueryDepthLimiter  # noqa: E402
+from strawberry.extensions.add_validation_rules import AddValidationRules  # noqa: E402
+
+_GRAPHQL_MAX_DEPTH = int(os.getenv("EDGEGUARD_GRAPHQL_MAX_DEPTH", "8"))
+_IS_PROD = os.getenv("EDGEGUARD_ENV", "dev").strip().lower() == "prod"
+
+_extensions: list = [QueryDepthLimiter(max_depth=_GRAPHQL_MAX_DEPTH)]
+if _IS_PROD:
+    # Block introspection in prod via the canonical graphql-core rule.
+    _extensions.append(AddValidationRules([NoSchemaIntrospectionCustomRule]))
+
+schema = strawberry.Schema(query=Query, extensions=_extensions)
 graphql_router = GraphQLRouter(schema, graphql_ide="graphiql" if GRAPHQL_PLAYGROUND else None)
 
 

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -84,6 +84,23 @@ if _ENV == "prod" and not _API_KEY:
         "EDGEGUARD_API_KEY must be set when EDGEGUARD_ENV=prod. "
         "Set a strong random value before starting the API in production."
     )
+
+# PR (security A6) — Red Team Tier A: in non-prod environments, refuse
+# to start an unauthenticated API endpoint that's reachable from the
+# network. Operator must EITHER set EDGEGUARD_API_KEY (auth enforced)
+# OR bind to loopback only (127.0.0.1). Genuine "public unauth dev"
+# is opt-in via EDGEGUARD_ALLOW_UNAUTH=1.
+_BIND_HOST = os.getenv("EDGEGUARD_API_HOST", "127.0.0.1").strip()
+_ALLOW_UNAUTH = os.getenv("EDGEGUARD_ALLOW_UNAUTH", "").strip().lower() in ("1", "true", "yes", "on")
+
+if not _API_KEY and _BIND_HOST not in ("127.0.0.1", "localhost", "::1") and not _ALLOW_UNAUTH:
+    raise RuntimeError(
+        f"EDGEGUARD_API_KEY is unset AND the bind host ({_BIND_HOST!r}) is not loopback. "
+        "Refusing to start an unauthenticated REST API reachable from the network. "
+        "Either set EDGEGUARD_API_KEY (recommended), bind to 127.0.0.1, "
+        "or opt in explicitly with EDGEGUARD_ALLOW_UNAUTH=1 (not recommended)."
+    )
+
 if not _API_KEY:
     logger.warning(
         "EDGEGUARD_API_KEY is not configured — all API endpoints are UNAUTHENTICATED. "

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -412,6 +412,45 @@ _RELATIONSHIP_BATCH_DEFAULT = 500
 _MAX_RETRY_FAILED_EVENTS = 20
 
 
+def _read_max_attr_value_bytes() -> int:
+    """Resolve ``EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES`` once at module load.
+
+    PR #40 commit X (bugbot MED): the previous code called
+    ``int(os.getenv("EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES", "4096"))`` INSIDE
+    ``parse_attribute`` — invoked per attribute, i.e. millions of times per
+    baseline run. Trivially cheap per call (low-microsecond) but cumulatively
+    measurable, and any malformed env value would re-raise on every row
+    instead of failing fast at startup.
+
+    Reading once at import time also gives operators a clear startup error
+    if they typo the value, instead of silent per-row spam.
+    """
+    raw = os.getenv("EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES", "4096").strip()
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        # Defensive: don't crash sync on a bad env value — fall back to default
+        # and log so the operator sees it once.
+        logger.warning(
+            "EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES=%r is not an integer; using default 4096",
+            raw,
+        )
+        return 4096
+    # Clamp to a sane range — operator who sets 0 or negative would refuse all
+    # attributes; operator who sets billions defeats the protection. Keep it
+    # at "what an actual MISP value could plausibly be".
+    if parsed < 64:
+        logger.warning(
+            "EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES=%d is below 64 (would refuse most legitimate values); using 64 floor",
+            parsed,
+        )
+        return 64
+    return parsed
+
+
+_MAX_ATTR_VALUE_BYTES = _read_max_attr_value_bytes()
+
+
 class MispTransientServerError(TransientServerError):
     """Raised manually for HTTP 5xx from MISP so @retry_with_backoff can catch
     it selectively. Inherits from ``collector_utils.TransientServerError`` so
@@ -1966,13 +2005,19 @@ class MISPToNeo4jSync:
         # 4096 chars is well above the 99.9th percentile.
         # Operators with genuine large-value use cases (rare) can override
         # via EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES.
-        _max_value_bytes = int(os.getenv("EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES", "4096"))
-        if len(value.encode("utf-8")) > _max_value_bytes:
+        #
+        # PR #40 commit X (bugbot MED): cap is read ONCE at module load
+        # (see ``_read_max_attr_value_bytes`` above), not per row. The
+        # previous form re-parsed the env var on every call → measurable
+        # CPU on million-attribute baselines, plus malformed env values
+        # would re-raise per-row instead of failing fast at startup.
+        encoded_len = len(value.encode("utf-8"))
+        if encoded_len > _MAX_ATTR_VALUE_BYTES:
             logger.warning(
                 "Refusing oversized MISP attribute value (%d bytes > cap %d) — "
                 "type=%s event=%s. Set EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES to override.",
-                len(value.encode("utf-8")),
-                _max_value_bytes,
+                encoded_len,
+                _MAX_ATTR_VALUE_BYTES,
                 attr_type,
                 event_info.get("id", "?"),
             )

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1956,6 +1956,28 @@ class MISPToNeo4jSync:
         if not value:
             return None, []
 
+        # PR (security A9) — Red Team Tier A: cap inbound attribute value
+        # size. Without this, a poisoned/buggy upstream feed (compromised
+        # OTX pulse, hostile CyberCure indicator, malformed NVD item)
+        # could stuff a 100MB string into one attribute → sync worker
+        # OOMs, MISP cache bloats, Neo4j page cache thrashes once stored.
+        # 4 KB is generous: longest legitimate MISP value is a SHA-512
+        # (128 chars), an IPv6 address (45 chars), or a long URL (~2KB).
+        # 4096 chars is well above the 99.9th percentile.
+        # Operators with genuine large-value use cases (rare) can override
+        # via EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES.
+        _max_value_bytes = int(os.getenv("EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES", "4096"))
+        if len(value.encode("utf-8")) > _max_value_bytes:
+            logger.warning(
+                "Refusing oversized MISP attribute value (%d bytes > cap %d) — "
+                "type=%s event=%s. Set EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES to override.",
+                len(value.encode("utf-8")),
+                _max_value_bytes,
+                attr_type,
+                event_info.get("id", "?"),
+            )
+            return None, []
+
         # MISP attribute UUID — stable cross-instance identifier (unlike attr.id which
         # is a per-instance auto-increment). Captured once and threaded into every
         # item dict so Neo4j nodes carry direct traceability back to the originating

--- a/tests/test_auth_and_api_hardening.py
+++ b/tests/test_auth_and_api_hardening.py
@@ -326,6 +326,35 @@ def test_parse_attribute_rejects_oversized_value(monkeypatch):
     assert rels == [], "oversized attribute must produce no relationships"
 
 
+def test_max_attr_value_bytes_is_read_once_at_module_load():
+    """PR #40 commit X (bugbot MED) regression pin.
+
+    The cap MUST be resolved at module-import time, not on every call to
+    ``parse_attribute``. Previously ``int(os.getenv(...))`` was inside
+    the per-attribute hot loop, parsed millions of times per baseline
+    run. Pin: source-grep that the assignment is at module top level
+    (the marker constant) and that ``parse_attribute`` references it
+    rather than re-reading the env var.
+    """
+    path = os.path.join(_SRC, "run_misp_to_neo4j.py")
+    with open(path) as fh:
+        src = fh.read()
+    # Module-level constant must exist
+    assert "_MAX_ATTR_VALUE_BYTES = _read_max_attr_value_bytes()" in src, (
+        "run_misp_to_neo4j.py must define _MAX_ATTR_VALUE_BYTES at module load — "
+        "without this the env var is parsed in the per-attribute hot loop"
+    )
+    # parse_attribute must NOT re-read the env var (negative pin: the
+    # specific bad pattern)
+    parse_start = src.find("def parse_attribute")
+    parse_end = src.find("\n    def ", parse_start + 1)
+    parse_body = src[parse_start:parse_end]
+    assert 'os.getenv("EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES"' not in parse_body, (
+        "parse_attribute MUST NOT call os.getenv on the cap — use _MAX_ATTR_VALUE_BYTES "
+        "(the module-level constant resolved once at import)"
+    )
+
+
 def test_parse_attribute_accepts_normal_value():
     """Negative pin: a normal-sized value (well under 4KB default) must
     parse normally — the cap must not break the happy path."""

--- a/tests/test_auth_and_api_hardening.py
+++ b/tests/test_auth_and_api_hardening.py
@@ -122,7 +122,12 @@ def test_graphql_introspection_disabled_in_prod(monkeypatch):
     # _IS_PROD and re-builds _extensions accordingly.
     monkeypatch.setenv("EDGEGUARD_ENV", "prod")
     monkeypatch.setenv("EDGEGUARD_API_KEY", "test-key-must-be-set-in-prod")
-    monkeypatch.setenv("EDGEGUARD_API_HOST", "127.0.0.1")  # loopback so A6 doesn't refuse
+    # PR #40 commit X (bugbot MED): the previous code set EDGEGUARD_API_HOST,
+    # which graphql_api.py never reads. With EDGEGUARD_GRAPHQL_HOST set to a
+    # non-loopback value in the host environment (Docker CI sets
+    # 0.0.0.0), the module's import-time A6 check would raise RuntimeError
+    # and crash the test setup. Set the var graphql_api ACTUALLY reads.
+    monkeypatch.setenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")
 
     import importlib
 
@@ -142,7 +147,7 @@ def test_graphql_introspection_disabled_in_prod(monkeypatch):
     # Cleanup: reload once more without prod so other tests get back to baseline
     monkeypatch.delenv("EDGEGUARD_ENV", raising=False)
     monkeypatch.delenv("EDGEGUARD_API_KEY", raising=False)
-    monkeypatch.delenv("EDGEGUARD_API_HOST", raising=False)
+    monkeypatch.delenv("EDGEGUARD_GRAPHQL_HOST", raising=False)
     if "graphql_api" in sys.modules:
         del sys.modules["graphql_api"]
 
@@ -152,7 +157,9 @@ def test_graphql_introspection_left_on_in_dev(monkeypatch):
     developers can use GraphiQL / Apollo Studio / schema autocomplete."""
     monkeypatch.delenv("EDGEGUARD_ENV", raising=False)  # default: dev
     monkeypatch.delenv("EDGEGUARD_API_KEY", raising=False)
-    monkeypatch.setenv("EDGEGUARD_API_HOST", "127.0.0.1")
+    # Set the var graphql_api ACTUALLY reads (see comment in the prod-mode
+    # test above for why setting EDGEGUARD_API_HOST was the wrong fix).
+    monkeypatch.setenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")
 
     import importlib
 

--- a/tests/test_auth_and_api_hardening.py
+++ b/tests/test_auth_and_api_hardening.py
@@ -1,0 +1,313 @@
+"""Security PR regression pins for the auth + API hardening fixes batch.
+
+Closes Tier S/A items from the proactive Red Team audit:
+
+* **S6** AIRFLOW_API_PASSWORD default ``"airflow"`` — now SKIPS DAG check
+  when unset instead of using the default credential
+* **S7** ``verify=False`` hardcoded in cmd_doctor MISP probe — now uses
+  ``SSL_VERIFY``
+* **S8** GraphQL no query depth/complexity limits — now caps depth at 8
+  via ``QueryDepthLimiter`` extension
+* **A6** ``EDGEGUARD_API_KEY`` only enforced in prod — now refuses to
+  start unauthenticated on a non-loopback bind in any env
+* **A7** GraphQL introspection on by default — now disabled in prod
+  via ``NoSchemaIntrospectionCustomRule``
+* **A8** No SSRF guards on collectors — now ``allow_redirects=False``
+  default in the shared ``request_with_rate_limit_retries`` helper
+* **A9** No bound on inbound MISP attribute size — now 4 KB cap
+  (configurable via ``EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES``)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+# ---------------------------------------------------------------------------
+# S7 — cmd_doctor MISP probe must use SSL_VERIFY, not hardcoded False
+# ---------------------------------------------------------------------------
+
+
+def _code_only(text: str) -> str:
+    return "\n".join(line for line in text.splitlines() if not line.lstrip().startswith("#"))
+
+
+def test_cmd_doctor_misp_probe_does_not_use_verify_false():
+    """Source-grep pin: the cmd_doctor MISP /events/index probe must NOT
+    use ``verify=False`` (would send the API key over MITM-able TLS)."""
+    path = os.path.join(_SRC, "edgeguard.py")
+    with open(path) as fh:
+        src = _code_only(fh.read())
+    # Locate the MISP probe block
+    probe_start = src.find("/events/index")
+    assert probe_start > 0, "could not locate MISP /events/index probe in edgeguard.py"
+    # Walk ~30 lines forward
+    window = src[probe_start : probe_start + 1500]
+    assert "verify=False" not in window, (
+        "cmd_doctor MISP probe MUST NOT use verify=False — sends API key over MITM-able TLS. "
+        "Use SSL_VERIFY (the configured default) instead."
+    )
+    assert "verify=SSL_VERIFY" in window, "MISP probe must explicitly pass verify=SSL_VERIFY"
+
+
+# ---------------------------------------------------------------------------
+# S6 — AIRFLOW_API_PASSWORD must NOT default to "airflow"
+# ---------------------------------------------------------------------------
+
+
+def test_cmd_doctor_does_not_default_airflow_password_to_airflow():
+    """Source-grep pin: the previous
+    ``os.getenv("AIRFLOW_API_PASSWORD", "airflow")`` is the smoking gun.
+    Default credentials must NOT be silently used."""
+    path = os.path.join(_SRC, "edgeguard.py")
+    with open(path) as fh:
+        src = _code_only(fh.read())
+    assert 'os.getenv("AIRFLOW_API_PASSWORD", "airflow")' not in src, (
+        "AIRFLOW_API_PASSWORD must NOT default to the literal 'airflow' — "
+        "operators who skip setting it would expose the Airflow REST API "
+        "(DAG triggering, task-instance reset) to anyone reaching port 8082"
+    )
+    # Positive pin: must use the empty-string default + skip-if-empty pattern
+    assert 'os.getenv("AIRFLOW_API_PASSWORD", "")' in src, (
+        "use the empty-default + skip pattern so unset env → skip API check, not weak auth"
+    )
+
+
+# ---------------------------------------------------------------------------
+# S8 — GraphQL must enforce a query depth cap
+# ---------------------------------------------------------------------------
+
+
+def test_graphql_schema_includes_query_depth_limiter():
+    """Pin the QueryDepthLimiter extension. Without it, an attacker can
+    issue deeply-nested queries that fan out into dozens of OPTIONAL MATCH
+    joins per resolver and exhaust the Neo4j bolt pool."""
+    import graphql_api
+
+    schema_extensions = getattr(graphql_api.schema, "extensions", []) or []
+    extension_class_names = [type(e).__name__ for e in schema_extensions]
+    assert "QueryDepthLimiter" in extension_class_names, (
+        f"GraphQL schema must include QueryDepthLimiter extension; got extensions: {extension_class_names}"
+    )
+
+
+def test_graphql_max_depth_default_is_reasonable():
+    """The default max depth (8) must be > 0 and < some absurd value.
+    8 is well above the deepest legitimate query (CVE → vuln → indicator
+    → malware → technique → tactic = 6) and well below an unbounded
+    DoS surface."""
+    import graphql_api
+
+    assert 4 <= graphql_api._GRAPHQL_MAX_DEPTH <= 16, (
+        f"GraphQL max depth must be a sane positive bounded value; got {graphql_api._GRAPHQL_MAX_DEPTH}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A7 — GraphQL introspection must be disabled in prod
+# ---------------------------------------------------------------------------
+
+
+def test_graphql_introspection_disabled_in_prod(monkeypatch):
+    """When EDGEGUARD_ENV=prod, the schema must include the
+    NoSchemaIntrospectionCustomRule validation. Without it,
+    reconnaissance probes can pull the entire schema even when the
+    GraphiQL playground is disabled."""
+    # Reload graphql_api with the prod env var set so the module re-evaluates
+    # _IS_PROD and re-builds _extensions accordingly.
+    monkeypatch.setenv("EDGEGUARD_ENV", "prod")
+    monkeypatch.setenv("EDGEGUARD_API_KEY", "test-key-must-be-set-in-prod")
+    monkeypatch.setenv("EDGEGUARD_API_HOST", "127.0.0.1")  # loopback so A6 doesn't refuse
+
+    import importlib
+
+    if "graphql_api" in sys.modules:
+        del sys.modules["graphql_api"]
+    import graphql_api
+
+    importlib.reload(graphql_api)
+
+    schema_extensions = getattr(graphql_api.schema, "extensions", []) or []
+    extension_class_names = [type(e).__name__ for e in schema_extensions]
+    assert "AddValidationRules" in extension_class_names, (
+        f"In prod, schema must include AddValidationRules (carrying NoSchemaIntrospectionCustomRule); "
+        f"got: {extension_class_names}"
+    )
+
+    # Cleanup: reload once more without prod so other tests get back to baseline
+    monkeypatch.delenv("EDGEGUARD_ENV", raising=False)
+    monkeypatch.delenv("EDGEGUARD_API_KEY", raising=False)
+    monkeypatch.delenv("EDGEGUARD_API_HOST", raising=False)
+    if "graphql_api" in sys.modules:
+        del sys.modules["graphql_api"]
+
+
+def test_graphql_introspection_left_on_in_dev(monkeypatch):
+    """Negative pin: in dev/staging, introspection MUST stay on so
+    developers can use GraphiQL / Apollo Studio / schema autocomplete."""
+    monkeypatch.delenv("EDGEGUARD_ENV", raising=False)  # default: dev
+    monkeypatch.delenv("EDGEGUARD_API_KEY", raising=False)
+    monkeypatch.setenv("EDGEGUARD_API_HOST", "127.0.0.1")
+
+    import importlib
+
+    if "graphql_api" in sys.modules:
+        del sys.modules["graphql_api"]
+    import graphql_api
+
+    importlib.reload(graphql_api)
+
+    schema_extensions = getattr(graphql_api.schema, "extensions", []) or []
+    extension_class_names = [type(e).__name__ for e in schema_extensions]
+    # AddValidationRules is the carrier for the introspection-disable rule;
+    # in dev it must NOT be present (or if present, must not carry the rule).
+    # Cheapest pin: assert it's absent in dev.
+    assert "AddValidationRules" not in extension_class_names, (
+        "Dev mode must NOT add the introspection-disable rule (developers need GraphiQL)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# A6 — Refuse to start unauthenticated on non-loopback bind
+# ---------------------------------------------------------------------------
+
+
+def test_query_api_refuses_to_start_unauthenticated_on_external_bind(monkeypatch):
+    """Source-grep pin: query_api.py must refuse to start (raise
+    RuntimeError) when EDGEGUARD_API_KEY is unset AND the bind host
+    is not loopback AND EDGEGUARD_ALLOW_UNAUTH is not set.
+
+    Direct import-time check would also work but is harder to test in
+    isolation because importing query_api boots the full Neo4j driver
+    and FastAPI app. Source-grep is the practical pin."""
+    path = os.path.join(_SRC, "query_api.py")
+    with open(path) as fh:
+        src = _code_only(fh.read())
+    assert "Refusing to start an unauthenticated REST API" in src, (
+        "query_api.py must refuse to start when EDGEGUARD_API_KEY is unset "
+        "AND bound to a non-loopback host (without explicit EDGEGUARD_ALLOW_UNAUTH=1)"
+    )
+    assert "EDGEGUARD_ALLOW_UNAUTH" in src, "must offer the explicit opt-in escape hatch"
+
+
+def test_graphql_api_refuses_to_start_unauthenticated_on_external_bind():
+    """Same contract for graphql_api.py."""
+    path = os.path.join(_SRC, "graphql_api.py")
+    with open(path) as fh:
+        src = _code_only(fh.read())
+    assert "Refusing to start an unauthenticated GraphQL endpoint" in src, (
+        "graphql_api.py must refuse to start when EDGEGUARD_API_KEY is unset AND bound to a non-loopback host"
+    )
+    assert "EDGEGUARD_ALLOW_UNAUTH" in src
+
+
+# ---------------------------------------------------------------------------
+# A8 — Collectors must NOT follow redirects by default
+# ---------------------------------------------------------------------------
+
+
+def test_collector_helper_disables_redirects_by_default():
+    """Source-grep pin on the shared helper: SSRF guard via
+    ``allow_redirects=False`` default.
+
+    If absent, a hijacked upstream feed could redirect to
+    169.254.169.254 (cloud metadata) or 127.0.0.1:7474 (Neo4j Browser)
+    and the response body would land in MISP + Neo4j."""
+    path = os.path.join(_SRC, "collectors", "collector_utils.py")
+    with open(path) as fh:
+        src = _code_only(fh.read())
+    # The helper must explicitly setdefault allow_redirects to False
+    assert 'kwargs.setdefault("allow_redirects", False)' in src, (
+        "request_with_rate_limit_retries must set allow_redirects=False default"
+    )
+
+
+def test_collector_helper_allows_caller_override():
+    """The default is False but caller can pass True explicitly when
+    redirect-following is genuinely needed and the destination is trusted."""
+    from unittest.mock import MagicMock, patch
+
+    from collectors.collector_utils import request_with_rate_limit_retries
+
+    fake_resp = MagicMock(status_code=200)
+    with patch("collectors.collector_utils.requests.request", return_value=fake_resp) as mock_req:
+        request_with_rate_limit_retries("GET", "https://example.com", allow_redirects=True)
+    # The request was called with allow_redirects=True (caller override honored)
+    assert mock_req.call_args.kwargs.get("allow_redirects") is True
+
+
+def test_collector_helper_default_blocks_redirects():
+    """Default path: caller doesn't pass allow_redirects → False enforced."""
+    from unittest.mock import MagicMock, patch
+
+    from collectors.collector_utils import request_with_rate_limit_retries
+
+    fake_resp = MagicMock(status_code=200)
+    with patch("collectors.collector_utils.requests.request", return_value=fake_resp) as mock_req:
+        request_with_rate_limit_retries("GET", "https://example.com")
+    assert mock_req.call_args.kwargs.get("allow_redirects") is False
+
+
+# ---------------------------------------------------------------------------
+# A9 — MISP attribute value size cap
+# ---------------------------------------------------------------------------
+
+
+def test_parse_attribute_rejects_oversized_value(monkeypatch):
+    """A 100KB attribute value (> 4KB default cap) must be REFUSED
+    rather than ingested into Neo4j. Without this, a poisoned upstream
+    feed crashes the sync worker (OOM) and bloats Neo4j page cache."""
+    # Force a small cap so the test doesn't allocate megabytes
+    monkeypatch.setenv("EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES", "100")
+
+    # Defer the heavy imports; bypass __init__ so we don't try to connect to MISP
+    import sys as _sys
+
+    # run_misp_to_neo4j requires several deps; if it fails to import in the
+    # test env, skip rather than fail
+    try:
+        if "run_misp_to_neo4j" in _sys.modules:
+            del _sys.modules["run_misp_to_neo4j"]
+        import run_misp_to_neo4j
+    except Exception:
+        import pytest
+
+        pytest.skip("run_misp_to_neo4j not importable in this env")
+
+    sync = run_misp_to_neo4j.MISPToNeo4jSync.__new__(run_misp_to_neo4j.MISPToNeo4jSync)
+    # Parse an attribute with a 200-byte value (exceeds the 100-byte test cap)
+    oversized = "X" * 200
+    item, rels = sync.parse_attribute(
+        {"type": "ip-src", "value": oversized, "uuid": "test-uuid"},
+        {"id": 42, "info": "test", "date": "2026-04-18", "Tag": []},
+    )
+    assert item is None, f"oversized attribute must be refused; got item={item}"
+    assert rels == [], "oversized attribute must produce no relationships"
+
+
+def test_parse_attribute_accepts_normal_value():
+    """Negative pin: a normal-sized value (well under 4KB default) must
+    parse normally — the cap must not break the happy path."""
+    import sys as _sys
+
+    try:
+        if "run_misp_to_neo4j" in _sys.modules:
+            del _sys.modules["run_misp_to_neo4j"]
+        import run_misp_to_neo4j
+    except Exception:
+        import pytest
+
+        pytest.skip("run_misp_to_neo4j not importable in this env")
+
+    sync = run_misp_to_neo4j.MISPToNeo4jSync.__new__(run_misp_to_neo4j.MISPToNeo4jSync)
+    # Normal IPv4 (15 chars) — well under any sane cap
+    item, _ = sync.parse_attribute(
+        {"type": "ip-src", "value": "203.0.113.5", "uuid": "test-uuid"},
+        {"id": 42, "info": "test", "date": "2026-04-18", "Tag": []},
+    )
+    assert item is not None, "normal-sized attribute must parse — cap must not break happy path"

--- a/tests/test_auth_and_api_hardening.py
+++ b/tests/test_auth_and_api_hardening.py
@@ -206,6 +206,35 @@ def test_graphql_api_refuses_to_start_unauthenticated_on_external_bind():
     assert "EDGEGUARD_ALLOW_UNAUTH" in src
 
 
+def test_graphql_api_security_check_reads_same_env_as_actual_bind():
+    """PR #40 commit X (bugbot HIGH) regression pin.
+
+    The bind-host security check MUST read the same env var the server
+    actually binds to. Previously the check read ``EDGEGUARD_API_HOST``
+    first (a REST-API var; GraphQL server never honors it), then fell
+    back to ``EDGEGUARD_GRAPHQL_HOST``. An operator setting
+    ``EDGEGUARD_API_HOST=127.0.0.1`` + ``EDGEGUARD_GRAPHQL_HOST=0.0.0.0``
+    would PASS the safety check (sees 127.0.0.1 from API_HOST) while
+    the server actually bound to 0.0.0.0 unauthenticated.
+
+    Pin: the security check env var === the actual-bind env var.
+    """
+    path = os.path.join(_SRC, "graphql_api.py")
+    with open(path) as fh:
+        src = _code_only(fh.read())
+    # The security check should NOT consult EDGEGUARD_API_HOST
+    # (that's a REST-only var the GraphQL server doesn't honor)
+    assert 'os.getenv("EDGEGUARD_API_HOST"' not in src, (
+        "graphql_api.py security check must NOT read EDGEGUARD_API_HOST — "
+        "that env var is for REST API only; GraphQL server reads "
+        "EDGEGUARD_GRAPHQL_HOST. Mixed precedence creates a bypass."
+    )
+    # Both the security check and the server bind must read the same var
+    assert src.count('os.getenv("EDGEGUARD_GRAPHQL_HOST"') >= 2, (
+        "graphql_api.py must read EDGEGUARD_GRAPHQL_HOST in BOTH the security check AND the actual server bind"
+    )
+
+
 # ---------------------------------------------------------------------------
 # A8 — Collectors must NOT follow redirects by default
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes the most-skipped Tier-S bucket from the proactive Red Team audit (option **A** from the synthesis). 7 independent + small fixes bundled because they share a theme: defense in depth on the auth + outbound surface.

| # | Sev | What | File |
|---|---|---|---|
| **S6** | HIGH | `AIRFLOW_API_PASSWORD` defaulted to `"airflow"` — exposed Airflow REST API to anyone reaching port 8082 with the default credential | `src/edgeguard.py` |
| **S7** | HIGH | `verify=False` hardcoded in cmd_doctor MISP probe — sent API key over MITM-able TLS | `src/edgeguard.py` |
| **S8** | HIGH | GraphQL had NO query depth limits — DoS via deeply-nested OPTIONAL MATCH fan-out | `src/graphql_api.py` |
| **A6** | MED | `EDGEGUARD_API_KEY` only enforced when `EDGEGUARD_ENV=prod` — staging silently anonymous | both APIs |
| **A7** | MED | GraphQL introspection on by default — schema reconnaissance | `src/graphql_api.py` |
| **A8** | MED | Collectors followed redirects by default — SSRF vector to cloud metadata / internal services | `src/collectors/collector_utils.py` |
| **A9** | MED | No bound on inbound MISP attribute size — OOM via 100MB attribute | `src/run_misp_to_neo4j.py` |

## Operator-visible behavior changes

- `edgeguard doctor` now skips the deep DAG-list API check when `AIRFLOW_API_PASSWORD` is unset (info log explains how to enable). The `/health` probe still runs.
- REST + GraphQL **refuse to start** when ALL: `EDGEGUARD_API_KEY` unset AND non-loopback bind AND no explicit `EDGEGUARD_ALLOW_UNAUTH=1` opt-in. Loopback-bind defaults are unaffected.
- Schema introspection only disabled when `EDGEGUARD_ENV=prod`. Dev/staging keeps GraphiQL working.
- `request_with_rate_limit_retries` now sets `allow_redirects=False` by default. Callers can pass `allow_redirects=True` explicitly when redirect-following is intentional.
- Default MISP attribute value cap: 4 KB. Override via `EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES`.

## Test plan

- [x] 13 new tests in `tests/test_auth_and_api_hardening.py` covering all 7 fixes
- [x] 466/466 pre-existing pytest pass — 479 total
- [x] ruff format/check + mypy clean
- [x] GraphQL extensions verified: prod reload includes `AddValidationRules`, dev reload doesn't
- [x] SSRF default behavioral test: `requests.request` receives `allow_redirects=False`
- [x] MISP value cap behavioral test: oversized → refused; normal → parsed
- [ ] CI green
- [ ] Bugbot review clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes security-critical startup/auth behavior and GraphQL validation, which can block deployments (new refusal-to-start checks) and potentially break clients relying on redirects or schema introspection.
> 
> **Overview**
> Closes multiple Red Team audit findings by tightening defaults across outbound HTTP, CLI diagnostics, and both REST/GraphQL APIs.
> 
> Collectors now **disable HTTP redirects by default** in `request_with_rate_limit_retries` (SSRF hardening, overrideable per call). `edgeguard doctor` stops using `verify=False` for the MISP probe and no longer falls back to the default `airflow:airflow` password—skipping the Airflow DAG API diagnostic unless `AIRFLOW_API_PASSWORD` is explicitly set.
> 
> Both REST (`query_api.py`) and GraphQL (`graphql_api.py`) **refuse to start unauthenticated** when bound to a non-loopback host unless `EDGEGUARD_ALLOW_UNAUTH=1` is set. GraphQL additionally adds **query depth limiting** (configurable via `EDGEGUARD_GRAPHQL_MAX_DEPTH`) and **disables introspection in prod**.
> 
> The MISP→Neo4j sync path caps inbound MISP attribute value size (default 4KB, configurable via `EDGEGUARD_MISP_MAX_ATTR_VALUE_BYTES`) and resolves that cap once at module load for performance and safer misconfiguration handling. Adds regression tests covering all hardening changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3d24476668dc04f56fd5cdb871a4c96f323b3676. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->