### PR TITLE
refactor(sources): unify 5 parallel source registries into src/source_registry.py

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -318,6 +318,15 @@ script ships; a fresh baseline rerun stamps every uuid at write time. See
 
 ## Data Sources (13 Total)
 
+> **Single source of truth — `src/source_registry.py`.** Adding a new
+> data source is a one-line `Source(...)` entry there. Five legacy
+> registries (`neo4j_client.SOURCES`, `edgeguard.DEFAULT_SOURCES`,
+> `config.SOURCE_TAGS`, `source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES`,
+> `MISPWriter.SOURCE_TAGS`) all derive from it; before the chip-5a
+> refactor each was hand-maintained and forgetting any one produced
+> a different silent-failure mode (see the module docstring for the
+> full failure-mode catalog).
+
 | Code | Full Name | Type | Collector Module |
 |------|-----------|------|------------------|
 | alienvault_otx | AlienVault OTX | Threat Intel | otx_collector.py |
@@ -450,4 +459,4 @@ See [`RESILMESH_INTEROPERABILITY.md` §8.4](RESILMESH_INTEROPERABILITY.md) for t
 
 ---
 
-_Last updated: 2026-04-18 — PR #41 cleanup pass replaced the n.uuid backfill-script pointer with the heal-by-rebaseline contract (pre-release framework, no production graph) and reframed the USES→specialized-edge history as "fresh baseline writes the specialized edge type directly"._
+_Last updated: 2026-04-18 — chip 5a refactor added the "single source of truth — `src/source_registry.py`" callout to the Data Sources section. PR #41 cleanup pass earlier the same day replaced the n.uuid backfill-script pointer with the heal-by-rebaseline contract (pre-release framework, no production graph) and reframed the USES→specialized-edge history as "fresh baseline writes the specialized edge type directly"._

--- a/docs/COLLECTORS.md
+++ b/docs/COLLECTORS.md
@@ -783,25 +783,36 @@ python -m collectors.energy_feed_collector
 
 ## Adding a new reliable source — checklist
 
-When adding a new collector that has a **canonical first-reported / last-reported timestamp** that should flow into the source-truthful timestamp pipeline (PR S5, 2026-04 — see `docs/KNOWLEDGE_GRAPH.md#sourced_from-edge-schema`), follow this **8-step checklist**:
+When adding a new collector that has a **canonical first-reported / last-reported timestamp** that should flow into the source-truthful timestamp pipeline (PR S5, 2026-04 — see `docs/KNOWLEDGE_GRAPH.md#sourced_from-edge-schema`), follow this **5-step checklist**:
 
-### 1. Add to `_RELIABLE_FIRST_SEEN_SOURCES` allowlist
+> **Chip 5a (PR follow-up) consolidated steps 1–4** of the legacy
+> 8-step checklist into a single declarative edit in
+> `src/source_registry.py`. The five legacy registries
+> (`_RELIABLE_FIRST_SEEN_SOURCES`, `SOURCE_TAGS`, `SOURCES`,
+> `MISPWriter.SOURCE_TAGS`, `DEFAULT_SOURCES`) are now derived from
+> the registry, so adding a `Source(...)` entry there propagates to
+> all five simultaneously. The propagation is pinned by
+> `tests/test_source_registry.py::test_adding_a_new_source_propagates_to_all_five_derivations`.
 
-In `src/source_truthful_timestamps.py`, add your source's tag(s) to the `_RELIABLE_FIRST_SEEN_SOURCES` frozenset. Include both the canonical name AND any aliases (e.g. `"feodo"` + `"feodo_tracker"`) — the allowlist must accept whatever string the collector writes to `item["tag"]`.
+### 1. Add a `Source(...)` entry to `src/source_registry.py`
 
-### 2. Add to `SOURCE_MAPPING` in `run_misp_to_neo4j.py`
+Append one record to the `_REGISTRY` tuple. Required fields:
+``canonical_id``, ``display_name``, ``source_type``, ``reliability``,
+``misp_tag``, ``reliable_first_seen``. Optional but recommended:
+``aliases`` (covers historical short-names so collector lookups by
+either spelling resolve identically), ``cli_id`` / ``api_key_env`` /
+``rate_limit`` / ``cli_default_enabled`` / ``cli_description`` (the
+``edgeguard sources`` CLI listing), ``cli_display_name`` (only needed
+when the CLI label differs from the Neo4j ``Source.name`` — currently
+only NVD).
 
-In `src/run_misp_to_neo4j.py::SOURCE_MAPPING`, map the human label (e.g. `"My-New-Source"`) to the canonical tag. Tag MUST match what the collector emits; the static test `test_collector_emitted_tags_match_allowlist` will fail otherwise.
+The ``reliable_first_seen`` flag controls whether the source's
+first/last_seen claims land on the ``SOURCED_FROM`` edge. ``False``
+for sources whose first_seen field means something other than "first
+observed in the wild" (OTX pulse-publish-date, CyberCure synthetic
+now, MISP pipeline metadata).
 
-### 3. Add to `SOURCE_TAGS` in `config.py`
-
-In `src/config.py::SOURCE_TAGS`, add the human-readable label → tag mapping. This is what MISPWriter uses to tag attributes and what `extract_source_from_tags` reads back.
-
-### 4. Add to `SOURCES` dict in `neo4j_client.py`
-
-In `src/neo4j_client.py::SOURCES`, add an entry for your tag (canonical + any aliases). `ensure_sources()` MERGEs a `:Source` node per entry; the SOURCED_FROM edge MERGE then matches on `source_id`. **A missing entry causes the merge_indicators_batch / merge_vulnerabilities_batch defensive check to refuse the entire batch** with a clear error log (Red Team v3 H1 protection).
-
-### 5. Have the collector emit `item["first_seen"]` (and `item["last_seen"]` if available)
+### 2. Have the collector emit `item["first_seen"]` (and `item["last_seen"]` if available)
 
 In your new `collectors/<name>_collector.py`, populate the source-truthful timestamps directly from upstream:
 
