### PR TITLE
feat(metrics): Prometheus counters for source-truthful timestamp pipeline

### DIFF
--- a/docs/PROMETHEUS_SETUP.md
+++ b/docs/PROMETHEUS_SETUP.md
@@ -189,7 +189,7 @@ on the failure-mode distribution of the input-hardening layer
 | Metric | Type | Labels | Description |
 |--------|------|--------|-------------|
 | `edgeguard_source_truthful_claim_accepted_total` | Counter | `source_id`, `field` | Per-source claim survived all layers and lands on `r.source_reported_first_at` / `r.source_reported_last_at`. `field ∈ {first_seen, last_seen}`. |
-| `edgeguard_source_truthful_claim_dropped_total` | Counter | `source_id`, `reason`, `field` | Per-source claim did NOT make it onto the edge. `reason ∈ {source_not_in_allowlist, no_data_from_source}`. Honest-NULL drops (source on the allowlist but supplied no value) ARE counted here under `no_data_from_source` — non-zero baseline expected. |
+| `edgeguard_source_truthful_claim_dropped_total` | Counter | `source_id`, `reason`, `field` | Per-source claim did NOT make it onto the edge. `reason ∈ {source_not_in_allowlist, no_data_from_source}`. `field ∈ {first_seen, last_seen}` — both reasons emit per-field (the relay-rejection drop and the honest-NULL drop appear in the same per-field denominator, so the operator query below is correct). Honest-NULL drops (source on the allowlist but supplied no value) ARE counted under `no_data_from_source` — non-zero baseline expected. |
 | `edgeguard_source_truthful_coerce_rejected_total` | Counter | `reason` | `coerce_iso` input rejected. `reason ∈ {sentinel_epoch, malformed_string, overflow}`. No `source_id` label — `coerce_iso` is a pure utility called from many sites without source context. |
 | `edgeguard_source_truthful_future_clamp_total` | Counter | - | Future-dated timestamp clamped to `now()`. Likely upstream feed bug or operator clock drift. The accompanying WARNING log carries the original value. |
 
@@ -203,12 +203,23 @@ a malformed or spoofed source tag from blowing up Prometheus.
 **Operator queries:**
 
 ```promql
-# Per-source acceptance rate (1.0 = source always supplies first_seen)
+# Per-source acceptance rate (1.0 = source always supplies first_seen).
+# Includes ALL drops in the denominator — both honest-NULL
+# (no_data_from_source) and unreliable-source filter
+# (source_not_in_allowlist) — so the rate reflects the full
+# pipeline, not just the post-allowlist-filter slice.
 rate(edgeguard_source_truthful_claim_accepted_total{field="first_seen"}[5m])
   /
-ignoring(reason) sum without(reason) (
+(
     rate(edgeguard_source_truthful_claim_accepted_total{field="first_seen"}[5m])
-  + rate(edgeguard_source_truthful_claim_dropped_total{reason="no_data_from_source", field="first_seen"}[5m])
+  + sum without (reason) (
+        rate(edgeguard_source_truthful_claim_dropped_total{field="first_seen"}[5m])
+    )
+)
+
+# Relay-rejection visibility — count of unreliable-source drops per source
+sum by (source_id) (
+    rate(edgeguard_source_truthful_claim_dropped_total{reason="source_not_in_allowlist"}[5m])
 )
 
 # coerce_iso failure-mode distribution (spot a misbehaving collector)

--- a/docs/PROMETHEUS_SETUP.md
+++ b/docs/PROMETHEUS_SETUP.md
@@ -177,6 +177,47 @@ for every sync run — the `EdgeGuardSyncCoverageGap` alert fires when it breaks
 | `edgeguard_sync_events_processed` | Gauge | - | Events whose `sync_to_neo4j` completed successfully |
 | `edgeguard_sync_events_failed` | Gauge | - | Events that failed permanently (first pass + retry pass + cap exhaustion) |
 
+### Source-truthful Timestamp Pipeline
+
+Added in 2026-04 (PR #41 follow-up — closes the observability gap that
+shipped with the source-truthful first_seen / last_seen edge architecture).
+Without these, an operator has zero signal on which sources actually
+supply per-source timestamp claims vs. emit honest-NULL, and zero signal
+on the failure-mode distribution of the input-hardening layer
+(`coerce_iso`).
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `edgeguard_source_truthful_claim_accepted_total` | Counter | `source_id`, `field` | Per-source claim survived all layers and lands on `r.source_reported_first_at` / `r.source_reported_last_at`. `field ∈ {first_seen, last_seen}`. |
+| `edgeguard_source_truthful_claim_dropped_total` | Counter | `source_id`, `reason`, `field` | Per-source claim did NOT make it onto the edge. `reason ∈ {source_not_in_allowlist, no_data_from_source}`. Honest-NULL drops (source on the allowlist but supplied no value) ARE counted here under `no_data_from_source` — non-zero baseline expected. |
+| `edgeguard_source_truthful_coerce_rejected_total` | Counter | `reason` | `coerce_iso` input rejected. `reason ∈ {sentinel_epoch, malformed_string, overflow}`. No `source_id` label — `coerce_iso` is a pure utility called from many sites without source context. |
+| `edgeguard_source_truthful_future_clamp_total` | Counter | - | Future-dated timestamp clamped to `now()`. Likely upstream feed bug or operator clock drift. The accompanying WARNING log carries the original value. |
+
+**Cardinality control:** the `source_id` label is bounded by an
+allowlist (~20 values: every reliable source plus a few intentionally-
+rejected relays the operator wants visibility into). Anything outside
+the allowlist collapses to `<other>`; `None` / empty collapses to
+`<unknown>`. This caps storage at low hundreds of cells and prevents
+a malformed or spoofed source tag from blowing up Prometheus.
+
+**Operator queries:**
+
+```promql
+# Per-source acceptance rate (1.0 = source always supplies first_seen)
+rate(edgeguard_source_truthful_claim_accepted_total{field="first_seen"}[5m])
+  /
+ignoring(reason) sum without(reason) (
+    rate(edgeguard_source_truthful_claim_accepted_total{field="first_seen"}[5m])
+  + rate(edgeguard_source_truthful_claim_dropped_total{reason="no_data_from_source", field="first_seen"}[5m])
+)
+
+# coerce_iso failure-mode distribution (spot a misbehaving collector)
+sum by (reason) (rate(edgeguard_source_truthful_coerce_rejected_total[5m]))
+
+# Spike alert: future-clamp rate > 1/min (likely upstream clock drift)
+rate(edgeguard_source_truthful_future_clamp_total[5m]) > 1 / 60
+```
+
 ## Using Metrics in Code
 
 ### Recording Collection
@@ -452,4 +493,4 @@ docker-compose -f docker-compose.monitoring.yml down -v
 
 ---
 
-_Last updated: 2026-03-24 — repo **`prometheus/prometheus.yml`** scrapes EdgeGuard metrics at **`host.docker.internal:8001`** (not 8000 REST). Metrics server default port **8001**._
+_Last updated: 2026-04-18 — added the four `edgeguard_source_truthful_*` counters that close the observability gap shipped with PR #41 (per-source first_seen / last_seen edge architecture); spawned-task chip 5b. Prior pass 2026-03-24: repo **`prometheus/prometheus.yml`** scrapes EdgeGuard metrics at **`host.docker.internal:8001`** (not 8000 REST). Metrics server default port **8001**._

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -338,36 +338,76 @@ def record_misp_attribute_dropped(reason: str, count: int = 1):
 
 # Allowlist used to keep the source_id label cardinality bounded. Anything
 # outside the list collapses to "<other>" so a malformed / surprise tag
-# can't blow up Prometheus storage. Mirrors
-# ``source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES`` plus a few
-# common relays we explicitly reject (so the operator can SEE the relay
-# rejection rate, not just have it disappear).
-_SOURCE_LABEL_ALLOWLIST = frozenset(
+# can't blow up Prometheus storage.
+#
+# Composition is two-part:
+#   1. RELIABLE — every entry in
+#      ``source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES``
+#      (mirrored byte-for-byte; see test
+#      ``test_source_label_allowlist_mirrors_reliable_first_seen_sources``
+#      that pins parity).
+#   2. REJECTED-ON-PURPOSE — relays we deliberately exclude from the
+#      reliable allowlist but still want metric visibility for so
+#      operators can SEE the rejection rate as signal, not silence.
+#
+# PR #42 audit M1 (Cross-Checker): the previous hand-maintained
+# allowlist drifted from ``_RELIABLE_FIRST_SEEN_SOURCES`` — it
+# included ``sslbl`` even though no source emits that tag (the
+# canonical SSL-Blacklist tags are ``ssl_blacklist`` /
+# ``abusech_ssl``). Drift was silent: the sslbl cell was dead and a
+# future source added to the reliable allowlist would have collapsed
+# into ``<other>`` until somebody remembered to update both files.
+_REJECTED_ON_PURPOSE_SOURCES: frozenset[str] = frozenset(
     {
-        # Allowlisted sources (mirror _RELIABLE_FIRST_SEEN_SOURCES).
-        "nvd",
-        "cisa",
-        "cisa_kev",
-        "mitre",
-        "mitre_attck",
-        "virustotal",
-        "vt",
-        "abuseipdb",
-        "threatfox",
-        "urlhaus",
-        "feodo",
-        "feodo_tracker",
-        "sslbl",
-        "ssl_blacklist",
-        "abusech_ssl",
-        # Rejected-on-purpose sources we still want a counter for so
-        # operators see the rejection rate as signal, not silence.
         "otx",
         "alienvault_otx",
         "cybercure",
         "misp",
     }
 )
+
+
+def _build_source_label_allowlist() -> frozenset[str]:
+    """Compose the metrics allowlist from the source-truthful module.
+
+    Lazy + late-bound so the import order (``metrics_server`` ←
+    ``source_truthful_timestamps``) doesn't form a cycle: the
+    source-truthful module imports ``record_*`` functions from us,
+    so we cannot import ``_RELIABLE_FIRST_SEEN_SOURCES`` at
+    module-load time. By the time any caller hits
+    ``_safe_source_label``, the source-truthful module is already
+    fully imported (the call only fires from inside its
+    ``extract_source_truthful_timestamps`` body).
+    """
+    try:
+        from source_truthful_timestamps import _RELIABLE_FIRST_SEEN_SOURCES
+    except ImportError:  # pragma: no cover — defensive
+        return _REJECTED_ON_PURPOSE_SOURCES
+    return frozenset(_RELIABLE_FIRST_SEEN_SOURCES) | _REJECTED_ON_PURPOSE_SOURCES
+
+
+# Module-level cache: built lazily on first call. ``None`` sentinel
+# means "not yet initialized"; ``frozenset()`` would be the empty
+# allowlist which is a different state (every source → ``<other>``).
+#
+# CRITICAL: this MUST be lazy. ``source_truthful_timestamps`` imports
+# the ``record_*`` helpers from this module. If we eagerly build the
+# allowlist at import time, Python's circular-import handling returns
+# a half-initialized ``metrics_server`` to ``source_truthful_timestamps``
+# — its defensive ``try/except ImportError`` catches the missing
+# names and silently installs no-op shims. The metrics never fire.
+# Lazy build avoids that: by the time ``_source_label_allowlist`` is
+# called from inside ``_safe_source_label``, both modules are fully
+# loaded and the import succeeds.
+_SOURCE_LABEL_ALLOWLIST_CACHE: frozenset[str] | None = None
+
+
+def _source_label_allowlist() -> frozenset[str]:
+    """Return the cached allowlist; build on first call."""
+    global _SOURCE_LABEL_ALLOWLIST_CACHE
+    if _SOURCE_LABEL_ALLOWLIST_CACHE is None:
+        _SOURCE_LABEL_ALLOWLIST_CACHE = _build_source_label_allowlist()
+    return _SOURCE_LABEL_ALLOWLIST_CACHE
 
 
 def _safe_source_label(source_id: str | None) -> str:
@@ -382,7 +422,40 @@ def _safe_source_label(source_id: str | None) -> str:
     norm = source_id.strip().lower()
     if not norm:
         return "<unknown>"
-    return norm if norm in _SOURCE_LABEL_ALLOWLIST else "<other>"
+    # Use the lazy lookup so a hypothetical late binding of
+    # source_truthful_timestamps still resolves correctly. Falls back
+    # to the eagerly-built constant if the module-level cache has
+    # already settled.
+    return norm if norm in _source_label_allowlist() else "<other>"
+
+
+# PR #42 audit M2 (Bug Hunter): bounded enums for ``reason`` labels on
+# the source-truthful counters. Without these, a future caller could
+# pass an unbounded string and blow up Prometheus cardinality —
+# Prometheus stores ONE time series per unique label combination, so
+# even one ``reason=<random uuid>`` per call would O(N) explode the
+# memory footprint over time. PR #42 audit M3 (Logic Tracker): the
+# ``field`` label gets the same treatment for the same reason, plus
+# the historical ``"both"`` value was dropped when source_not_in_allowlist
+# switched to per-field emit (see source_truthful_timestamps.py).
+_VALID_DROP_REASONS: frozenset[str] = frozenset({"source_not_in_allowlist", "no_data_from_source"})
+_VALID_COERCE_REASONS: frozenset[str] = frozenset({"sentinel_epoch", "malformed_string", "overflow"})
+_VALID_FIELD_LABELS: frozenset[str] = frozenset({"first_seen", "last_seen"})
+
+
+def _safe_enum_label(value: str | None, valid: frozenset[str]) -> str:
+    """Clamp a label value to a known enum; unknown → ``<other>``.
+
+    Empty / None → ``<unknown>`` (operator-distinguishable from
+    ``<other>``: the former is missing data, the latter is an
+    out-of-band reason value worth investigating).
+    """
+    if not value:
+        return "<unknown>"
+    norm = value.strip().lower()[:80].replace('"', "")
+    if not norm:
+        return "<unknown>"
+    return norm if norm in valid else "<other>"
 
 
 def record_source_truthful_claim_accepted(source_id: str | None, field: str) -> None:
@@ -391,7 +464,10 @@ def record_source_truthful_claim_accepted(source_id: str | None, field: str) -> 
     Called from ``extract_source_truthful_timestamps`` exactly once per
     (call, field) when the final post-Layer-2 value is non-NULL.
     """
-    SOURCE_TRUTHFUL_CLAIM_ACCEPTED.labels(source_id=_safe_source_label(source_id), field=field).inc()
+    SOURCE_TRUTHFUL_CLAIM_ACCEPTED.labels(
+        source_id=_safe_source_label(source_id),
+        field=_safe_enum_label(field, _VALID_FIELD_LABELS),
+    ).inc()
 
 
 def record_source_truthful_claim_dropped(source_id: str | None, reason: str, field: str) -> None:
@@ -402,8 +478,11 @@ def record_source_truthful_claim_dropped(source_id: str | None, reason: str, fie
     drops are counted here under ``no_data_from_source`` — operators
     monitoring this counter should expect a non-zero baseline.
     """
-    safe_reason = (reason or "unknown").replace('"', "")[:80]
-    SOURCE_TRUTHFUL_CLAIM_DROPPED.labels(source_id=_safe_source_label(source_id), reason=safe_reason, field=field).inc()
+    SOURCE_TRUTHFUL_CLAIM_DROPPED.labels(
+        source_id=_safe_source_label(source_id),
+        reason=_safe_enum_label(reason, _VALID_DROP_REASONS),
+        field=_safe_enum_label(field, _VALID_FIELD_LABELS),
+    ).inc()
 
 
 def record_source_truthful_coerce_rejected(reason: str) -> None:
@@ -414,8 +493,9 @@ def record_source_truthful_coerce_rejected(reason: str) -> None:
     (sentinel_epoch / malformed_string / overflow); see the counter
     definition for the full enum.
     """
-    safe = (reason or "unknown").replace('"', "")[:80]
-    SOURCE_TRUTHFUL_COERCE_REJECTED.labels(reason=safe).inc()
+    SOURCE_TRUTHFUL_COERCE_REJECTED.labels(
+        reason=_safe_enum_label(reason, _VALID_COERCE_REASONS),
+    ).inc()
 
 
 def record_source_truthful_future_clamp() -> None:

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -19,6 +19,10 @@ Metrics exposed:
 - edgeguard_last_success_timestamp - Unix timestamp of last successful collection
 - edgeguard_pipeline_duration_seconds - Total pipeline duration
 - edgeguard_dag_runs_total - DAG run counter by status
+- edgeguard_source_truthful_claim_accepted_total - Source-truthful timestamp claim accepted (per source + field)
+- edgeguard_source_truthful_claim_dropped_total - Source-truthful timestamp claim dropped (per source + reason + field)
+- edgeguard_source_truthful_coerce_rejected_total - coerce_iso input rejected (per failure-mode reason)
+- edgeguard_source_truthful_future_clamp_total - Future-dated timestamp clamped to now()
 """
 
 import json
@@ -229,6 +233,59 @@ ENRICHMENT_DURATION = Histogram(
     buckets=[0.1, 0.5, 1.0, 2.5, 5.0, 10.0, 30.0],
 )
 
+# ================================================================================
+# Source-truthful timestamp pipeline (PR #41 follow-up)
+# ================================================================================
+# Counters that surface how the per-source first_seen / last_seen pipeline
+# (src/source_truthful_timestamps.py) is performing in production. Without
+# them an operator has no visibility into:
+#  - which sources actually supply the values vs. emit honest-NULL
+#  - the failure-mode distribution of coerce_iso (sentinel epochs vs.
+#    malformed strings vs. overflow)
+#  - upstream feed bugs producing future-dated timestamps
+# Cardinality budget: ~16 sources × {first_seen, last_seen, both} × small
+# reason set ≈ low hundreds of cells; well within Prometheus comfort.
+
+SOURCE_TRUTHFUL_CLAIM_ACCEPTED = Counter(
+    "edgeguard_source_truthful_claim_accepted_total",
+    "Source-truthful timestamp claim accepted onto the SOURCED_FROM edge — by source + field. "
+    "Incremented exactly once per (extract call, field) when the final post-Layer-2 value is non-NULL.",
+    ["source_id", "field"],  # field ∈ {first_seen, last_seen}
+)
+
+SOURCE_TRUTHFUL_CLAIM_DROPPED = Counter(
+    "edgeguard_source_truthful_claim_dropped_total",
+    "Source-truthful timestamp claim dropped — by source + reason + field. "
+    "honest-NULL drops (source on the allowlist but supplied no value) ARE counted here under "
+    "reason=no_data_from_source — operators looking at total_dropped should expect a non-zero baseline.",
+    ["source_id", "reason", "field"],
+    # reason ∈ {
+    #   "source_not_in_allowlist",  # caller's source not on the reliable list (Layer 1 filter)
+    #   "no_data_from_source",      # source on the list but Layer 1 + Layer 2 both empty (honest-NULL)
+    # }
+    # field: first_seen / last_seen — "both" is used for the single
+    # source_not_in_allowlist emit (we never even attempt per-field).
+)
+
+SOURCE_TRUTHFUL_COERCE_REJECTED = Counter(
+    "edgeguard_source_truthful_coerce_rejected_total",
+    "coerce_iso input rejected — by failure-mode reason. No source_id label: coerce_iso is a "
+    "pure utility called from many sites (STIX exporter, alert processor, etc.) without source context.",
+    ["reason"],
+    # reason ∈ {
+    #   "sentinel_epoch",    # int/float ≤ 0 or > epoch ceil
+    #   "malformed_string",  # non-ISO / invalid calendar / non-ASCII / parse failure
+    #   "overflow",          # OverflowError / OSError from datetime.fromtimestamp
+    # }
+)
+
+SOURCE_TRUTHFUL_FUTURE_CLAMP = Counter(
+    "edgeguard_source_truthful_future_clamp_total",
+    "Future-dated timestamp clamped to now() — likely upstream feed bug or operator clock drift. "
+    "The corresponding WARNING log carries the original value for triage.",
+    [],
+)
+
 # Set application info
 APP_INFO.info(
     {"version": os.getenv("EDGEGUARD_VERSION", "1.0.0"), "environment": os.getenv("EDGEGUARD_ENV", "development")}
@@ -270,6 +327,103 @@ def record_misp_attribute_dropped(reason: str, count: int = 1):
     """Record an attribute dropped during dedup/parse — see MISP_ATTRIBUTES_DROPPED."""
     safe = (reason or "unknown").replace('"', "")[:80]
     MISP_ATTRIBUTES_DROPPED.labels(reason=safe).inc(count)
+
+
+# ----------------------------------------------------------------------------
+# Source-truthful timestamp pipeline helpers (see SOURCE_TRUTHFUL_* counters)
+# ----------------------------------------------------------------------------
+# These are imported defensively from src/source_truthful_timestamps.py so
+# they tolerate import failures (tests that don't bring up prometheus_client,
+# etc.). The counters themselves are always-on once this module imports.
+
+# Allowlist used to keep the source_id label cardinality bounded. Anything
+# outside the list collapses to "<other>" so a malformed / surprise tag
+# can't blow up Prometheus storage. Mirrors
+# ``source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES`` plus a few
+# common relays we explicitly reject (so the operator can SEE the relay
+# rejection rate, not just have it disappear).
+_SOURCE_LABEL_ALLOWLIST = frozenset(
+    {
+        # Allowlisted sources (mirror _RELIABLE_FIRST_SEEN_SOURCES).
+        "nvd",
+        "cisa",
+        "cisa_kev",
+        "mitre",
+        "mitre_attck",
+        "virustotal",
+        "vt",
+        "abuseipdb",
+        "threatfox",
+        "urlhaus",
+        "feodo",
+        "feodo_tracker",
+        "sslbl",
+        "ssl_blacklist",
+        "abusech_ssl",
+        # Rejected-on-purpose sources we still want a counter for so
+        # operators see the rejection rate as signal, not silence.
+        "otx",
+        "alienvault_otx",
+        "cybercure",
+        "misp",
+    }
+)
+
+
+def _safe_source_label(source_id: str | None) -> str:
+    """Coerce a source_id to a bounded-cardinality Prometheus label.
+
+    ``None`` / empty → ``"<unknown>"``; anything outside the allowlist →
+    ``"<other>"``. Caps Prometheus storage at ~20 source labels rather
+    than allowing an unbounded set of malformed / spoofed tags.
+    """
+    if not source_id:
+        return "<unknown>"
+    norm = source_id.strip().lower()
+    if not norm:
+        return "<unknown>"
+    return norm if norm in _SOURCE_LABEL_ALLOWLIST else "<other>"
+
+
+def record_source_truthful_claim_accepted(source_id: str | None, field: str) -> None:
+    """Record a source-truthful claim that survived the full pipeline.
+
+    Called from ``extract_source_truthful_timestamps`` exactly once per
+    (call, field) when the final post-Layer-2 value is non-NULL.
+    """
+    SOURCE_TRUTHFUL_CLAIM_ACCEPTED.labels(source_id=_safe_source_label(source_id), field=field).inc()
+
+
+def record_source_truthful_claim_dropped(source_id: str | None, reason: str, field: str) -> None:
+    """Record a source-truthful claim that did NOT make it onto the edge.
+
+    Called from ``extract_source_truthful_timestamps`` for two distinct
+    reasons (source_not_in_allowlist / no_data_from_source). Honest-NULL
+    drops are counted here under ``no_data_from_source`` — operators
+    monitoring this counter should expect a non-zero baseline.
+    """
+    safe_reason = (reason or "unknown").replace('"', "")[:80]
+    SOURCE_TRUTHFUL_CLAIM_DROPPED.labels(source_id=_safe_source_label(source_id), reason=safe_reason, field=field).inc()
+
+
+def record_source_truthful_coerce_rejected(reason: str) -> None:
+    """Record a coerce_iso input that the input-hardening layer refused.
+
+    Called from inside ``coerce_iso`` itself — pure utility, no source
+    context available. The reason label IS bounded
+    (sentinel_epoch / malformed_string / overflow); see the counter
+    definition for the full enum.
+    """
+    safe = (reason or "unknown").replace('"', "")[:80]
+    SOURCE_TRUTHFUL_COERCE_REJECTED.labels(reason=safe).inc()
+
+
+def record_source_truthful_future_clamp() -> None:
+    """Record one future-dated timestamp clamp (likely feed bug / clock drift).
+
+    The accompanying WARNING log carries the original value for triage.
+    """
+    SOURCE_TRUTHFUL_FUTURE_CLAMP.inc()
 
 
 def record_misp_unmapped_attribute_type(attr_type: str, count: int = 1):

--- a/src/source_truthful_timestamps.py
+++ b/src/source_truthful_timestamps.py
@@ -554,10 +554,17 @@ def extract_source_truthful_timestamps(
         the comment field.
     """
     if not is_reliable_first_seen_source(source_id):
-        # Single emit (field="both") — we never even attempt per-field
-        # extraction for unreliable sources, so per-field counters would
-        # double-count this case.
-        _metric_drop(source_id, "source_not_in_allowlist", "both")
+        # PR #42 audit M3 (Logic Tracker): emit per-field — symmetric
+        # with the no_data_from_source path below — so the documented
+        # PromQL acceptance-rate query
+        # ``accepted{field=X} / sum without(reason)(accepted+dropped){field=X}``
+        # gives correct denominators. Earlier draft emitted once with
+        # ``field="both"`` which broke per-field aggregation for
+        # relays like OTX (every OTX hit collapsed into a third
+        # ``field`` value not visible in the per-first_seen / per-last_seen
+        # operator queries).
+        _metric_drop(source_id, "source_not_in_allowlist", "first_seen")
+        _metric_drop(source_id, "source_not_in_allowlist", "last_seen")
         return (None, None)
 
     # Layer 1: MISP-native attribute fields (the lossless round-trip path)

--- a/src/source_truthful_timestamps.py
+++ b/src/source_truthful_timestamps.py
@@ -133,6 +133,44 @@ from typing import Any, Dict, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
+# ---------------------------------------------------------------------------
+# Prometheus counter wiring (defensive import)
+# ---------------------------------------------------------------------------
+# Imported defensively so this module stays importable in test contexts
+# that don't bring up prometheus_client (or that monkey-patch the
+# metrics registry between tests). The four ``_metric_*`` shims are
+# unconditionally callable; they no-op when the import fails.
+#
+# Counter design and label-cardinality budget live in
+# ``src/metrics_server.py`` next to the ``SOURCE_TRUTHFUL_*`` Counter
+# definitions. Spawned-task chip 5b from the PR #41 audit.
+try:
+    from metrics_server import (
+        record_source_truthful_claim_accepted as _metric_accept,
+    )
+    from metrics_server import (
+        record_source_truthful_claim_dropped as _metric_drop,
+    )
+    from metrics_server import (
+        record_source_truthful_coerce_rejected as _metric_coerce_reject,
+    )
+    from metrics_server import (
+        record_source_truthful_future_clamp as _metric_future_clamp,
+    )
+except ImportError:  # pragma: no cover — defensive
+
+    def _metric_accept(*_a: Any, **_kw: Any) -> None:
+        return None
+
+    def _metric_drop(*_a: Any, **_kw: Any) -> None:
+        return None
+
+    def _metric_coerce_reject(*_a: Any, **_kw: Any) -> None:
+        return None
+
+    def _metric_future_clamp(*_a: Any, **_kw: Any) -> None:
+        return None
+
 
 # ---------------------------------------------------------------------------
 # Sanity bounds for int/float Unix epoch parsing in coerce_iso
@@ -246,6 +284,7 @@ def _clamp_future_to_now(iso: Optional[str]) -> Optional[str]:
             iso,
             now.isoformat(),
         )
+        _metric_future_clamp()
         return now.isoformat()
     return iso
 
@@ -317,9 +356,14 @@ def coerce_iso(val: Any) -> Optional[str]:
         # limit (rejects overflow). Anything between is accepted.
         try:
             if not (_INT_EPOCH_FLOOR <= val <= _INT_EPOCH_CEIL):
+                # Counter (PR follow-up): operators can see the sentinel-vs-overflow
+                # distribution to spot a misbehaving collector dumping 0 / -1 vs.
+                # one accidentally feeding millisecond epochs as seconds.
+                _metric_coerce_reject("sentinel_epoch")
                 return None
             return datetime.fromtimestamp(val, tz=timezone.utc).isoformat()
         except (ValueError, OSError, OverflowError):
+            _metric_coerce_reject("overflow")
             return None
     if isinstance(val, datetime):
         return val.isoformat()
@@ -357,6 +401,7 @@ def coerce_iso(val: Any) -> Optional[str]:
             try:
                 datetime.fromisoformat(s)
             except ValueError:
+                _metric_coerce_reject("malformed_string")
                 return None
             return s + "T00:00:00+00:00"
         # 2. Full-string branch: validate via fromisoformat (with the
@@ -370,6 +415,7 @@ def coerce_iso(val: Any) -> Optional[str]:
             # downstream Cypher ``datetime()`` call. Logged at the
             # caller layer (extract_source_truthful_timestamps) where
             # source_id context is available for better triage.
+            _metric_coerce_reject("malformed_string")
             return None
         return s
     return None
@@ -505,6 +551,10 @@ def extract_source_truthful_timestamps(
         the comment field.
     """
     if not is_reliable_first_seen_source(source_id):
+        # Single emit (field="both") — we never even attempt per-field
+        # extraction for unreliable sources, so per-field counters would
+        # double-count this case.
+        _metric_drop(source_id, "source_not_in_allowlist", "both")
         return (None, None)
 
     # Layer 1: MISP-native attribute fields (the lossless round-trip path)
@@ -520,7 +570,23 @@ def extract_source_truthful_timestamps(
         first_seen = first_seen or _coerce_iso(tf_meta.get("first_seen"))
         last_seen = last_seen or _coerce_iso(tf_meta.get("last_seen"))
 
-    return (_clamp_future_to_now(first_seen), _clamp_future_to_now(last_seen))
+    # Final accept/drop accounting per field. Counter is emitted AFTER
+    # both layers run (so a Layer-2 fallback that fills in a missing
+    # Layer-1 value counts as accepted, not dropped). Honest-NULL drops
+    # — source on the allowlist but neither layer supplied a value —
+    # are counted under reason=no_data_from_source so operators can
+    # see the per-source baseline rate.
+    final_first = _clamp_future_to_now(first_seen)
+    final_last = _clamp_future_to_now(last_seen)
+    if final_first is not None:
+        _metric_accept(source_id, "first_seen")
+    else:
+        _metric_drop(source_id, "no_data_from_source", "first_seen")
+    if final_last is not None:
+        _metric_accept(source_id, "last_seen")
+    else:
+        _metric_drop(source_id, "no_data_from_source", "last_seen")
+    return (final_first, final_last)
 
 
 # PR (S5) (bugbot LOW): removed the unused

--- a/src/source_truthful_timestamps.py
+++ b/src/source_truthful_timestamps.py
@@ -158,17 +158,20 @@ try:
         record_source_truthful_future_clamp as _metric_future_clamp,
     )
 except ImportError:  # pragma: no cover — defensive
-
-    def _metric_accept(*_a: Any, **_kw: Any) -> None:
+    # Mypy enforces "all conditional function variants must have
+    # identical signatures" — keep these no-ops in lock-step with
+    # the metrics_server helpers they shadow. If you change a helper
+    # signature, change BOTH places.
+    def _metric_accept(source_id: Optional[str], field: str) -> None:
         return None
 
-    def _metric_drop(*_a: Any, **_kw: Any) -> None:
+    def _metric_drop(source_id: Optional[str], reason: str, field: str) -> None:
         return None
 
-    def _metric_coerce_reject(*_a: Any, **_kw: Any) -> None:
+    def _metric_coerce_reject(reason: str) -> None:
         return None
 
-    def _metric_future_clamp(*_a: Any, **_kw: Any) -> None:
+    def _metric_future_clamp() -> None:
         return None
 
 

--- a/tests/test_source_truthful_metrics.py
+++ b/tests/test_source_truthful_metrics.py
@@ -1,0 +1,394 @@
+"""PR follow-up — Prometheus counters for the source-truthful pipeline.
+
+Spawned-task chip 5b from the PR #41 audit closed an observability gap:
+zero counters in ``src/metrics_server.py`` matched ``first_seen``,
+``first_imported``, ``source_reported``, or ``source_truthful``. Operators
+had no signal on:
+
+- which sources actually supply per-source first/last_seen vs. emit
+  honest-NULL (Layer 1 + Layer 2 both empty)
+- the failure-mode distribution of ``coerce_iso``
+  (sentinel epochs vs. malformed strings vs. overflow)
+- upstream feed bugs producing future-dated timestamps that get clamped
+
+This module pins the four new counters (defined in
+``src/metrics_server.py``) and the wiring at three sites in
+``src/source_truthful_timestamps.py``:
+
+1. ``extract_source_truthful_timestamps`` — accept/drop per (source, field)
+2. ``coerce_iso`` — failure-mode counter (no source context)
+3. ``_clamp_future_to_now`` — future-clamp counter
+
+Test strategy: snapshot the counter value before each invocation and
+assert the post-call delta. We pull the value via
+``Counter._value.get()`` (private API but stable; same approach the
+prometheus_client docs use in their own examples). Snapshotting is
+required because the global registry persists across tests in the same
+process — comparing absolute values would couple tests to execution
+order.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Dict
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — snapshot a counter family by label-set so we can assert deltas
+# ---------------------------------------------------------------------------
+
+
+def _counter_value(counter, **labels) -> float:
+    """Read the current numeric value of a Counter cell.
+
+    ``Counter._value.get()`` is technically private but documented as the
+    stable read API in prometheus_client's own README + tests; the public
+    ``generate_latest()`` returns a serialized text payload that requires
+    parsing.
+    """
+    if labels:
+        cell = counter.labels(**labels)
+    else:
+        cell = counter
+    # ``_value`` is a ``Value`` object; ``.get()`` returns the float.
+    return float(cell._value.get())
+
+
+def _snapshot(counter, label_combos) -> Dict[tuple, float]:
+    """Snapshot multiple label-sets of one counter family."""
+    out: Dict[tuple, float] = {}
+    for combo in label_combos:
+        if isinstance(combo, dict):
+            out[tuple(sorted(combo.items()))] = _counter_value(counter, **combo)
+        else:
+            out[combo] = _counter_value(counter)
+    return out
+
+
+# ===========================================================================
+# 1. extract_source_truthful_timestamps — accept + drop counters
+# ===========================================================================
+
+
+def test_extract_emits_accepted_counter_for_present_first_seen_and_last_seen():
+    """Reliable source supplies both timestamps → two ACCEPTED increments
+    (one per field), zero DROPPED increments."""
+    from metrics_server import SOURCE_TRUTHFUL_CLAIM_ACCEPTED, SOURCE_TRUTHFUL_CLAIM_DROPPED
+    from source_truthful_timestamps import extract_source_truthful_timestamps
+
+    before_first = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="nvd", field="first_seen")
+    before_last = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="nvd", field="last_seen")
+    before_drop = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED,
+        source_id="nvd",
+        reason="no_data_from_source",
+        field="first_seen",
+    )
+
+    out = extract_source_truthful_timestamps(
+        {"first_seen": "2024-01-01T00:00:00+00:00", "last_seen": "2024-06-01T00:00:00+00:00"},
+        source_id="nvd",
+    )
+    assert out[0] is not None and out[1] is not None
+
+    after_first = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="nvd", field="first_seen")
+    after_last = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="nvd", field="last_seen")
+    after_drop = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED,
+        source_id="nvd",
+        reason="no_data_from_source",
+        field="first_seen",
+    )
+    assert after_first - before_first == 1.0, "first_seen ACCEPTED counter should have incremented by 1"
+    assert after_last - before_last == 1.0, "last_seen ACCEPTED counter should have incremented by 1"
+    assert after_drop - before_drop == 0.0, "no_data_from_source DROPPED counter should NOT have incremented"
+
+
+def test_extract_emits_no_data_counter_for_reliable_source_with_None_values():
+    """Reliable source on the allowlist but supplies neither value
+    (honest-NULL) → two no_data_from_source DROPPED increments, zero
+    ACCEPTED increments."""
+    from metrics_server import SOURCE_TRUTHFUL_CLAIM_ACCEPTED, SOURCE_TRUTHFUL_CLAIM_DROPPED
+    from source_truthful_timestamps import extract_source_truthful_timestamps
+
+    before_drop_first = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="cisa_kev", reason="no_data_from_source", field="first_seen"
+    )
+    before_drop_last = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="cisa_kev", reason="no_data_from_source", field="last_seen"
+    )
+    before_accept = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="cisa_kev", field="first_seen")
+
+    out = extract_source_truthful_timestamps({}, source_id="cisa_kev")
+    assert out == (None, None)
+
+    after_drop_first = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="cisa_kev", reason="no_data_from_source", field="first_seen"
+    )
+    after_drop_last = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="cisa_kev", reason="no_data_from_source", field="last_seen"
+    )
+    after_accept = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="cisa_kev", field="first_seen")
+    assert after_drop_first - before_drop_first == 1.0
+    assert after_drop_last - before_drop_last == 1.0
+    assert after_accept - before_accept == 0.0
+
+
+def test_extract_emits_source_not_in_allowlist_counter_once_for_unreliable_source():
+    """Unreliable source (OTX) → ONE source_not_in_allowlist DROPPED
+    increment with field='both'. Per-field drop counters must NOT
+    increment (we never even attempt extraction)."""
+    from metrics_server import SOURCE_TRUTHFUL_CLAIM_DROPPED
+    from source_truthful_timestamps import extract_source_truthful_timestamps
+
+    before_both = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="both"
+    )
+    before_first = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="no_data_from_source", field="first_seen"
+    )
+
+    out = extract_source_truthful_timestamps(
+        {"first_seen": "2024-01-01T00:00:00Z", "last_seen": "2024-06-01T00:00:00Z"},
+        source_id="otx",
+    )
+    assert out == (None, None)
+
+    after_both = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="both"
+    )
+    after_first = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="no_data_from_source", field="first_seen"
+    )
+    assert after_both - before_both == 1.0, "source_not_in_allowlist counter should fire exactly once for OTX"
+    assert after_first - before_first == 0.0, "per-field DROPPED counters must NOT fire for unreliable sources"
+
+
+def test_extract_layer2_fallback_counts_as_accepted_not_dropped():
+    """Layer 1 returns None but Layer 2 (NVD_META.published) fills in →
+    the call counts as ACCEPTED, NOT as no_data_from_source. Counter is
+    emitted AFTER both layers run, so a Layer-2 fallback that fills in
+    a missing Layer-1 value MUST count as accepted."""
+    from metrics_server import SOURCE_TRUTHFUL_CLAIM_ACCEPTED, SOURCE_TRUTHFUL_CLAIM_DROPPED
+    from source_truthful_timestamps import extract_source_truthful_timestamps
+
+    before_accept = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="nvd", field="first_seen")
+    before_drop = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="no_data_from_source", field="first_seen"
+    )
+
+    out = extract_source_truthful_timestamps(
+        {},  # Layer 1: empty
+        source_id="nvd",
+        nvd_meta={"published": "2024-03-15T10:00:00+00:00"},  # Layer 2 supplies
+    )
+    assert out[0] is not None  # first_seen WAS resolved via Layer 2
+
+    after_accept = _counter_value(SOURCE_TRUTHFUL_CLAIM_ACCEPTED, source_id="nvd", field="first_seen")
+    after_drop = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="no_data_from_source", field="first_seen"
+    )
+    assert after_accept - before_accept == 1.0, "Layer-2 fallback MUST count as accepted"
+    assert after_drop - before_drop == 0.0, "Layer-2 fallback MUST NOT also fire the dropped counter"
+
+
+# ===========================================================================
+# 2. coerce_iso — failure-mode counter (no source_id label)
+# ===========================================================================
+
+
+def test_coerce_iso_emits_sentinel_epoch_counter_for_zero_epoch():
+    """``coerce_iso(0)`` rejects (0 is below _INT_EPOCH_FLOOR=1) and
+    increments the sentinel_epoch counter."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    assert coerce_iso(0) is None
+    after = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    assert after - before == 1.0
+
+
+def test_coerce_iso_emits_sentinel_epoch_counter_for_negative_epoch():
+    """``coerce_iso(-1)`` also rejects with sentinel_epoch."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    assert coerce_iso(-1) is None
+    after = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    assert after - before == 1.0
+
+
+def test_coerce_iso_emits_sentinel_epoch_counter_for_above_ceil():
+    """An int above the year-9999 ceiling rejects with sentinel_epoch
+    (the bound check classifies all out-of-range int/float values
+    uniformly under sentinel_epoch — overflow is reserved for the
+    OverflowError exception path)."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    # Just above the 9999-12-31 ceil (253_402_300_799)
+    assert coerce_iso(253_402_300_800) is None
+    after = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    assert after - before == 1.0
+
+
+def test_coerce_iso_emits_malformed_string_counter_for_invalid_calendar():
+    """``coerce_iso("2024-13-99")`` is shape-valid (10 chars, hyphen
+    positions correct, all digits) but calendar-invalid → rejects with
+    malformed_string."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string")
+    assert coerce_iso("2024-13-99") is None
+    after = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string")
+    assert after - before == 1.0
+
+
+def test_coerce_iso_emits_malformed_string_counter_for_unparseable_full_string():
+    """``coerce_iso("not a date")`` fails the full-string fromisoformat
+    branch → rejects with malformed_string."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string")
+    assert coerce_iso("not a date at all") is None
+    after = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string")
+    assert after - before == 1.0
+
+
+def test_coerce_iso_does_not_emit_for_None():
+    """``None`` is a legitimate honest-NULL input, not a parse failure.
+    No counter should fire."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before_sent = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    before_mal = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string")
+    before_over = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="overflow")
+
+    assert coerce_iso(None) is None
+
+    assert _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch") - before_sent == 0.0
+    assert _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string") - before_mal == 0.0
+    assert _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="overflow") - before_over == 0.0
+
+
+def test_coerce_iso_does_not_emit_for_valid_iso():
+    """A clean valid input must NOT fire any of the rejection counters."""
+    from metrics_server import SOURCE_TRUTHFUL_COERCE_REJECTED
+    from source_truthful_timestamps import coerce_iso
+
+    before_sent = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch")
+    before_mal = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string")
+
+    out = coerce_iso("2024-01-01T00:00:00+00:00")
+    assert out == "2024-01-01T00:00:00+00:00"
+
+    assert _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="sentinel_epoch") - before_sent == 0.0
+    assert _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="malformed_string") - before_mal == 0.0
+
+
+# ===========================================================================
+# 3. _clamp_future_to_now — future-clamp counter
+# ===========================================================================
+
+
+def test_future_clamp_counter_increments_on_future_dated_value():
+    """A 5-year-future ISO timestamp routed through the helper module's
+    public extract path triggers the clamp + counter."""
+    from metrics_server import SOURCE_TRUTHFUL_FUTURE_CLAMP
+    from source_truthful_timestamps import _clamp_future_to_now
+
+    before = _counter_value(SOURCE_TRUTHFUL_FUTURE_CLAMP)
+    out = _clamp_future_to_now("2099-01-01T00:00:00+00:00")
+    assert out is not None and not out.startswith("2099")  # was clamped to now
+    after = _counter_value(SOURCE_TRUTHFUL_FUTURE_CLAMP)
+    assert after - before == 1.0
+
+
+def test_future_clamp_counter_does_not_increment_for_past_value():
+    """Past-dated values pass through unchanged; counter must NOT fire."""
+    from metrics_server import SOURCE_TRUTHFUL_FUTURE_CLAMP
+    from source_truthful_timestamps import _clamp_future_to_now
+
+    before = _counter_value(SOURCE_TRUTHFUL_FUTURE_CLAMP)
+    out = _clamp_future_to_now("2020-01-01T00:00:00+00:00")
+    assert out == "2020-01-01T00:00:00+00:00"
+    after = _counter_value(SOURCE_TRUTHFUL_FUTURE_CLAMP)
+    assert after - before == 0.0
+
+
+def test_future_clamp_counter_does_not_increment_for_unparseable_value():
+    """Unparseable input is left alone and the counter must NOT fire
+    (clamp helper only counts SUCCESSFUL clamps, not parse failures —
+    those are handled by coerce_iso's malformed_string counter)."""
+    from metrics_server import SOURCE_TRUTHFUL_FUTURE_CLAMP
+    from source_truthful_timestamps import _clamp_future_to_now
+
+    before = _counter_value(SOURCE_TRUTHFUL_FUTURE_CLAMP)
+    out = _clamp_future_to_now("not a date")
+    assert out == "not a date"  # passed through
+    after = _counter_value(SOURCE_TRUTHFUL_FUTURE_CLAMP)
+    assert after - before == 0.0
+
+
+# ===========================================================================
+# 4. _safe_source_label — cardinality control on the source_id label
+# ===========================================================================
+
+
+def test_safe_source_label_accepts_allowlisted_sources():
+    """Every reliable source identifier must pass through the
+    cardinality guard unchanged (lowercased)."""
+    from metrics_server import _safe_source_label
+
+    for src in ("nvd", "cisa", "cisa_kev", "mitre_attck", "virustotal", "abuseipdb", "threatfox"):
+        assert _safe_source_label(src) == src.lower()
+
+
+def test_safe_source_label_collapses_unknown_sources_to_other():
+    """A source_id outside the allowlist MUST collapse to ``<other>`` —
+    prevents an attacker (or a buggy collector) from blowing up
+    Prometheus storage by emitting a fresh source label per attribute."""
+    from metrics_server import _safe_source_label
+
+    assert _safe_source_label("totally_made_up_source") == "<other>"
+    assert _safe_source_label("UPPERCASE_SOURCE") == "<other>"
+
+
+def test_safe_source_label_collapses_None_and_empty_to_unknown():
+    """``None`` / empty / whitespace-only → ``<unknown>``."""
+    from metrics_server import _safe_source_label
+
+    assert _safe_source_label(None) == "<unknown>"
+    assert _safe_source_label("") == "<unknown>"
+    assert _safe_source_label("   ") == "<unknown>"
+
+
+# ===========================================================================
+# 5. End-to-end smoke test — counter values reachable via /metrics endpoint
+# ===========================================================================
+
+
+def test_new_counters_appear_in_generate_latest_output():
+    """The four new counter families must appear in the Prometheus text
+    payload that the metrics endpoint serves. Catches a regression where
+    a future refactor moves the Counter definitions out of the registry
+    that ``generate_latest()`` walks."""
+    from prometheus_client import generate_latest
+
+    payload = generate_latest().decode("utf-8")
+    assert "edgeguard_source_truthful_claim_accepted_total" in payload
+    assert "edgeguard_source_truthful_claim_dropped_total" in payload
+    assert "edgeguard_source_truthful_coerce_rejected_total" in payload
+    assert "edgeguard_source_truthful_future_clamp_total" in payload

--- a/tests/test_source_truthful_metrics.py
+++ b/tests/test_source_truthful_metrics.py
@@ -140,17 +140,29 @@ def test_extract_emits_no_data_counter_for_reliable_source_with_None_values():
     assert after_accept - before_accept == 0.0
 
 
-def test_extract_emits_source_not_in_allowlist_counter_once_for_unreliable_source():
-    """Unreliable source (OTX) → ONE source_not_in_allowlist DROPPED
-    increment with field='both'. Per-field drop counters must NOT
-    increment (we never even attempt extraction)."""
+def test_extract_emits_source_not_in_allowlist_counter_per_field_for_unreliable_source():
+    """PR #42 audit M3 (Logic Tracker): unreliable source (OTX) →
+    TWO source_not_in_allowlist DROPPED increments, one per field
+    (first_seen + last_seen). The earlier draft of this test asserted
+    a single field='both' emit; the per-field-symmetric emit makes
+    the documented PromQL acceptance-rate query
+    ``accepted{field=X} / sum without(reason)(accepted+dropped){field=X}``
+    correct (the relay drop now appears in the same field-bucketed
+    denominator as the no_data drop).
+
+    no_data_from_source counters MUST NOT fire — we never even
+    attempt Layer-1/Layer-2 extraction for unreliable sources.
+    """
     from metrics_server import SOURCE_TRUTHFUL_CLAIM_DROPPED
     from source_truthful_timestamps import extract_source_truthful_timestamps
 
-    before_both = _counter_value(
-        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="both"
-    )
     before_first = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="first_seen"
+    )
+    before_last = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="last_seen"
+    )
+    before_no_data = _counter_value(
         SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="no_data_from_source", field="first_seen"
     )
 
@@ -160,14 +172,18 @@ def test_extract_emits_source_not_in_allowlist_counter_once_for_unreliable_sourc
     )
     assert out == (None, None)
 
-    after_both = _counter_value(
-        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="both"
-    )
     after_first = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="first_seen"
+    )
+    after_last = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="source_not_in_allowlist", field="last_seen"
+    )
+    after_no_data = _counter_value(
         SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="otx", reason="no_data_from_source", field="first_seen"
     )
-    assert after_both - before_both == 1.0, "source_not_in_allowlist counter should fire exactly once for OTX"
-    assert after_first - before_first == 0.0, "per-field DROPPED counters must NOT fire for unreliable sources"
+    assert after_first - before_first == 1.0, "source_not_in_allowlist must fire for field=first_seen"
+    assert after_last - before_last == 1.0, "source_not_in_allowlist must fire for field=last_seen"
+    assert after_no_data - before_no_data == 0.0, "no_data_from_source must NOT fire for unreliable sources"
 
 
 def test_extract_layer2_fallback_counts_as_accepted_not_dropped():
@@ -392,3 +408,110 @@ def test_new_counters_appear_in_generate_latest_output():
     assert "edgeguard_source_truthful_claim_dropped_total" in payload
     assert "edgeguard_source_truthful_coerce_rejected_total" in payload
     assert "edgeguard_source_truthful_future_clamp_total" in payload
+
+
+# ===========================================================================
+# 6. Cross-module parity (PR #42 audit M1) — allowlist drift detector
+# ===========================================================================
+
+
+def test_source_label_allowlist_mirrors_reliable_first_seen_sources():
+    """PR #42 audit M1 (Cross-Checker): the metrics ``_SOURCE_LABEL_ALLOWLIST``
+    MUST be a SUPERSET of ``_RELIABLE_FIRST_SEEN_SOURCES`` so every reliable
+    source resolves to its own Prometheus cell (rather than collapsing
+    into ``<other>``).
+
+    Drift is silent: the previous draft included ``sslbl`` even though
+    no source emits that tag, and any new source added to the reliable
+    allowlist would have been missed. This test catches the next drift
+    automatically.
+    """
+    from metrics_server import _REJECTED_ON_PURPOSE_SOURCES, _source_label_allowlist
+    from source_truthful_timestamps import _RELIABLE_FIRST_SEEN_SOURCES
+
+    allowlist = _source_label_allowlist()
+    missing = set(_RELIABLE_FIRST_SEEN_SOURCES) - allowlist
+    assert not missing, (
+        f"_SOURCE_LABEL_ALLOWLIST is missing reliable sources: {missing}. "
+        "Every source on the source-truthful allowlist MUST appear here so "
+        "its metric label resolves to its own cell, not <other>."
+    )
+    # Symmetric: every metric-allowlisted entry must be either a reliable
+    # source OR an explicitly-rejected relay (otherwise it's dead weight).
+    extras = allowlist - set(_RELIABLE_FIRST_SEEN_SOURCES) - _REJECTED_ON_PURPOSE_SOURCES
+    assert not extras, (
+        f"_SOURCE_LABEL_ALLOWLIST has extras not in either canonical set: {extras}. "
+        "Allowlist composition is RELIABLE ∪ REJECTED_ON_PURPOSE — anything else is drift."
+    )
+
+
+# ===========================================================================
+# 7. PR #42 audit M2 — bounded enum guards on reason/field labels
+# ===========================================================================
+
+
+def test_drop_counter_clamps_unknown_reason_to_other():
+    """An out-of-band reason value (future caller passes
+    ``reason="garbage"``) MUST clamp to ``<other>`` rather than create
+    a new Prometheus cell — otherwise cardinality grows unbounded."""
+    from metrics_server import (
+        SOURCE_TRUTHFUL_CLAIM_DROPPED,
+        record_source_truthful_claim_dropped,
+    )
+
+    before = _counter_value(SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="<other>", field="first_seen")
+    record_source_truthful_claim_dropped("nvd", "totally_made_up_reason", "first_seen")
+    after = _counter_value(SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="<other>", field="first_seen")
+    assert after - before == 1.0
+
+
+def test_coerce_counter_clamps_unknown_reason_to_other():
+    """Same protection on ``record_source_truthful_coerce_rejected``."""
+    from metrics_server import (
+        SOURCE_TRUTHFUL_COERCE_REJECTED,
+        record_source_truthful_coerce_rejected,
+    )
+
+    before = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="<other>")
+    record_source_truthful_coerce_rejected("garbage_reason_not_in_enum")
+    after = _counter_value(SOURCE_TRUTHFUL_COERCE_REJECTED, reason="<other>")
+    assert after - before == 1.0
+
+
+def test_drop_counter_clamps_unknown_field_to_other():
+    """The ``field`` label is also enum-guarded — ``"both"`` (the legacy
+    pre-M3 value) and any other out-of-band value collapse to
+    ``<other>`` so we'd see the regression as a metric blip rather
+    than as silent cardinality drift."""
+    from metrics_server import (
+        SOURCE_TRUTHFUL_CLAIM_DROPPED,
+        record_source_truthful_claim_dropped,
+    )
+
+    before = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="no_data_from_source", field="<other>"
+    )
+    record_source_truthful_claim_dropped("nvd", "no_data_from_source", "both")  # legacy field value
+    after = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="no_data_from_source", field="<other>"
+    )
+    assert after - before == 1.0
+
+
+def test_drop_counter_clamps_empty_field_to_unknown():
+    """Empty / None field → ``<unknown>`` (distinguishable from
+    ``<other>``: empty means missing data, other means out-of-band
+    value)."""
+    from metrics_server import (
+        SOURCE_TRUTHFUL_CLAIM_DROPPED,
+        record_source_truthful_claim_dropped,
+    )
+
+    before = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="no_data_from_source", field="<unknown>"
+    )
+    record_source_truthful_claim_dropped("nvd", "no_data_from_source", "")
+    after = _counter_value(
+        SOURCE_TRUTHFUL_CLAIM_DROPPED, source_id="nvd", reason="no_data_from_source", field="<unknown>"
+    )
+    assert after - before == 1.0


### PR DESCRIPTION
## Summary

Closes spawned-task chip 5b from the PR #41 audit: the source-truthful first_seen / last_seen pipeline that shipped in PR #41 had **zero observability counters** in `src/metrics_server.py`. Operators had no signal on which sources actually supply per-source timestamp claims vs. emit honest-NULL, no signal on the failure-mode distribution of `coerce_iso`, and no signal on upstream feed bugs producing future-dated values.

This PR adds **4 new Prometheus counters** wired at 3 sites in `src/source_truthful_timestamps.py`, with **18 regression tests** and a new "Source-truthful Timestamp Pipeline" section in `docs/PROMETHEUS_SETUP.md`.

## What's new

| Counter | Labels | Purpose |
|---------|--------|---------|
| `edgeguard_source_truthful_claim_accepted_total` | `source_id`, `field` | Per-source claim survived the full pipeline → lands on `r.source_reported_first_at` / `r.source_reported_last_at` |
| `edgeguard_source_truthful_claim_dropped_total` | `source_id`, `reason`, `field` | Per-source claim did NOT make it onto the edge. `reason ∈ {source_not_in_allowlist, no_data_from_source}`. **Honest-NULL drops are counted under `no_data_from_source` — non-zero baseline is normal.** |
| `edgeguard_source_truthful_coerce_rejected_total` | `reason` | `coerce_iso` input rejected. `reason ∈ {sentinel_epoch, malformed_string, overflow}`. No `source_id` label — `coerce_iso` is a pure utility called from many sites without source context. |
| `edgeguard_source_truthful_future_clamp_total` | _(none)_ | Future-dated timestamp clamped to `now()` — likely upstream feed bug or operator clock drift. The accompanying WARNING log carries the original value. |

## Cardinality control

The `source_id` label is bounded by an allowlist (~20 values). Anything outside the allowlist collapses to `<other>`; `None` / empty collapses to `<unknown>`. Caps storage at low hundreds of cells and prevents a malformed or spoofed source tag from blowing up Prometheus.

## Wiring (3 sites)

1. **`extract_source_truthful_timestamps`** — accept/drop accounting per `(source, field)` AFTER both Layer 1 + Layer 2 run, so a Layer-2 fallback that fills in a missing Layer-1 value counts as ACCEPTED, not DROPPED.
2. **`coerce_iso`** — failure-mode counter on every rejection (sentinel/malformed/overflow), no source context.
3. **`_clamp_future_to_now`** — single counter on every successful clamp.

Metric helpers are imported defensively so the module stays importable in test contexts that don't bring up `prometheus_client`.

## Out of scope

- No changes to existing pipeline behavior — observability only.
- No Grafana dashboard JSON (separate task).
- No alert rules (deployment-specific thresholds; PromQL examples shown in the docs).

## Test plan

- [x] `pytest tests/test_source_truthful_metrics.py` → 18 new tests pass
- [x] `pytest` → 581 passed, 3 skipped (pre-existing env guards), no regressions
- [x] `ruff format src/ dags/ tests/ scripts/` → clean
- [x] `ruff check src/ dags/ tests/ scripts/` → clean
- [ ] Manual: hit `curl http://localhost:8001/metrics | grep source_truthful` after a baseline run; confirm non-zero values for accepted-counter on NVD / CISA, expected non-zero `no_data_from_source` for sources that returned NULL
- [ ] Manual: confirm `<other>` and `<unknown>` cardinality-collapse labels appear when an unknown / empty source_id flows through

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily observability-only, but it changes `source_truthful_timestamps` hot paths (`coerce_iso`, `_clamp_future_to_now`, `extract_source_truthful_timestamps`) and introduces lazy cross-module imports/caches that could cause subtle runtime/import-order issues if misbehaving.
> 
> **Overview**
> Adds **four new Prometheus counters** to make the source-truthful `first_seen`/`last_seen` pipeline observable: accepted vs dropped claims (per `source_id` and `field`), `coerce_iso` rejection reasons, and future-date clamps.
> 
> Wires these counters into `src/source_truthful_timestamps.py` with defensive imports, per-field accounting (including reliable-source honest-NULL drops), and **cardinality guards** (`source_id` allowlist plus enum-clamped `reason`/`field` labels). Updates `docs/PROMETHEUS_SETUP.md` with metric definitions and PromQL examples, and adds a comprehensive regression test suite covering counter increments, label clamping, allowlist parity, and presence in `/metrics` output.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7f57b4ad6738706a67e6799ff9453c8940fe5492. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->