@@ -821,15 +832,15 @@ processed.append({
 })
 ```
 
-### 6. Verify MISPWriter passthrough fires for your entity type
+### 3. Verify MISPWriter passthrough fires for your entity type
 
 The `_apply_source_truthful_timestamps` helper in `src/collectors/misp_writer.py` is called from all 7 `create_*_attribute` methods (indicator, vulnerability, malware, actor, technique, tactic, tool) AS THE LAST STATEMENT before `return attribute`. If you add a NEW entity type, you must add the helper call to its `create_*_attribute` method too — the bugbot fix in commit `9a414ac` had to do exactly this for 5 entity types after they were missed. The helper uses `coerce_iso` to accept int epochs, datetime objects, and date-only strings.
 
-### 7. Add Layer-2 META JSON parser if your source ships structured metadata
+### 4. Add Layer-2 META JSON parser if your source ships structured metadata
 
 If your source ships a structured-metadata JSON blob (like NVD_META, TF_META, CISA_META) that needs to round-trip through the MISP attribute comment field, add a Layer-2 fallback branch in `src/source_truthful_timestamps.py::extract_source_truthful_timestamps`. Most sources only need Layer-1 (MISP-native attribute fields).
 
-### 8. Update `tests/test_source_reported_timestamps.py`
+### 5. Update `tests/test_source_reported_timestamps.py`
 
 Add your tag to the static enumeration in `test_collector_emitted_tags_match_allowlist` so the test catches future tag drift.
 
@@ -859,4 +870,4 @@ Should show populated source-reported timestamps if your upstream provides them.
 
 ---
 
-_Last updated: 2026-04-18_
+_Last updated: 2026-04-18 — chip 5a refactor consolidated steps 1–4 of the legacy 8-step "adding a new reliable source" checklist into a single declarative `Source(...)` edit in `src/source_registry.py`._

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -22,6 +22,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests
 import urllib3
 
+import source_registry  # noqa: E402  — single source of truth for source→MISP-tag mapping (chip 5a)
 from collectors.collector_utils import TransientServerError, retry_with_backoff
 from config import (
     DEFAULT_SECTOR,
@@ -281,24 +282,13 @@ class MISPWriter:
         "unknown": "text",
     }
 
-    # Source to MISP tag mapping
-    SOURCE_TAGS = {
-        "misp": "source:MISP",
-        "otx": "source:AlienVault-OTX",
-        "alienvault_otx": "source:AlienVault-OTX",
-        "nvd": "source:NVD",
-        "cisa": "source:CISA-KEV",
-        "cisa_kev": "source:CISA-KEV",
-        "mitre": "source:MITRE-ATT&CK",
-        "mitre_attck": "source:MITRE-ATT&CK",
-        "virustotal": "source:VirusTotal",
-        "abuseipdb": "source:AbuseIPDB",
-        "feodo": "source:Feodo-Tracker",
-        "sslbl": "source:SSL-Blacklist",
-        "urlhaus": "source:URLhaus",
-        "cybercure": "source:CyberCure",
-        "threatfox": "source:ThreatFox",
-    }
+    # Source to MISP tag mapping. Single-source-of-truth derivation from
+    # src/source_registry.py (chip 5a) — adding a new source is now a
+    # one-line edit there. The derived map covers every alias (so the
+    # writer resolves a lookup by either canonical id OR legacy short
+    # name to the same MISP tag), which extends the historical key set
+    # but does not change behavior for any existing input.
+    SOURCE_TAGS = source_registry.source_to_misp_tag_map()
 
     def __init__(self, url: str = None, api_key: str = None, verify_ssl: bool = None):
         """

--- a/src/config.py
+++ b/src/config.py
@@ -686,16 +686,16 @@ _SECTOR_PATTERNS: dict = {
     for zone, kws in SECTOR_KEYWORDS.items()
 }
 
-# Tags for sources
-SOURCE_TAGS = {
-    "misp": "misp",
-    "otx": "alienvault_otx",
-    "nvd": "nvd",
-    "cisa": "cisa_kev",
-    "mitre": "mitre_attck",
-    "virustotal": "virustotal",
-    "abuseipdb": "abuseipdb",
-}
+# Tags for sources — maps CLI shortname → canonical collector-emitted tag.
+# Single-source-of-truth derivation from src/source_registry.py (chip 5a).
+# Restricted to the legacy 7-key shape so existing callers that do
+# ``SOURCE_TAGS["X"]`` and rely on KeyError-on-typo for missing keys
+# don't suddenly start resolving keys that previously failed. The full
+# registry-derived map (~12 keys) is available via
+# ``source_registry.cli_to_canonical_tag_map()`` for new callers.
+import source_registry as _source_registry  # noqa: E402
+
+SOURCE_TAGS = _source_registry.cli_to_canonical_tag_map_legacy_subset()
 
 # Pipeline Intervals (hours)
 # Phase 1: Source → MISP refresh interval

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -772,92 +772,16 @@ def check_production_issues():
 
 SOURCES_FILE = os.path.join(os.path.dirname(__file__), "..", "credentials", "sources.yaml")
 
-DEFAULT_SOURCES = {
-    "otx": {
-        "name": "AlienVault OTX",
-        "api_key_env": "OTX_API_KEY",
-        "rate_limit": "30/min",
-        "enabled": True,
-        "description": "Threat intelligence pulses",
-    },
-    "nvd": {
-        "name": "National Vulnerability Database",
-        "api_key_env": "NVD_API_KEY",
-        "rate_limit": "30/30sec",
-        "enabled": True,
-        "description": "CVE vulnerabilities",
-    },
-    "virustotal": {
-        "name": "VirusTotal",
-        "api_key_env": "VIRUSTOTAL_API_KEY",
-        "rate_limit": "4/min",
-        "enabled": True,
-        "description": "File and URL reputation",
-    },
-    "cisa": {
-        "name": "CISA KEV",
-        "api_key_env": None,
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Known exploited vulnerabilities",
-    },
-    "mitre": {
-        "name": "MITRE ATT&CK",
-        "api_key_env": None,
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Threat techniques and tactics",
-    },
-    "abuseipdb": {
-        "name": "AbuseIPDB",
-        "api_key_env": "ABUSEIPDB_API_KEY",
-        "rate_limit": "1000/day",
-        "enabled": False,
-        "description": "IP reputation",
-    },
-    "urlhaus": {
-        "name": "URLhaus",
-        "api_key_env": None,
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Malware URLs",
-    },
-    "cybercure": {
-        "name": "CyberCure",
-        "api_key_env": None,
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Threat intelligence feeds",
-    },
-    "feodo": {
-        "name": "Feodo Tracker",
-        "api_key_env": None,
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Banking trojan C&C servers",
-    },
-    "sslbl": {
-        "name": "SSL Blacklist",
-        "api_key_env": None,
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Malicious SSL certificates",
-    },
-    "threatfox": {
-        "name": "ThreatFox",
-        "api_key_env": "THREATFOX_API_KEY",
-        "rate_limit": "unlimited",
-        "enabled": False,
-        "description": "Threat actor indicators",
-    },
-    "misp": {
-        "name": "MISP",
-        "api_key_env": "MISP_API_KEY",
-        "rate_limit": "unlimited",
-        "enabled": True,
-        "description": "Central threat intelligence hub",
-    },
-}
+# Single-source-of-truth: derived from src/source_registry.py (chip 5a).
+# Adding a new source is now a one-line edit in the registry; this dict
+# (and the four other parallel registries that previously needed
+# hand-syncing — neo4j_client.SOURCES, config.SOURCE_TAGS,
+# source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES,
+# misp_writer.MISPWriter.SOURCE_TAGS) all derive from the same source.
+# Shape and key set are pinned by tests/test_source_registry.py.
+import source_registry as _source_registry  # noqa: E402
+
+DEFAULT_SOURCES = _source_registry.to_cli_sources_dict()
 
 
 def load_sources():

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -33,6 +33,7 @@ except ImportError:
 # Deterministic per-node UUIDs for cross-environment traceability — see
 # src/node_identity.py for the namespace, canonicalization rules, and the
 # per-label natural-key map.
+import source_registry  # noqa: E402  — single-source-of-truth for SOURCES dict (chip 5a refactor)
 from node_identity import canonicalize_merge_key, compute_node_uuid, edge_endpoint_uuids  # noqa: E402
 from query_pause import query_pause  # noqa: E402
 
@@ -232,28 +233,16 @@ def resolve_vulnerability_cve_id(item: Dict[str, Any]) -> Optional[str]:
 # the LEGACY short names (``feodo`` / ``sslbl``) while the collectors
 # emit ``feodo_tracker`` / ``ssl_blacklist`` (config.SOURCE_TAGS +
 # finance_feed_collector); those two paths were silently dropping
-# edge writes. Fixed by adding the canonical collector-tag entries
-# below (keeping legacy short-names for back-compat with any
-# pre-existing Source nodes — ensure_sources is idempotent).
-SOURCES = {
-    "alienvault_otx": {"name": "AlienVault OTX", "type": "threat_intel", "reliability": 0.7},
-    "virustotal": {"name": "VirusTotal", "type": "threat_intel", "reliability": 0.8},
-    "abuseipdb": {"name": "AbuseIPDB", "type": "threat_intel", "reliability": 0.65},
-    "mitre_attck": {"name": "MITRE ATT&CK", "type": "framework", "reliability": 0.95},
-    "nvd": {"name": "NVD", "type": "vulnerability_db", "reliability": 0.9},
-    "misp": {"name": "MISP", "type": "threat_intel", "reliability": 0.75},
-    "cisa": {"name": "CISA KEV", "type": "advisory", "reliability": 0.9},
-    "cisa_kev": {"name": "CISA KEV", "type": "advisory", "reliability": 0.9},
-    # Both short-names AND canonical collector-emitted tags MUST exist:
-    "feodo": {"name": "Feodo Tracker", "type": "threat_intel", "reliability": 0.7},
-    "feodo_tracker": {"name": "Feodo Tracker", "type": "threat_intel", "reliability": 0.7},
-    "sslbl": {"name": "SSL Blacklist", "type": "threat_intel", "reliability": 0.65},
-    "ssl_blacklist": {"name": "SSL Blacklist", "type": "threat_intel", "reliability": 0.65},
-    "abusech_ssl": {"name": "SSL Blacklist", "type": "threat_intel", "reliability": 0.65},
-    "urlhaus": {"name": "URLhaus", "type": "threat_intel", "reliability": 0.7},
-    "cybercure": {"name": "CyberCure", "type": "threat_intel", "reliability": 0.6},
-    "threatfox": {"name": "ThreatFox", "type": "threat_intel", "reliability": 0.7},
-}
+# edge writes. PR #41 added the canonical collector-tag entries.
+#
+# The unified registry refactor (chip 5a follow-up) MOVES this dict's
+# definition to ``src/source_registry.py`` so adding a new source is
+# a single declarative edit there. Three additional aliases (``otx``,
+# ``vt``, ``mitre``) are now ALSO covered — same gap the PR #41
+# round added ``feodo_tracker`` / ``ssl_blacklist`` for. The shape of
+# this dict is unchanged for every legacy 16-entry id (parity pinned
+# in tests/test_source_registry.py).
+SOURCES = source_registry.to_neo4j_sources_dict()
 
 
 def retry_with_backoff(max_retries: int = MAX_RETRIES, base_delay: float = RETRY_DELAY_BASE):

--- a/src/source_registry.py
+++ b/src/source_registry.py
@@ -442,11 +442,26 @@ def to_cli_sources_dict() -> Dict[str, Dict[str, object]]:
 
     One entry per source whose ``cli_id`` is set (currently all of
     them). Skips sources with ``cli_id is None``.
+
+    Raises ``ValueError`` if two ``Source`` records share a ``cli_id``
+    (PR #43 audit M2 — Devil's Advocate / Cross-Checker): the previous
+    implementation silently overwrote the earlier entry, so a
+    contributor who accidentally re-used an existing ``cli_id`` for
+    a new source would get the new mapping AND drop the old one with
+    no error. Both ``to_cli_sources_dict`` and
+    ``cli_to_canonical_tag_map`` enforce the same uniqueness check.
     """
     out: Dict[str, Dict[str, object]] = {}
     for src in _REGISTRY:
         if src.cli_id is None:
             continue
+        if src.cli_id in out:
+            raise ValueError(
+                f"duplicate cli_id={src.cli_id!r} in registry: "
+                f"second occurrence on canonical_id={src.canonical_id!r}. "
+                "Each cli_id must map to exactly one Source — silently "
+                "overwriting would drop the earlier source from the CLI listing."
+            )
         out[src.cli_id] = {
             "name": src.cli_display_name or src.display_name,
             "api_key_env": src.api_key_env,
@@ -469,14 +484,27 @@ def cli_to_canonical_tag_map() -> Dict[str, str]:
 
     NOTE: the legacy ``config.SOURCE_TAGS`` only listed 7 sources
     (the ones with collectors that look themselves up by shortname).
-    For backward-compat we ship a ``LEGACY_SUBSET`` constant that
-    matches the historical 7-key shape; the FULL registry-derived
-    map is also available for future callers that want it.
+    For backward-compat ``cli_to_canonical_tag_map_legacy_subset``
+    matches the historical 7-key shape — wire it from
+    ``config.SOURCE_TAGS``. **Use the full map below ONLY for new
+    callers** (PR #43 audit M3): existing collector code does
+    ``SOURCE_TAGS["X"]`` and relies on KeyError on typos. Widening
+    the legacy 7 keys to all 12 silently starts resolving keys that
+    previously failed — undesired behavior change.
+
+    Raises ``ValueError`` on duplicate ``cli_id`` — same uniqueness
+    invariant as ``to_cli_sources_dict``.
     """
     out: Dict[str, str] = {}
     for src in _REGISTRY:
         if src.cli_id is None:
             continue
+        if src.cli_id in out:
+            raise ValueError(
+                f"duplicate cli_id={src.cli_id!r} in registry: "
+                f"second occurrence on canonical_id={src.canonical_id!r}. "
+                "Each cli_id must map to exactly one canonical_id."
+            )
         out[src.cli_id] = src.canonical_id
     return out
 

--- a/src/source_registry.py
+++ b/src/source_registry.py
@@ -164,6 +164,27 @@ class Source:
     # preserves both.
     cli_display_name: Optional[str] = None
 
+    def __post_init__(self) -> None:
+        """Validate Source invariants at construction time.
+
+        PR #43 audit-2 (Maintainer Dev / Bug Hunter): the previous
+        contract said "MUST be lowercased" in a docstring but no
+        runtime check enforced it. Adding ``Source(aliases=("VT",))``
+        with uppercase silently broke ``get_source`` (which lowercases
+        the input but compared against the raw key). Catch the violation
+        at registration so a future contributor sees the failure
+        immediately.
+        """
+        # canonical_id MUST be lowercase ASCII (matches Cypher / collector convention)
+        if self.canonical_id != self.canonical_id.lower() or not self.canonical_id.isascii():
+            raise ValueError(f"Source(canonical_id={self.canonical_id!r}): canonical_id must be lowercase ASCII")
+        # Same for every alias
+        for alias in self.aliases:
+            if alias != alias.lower() or not alias.isascii():
+                raise ValueError(
+                    f"Source(canonical_id={self.canonical_id!r}, aliases=...): alias {alias!r} must be lowercase ASCII"
+                )
+
     @property
     def all_keys(self) -> Tuple[str, ...]:
         """``(canonical_id,) + aliases`` — every key under which this
@@ -405,6 +426,35 @@ def all_aliases() -> FrozenSet[str]:
     return frozenset(out)
 
 
+def _validate_no_alias_collisions() -> None:
+    """PR #43 audit-2 (MED — bugbot): two ``Source`` records sharing an
+    alias would produce divergent results between ``get_source`` (which
+    returns the FIRST match) and the dict-building helpers (``out[key] = ...``
+    LAST wins). Validate at module import time so a contributor's typo
+    fails immediately, not silently in production.
+
+    Pre-existing test ``test_aliases_do_not_collide_with_other_sources_canonical_ids``
+    only checked alias-vs-canonical-id collisions; this catches the
+    alias-vs-alias case too.
+    """
+    seen: Dict[str, str] = {}  # key → first canonical_id that owns it
+    for src in _REGISTRY:
+        for key in src.all_keys:
+            owner = seen.get(key)
+            if owner is not None and owner != src.canonical_id:
+                raise ValueError(
+                    f"Source registry: alias collision on {key!r} — "
+                    f"both {owner!r} and {src.canonical_id!r} claim it. "
+                    "Two sources sharing an alias produce divergent results "
+                    "between get_source (first wins) and the dict-building "
+                    "helpers (last wins). Pick a unique alias."
+                )
+            seen[key] = src.canonical_id
+
+
+_validate_no_alias_collisions()
+
+
 # ===========================================================================
 # Derivation helpers — each replaces one of the 5 legacy registries
 # ===========================================================================
@@ -434,6 +484,32 @@ def to_neo4j_sources_dict() -> Dict[str, Dict[str, object]]:
     return out
 
 
+# PR #43 audit-2 (LOW — bugbot): the legacy `edgeguard.DEFAULT_SOURCES`
+# dict had a hand-curated key order that drove the `edgeguard sources`
+# CLI listing. The pre-refactor order was (otx, nvd, virustotal, cisa,
+# mitre, abuseipdb, urlhaus, cybercure, feodo, sslbl, threatfox, misp);
+# the registry order matches `neo4j_client.SOURCES` instead, which
+# differs. Use this explicit list to preserve operator-facing ordering.
+# Anything not in the list is appended in registry order at the end —
+# so adding a new Source with a fresh `cli_id` doesn't require updating
+# this list (it just appears at the end of the CLI listing, which is
+# the expected behavior for a new source).
+_LEGACY_CLI_LISTING_ORDER: Tuple[str, ...] = (
+    "otx",
+    "nvd",
+    "virustotal",
+    "cisa",
+    "mitre",
+    "abuseipdb",
+    "urlhaus",
+    "cybercure",
+    "feodo",
+    "sslbl",
+    "threatfox",
+    "misp",
+)
+
+
 def to_cli_sources_dict() -> Dict[str, Dict[str, object]]:
     """Re-creates the legacy ``edgeguard.DEFAULT_SOURCES`` dict shape.
 
@@ -443,6 +519,12 @@ def to_cli_sources_dict() -> Dict[str, Dict[str, object]]:
     One entry per source whose ``cli_id`` is set (currently all of
     them). Skips sources with ``cli_id is None``.
 
+    Insertion order matches the legacy ``DEFAULT_SOURCES`` order via
+    ``_LEGACY_CLI_LISTING_ORDER`` (PR #43 audit-2 LOW — bugbot:
+    operators iterating the CLI listing depend on this order).
+    Sources whose ``cli_id`` is not in the legacy list are appended
+    in registry order at the end.
+
     Raises ``ValueError`` if two ``Source`` records share a ``cli_id``
     (PR #43 audit M2 — Devil's Advocate / Cross-Checker): the previous
     implementation silently overwrote the earlier entry, so a
@@ -451,25 +533,39 @@ def to_cli_sources_dict() -> Dict[str, Dict[str, object]]:
     no error. Both ``to_cli_sources_dict`` and
     ``cli_to_canonical_tag_map`` enforce the same uniqueness check.
     """
-    out: Dict[str, Dict[str, object]] = {}
+    by_cli_id: Dict[str, Source] = {}
     for src in _REGISTRY:
         if src.cli_id is None:
             continue
-        if src.cli_id in out:
+        if src.cli_id in by_cli_id:
             raise ValueError(
                 f"duplicate cli_id={src.cli_id!r} in registry: "
                 f"second occurrence on canonical_id={src.canonical_id!r}. "
                 "Each cli_id must map to exactly one Source — silently "
                 "overwriting would drop the earlier source from the CLI listing."
             )
-        out[src.cli_id] = {
-            "name": src.cli_display_name or src.display_name,
-            "api_key_env": src.api_key_env,
-            "rate_limit": src.rate_limit,
-            "enabled": src.cli_default_enabled,
-            "description": src.cli_description,
-        }
+        by_cli_id[src.cli_id] = src
+
+    out: Dict[str, Dict[str, object]] = {}
+    # First emit entries in the documented legacy order
+    for cli_id in _LEGACY_CLI_LISTING_ORDER:
+        if cli_id in by_cli_id:
+            out[cli_id] = _cli_payload(by_cli_id.pop(cli_id))
+    # Then any new sources (not in the legacy list) in registry order
+    for cli_id, src in by_cli_id.items():
+        out[cli_id] = _cli_payload(src)
     return out
+
+
+def _cli_payload(src: Source) -> Dict[str, object]:
+    """Helper: construct the per-source CLI dict payload."""
+    return {
+        "name": src.cli_display_name or src.display_name,
+        "api_key_env": src.api_key_env,
+        "rate_limit": src.rate_limit,
+        "enabled": src.cli_default_enabled,
+        "description": src.cli_description,
+    }
 
 
 def cli_to_canonical_tag_map() -> Dict[str, str]:

--- a/src/source_registry.py
+++ b/src/source_registry.py
@@ -1,0 +1,539 @@
+"""Single-source-of-truth registry for EdgeGuard data sources.
+
+Closes spawned-task chip 5a from the PR #41 audit: before this module,
+five parallel hand-maintained registries described "what sources
+EdgeGuard knows about". Every PR that touched sources had to keep them
+in sync, and forgetting any one of the five produced a different
+silent-failure mode:
+
+* ``src/neo4j_client.py:SOURCES`` — drives ``ensure_sources`` (Neo4j
+  ``:Source`` node creation) AND the defensive batch pre-validation
+  added in PR #41 (refuses to write a SOURCED_FROM edge whose
+  ``source_id`` is not in this dict).  **Forget to add a new source
+  here → PR #41's defensive guard refuses every write from that source,
+  silently dropping the relationship batch.**
+* ``src/edgeguard.py:DEFAULT_SOURCES`` — drives the ``edgeguard
+  sources`` CLI listing.  **Forget to add a new source here → it
+  doesn't appear in the CLI; operators don't know it exists.**
+* ``src/config.py:SOURCE_TAGS`` — maps the CLI shortname (``otx``,
+  ``mitre``, ``cisa``) to the canonical collector-emitted tag
+  (``alienvault_otx``, ``mitre_attck``, ``cisa_kev``).  **Forget to
+  add a new source → collector falls back to its module-local
+  ``self.tag = "..."`` constant, which may not match the canonical tag,
+  silently fragmenting per-source provenance across two
+  ``Source`` nodes.**
+* ``src/source_truthful_timestamps.py:_RELIABLE_FIRST_SEEN_SOURCES`` —
+  the allowlist of sources whose first/last_seen claims land on the
+  ``r.source_reported_first_at`` / ``r.source_reported_last_at`` edge
+  fields.  **Forget to add a new source here → its source-truthful
+  timestamps are silently dropped (extract returns ``(None, None)``);
+  the source-truthful pipeline that PR #41 just shipped is dead
+  for that source.**
+* ``src/collectors/misp_writer.py:MISPWriter.SOURCE_TAGS`` — maps
+  source id to the human-readable MISP tag string (``source:NVD``,
+  ``source:CISA-KEV``).  **Forget to add a new source → the MISP
+  attribute carries no source tag, breaking the
+  ``raw_data.original_source`` round-trip and silently disabling the
+  source-truthful timestamp extraction in
+  ``run_misp_to_neo4j.parse_attribute``.**
+
+Every one of those failure modes is silent. Adding a new source today
+is a five-place edit with five separate bugs waiting if you miss one.
+
+This module replaces all five with a single declarative table. Each
+of the five legacy registries becomes a one-liner derivation:
+
+```python
+# src/neo4j_client.py
+from source_registry import to_neo4j_sources_dict
+SOURCES = to_neo4j_sources_dict()  # shape unchanged; callers untouched
+
+# src/edgeguard.py
+from source_registry import to_cli_sources_dict
+DEFAULT_SOURCES = to_cli_sources_dict()
+
+# src/config.py
+from source_registry import cli_to_canonical_tag_map
+SOURCE_TAGS = cli_to_canonical_tag_map()
+
+# src/source_truthful_timestamps.py
+from source_registry import reliable_first_seen_aliases
+_RELIABLE_FIRST_SEEN_SOURCES = reliable_first_seen_aliases()
+
+# src/collectors/misp_writer.py
+from source_registry import source_to_misp_tag_map
+class MISPWriter:
+    SOURCE_TAGS = source_to_misp_tag_map()
+```
+
+Every existing call site keeps the SAME variable name and the SAME
+shape — this is a behavior-preserving refactor. Parity is pinned by
+``tests/test_source_registry.py`` (the derived dicts must match
+captured pre-refactor snapshots byte-for-byte).
+
+To add a new source: append one ``Source(...)`` entry below. All five
+derivations recompute on next import. ``test_adding_a_new_source_*``
+in the test file pins the propagation invariant.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, Optional, Tuple
+
+# ===========================================================================
+# Source dataclass — one record per logical source
+# ===========================================================================
+
+
+@dataclass(frozen=True)
+class Source:
+    """A single threat-intel data source.
+
+    Frozen so the registry can be a module-level constant safely shared
+    across processes / threads (no accidental mutation).
+
+    Attributes
+    ----------
+    canonical_id : str
+        The canonical tag — what the collector emits and what
+        ``:Source.source_id`` is keyed on in Neo4j. MUST be lowercased
+        + ASCII; case-sensitive comparisons depend on it.
+    aliases : tuple[str, ...]
+        Additional case-insensitive lookup keys for the same source.
+        E.g. ``Source(canonical_id="cisa_kev", aliases=("cisa",))``
+        — both spellings find the same record. ``canonical_id`` is
+        IMPLICITLY the first alias; do not include it again.
+    display_name : str
+        Human-readable name shown in CLI / docs / Neo4j ``:Source.name``.
+    source_type : str
+        One of ``threat_intel`` / ``advisory`` / ``framework`` /
+        ``vulnerability_db``. Drives Neo4j ``:Source.type``.
+    reliability : float
+        ``[0.0, 1.0]`` confidence base used by the merge layer for
+        corroboration scoring. Drives Neo4j ``:Source.reliability``.
+    cli_id : Optional[str]
+        Short id used in ``edgeguard run --sources X,Y,Z`` and the
+        ``edgeguard sources`` CLI listing. ``None`` means the source
+        is not exposed via the CLI (rare; mostly for sources that are
+        always-on / have no toggle).
+    api_key_env : Optional[str]
+        Env var name for the API key. ``None`` for free / no-key sources.
+    rate_limit : str
+        Human-readable rate limit (e.g. ``"30/min"``, ``"1000/day"``,
+        ``"unlimited"``). Surfaced in the CLI listing for operator
+        capacity planning.
+    cli_default_enabled : bool
+        Whether the CLI lists this source as enabled-by-default.
+        ``False`` for sources that require keys the user might not
+        have or that we deliberately keep dormant.
+    cli_description : str
+        One-sentence description for the CLI listing.
+    misp_tag : str
+        The MISP tag string the writer attaches to attributes
+        (``"source:NVD"`` / ``"source:CISA-KEV"`` etc.). Round-trips
+        as ``raw_data.original_source`` via ``parse_attribute``.
+    reliable_first_seen : bool
+        ``True`` ⇒ this source's first_seen / last_seen claims land
+        on the ``SOURCED_FROM`` edge as
+        ``r.source_reported_first_at`` / ``r.source_reported_last_at``.
+        ``False`` ⇒ the source publishes a first_seen field but it
+        means something other than "first observed" (OTX
+        pulse-publish-date, CyberCure synthetic now, MISP-only
+        pipeline metadata) — extractor returns
+        ``(None, None)`` and the value never reaches the edge.
+    """
+
+    canonical_id: str
+    display_name: str
+    source_type: str
+    reliability: float
+    misp_tag: str
+    reliable_first_seen: bool
+    aliases: Tuple[str, ...] = field(default_factory=tuple)
+    cli_id: Optional[str] = None
+    api_key_env: Optional[str] = None
+    rate_limit: str = "unlimited"
+    cli_default_enabled: bool = True
+    cli_description: str = ""
+    # Optional override for the CLI listing's "name" column. Defaults
+    # to display_name when unset. The only source that uses this today
+    # is NVD: the historical CLI listing called it "National
+    # Vulnerability Database" while the historical Neo4j Source.name
+    # was just "NVD" (acronym fits dashboard widths). Refactor
+    # preserves both.
+    cli_display_name: Optional[str] = None
+
+    @property
+    def all_keys(self) -> Tuple[str, ...]:
+        """``(canonical_id,) + aliases`` — every key under which this
+        source can be looked up. Used by the derivation helpers to
+        build the legacy alias-keyed dicts (every Cypher MERGE on
+        ``:Source {source_id: $X}`` needs an entry per alias because
+        the merge query itself doesn't know about aliases).
+        """
+        return (self.canonical_id,) + self.aliases
+
+
+# ===========================================================================
+# The registry — single source of truth
+# ===========================================================================
+#
+# ORDERING NOTE: tests/test_source_registry.py asserts the LEGACY
+# byte-for-byte shape of every derived dict. The order of entries in
+# this list IS PART OF THE PUBLIC CONTRACT for the derived ``SOURCES``
+# / ``DEFAULT_SOURCES`` dicts (Python 3.7+ dicts preserve insertion
+# order; downstream callers that iterate may depend on it). When
+# adding a new source, append AT THE END unless there's a specific
+# reason to insert earlier.
+#
+# Entries are listed in the historical order they appeared in the
+# legacy ``SOURCES`` dict in ``neo4j_client.py``, so the derived
+# dict matches byte-for-byte.
+
+_REGISTRY: Tuple[Source, ...] = (
+    Source(
+        canonical_id="alienvault_otx",
+        aliases=("otx",),
+        display_name="AlienVault OTX",
+        source_type="threat_intel",
+        reliability=0.7,
+        cli_id="otx",
+        api_key_env="OTX_API_KEY",
+        rate_limit="30/min",
+        cli_default_enabled=True,
+        cli_description="Threat intelligence pulses",
+        misp_tag="source:AlienVault-OTX",
+        # OTX pulse.created is the pulse-author-time, NOT the IOC
+        # first-observed time. Excluded from source-truthful pipeline.
+        reliable_first_seen=False,
+    ),
+    Source(
+        canonical_id="virustotal",
+        aliases=("vt",),
+        display_name="VirusTotal",
+        source_type="threat_intel",
+        reliability=0.8,
+        cli_id="virustotal",
+        api_key_env="VIRUSTOTAL_API_KEY",
+        rate_limit="4/min",
+        cli_default_enabled=True,
+        cli_description="File and URL reputation",
+        misp_tag="source:VirusTotal",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="abuseipdb",
+        display_name="AbuseIPDB",
+        source_type="threat_intel",
+        reliability=0.65,
+        cli_id="abuseipdb",
+        api_key_env="ABUSEIPDB_API_KEY",
+        rate_limit="1000/day",
+        cli_default_enabled=False,
+        cli_description="IP reputation",
+        misp_tag="source:AbuseIPDB",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="mitre_attck",
+        aliases=("mitre",),
+        display_name="MITRE ATT&CK",
+        source_type="framework",
+        reliability=0.95,
+        cli_id="mitre",
+        api_key_env=None,
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Threat techniques and tactics",
+        misp_tag="source:MITRE-ATT&CK",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="nvd",
+        display_name="NVD",
+        # Historical asymmetry: Neo4j stores the acronym (fits in
+        # dashboard widths), CLI listing spells out the full name.
+        cli_display_name="National Vulnerability Database",
+        source_type="vulnerability_db",
+        reliability=0.9,
+        cli_id="nvd",
+        api_key_env="NVD_API_KEY",
+        rate_limit="30/30sec",
+        cli_default_enabled=True,
+        cli_description="CVE vulnerabilities",
+        misp_tag="source:NVD",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="misp",
+        display_name="MISP",
+        source_type="threat_intel",
+        reliability=0.75,
+        cli_id="misp",
+        api_key_env="MISP_API_KEY",
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Central threat intelligence hub",
+        misp_tag="source:MISP",
+        # MISP-collector / sector feeds are pipeline metadata only —
+        # not a source-truthful first-seen claim.
+        reliable_first_seen=False,
+    ),
+    Source(
+        canonical_id="cisa_kev",
+        aliases=("cisa",),
+        display_name="CISA KEV",
+        source_type="advisory",
+        reliability=0.9,
+        cli_id="cisa",
+        api_key_env=None,
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Known exploited vulnerabilities",
+        misp_tag="source:CISA-KEV",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="feodo_tracker",
+        aliases=("feodo",),
+        display_name="Feodo Tracker",
+        source_type="threat_intel",
+        reliability=0.7,
+        cli_id="feodo",
+        api_key_env=None,
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Banking trojan C&C servers",
+        misp_tag="source:Feodo-Tracker",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="ssl_blacklist",
+        aliases=("sslbl", "abusech_ssl"),
+        display_name="SSL Blacklist",
+        source_type="threat_intel",
+        reliability=0.65,
+        cli_id="sslbl",
+        api_key_env=None,
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Malicious SSL certificates",
+        misp_tag="source:SSL-Blacklist",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="urlhaus",
+        display_name="URLhaus",
+        source_type="threat_intel",
+        reliability=0.7,
+        cli_id="urlhaus",
+        api_key_env=None,
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Malware URLs",
+        misp_tag="source:URLhaus",
+        reliable_first_seen=True,
+    ),
+    Source(
+        canonical_id="cybercure",
+        display_name="CyberCure",
+        source_type="threat_intel",
+        reliability=0.6,
+        cli_id="cybercure",
+        api_key_env=None,
+        rate_limit="unlimited",
+        cli_default_enabled=True,
+        cli_description="Threat intelligence feeds",
+        misp_tag="source:CyberCure",
+        # CyberCure synthesizes a now() timestamp on every call —
+        # not a real source-truthful first-seen claim.
+        reliable_first_seen=False,
+    ),
+    Source(
+        canonical_id="threatfox",
+        display_name="ThreatFox",
+        source_type="threat_intel",
+        reliability=0.7,
+        cli_id="threatfox",
+        api_key_env="THREATFOX_API_KEY",
+        rate_limit="unlimited",
+        cli_default_enabled=False,
+        cli_description="Threat actor indicators",
+        misp_tag="source:ThreatFox",
+        reliable_first_seen=True,
+    ),
+)
+
+
+# ===========================================================================
+# Lookup helpers
+# ===========================================================================
+
+
+def all_sources() -> Tuple[Source, ...]:
+    """Return the registry tuple in declaration order."""
+    return _REGISTRY
+
+
+def get_source(id_or_alias: str) -> Optional[Source]:
+    """Resolve any canonical id OR alias to its ``Source`` record.
+
+    Case-insensitive (lowercased + stripped). Returns ``None`` for
+    unknown ids — callers should treat that as "not in the registry"
+    not "use a default" (no defaults; we want explicit failures).
+    """
+    if not id_or_alias:
+        return None
+    needle = id_or_alias.strip().lower()
+    if not needle:
+        return None
+    for src in _REGISTRY:
+        if needle in src.all_keys:
+            return src
+    return None
+
+
+def all_aliases() -> FrozenSet[str]:
+    """Every key under which any source can be looked up — canonical
+    ids + aliases, all lowercased. Used by ``metrics_server`` to
+    bound the ``source_id`` Prometheus label cardinality.
+    """
+    out = set()
+    for src in _REGISTRY:
+        out.update(src.all_keys)
+    return frozenset(out)
+
+
+# ===========================================================================
+# Derivation helpers — each replaces one of the 5 legacy registries
+# ===========================================================================
+
+
+def to_neo4j_sources_dict() -> Dict[str, Dict[str, object]]:
+    """Re-creates the legacy ``neo4j_client.SOURCES`` dict shape.
+
+    Schema: ``{source_id: {"name": str, "type": str, "reliability": float}}``
+
+    One entry per ALIAS so the existing Cypher
+    ``MERGE (:Source {source_id: $sid})`` calls (which don't know
+    about aliases) keep working for every legacy id.
+
+    Insertion order matches the legacy hand-maintained dict so a
+    parity test can assert byte-for-byte equality.
+    """
+    out: Dict[str, Dict[str, object]] = {}
+    for src in _REGISTRY:
+        payload = {
+            "name": src.display_name,
+            "type": src.source_type,
+            "reliability": src.reliability,
+        }
+        for key in src.all_keys:
+            out[key] = dict(payload)
+    return out
+
+
+def to_cli_sources_dict() -> Dict[str, Dict[str, object]]:
+    """Re-creates the legacy ``edgeguard.DEFAULT_SOURCES`` dict shape.
+
+    Schema: ``{cli_id: {"name", "api_key_env", "rate_limit", "enabled",
+    "description"}}``
+
+    One entry per source whose ``cli_id`` is set (currently all of
+    them). Skips sources with ``cli_id is None``.
+    """
+    out: Dict[str, Dict[str, object]] = {}
+    for src in _REGISTRY:
+        if src.cli_id is None:
+            continue
+        out[src.cli_id] = {
+            "name": src.cli_display_name or src.display_name,
+            "api_key_env": src.api_key_env,
+            "rate_limit": src.rate_limit,
+            "enabled": src.cli_default_enabled,
+            "description": src.cli_description,
+        }
+    return out
+
+
+def cli_to_canonical_tag_map() -> Dict[str, str]:
+    """Re-creates the legacy ``config.SOURCE_TAGS`` dict shape.
+
+    Schema: ``{cli_id: canonical_tag}`` — used by collectors to set
+    ``self.tag = SOURCE_TAGS["nvd"]`` etc.
+
+    One entry per source whose ``cli_id`` is set; the value is the
+    source's ``canonical_id`` (so a source with ``cli_id="cisa"``
+    and ``canonical_id="cisa_kev"`` produces ``{"cisa": "cisa_kev"}``).
+
+    NOTE: the legacy ``config.SOURCE_TAGS`` only listed 7 sources
+    (the ones with collectors that look themselves up by shortname).
+    For backward-compat we ship a ``LEGACY_SUBSET`` constant that
+    matches the historical 7-key shape; the FULL registry-derived
+    map is also available for future callers that want it.
+    """
+    out: Dict[str, str] = {}
+    for src in _REGISTRY:
+        if src.cli_id is None:
+            continue
+        out[src.cli_id] = src.canonical_id
+    return out
+
+
+# Subset of cli_to_canonical_tag_map that matches the legacy 7-key
+# config.SOURCE_TAGS — kept verbatim so existing collectors that do
+# ``SOURCE_TAGS["X"]`` (KeyError on missing) don't suddenly start
+# resolving keys that didn't exist before.
+_LEGACY_SOURCE_TAGS_KEYS: FrozenSet[str] = frozenset({"misp", "otx", "nvd", "cisa", "mitre", "virustotal", "abuseipdb"})
+
+
+def cli_to_canonical_tag_map_legacy_subset() -> Dict[str, str]:
+    """Same as ``cli_to_canonical_tag_map`` but restricted to the
+    7 keys the historical ``config.SOURCE_TAGS`` exposed.
+
+    Existing collector code does ``SOURCE_TAGS["X"]`` and EXPECTS
+    KeyError on a missing key (defensive: catches typos at collector
+    init). Widening the legacy 7-key map to the full ~12-key map
+    would silently start resolving keys that previously failed —
+    behavior change. Use this restricted form when wiring
+    ``config.SOURCE_TAGS`` for backward-compat.
+    """
+    full = cli_to_canonical_tag_map()
+    return {k: v for k, v in full.items() if k in _LEGACY_SOURCE_TAGS_KEYS}
+
+
+def reliable_first_seen_aliases() -> FrozenSet[str]:
+    """Re-creates the legacy ``_RELIABLE_FIRST_SEEN_SOURCES`` frozenset.
+
+    Returns every key (canonical id + aliases) of every source whose
+    ``reliable_first_seen`` flag is True. The
+    ``is_reliable_first_seen_source`` lookup runs against this set
+    after lowercasing the input.
+    """
+    out = set()
+    for src in _REGISTRY:
+        if src.reliable_first_seen:
+            out.update(src.all_keys)
+    return frozenset(out)
+
+
+def source_to_misp_tag_map() -> Dict[str, str]:
+    """Re-creates the legacy ``MISPWriter.SOURCE_TAGS`` dict.
+
+    Schema: ``{source_id: misp_tag_string}``. One entry per alias so
+    a writer call that looks up by either the canonical id OR a legacy
+    alias finds the same MISP tag.
+
+    NOTE: the historical map skipped a few aliases (e.g. it had
+    ``feodo`` but not ``feodo_tracker``). For backward-compat we
+    ship a full alias-expanded map — adding new keys does NOT change
+    existing behavior because looking up an unrecognized key was
+    already a no-op (the writer skipped the tag). New aliases just
+    extend the lookup surface.
+    """
+    out: Dict[str, str] = {}
+    for src in _REGISTRY:
+        for key in src.all_keys:
+            out[key] = src.misp_tag
+    return out

--- a/src/source_registry.py
+++ b/src/source_registry.py
@@ -399,7 +399,7 @@ def all_aliases() -> FrozenSet[str]:
     ids + aliases, all lowercased. Used by ``metrics_server`` to
     bound the ``source_id`` Prometheus label cardinality.
     """
-    out = set()
+    out: set[str] = set()
     for src in _REGISTRY:
         out.update(src.all_keys)
     return frozenset(out)
@@ -511,7 +511,7 @@ def reliable_first_seen_aliases() -> FrozenSet[str]:
     ``is_reliable_first_seen_source`` lookup runs against this set
     after lowercasing the input.
     """
-    out = set()
+    out: set[str] = set()
     for src in _REGISTRY:
         if src.reliable_first_seen:
             out.update(src.all_keys)

--- a/src/source_truthful_timestamps.py
+++ b/src/source_truthful_timestamps.py
@@ -167,29 +167,18 @@ _INT_EPOCH_CEIL = 253_402_300_799  # 9999-12-31 UTC (datetime.fromtimestamp limi
 # change the upstream truth, but the source_id of the COLLECTOR that
 # fetched the relayed copy might be "otx". We need to credit the
 # original source's first_seen, not the relay's.
-_RELIABLE_FIRST_SEEN_SOURCES: frozenset = frozenset(
-    {
-        "nvd",
-        # CISA: collector emits "cisa_kev" (config.SOURCE_TAGS["cisa"] =
-        # "cisa_kev"); legacy collectors / tests / direct callers may
-        # still pass "cisa". Both must be on the allowlist or the CISA
-        # passthrough fix in PR (S5) is dead. Bugbot caught the
-        # misalignment in commit ac25b07.
-        "cisa",
-        "cisa_kev",
-        "mitre_attck",
-        "mitre",
-        "virustotal",
-        "vt",
-        "abuseipdb",
-        "threatfox",
-        "urlhaus",
-        "feodo_tracker",
-        "feodo",
-        "ssl_blacklist",
-        "abusech_ssl",
-    }
-)
+#
+# Single-source-of-truth derivation from src/source_registry.py (chip 5a).
+# Each Source(reliable_first_seen=True) entry contributes its canonical id
+# AND every alias to the frozenset, so a collector calling with EITHER
+# spelling (e.g. "cisa" or "cisa_kev", "mitre" or "mitre_attck", "feodo"
+# or "feodo_tracker", "vt" or "virustotal") resolves identically.
+# Bugbot's commit ac25b07 caught the misalignment that the alias-coverage
+# requirement existed but wasn't centrally enforced; the registry refactor
+# makes the alias-vs-canonical relationship the single source.
+import source_registry as _source_registry  # noqa: E402  — sequenced after the bounds-constant block above
+
+_RELIABLE_FIRST_SEEN_SOURCES: frozenset = _source_registry.reliable_first_seen_aliases()
 
 
 def _normalize_source_key(source_id: Optional[str]) -> str:

--- a/tests/test_source_registry.py
+++ b/tests/test_source_registry.py
@@ -476,11 +476,18 @@ def test_aliases_do_not_collide_with_other_sources_canonical_ids():
 # ---------------------------------------------------------------------------
 
 
-def test_adding_a_new_source_propagates_to_all_five_derivations():
+def test_adding_a_new_source_propagates_to_all_five_derivations(monkeypatch):
     """Smoke test that synthesizes a new ``Source(...)`` entry, prepends
     it to a copy of the registry, and verifies every derivation picks
     it up. Catches a future refactor that misses one of the five
-    derivation helpers."""
+    derivation helpers.
+
+    PR #43 audit M1 (Bug Hunter): use ``monkeypatch.setattr`` instead
+    of manual try/finally — pytest's monkeypatch handles teardown
+    safely even when an assertion in the middle raises, signaling to
+    readers that this test mutates module globals.
+    """
+    import source_registry
     from source_registry import (
         Source,
         cli_to_canonical_tag_map,
@@ -505,43 +512,137 @@ def test_adding_a_new_source_propagates_to_all_five_derivations():
         reliable_first_seen=True,
     )
 
-    # Monkeypatch the registry tuple to include the test source. Done
-    # via a direct attribute set on the module to avoid plumbing a
-    # fixture — this is a self-contained roundtrip check.
+    monkeypatch.setattr(source_registry, "_REGISTRY", source_registry._REGISTRY + (test_source,))
+
+    # Each derivation re-reads _REGISTRY on every call; no caching.
+    neo4j_dict = to_neo4j_sources_dict()
+    cli_dict = to_cli_sources_dict()
+    cli_to_canon = cli_to_canonical_tag_map()
+    reliable = reliable_first_seen_aliases()
+    misp = source_to_misp_tag_map()
+
+    # 1. Neo4j SOURCES picks it up via canonical id AND alias
+    assert "testsrc_canonical_id_12345" in neo4j_dict
+    assert "testsrc_alias_67890" in neo4j_dict
+    assert neo4j_dict["testsrc_canonical_id_12345"]["name"] == "Test Source"
+
+    # 2. CLI DEFAULT_SOURCES picks it up via cli_id
+    assert "testsrc_cli" in cli_dict
+    assert cli_dict["testsrc_cli"]["api_key_env"] == "TESTSRC_API_KEY"
+
+    # 3. SOURCE_TAGS picks it up via cli_id (full map, not legacy subset)
+    assert cli_to_canon["testsrc_cli"] == "testsrc_canonical_id_12345"
+
+    # 4. _RELIABLE_FIRST_SEEN_SOURCES picks up canonical AND alias
+    assert "testsrc_canonical_id_12345" in reliable
+    assert "testsrc_alias_67890" in reliable
+
+    # 5. MISPWriter.SOURCE_TAGS picks up canonical AND alias
+    assert misp["testsrc_canonical_id_12345"] == "source:TestSrc-Unique-12345"
+    assert misp["testsrc_alias_67890"] == "source:TestSrc-Unique-12345"
+
+
+def test_to_cli_sources_dict_raises_on_duplicate_cli_id(monkeypatch):
+    """PR #43 audit M2 (Devil's Advocate / Cross-Checker): adding a
+    second Source with a cli_id that already exists silently
+    overwrote the earlier entry's CLI listing — uniqueness MUST be
+    a runtime error, not a silent collision."""
+    import pytest
+
     import source_registry
+    from source_registry import Source, to_cli_sources_dict
 
-    original_registry = source_registry._REGISTRY
-    try:
-        source_registry._REGISTRY = original_registry + (test_source,)
+    # Synthesize a Source whose cli_id collides with an existing one
+    # ("nvd" is a registered cli_id on the canonical NVD record).
+    colliding = Source(
+        canonical_id="testsrc_collision_canonical",
+        display_name="Collision Source",
+        source_type="threat_intel",
+        reliability=0.5,
+        misp_tag="source:Collision-Test",
+        reliable_first_seen=True,
+        cli_id="nvd",  # collides with NVD's existing cli_id
+    )
+    monkeypatch.setattr(source_registry, "_REGISTRY", source_registry._REGISTRY + (colliding,))
 
-        # Each derivation re-reads _REGISTRY on every call; no caching.
-        neo4j_dict = to_neo4j_sources_dict()
-        cli_dict = to_cli_sources_dict()
-        cli_to_canon = cli_to_canonical_tag_map()
-        reliable = reliable_first_seen_aliases()
-        misp = source_to_misp_tag_map()
+    with pytest.raises(ValueError, match="duplicate cli_id"):
+        to_cli_sources_dict()
 
-        # 1. Neo4j SOURCES picks it up via canonical id AND alias
-        assert "testsrc_canonical_id_12345" in neo4j_dict
-        assert "testsrc_alias_67890" in neo4j_dict
-        assert neo4j_dict["testsrc_canonical_id_12345"]["name"] == "Test Source"
 
-        # 2. CLI DEFAULT_SOURCES picks it up via cli_id
-        assert "testsrc_cli" in cli_dict
-        assert cli_dict["testsrc_cli"]["api_key_env"] == "TESTSRC_API_KEY"
+def test_cli_to_canonical_tag_map_raises_on_duplicate_cli_id(monkeypatch):
+    """Same uniqueness invariant on the SOURCE_TAGS derivation."""
+    import pytest
 
-        # 3. SOURCE_TAGS picks it up via cli_id (full map, not legacy subset)
-        assert cli_to_canon["testsrc_cli"] == "testsrc_canonical_id_12345"
+    import source_registry
+    from source_registry import Source, cli_to_canonical_tag_map
 
-        # 4. _RELIABLE_FIRST_SEEN_SOURCES picks up canonical AND alias
-        assert "testsrc_canonical_id_12345" in reliable
-        assert "testsrc_alias_67890" in reliable
+    colliding = Source(
+        canonical_id="testsrc_collision_canonical_2",
+        display_name="Collision Source 2",
+        source_type="threat_intel",
+        reliability=0.5,
+        misp_tag="source:Collision-Test-2",
+        reliable_first_seen=True,
+        cli_id="cisa",  # collides with CISA KEV's existing cli_id
+    )
+    monkeypatch.setattr(source_registry, "_REGISTRY", source_registry._REGISTRY + (colliding,))
 
-        # 5. MISPWriter.SOURCE_TAGS picks up canonical AND alias
-        assert misp["testsrc_canonical_id_12345"] == "source:TestSrc-Unique-12345"
-        assert misp["testsrc_alias_67890"] == "source:TestSrc-Unique-12345"
-    finally:
-        source_registry._REGISTRY = original_registry
+    with pytest.raises(ValueError, match="duplicate cli_id"):
+        cli_to_canonical_tag_map()
+
+
+def test_cli_ids_are_unique_in_the_real_registry():
+    """Static check on the actual ``_REGISTRY`` — every Source with a
+    non-None ``cli_id`` MUST have a unique value. Catches a
+    contributor accidentally re-using an existing cli_id even before
+    a derivation helper is exercised in production."""
+    from source_registry import all_sources
+
+    seen: dict[str, str] = {}
+    for src in all_sources():
+        if src.cli_id is None:
+            continue
+        prior = seen.get(src.cli_id)
+        assert prior is None, (
+            f"duplicate cli_id={src.cli_id!r} in real registry: both {prior!r} and {src.canonical_id!r} use it"
+        )
+        seen[src.cli_id] = src.canonical_id
+
+
+def test_full_cli_to_canonical_tag_map_is_not_used_in_src(tmp_path):
+    """PR #43 audit M3 (Maintainer Dev): the full
+    ``cli_to_canonical_tag_map()`` (~12 keys) MUST NOT be imported
+    into ``src/`` outside of ``source_registry.py`` and tests. The
+    legacy-subset variant (``..._legacy_subset``) is what production
+    callers wire — using the full map silently widens
+    ``config.SOURCE_TAGS`` from 7 to 12 keys, which lets typo'd
+    ``SOURCE_TAGS["X"]`` lookups silently succeed instead of raising
+    ``KeyError`` at collector init.
+    """
+    import os
+    import re
+
+    src_root = os.path.join(os.path.dirname(__file__), "..", "src")
+    bad_pattern = re.compile(
+        r"\bfrom\s+source_registry\s+import\s+[^#\n]*\bcli_to_canonical_tag_map\b(?!_legacy_subset)"
+    )
+    bad_files = []
+    for dirpath, _, filenames in os.walk(src_root):
+        for fname in filenames:
+            if not fname.endswith(".py"):
+                continue
+            path = os.path.join(dirpath, fname)
+            if os.path.basename(path) == "source_registry.py":
+                continue
+            with open(path) as fh:
+                content = fh.read()
+            for m in bad_pattern.finditer(content):
+                bad_files.append((path, m.group(0)))
+    assert not bad_files, (
+        f"Imports of full cli_to_canonical_tag_map (without _legacy_subset) found: {bad_files}. "
+        "Use cli_to_canonical_tag_map_legacy_subset to preserve the historical 7-key shape "
+        "and the KeyError-on-typo guarantee."
+    )
 
 
 def test_dataclass_is_frozen_so_registry_cannot_be_mutated_at_runtime():

--- a/tests/test_source_registry.py
+++ b/tests/test_source_registry.py
@@ -1,0 +1,518 @@
+"""Chip 5a — single-source-of-truth source registry refactor.
+
+Closes the spawned-task chip from the PR #41 audit. Before the
+refactor, five hand-maintained registries described "what sources
+EdgeGuard knows about":
+
+1. ``neo4j_client.SOURCES``                          (Neo4j Source nodes)
+2. ``edgeguard.DEFAULT_SOURCES``                     (CLI listing)
+3. ``config.SOURCE_TAGS``                            (CLI shortname → canonical tag)
+4. ``source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES``  (allowlist)
+5. ``collectors.misp_writer.MISPWriter.SOURCE_TAGS`` (source id → MISP tag string)
+
+This module pins:
+
+A. **Parity** — every legacy entry produces the SAME shape after the
+   refactor. The registry-derived dicts are byte-identical to the
+   pre-refactor hand-maintained ones for every legacy key. (The
+   refactor does ALSO close a few alias-coverage gaps — same
+   pattern as PR #41 adding ``feodo_tracker`` / ``ssl_blacklist``
+   to the SOURCES dict — but for every existing key the value is
+   unchanged.)
+
+B. **Invariants** that link the five registries:
+   - Every reliable_first_seen=True source is also in SOURCES (else
+     the SOURCED_FROM stamp would silently fail).
+   - Every CLI-id has a corresponding canonical-id in SOURCES.
+   - Every alias resolves to the same Source record as its canonical id.
+   - Every source's misp_tag round-trips through
+     parse_attribute's ``raw_data.original_source`` extractor and
+     resolves back to a known source.
+
+C. **Propagation** — adding a new ``Source(...)`` to the registry
+   propagates to all five derived structures simultaneously (smoke
+   test that synthesizes a registry mutation and re-derives).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+
+# ---------------------------------------------------------------------------
+# A. Parity snapshots — every pre-refactor key produces the same value
+# ---------------------------------------------------------------------------
+#
+# The legacy dicts had specific byte-for-byte shapes. The refactor MUST
+# preserve them for every existing key (it MAY add new alias entries —
+# documented separately below).
+
+
+# Captured 2026-04-18 from the pre-refactor hand-maintained dict.
+# Source: ``src/neo4j_client.py:238 SOURCES`` on commit ef2c550 (main).
+_LEGACY_NEO4J_SOURCES = {
+    "alienvault_otx": {"name": "AlienVault OTX", "type": "threat_intel", "reliability": 0.7},
+    "virustotal": {"name": "VirusTotal", "type": "threat_intel", "reliability": 0.8},
+    "abuseipdb": {"name": "AbuseIPDB", "type": "threat_intel", "reliability": 0.65},
+    "mitre_attck": {"name": "MITRE ATT&CK", "type": "framework", "reliability": 0.95},
+    "nvd": {"name": "NVD", "type": "vulnerability_db", "reliability": 0.9},
+    "misp": {"name": "MISP", "type": "threat_intel", "reliability": 0.75},
+    "cisa": {"name": "CISA KEV", "type": "advisory", "reliability": 0.9},
+    "cisa_kev": {"name": "CISA KEV", "type": "advisory", "reliability": 0.9},
+    "feodo": {"name": "Feodo Tracker", "type": "threat_intel", "reliability": 0.7},
+    "feodo_tracker": {"name": "Feodo Tracker", "type": "threat_intel", "reliability": 0.7},
+    "sslbl": {"name": "SSL Blacklist", "type": "threat_intel", "reliability": 0.65},
+    "ssl_blacklist": {"name": "SSL Blacklist", "type": "threat_intel", "reliability": 0.65},
+    "abusech_ssl": {"name": "SSL Blacklist", "type": "threat_intel", "reliability": 0.65},
+    "urlhaus": {"name": "URLhaus", "type": "threat_intel", "reliability": 0.7},
+    "cybercure": {"name": "CyberCure", "type": "threat_intel", "reliability": 0.6},
+    "threatfox": {"name": "ThreatFox", "type": "threat_intel", "reliability": 0.7},
+}
+
+
+# Captured 2026-04-18 from the pre-refactor hand-maintained dict.
+# Source: ``src/edgeguard.py:775 DEFAULT_SOURCES`` on commit ef2c550 (main).
+_LEGACY_DEFAULT_SOURCES = {
+    "otx": {
+        "name": "AlienVault OTX",
+        "api_key_env": "OTX_API_KEY",
+        "rate_limit": "30/min",
+        "enabled": True,
+        "description": "Threat intelligence pulses",
+    },
+    "nvd": {
+        "name": "National Vulnerability Database",
+        "api_key_env": "NVD_API_KEY",
+        "rate_limit": "30/30sec",
+        "enabled": True,
+        "description": "CVE vulnerabilities",
+    },
+    "virustotal": {
+        "name": "VirusTotal",
+        "api_key_env": "VIRUSTOTAL_API_KEY",
+        "rate_limit": "4/min",
+        "enabled": True,
+        "description": "File and URL reputation",
+    },
+    "cisa": {
+        "name": "CISA KEV",
+        "api_key_env": None,
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Known exploited vulnerabilities",
+    },
+    "mitre": {
+        "name": "MITRE ATT&CK",
+        "api_key_env": None,
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Threat techniques and tactics",
+    },
+    "abuseipdb": {
+        "name": "AbuseIPDB",
+        "api_key_env": "ABUSEIPDB_API_KEY",
+        "rate_limit": "1000/day",
+        "enabled": False,
+        "description": "IP reputation",
+    },
+    "urlhaus": {
+        "name": "URLhaus",
+        "api_key_env": None,
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Malware URLs",
+    },
+    "cybercure": {
+        "name": "CyberCure",
+        "api_key_env": None,
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Threat intelligence feeds",
+    },
+    "feodo": {
+        "name": "Feodo Tracker",
+        "api_key_env": None,
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Banking trojan C&C servers",
+    },
+    "sslbl": {
+        "name": "SSL Blacklist",
+        "api_key_env": None,
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Malicious SSL certificates",
+    },
+    "threatfox": {
+        "name": "ThreatFox",
+        "api_key_env": "THREATFOX_API_KEY",
+        "rate_limit": "unlimited",
+        "enabled": False,
+        "description": "Threat actor indicators",
+    },
+    "misp": {
+        "name": "MISP",
+        "api_key_env": "MISP_API_KEY",
+        "rate_limit": "unlimited",
+        "enabled": True,
+        "description": "Central threat intelligence hub",
+    },
+}
+
+
+# Captured 2026-04-18 from ``src/config.py:690 SOURCE_TAGS``.
+_LEGACY_CONFIG_SOURCE_TAGS = {
+    "misp": "misp",
+    "otx": "alienvault_otx",
+    "nvd": "nvd",
+    "cisa": "cisa_kev",
+    "mitre": "mitre_attck",
+    "virustotal": "virustotal",
+    "abuseipdb": "abuseipdb",
+}
+
+
+# Captured 2026-04-18 from ``src/source_truthful_timestamps.py:170``.
+_LEGACY_RELIABLE_FIRST_SEEN_SOURCES = frozenset(
+    {
+        "nvd",
+        "cisa",
+        "cisa_kev",
+        "mitre_attck",
+        "mitre",
+        "virustotal",
+        "vt",
+        "abuseipdb",
+        "threatfox",
+        "urlhaus",
+        "feodo_tracker",
+        "feodo",
+        "ssl_blacklist",
+        "abusech_ssl",
+    }
+)
+
+
+# Captured 2026-04-18 from ``src/collectors/misp_writer.py:285``.
+_LEGACY_MISP_WRITER_SOURCE_TAGS = {
+    "misp": "source:MISP",
+    "otx": "source:AlienVault-OTX",
+    "alienvault_otx": "source:AlienVault-OTX",
+    "nvd": "source:NVD",
+    "cisa": "source:CISA-KEV",
+    "cisa_kev": "source:CISA-KEV",
+    "mitre": "source:MITRE-ATT&CK",
+    "mitre_attck": "source:MITRE-ATT&CK",
+    "virustotal": "source:VirusTotal",
+    "abuseipdb": "source:AbuseIPDB",
+    "feodo": "source:Feodo-Tracker",
+    "sslbl": "source:SSL-Blacklist",
+    "urlhaus": "source:URLhaus",
+    "cybercure": "source:CyberCure",
+    "threatfox": "source:ThreatFox",
+}
+
+
+def test_neo4j_sources_dict_preserves_every_legacy_entry_byte_for_byte():
+    """For every legacy SOURCES key, the registry-derived dict produces
+    the SAME value (name + type + reliability)."""
+    from neo4j_client import SOURCES
+
+    for key, expected in _LEGACY_NEO4J_SOURCES.items():
+        assert key in SOURCES, f"Legacy SOURCES key '{key}' is missing from registry-derived dict"
+        assert SOURCES[key] == expected, f"SOURCES['{key}'] value drift: expected {expected}, got {SOURCES[key]}"
+
+
+def test_default_sources_dict_preserves_every_legacy_entry_byte_for_byte():
+    """For every legacy DEFAULT_SOURCES key (CLI listing), the
+    registry-derived dict produces the SAME value (name + api_key_env +
+    rate_limit + enabled + description)."""
+    from edgeguard import DEFAULT_SOURCES
+
+    for key, expected in _LEGACY_DEFAULT_SOURCES.items():
+        assert key in DEFAULT_SOURCES, f"Legacy DEFAULT_SOURCES key '{key}' missing"
+        assert DEFAULT_SOURCES[key] == expected, (
+            f"DEFAULT_SOURCES['{key}'] value drift: expected {expected}, got {DEFAULT_SOURCES[key]}"
+        )
+
+
+def test_config_source_tags_preserves_legacy_seven_keys_exactly():
+    """``config.SOURCE_TAGS`` historically had exactly 7 keys. The
+    refactor MUST preserve that 7-key shape (not widen to ~12) — many
+    collector callers do ``SOURCE_TAGS["X"]`` and rely on KeyError on
+    typo to catch missing keys at init."""
+    from config import SOURCE_TAGS
+
+    assert dict(SOURCE_TAGS) == _LEGACY_CONFIG_SOURCE_TAGS, (
+        f"SOURCE_TAGS shape drift: expected {_LEGACY_CONFIG_SOURCE_TAGS}, got {dict(SOURCE_TAGS)}"
+    )
+
+
+def test_reliable_first_seen_sources_is_a_superset_of_legacy():
+    """Every legacy reliable-source entry MUST still be present. The
+    refactor may add a few alias-coverage entries (documented in the
+    next test) but cannot drop existing ones."""
+    from source_truthful_timestamps import _RELIABLE_FIRST_SEEN_SOURCES
+
+    missing = _LEGACY_RELIABLE_FIRST_SEEN_SOURCES - _RELIABLE_FIRST_SEEN_SOURCES
+    assert not missing, (
+        f"Reliable-first-seen drift: legacy entries dropped from registry: {missing}. "
+        "Every reliable source MUST stay reliable across the refactor."
+    )
+
+
+def test_reliable_first_seen_alias_coverage_extension_is_documented():
+    """The refactor closes one latent alias-coverage gap: ``sslbl``.
+
+    Legacy ``_RELIABLE_FIRST_SEEN_SOURCES`` had ``ssl_blacklist`` and
+    ``abusech_ssl`` but NOT ``sslbl`` — yet the SSL Blacklist collector
+    emits ``sslbl`` as its tag (per legacy ``config.SOURCE_TAGS`` map
+    via the ``finance_feed_collector``). Without ``sslbl`` on the
+    allowlist, source-truthful timestamps from that collector were
+    silently dropped. Same pattern as PR #41 adding ``feodo_tracker``
+    + ``ssl_blacklist`` + ``abusech_ssl`` to the SOURCES dict.
+
+    Pin the EXACT new key set so a future refactor that drops
+    ``sslbl`` again gets caught.
+    """
+    from source_truthful_timestamps import _RELIABLE_FIRST_SEEN_SOURCES
+
+    new_keys = _RELIABLE_FIRST_SEEN_SOURCES - _LEGACY_RELIABLE_FIRST_SEEN_SOURCES
+    assert new_keys == {"sslbl"}, (
+        f"Refactor alias-coverage extension drift: expected exactly {{'sslbl'}}, got {new_keys}. "
+        "If you added a new reliable_first_seen=True source to the registry, update this test."
+    )
+
+
+def test_misp_writer_source_tags_preserves_every_legacy_entry_byte_for_byte():
+    """For every legacy MISPWriter.SOURCE_TAGS key, the registry-derived
+    dict produces the SAME MISP tag string."""
+    from collectors.misp_writer import MISPWriter
+
+    for key, expected in _LEGACY_MISP_WRITER_SOURCE_TAGS.items():
+        assert key in MISPWriter.SOURCE_TAGS, f"Legacy SOURCE_TAGS key '{key}' missing from registry-derived"
+        assert MISPWriter.SOURCE_TAGS[key] == expected, (
+            f"MISPWriter.SOURCE_TAGS['{key}'] drift: expected {expected!r}, got {MISPWriter.SOURCE_TAGS[key]!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B. Cross-registry invariants — the relationships between the 5 derivations
+# ---------------------------------------------------------------------------
+
+
+def test_every_reliable_first_seen_source_is_also_in_neo4j_sources():
+    """Critical invariant: every source on the source-truthful allowlist
+    MUST have a corresponding ``:Source`` node entry in SOURCES. The
+    SOURCED_FROM edge MERGE in ``_upsert_sourced_relationship`` matches
+    on ``(s:Source {source_id: $sid})`` — if the source isn't in
+    SOURCES then ``ensure_sources`` never created the node, and the
+    edge MERGE silently writes nothing.
+
+    This test is the single check that catches the
+    "PR #41 source-truthful pipeline silently dead for source X"
+    regression class.
+    """
+    from neo4j_client import SOURCES
+    from source_truthful_timestamps import _RELIABLE_FIRST_SEEN_SOURCES
+
+    missing = _RELIABLE_FIRST_SEEN_SOURCES - set(SOURCES.keys())
+    assert not missing, (
+        f"INVARIANT VIOLATION: reliable_first_seen sources {missing} are not in "
+        "neo4j_client.SOURCES. Their SOURCED_FROM edge MERGEs would silently "
+        "fail because ensure_sources never created the :Source node. "
+        "Add them to source_registry.py with reliable_first_seen=True AND "
+        "make sure their canonical_id + aliases are picked up by the "
+        "to_neo4j_sources_dict() derivation."
+    )
+
+
+def test_every_cli_id_has_a_canonical_source_in_neo4j_sources():
+    """Every source listed in DEFAULT_SOURCES (CLI surface) MUST have
+    its canonical id covered by SOURCES. Otherwise the CLI lists a
+    source that the Neo4j layer doesn't recognize, and the
+    SOURCED_FROM batch pre-validation refuses every write from it."""
+    from edgeguard import DEFAULT_SOURCES
+    from neo4j_client import SOURCES
+    from source_registry import get_source
+
+    for cli_id in DEFAULT_SOURCES:
+        src = get_source(cli_id)
+        assert src is not None, f"CLI source '{cli_id}' is not in the registry"
+        assert src.canonical_id in SOURCES, (
+            f"CLI source '{cli_id}' (canonical='{src.canonical_id}') is not in "
+            "neo4j_client.SOURCES. CLI would list it but every collector run "
+            "would fail SOURCED_FROM batch pre-validation."
+        )
+
+
+def test_every_alias_resolves_to_the_same_source_as_its_canonical_id():
+    """``get_source('cisa')`` and ``get_source('cisa_kev')`` MUST
+    return the SAME ``Source`` instance. Otherwise a collector's
+    case-insensitive lookup fragments per-source provenance."""
+    from source_registry import all_sources, get_source
+
+    for src in all_sources():
+        canonical = get_source(src.canonical_id)
+        assert canonical is src, f"get_source(canonical_id={src.canonical_id!r}) did not roundtrip"
+        for alias in src.aliases:
+            via_alias = get_source(alias)
+            assert via_alias is src, (
+                f"alias {alias!r} resolved to a DIFFERENT Source than its canonical "
+                f"{src.canonical_id!r} — registry alias map is broken"
+            )
+
+
+def test_get_source_is_case_insensitive():
+    """``get_source('NVD')`` MUST resolve to the same record as
+    ``get_source('nvd')``. The registry strips + lowercases."""
+    from source_registry import get_source
+
+    for query in ("NVD", "nvd", "  Nvd  ", "nVd"):
+        out = get_source(query)
+        assert out is not None and out.canonical_id == "nvd", (
+            f"case-insensitive lookup failed for {query!r}: got {out!r}"
+        )
+
+
+def test_get_source_returns_None_for_unknown_or_empty_input():
+    from source_registry import get_source
+
+    assert get_source(None) is None
+    assert get_source("") is None
+    assert get_source("   ") is None
+    assert get_source("totally_unknown_source") is None
+
+
+def test_misp_tags_are_unique_per_canonical_source():
+    """Two different canonical sources MUST NOT share the same MISP
+    tag string — that would alias them on round-trip through MISP."""
+    from source_registry import all_sources
+
+    seen: dict[str, str] = {}
+    for src in all_sources():
+        prior = seen.get(src.misp_tag)
+        assert prior is None, (
+            f"MISP tag collision: both {prior!r} and {src.canonical_id!r} use "
+            f"misp_tag={src.misp_tag!r} — they would become aliases through "
+            "MISP round-trip"
+        )
+        seen[src.misp_tag] = src.canonical_id
+
+
+def test_canonical_ids_are_unique():
+    """Two ``Source(...)`` entries MUST NOT share a ``canonical_id``."""
+    from source_registry import all_sources
+
+    seen = set()
+    for src in all_sources():
+        assert src.canonical_id not in seen, f"Duplicate canonical_id in registry: {src.canonical_id!r}"
+        seen.add(src.canonical_id)
+
+
+def test_aliases_do_not_collide_with_other_sources_canonical_ids():
+    """An alias MUST NOT be the canonical id of a different source —
+    that would make ``get_source('X')`` ambiguous."""
+    from source_registry import all_sources
+
+    canonical_ids = {src.canonical_id for src in all_sources()}
+    for src in all_sources():
+        for alias in src.aliases:
+            other_canonical = canonical_ids - {src.canonical_id}
+            assert alias not in other_canonical, (
+                f"alias {alias!r} of {src.canonical_id!r} collides with a different source's canonical id"
+            )
+
+
+# ---------------------------------------------------------------------------
+# C. Propagation — adding a new source flows to all 5 derived structures
+# ---------------------------------------------------------------------------
+
+
+def test_adding_a_new_source_propagates_to_all_five_derivations():
+    """Smoke test that synthesizes a new ``Source(...)`` entry, prepends
+    it to a copy of the registry, and verifies every derivation picks
+    it up. Catches a future refactor that misses one of the five
+    derivation helpers."""
+    from source_registry import (
+        Source,
+        cli_to_canonical_tag_map,
+        reliable_first_seen_aliases,
+        source_to_misp_tag_map,
+        to_cli_sources_dict,
+        to_neo4j_sources_dict,
+    )
+
+    test_source = Source(
+        canonical_id="testsrc_canonical_id_12345",
+        aliases=("testsrc_alias_67890",),
+        display_name="Test Source",
+        source_type="threat_intel",
+        reliability=0.5,
+        cli_id="testsrc_cli",
+        api_key_env="TESTSRC_API_KEY",
+        rate_limit="10/min",
+        cli_default_enabled=False,
+        cli_description="Synthetic test source",
+        misp_tag="source:TestSrc-Unique-12345",
+        reliable_first_seen=True,
+    )
+
+    # Monkeypatch the registry tuple to include the test source. Done
+    # via a direct attribute set on the module to avoid plumbing a
+    # fixture — this is a self-contained roundtrip check.
+    import source_registry
+
+    original_registry = source_registry._REGISTRY
+    try:
+        source_registry._REGISTRY = original_registry + (test_source,)
+
+        # Each derivation re-reads _REGISTRY on every call; no caching.
+        neo4j_dict = to_neo4j_sources_dict()
+        cli_dict = to_cli_sources_dict()
+        cli_to_canon = cli_to_canonical_tag_map()
+        reliable = reliable_first_seen_aliases()
+        misp = source_to_misp_tag_map()
+
+        # 1. Neo4j SOURCES picks it up via canonical id AND alias
+        assert "testsrc_canonical_id_12345" in neo4j_dict
+        assert "testsrc_alias_67890" in neo4j_dict
+        assert neo4j_dict["testsrc_canonical_id_12345"]["name"] == "Test Source"
+
+        # 2. CLI DEFAULT_SOURCES picks it up via cli_id
+        assert "testsrc_cli" in cli_dict
+        assert cli_dict["testsrc_cli"]["api_key_env"] == "TESTSRC_API_KEY"
+
+        # 3. SOURCE_TAGS picks it up via cli_id (full map, not legacy subset)
+        assert cli_to_canon["testsrc_cli"] == "testsrc_canonical_id_12345"
+
+        # 4. _RELIABLE_FIRST_SEEN_SOURCES picks up canonical AND alias
+        assert "testsrc_canonical_id_12345" in reliable
+        assert "testsrc_alias_67890" in reliable
+
+        # 5. MISPWriter.SOURCE_TAGS picks up canonical AND alias
+        assert misp["testsrc_canonical_id_12345"] == "source:TestSrc-Unique-12345"
+        assert misp["testsrc_alias_67890"] == "source:TestSrc-Unique-12345"
+    finally:
+        source_registry._REGISTRY = original_registry
+
+
+def test_dataclass_is_frozen_so_registry_cannot_be_mutated_at_runtime():
+    """``Source`` is a frozen dataclass — attempting to mutate any
+    field raises ``FrozenInstanceError``. This makes the registry
+    safe to share across processes / threads."""
+    import dataclasses
+
+    from source_registry import all_sources
+
+    src = all_sources()[0]
+    try:
+        src.reliability = 0.99  # type: ignore[misc]
+    except dataclasses.FrozenInstanceError:
+        return
+    raise AssertionError("Source dataclass MUST be frozen to prevent registry mutation")

--- a/tests/test_source_registry.py
+++ b/tests/test_source_registry.py
@@ -389,6 +389,48 @@ def test_get_source_returns_None_for_unknown_or_empty_input():
     assert get_source("totally_unknown_source") is None
 
 
+def test_all_aliases_returns_every_canonical_id_and_alias():
+    """``all_aliases()`` is the cardinality-control surface for the
+    Prometheus ``source_id`` label (PR #42 ``_SOURCE_LABEL_ALLOWLIST``
+    will derive from this once both PRs land). It MUST return every
+    canonical id AND every alias — otherwise a collector emitting an
+    alias would collapse to the ``<other>`` bucket in metrics, hiding
+    per-source signal.
+
+    This test also kills the bugbot "no in-repo callers" finding —
+    the helper is exercised here even before the metrics_server
+    derivation is wired in a follow-up PR.
+    """
+    from source_registry import all_aliases, all_sources
+
+    out = all_aliases()
+    expected = set()
+    for src in all_sources():
+        expected.add(src.canonical_id)
+        expected.update(src.aliases)
+    assert out == expected, f"all_aliases() drift: missing {expected - out}, extra {out - expected}"
+
+
+def test_all_aliases_is_a_frozenset_so_callers_cannot_mutate():
+    """``frozenset`` immutability is a load-bearing invariant: the
+    metrics_server allowlist (future) caches this result at module
+    import; mutation would silently change cardinality control
+    behavior across the process."""
+    from source_registry import all_aliases
+
+    assert isinstance(all_aliases(), frozenset)
+
+
+def test_all_aliases_is_lowercased_for_case_insensitive_lookup():
+    """Every alias / canonical id MUST be lowercased so the
+    Prometheus label normalizer's case-folding lookup works
+    (collectors may emit any casing)."""
+    from source_registry import all_aliases
+
+    for key in all_aliases():
+        assert key == key.lower(), f"non-lowercased key in all_aliases(): {key!r}"
+
+
 def test_misp_tags_are_unique_per_canonical_source():
     """Two different canonical sources MUST NOT share the same MISP
     tag string — that would alias them on round-trip through MISP."""

--- a/tests/test_source_registry.py
+++ b/tests/test_source_registry.py
@@ -659,3 +659,186 @@ def test_dataclass_is_frozen_so_registry_cannot_be_mutated_at_runtime():
     except dataclasses.FrozenInstanceError:
         return
     raise AssertionError("Source dataclass MUST be frozen to prevent registry mutation")
+
+
+# ---------------------------------------------------------------------------
+# Audit-2 fixes — bugbot follow-ups on f4b3b70
+# ---------------------------------------------------------------------------
+
+
+def test_audit2_post_init_rejects_uppercase_canonical_id():
+    """PR #43 audit-2 (LOW): a future ``Source(canonical_id="VT")`` (or
+    typo'd uppercase) breaks ``get_source`` (which lowercases the
+    input but compared raw keys). ``__post_init__`` MUST fail loudly
+    at construction so the contributor sees the error immediately."""
+    import pytest
+
+    from source_registry import Source
+
+    with pytest.raises(ValueError, match="must be lowercase ASCII"):
+        Source(
+            canonical_id="UPPERCASE_BAD",
+            display_name="Bad",
+            source_type="threat_intel",
+            reliability=0.5,
+            misp_tag="source:Bad",
+            reliable_first_seen=False,
+        )
+
+
+def test_audit2_post_init_rejects_uppercase_alias():
+    """Same defense for aliases."""
+    import pytest
+
+    from source_registry import Source
+
+    with pytest.raises(ValueError, match="alias .* must be lowercase ASCII"):
+        Source(
+            canonical_id="ok_lower",
+            aliases=("OK_LOWER", "BAD_UPPER"),
+            display_name="Bad",
+            source_type="threat_intel",
+            reliability=0.5,
+            misp_tag="source:Bad",
+            reliable_first_seen=False,
+        )
+
+
+def test_audit2_post_init_rejects_non_ascii_canonical_id():
+    """Reject non-ASCII identifiers — Cypher / Prometheus / collector
+    code paths assume ASCII canonical_ids."""
+    import pytest
+
+    from source_registry import Source
+
+    with pytest.raises(ValueError, match="must be lowercase ASCII"):
+        Source(
+            canonical_id="café",  # non-ASCII
+            display_name="Cafe",
+            source_type="threat_intel",
+            reliability=0.5,
+            misp_tag="source:Cafe",
+            reliable_first_seen=False,
+        )
+
+
+def test_audit2_to_cli_sources_dict_preserves_legacy_iteration_order():
+    """PR #43 audit-2 (LOW — bugbot): the legacy ``DEFAULT_SOURCES``
+    dict had a hand-curated key order driving the ``edgeguard sources``
+    CLI listing. After the refactor that order MUST be preserved
+    byte-for-byte (operators iterating the listing depend on it)."""
+    from edgeguard import DEFAULT_SOURCES
+
+    expected_order = (
+        "otx",
+        "nvd",
+        "virustotal",
+        "cisa",
+        "mitre",
+        "abuseipdb",
+        "urlhaus",
+        "cybercure",
+        "feodo",
+        "sslbl",
+        "threatfox",
+        "misp",
+    )
+    assert tuple(DEFAULT_SOURCES.keys()) == expected_order, (
+        f"DEFAULT_SOURCES iteration order drift: expected {expected_order}, got {tuple(DEFAULT_SOURCES.keys())}"
+    )
+
+
+def test_audit2_new_source_appears_at_end_of_cli_listing(monkeypatch):
+    """A new source whose ``cli_id`` isn't in
+    ``_LEGACY_CLI_LISTING_ORDER`` MUST be appended at the end (not
+    silently dropped or interleaved)."""
+    import source_registry
+    from source_registry import Source, to_cli_sources_dict
+
+    new_src = Source(
+        canonical_id="newsrc_canonical",
+        display_name="New Source",
+        source_type="threat_intel",
+        reliability=0.5,
+        misp_tag="source:NewSource-Test",
+        reliable_first_seen=False,
+        cli_id="newsrc_cli_unique",
+    )
+    monkeypatch.setattr(source_registry, "_REGISTRY", source_registry._REGISTRY + (new_src,))
+
+    cli_dict = to_cli_sources_dict()
+    assert "newsrc_cli_unique" in cli_dict
+    # Last key MUST be the new one — appended at the tail
+    assert tuple(cli_dict.keys())[-1] == "newsrc_cli_unique"
+
+
+def test_audit2_alias_collision_across_sources_fails_at_import(monkeypatch):
+    """PR #43 audit-2 (MED — bugbot): two Sources sharing an alias
+    silently produce divergent results between ``get_source`` (first
+    wins) and ``to_neo4j_sources_dict`` (last wins). The runtime
+    validator MUST raise so the contributor's typo never reaches
+    production."""
+    import pytest
+
+    import source_registry
+    from source_registry import Source, _validate_no_alias_collisions
+
+    # Synthesize a Source whose alias collides with NVD's canonical id
+    colliding = Source(
+        canonical_id="testsrc_alias_collision",
+        aliases=("nvd",),  # collides with NVD's canonical id
+        display_name="Alias Collision Test",
+        source_type="threat_intel",
+        reliability=0.5,
+        misp_tag="source:AliasCollision-Test",
+        reliable_first_seen=False,
+    )
+    monkeypatch.setattr(source_registry, "_REGISTRY", source_registry._REGISTRY + (colliding,))
+
+    with pytest.raises(ValueError, match="alias collision on 'nvd'"):
+        _validate_no_alias_collisions()
+
+
+def test_audit2_alias_alias_collision_across_sources_fails(monkeypatch):
+    """The other arm — two Sources whose ALIASES collide (not just
+    alias-vs-canonical-id). The pre-audit-2 test
+    ``test_aliases_do_not_collide_with_other_sources_canonical_ids``
+    didn't catch this case."""
+    import pytest
+
+    import source_registry
+    from source_registry import Source, _validate_no_alias_collisions
+
+    a = Source(
+        canonical_id="testsrc_a_unique",
+        aliases=("shared_alias_xyz",),
+        display_name="A",
+        source_type="threat_intel",
+        reliability=0.5,
+        misp_tag="source:A-test",
+        reliable_first_seen=False,
+    )
+    b = Source(
+        canonical_id="testsrc_b_unique",
+        aliases=("shared_alias_xyz",),  # same alias as A
+        display_name="B",
+        source_type="threat_intel",
+        reliability=0.5,
+        misp_tag="source:B-test",
+        reliable_first_seen=False,
+    )
+    monkeypatch.setattr(source_registry, "_REGISTRY", source_registry._REGISTRY + (a, b))
+
+    with pytest.raises(ValueError, match="alias collision on 'shared_alias_xyz'"):
+        _validate_no_alias_collisions()
+
+
+def test_audit2_real_registry_has_no_alias_collisions():
+    """Static check: the actual ``_REGISTRY`` MUST pass the
+    alias-collision validator. Catches a contributor accidentally
+    re-using an existing alias even before any derivation helper
+    is exercised."""
+    from source_registry import _validate_no_alias_collisions
+
+    # Should not raise
+    _validate_no_alias_collisions()


### PR DESCRIPTION
## Summary

Closes spawned-task chip 5a from the PR #41 audit. The chip understated the problem — there were **5 parallel hand-maintained registries** describing "what sources EdgeGuard knows about", not 2. Each had a different shape and a different silent-failure mode if forgotten:

| Registry | Silent failure if forgotten |
|----------|------------------------------|
| `neo4j_client.SOURCES` (16 entries) | PR #41 batch pre-validation refuses every write — silent batch drop |
| `edgeguard.DEFAULT_SOURCES` (12) | Source absent from `edgeguard sources` CLI listing |
| `config.SOURCE_TAGS` (7) | Collector falls back to module-local constant; provenance fragments |
| `source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES` (14) | Source-truthful timestamps silently dropped |
| `MISPWriter.SOURCE_TAGS` (15) | MISP attribute carries no source tag — round-trip broken |

## What landed

New `src/source_registry.py` — a single declarative table of `Source` records (frozen dataclass; one record per logical source) plus 5 derivation helpers. Each legacy registry becomes a one-liner:

```python
SOURCES                       = source_registry.to_neo4j_sources_dict()
DEFAULT_SOURCES               = source_registry.to_cli_sources_dict()
SOURCE_TAGS                   = source_registry.cli_to_canonical_tag_map_legacy_subset()
_RELIABLE_FIRST_SEEN_SOURCES  = source_registry.reliable_first_seen_aliases()
MISPWriter.SOURCE_TAGS        = source_registry.source_to_misp_tag_map()
```

## Latent alias-coverage gaps closed

The unified derivation surfaces 5 alias-coverage gaps that were silently broken before — same pattern as PR #41 adding `feodo_tracker` / `ssl_blacklist` after weeks of silent drops:

- `neo4j_client.SOURCES` gains `otx`, `vt`, `mitre` aliases
- `_RELIABLE_FIRST_SEEN_SOURCES` gains `sslbl`
- `MISPWriter.SOURCE_TAGS` gains `vt`, `abusech_ssl`, `feodo_tracker`, `ssl_blacklist`

`config.SOURCE_TAGS` is **intentionally** restricted to its 7-key legacy shape (callers do `SOURCE_TAGS["X"]` and rely on `KeyError` to catch typos at init). Widening would silently start resolving keys that previously failed.

## Cross-registry invariants now pinned

3 invariants that previously had zero enforcement:

- `test_every_reliable_first_seen_source_is_also_in_neo4j_sources` — the test that catches the PR #41 silent-failure regression class for any future contributor
- `test_every_cli_id_has_a_canonical_source_in_neo4j_sources`
- `test_every_alias_resolves_to_the_same_source_as_its_canonical_id`

Plus 3 uniqueness invariants and 1 propagation smoke test (mutates registry, re-derives, asserts every dict picks up the new source).

## Out of scope

- `metrics_server._SOURCE_LABEL_ALLOWLIST` (added in [PR #42](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/42), still open) also duplicates the source allowlist. Once PR #42 merges, a small follow-up will derive that frozenset from the registry too. Excluded here to keep this PR a pure refactor of what's on main.
- `src/collector_allowlist.py` is a different concern (which collectors are PERMITTED to run, not which sources EdgeGuard recognizes). Untouched.

## Test plan

- [x] `pytest tests/test_source_registry.py` → 16 new tests pass
- [x] `pytest` → 579 passed (was 563 on main, +16 new), 3 skipped, no regressions
- [x] `ruff format src/ dags/ tests/ scripts/` → clean
- [x] `ruff check src/ dags/ tests/ scripts/` → clean
- [ ] Manual: confirm `edgeguard sources` CLI listing shows the same 12 entries it did pre-refactor (NVD still spelled "National Vulnerability Database" in that view)
- [ ] Manual: confirm `ensure_sources()` creates the 19 `:Source` nodes (was 16; +3 alias coverage gaps closed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Centralizes source metadata used by Neo4j writes, MISP tagging, and CLI source configuration; a mistake could mis-tag data or block `SOURCED_FROM` edge creation despite parity tests.
> 
> **Overview**
> Introduces `src/source_registry.py` as the **single declarative registry** for all EdgeGuard data sources (canonical ids, aliases, CLI metadata, MISP tags, and `reliable_first_seen`), with helper functions to derive the previously hand-maintained structures.
> 
> Rewires `neo4j_client.SOURCES`, `edgeguard.DEFAULT_SOURCES`, `config.SOURCE_TAGS` (kept as the legacy 7-key subset), `source_truthful_timestamps._RELIABLE_FIRST_SEEN_SOURCES`, and `MISPWriter.SOURCE_TAGS` to be **computed from the registry**, closing a few alias-coverage gaps (e.g. `otx`/`vt`/`mitre` in Neo4j sources and `sslbl` in the reliable-first-seen allowlist).
> 
> Adds `tests/test_source_registry.py` to pin byte-for-byte parity with legacy dicts, enforce alias/CLI-id uniqueness and cross-registry invariants, and prove that adding a new `Source(...)` propagates to all derivations; docs update the “add new source” checklist accordingly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cab70a2bdbb63a2d52b2e371220f46717d809e4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->