### PR TITLE
fix(audit): P0 ship-blockers from comprehensive 7-agent audit (PR-A of 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -77,8 +77,24 @@ THREATFOX_API_KEY=
 
 # ── EdgeGuard API ──────────────────────────────────────────────────────────────
 
-# Public API key (set to a strong random value in production).
-# Leave empty only for local development.
+# Public API key for the FastAPI REST endpoint (port 8000) and GraphQL endpoint
+# (port 4001). Required when binding to 0.0.0.0 (the docker-compose default —
+# necessary for Docker port-forwarding from the host).
+#
+# CRITICAL: with EDGEGUARD_API_KEY empty AND the container bound to 0.0.0.0
+# (compose default), the api / graphql containers REFUSE TO START — the
+# safety check at src/query_api.py:96 raises ``RuntimeError``. This is
+# intentional: an unauthenticated API reachable on the docker network is
+# a lateral-movement target.
+#
+# How to satisfy the check:
+#   1. RECOMMENDED — let install.sh auto-generate a 32-byte hex key on first
+#      .env creation. Already done if you ran ``./install.sh``.
+#   2. MANUAL — run ``openssl rand -hex 32`` (or ``python3 -c 'import secrets;
+#      print(secrets.token_hex(32))'``) and paste the value below.
+#   3. LAST RESORT — opt out of auth entirely by also setting
+#      ``EDGEGUARD_ALLOW_UNAUTH=1``. Suitable for ephemeral local dev only.
+#      DO NOT ship this to production.
 EDGEGUARD_API_KEY=
 
 # Admin query endpoint (disabled by default).

--- a/.env.example
+++ b/.env.example
@@ -162,7 +162,25 @@ OTEL_EXPORTER_OTLP_INSECURE=false
 
 # Port for the EdgeGuard GraphQL endpoint (mirrors ISIM GraphQL on port 4001).
 EDGEGUARD_GRAPHQL_PORT=4001
-EDGEGUARD_GRAPHQL_HOST=127.0.0.1
+
+# PR-A audit fix (Bugbot HIGH on commit 2cdbb1e): the previous
+# ``EDGEGUARD_GRAPHQL_HOST=127.0.0.1`` line here was a regression
+# trap. install.sh copies .env.example → .env, so docker compose
+# would resolve ``${EDGEGUARD_GRAPHQL_HOST:-0.0.0.0}`` to
+# 127.0.0.1, which is the container's INTERNAL loopback. Docker's
+# port-forwarding bridge can't deliver host traffic to container-
+# internal loopback — the GraphQL endpoint becomes silently
+# unreachable from the host (the healthcheck inside the container
+# still reports healthy, masking the failure).
+#
+# Same pattern as EDGEGUARD_API_HOST (not listed in .env.example
+# either) — operators who genuinely want to bind GraphQL to host
+# loopback must use a different mechanism (reverse proxy on the
+# host side, or change the compose ``ports:`` mapping). For the
+# default ``docker compose up`` flow, leave this UNSET so compose
+# falls back to its 0.0.0.0 default and the safety check at
+# src/graphql_api.py:101 gates the bind via EDGEGUARD_API_KEY.
+# EDGEGUARD_GRAPHQL_HOST=
 
 # Disable the interactive GraphiQL browser explorer in production.
 EDGEGUARD_GRAPHQL_PLAYGROUND=false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,13 @@ jobs:
     name: Lint & type-check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      # PR-A audit fix (Dependency HIGH-5): pin to commit SHA, not floating
+      # @v4. The tj-actions/changed-files attack (March 2025) exploited the
+      # mutability of major-version tags. Renovate/Dependabot can update.
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -42,10 +45,10 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -69,7 +72,7 @@ jobs:
             --cov-fail-under=30
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: coverage-report
           path: coverage.xml
@@ -79,7 +82,7 @@ jobs:
     name: Docker build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Build Docker image
         run: docker build -t edgeguard-kg:ci .
@@ -92,10 +95,10 @@ jobs:
     name: Dependency security scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
 
       - name: Set up Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -134,7 +137,7 @@ jobs:
           pip-audit -r requirements.txt --output json -o pip-audit.json
 
       - name: Upload audit results
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
           name: pip-audit
           path: pip-audit.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -57,4 +57,14 @@ EXPOSE 8000
 
 # Default command: start the query API.
 # Override with "python src/run_pipeline.py" to run the pipeline instead.
-CMD ["python", "-m", "uvicorn", "src.query_api:app", "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+#
+# PR-A audit fix (Bugbot HIGH on commit ce37238): the previous CMD was
+# ``["python", "-m", "uvicorn", "src.query_api:app", "--host", "0.0.0.0", ...]``
+# which bypassed the module-level safety check at ``src/query_api.py:88-102``.
+# Anyone running ``docker run edgeguard-kg:latest`` directly (without
+# compose) hit the uvicorn CLI flag and bound 0.0.0.0 unauthenticated —
+# defeating the whole point of A6. Match the compose command shape so the
+# Python module's safety check actually gates the bind for both invocation
+# paths. Operators who want a non-loopback bind via ``docker run`` must
+# set EDGEGUARD_API_HOST + EDGEGUARD_API_KEY (or EDGEGUARD_ALLOW_UNAUTH=1).
+CMD ["python", "-m", "src.query_api"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -132,8 +132,13 @@ services:
       # cypher-shell that creates+deletes a sentinel node — proves writability
       # AND auth in one round-trip. The sentinel is _HC label (no schema
       # collision) and DELETE is idempotent.
+      # PR-A audit fix (Bugbot MED on commit f60e213): quote BOTH env vars
+      # so passwords containing shell metacharacters ($, &, ;, spaces, etc.)
+      # don't break the healthcheck. Without quoting, e.g. NEO4J_PASSWORD="a&b"
+      # would split mid-arg and the healthcheck would fail with a confusing
+      # auth error rather than the actual writability test.
       test: ["CMD-SHELL",
-             "cypher-shell -u $$EG_NEO4J_USER -p $$EG_NEO4J_PASSWORD 'CREATE (n:_HC) DELETE n' || exit 1"]
+             "cypher-shell -u \"$$EG_NEO4J_USER\" -p \"$$EG_NEO4J_PASSWORD\" 'CREATE (n:_HC) DELETE n' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,6 +89,13 @@ services:
       - "127.0.0.1:7687:7687"   # Bolt protocol — loopback only
     environment:
       NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
+      # PR-A audit fix (Prod Readiness HIGH): expose user+password as separate
+      # env vars for the writability healthcheck (the Neo4j entrypoint only
+      # consumes NEO4J_AUTH; the healthcheck command needs the parts directly,
+      # and bash parameter expansion (${NEO4J_AUTH%%/*}) is /bin/sh-fragile in
+      # the Neo4j container).
+      EG_NEO4J_USER: ${NEO4J_USER:-neo4j}
+      EG_NEO4J_PASSWORD: ${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
       NEO4J_dbms_security_procedures_allowlist: "apoc.*"
@@ -105,15 +112,32 @@ services:
     deploy:
       resources:
         limits:
-          memory: ${NEO4J_CONTAINER_MEMORY_LIMIT:-4g}
+          # PR-A audit fix (Prod Readiness HIGH): default bumped 4g→8g. The
+          # 4g default was too small for any baseline run (the per-tx max alone
+          # is 4g per ${NEO4J_TX_MEMORY_MAX:-4g} above, leaving zero headroom
+          # for heap+pagecache+OS); fresh-clone deployments would OOM on the
+          # first ``docker compose up`` baseline. 8g matches the JVM-default
+          # math (heap_max 2g + pagecache 1g + tx_max 4g + ~1g OS = 8g floor).
+          # Production deployments should still set NEO4J_CONTAINER_MEMORY_LIMIT
+          # explicitly per docs/DOCKER_SETUP_GUIDE.md (recommended 32g for the
+          # 730d baseline workload).
+          memory: ${NEO4J_CONTAINER_MEMORY_LIMIT:-8g}
     networks:
       - edgeguard_net
     healthcheck:
-      test: ["CMD", "wget", "-q", "--tries=1", "--spider", "http://localhost:7474"]
+      # PR-A audit fix (Prod Readiness HIGH): the previous ``wget --spider`` test
+      # checked HTTP port 7474 was OPEN — but a Neo4j in disk-full read-only
+      # mode keeps the HTTP listener up while refusing all writes, so the
+      # service shows ``healthy`` while every Cypher write fails. Replace with
+      # cypher-shell that creates+deletes a sentinel node — proves writability
+      # AND auth in one round-trip. The sentinel is _HC label (no schema
+      # collision) and DELETE is idempotent.
+      test: ["CMD-SHELL",
+             "cypher-shell -u $$EG_NEO4J_USER -p $$EG_NEO4J_PASSWORD 'CREATE (n:_HC) DELETE n' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
-      start_period: 60s
+      start_period: 90s
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Airflow metadata DB — PostgreSQL (required for LocalExecutor)
@@ -144,7 +168,13 @@ services:
     deploy:
       resources:
         limits:
-          memory: 512m
+          # PR-A audit fix (Prod Readiness MED): default bumped 512m→2g. Airflow
+          # 3.x emits per-task heartbeats every 30s × 11 collectors during a
+          # baseline running 24h+; a 512m metadata DB is undersized for that
+          # write load and leads to slow scheduler queries (visible as DAG
+          # task scheduling latency). 2g matches typical Airflow 3.x guidance
+          # for a single-node LocalExecutor stack.
+          memory: ${AIRFLOW_POSTGRES_MEMORY_LIMIT:-2g}
 
   # ─────────────────────────────────────────────────────────────────────────────
   # Airflow — DAG orchestration (standalone: webserver + scheduler + triggerer)
@@ -263,12 +293,23 @@ services:
     image: edgeguard-kg:latest
     container_name: edgeguard_api
     restart: unless-stopped
-    command: ["python", "-m", "uvicorn", "src.query_api:app",
-              "--host", "0.0.0.0", "--port", "8000", "--workers", "2"]
+    # PR-A audit fix (Red Team HIGH): use the ``__main__`` block in
+    # src/query_api.py instead of the uvicorn CLI flags, so the EDGEGUARD_API_HOST
+    # / EDGEGUARD_API_KEY safety check (lines 88-102 of src/query_api.py) actually
+    # gates the bind. The previous ``--host 0.0.0.0`` CLI flag bypassed the env-var
+    # check: the Python module saw EDGEGUARD_API_HOST=127.0.0.1 (default), the A6
+    # check passed, then uvicorn bound 0.0.0.0 anyway — making the API reachable
+    # from any other container on edgeguard_net WITHOUT auth. Now: the module
+    # reads EDGEGUARD_API_HOST at startup, the safety check refuses to start
+    # unless either EDGEGUARD_API_KEY is set OR the host is loopback OR the
+    # operator opts in via EDGEGUARD_ALLOW_UNAUTH=1.
+    command: ["python", "-m", "src.query_api"]
     ports:
       - "127.0.0.1:8000:8000"   # REST API — loopback only; use reverse proxy for external access
     environment:
       <<: *common-env
+      EDGEGUARD_API_HOST: ${EDGEGUARD_API_HOST:-0.0.0.0}
+      EDGEGUARD_API_PORT: "8000"
       EDGEGUARD_ENABLE_ADMIN_QUERY: ${EDGEGUARD_ENABLE_ADMIN_QUERY:-false}
       EDGEGUARD_ADMIN_TOKEN: ${EDGEGUARD_ADMIN_TOKEN:-}
       PYTHONPATH: /app/src
@@ -305,14 +346,18 @@ services:
     image: edgeguard-kg:latest
     container_name: edgeguard_graphql
     restart: unless-stopped
-    command: ["python", "-m", "uvicorn", "src.graphql_api:app",
-              "--host", "0.0.0.0", "--port", "4001", "--workers", "2"]
+    # PR-A audit fix (Red Team HIGH): symmetric with ``api`` above — invoke the
+    # Python module directly so the EDGEGUARD_GRAPHQL_HOST env-var safety check
+    # actually gates the bind. The previous ``--host 0.0.0.0`` CLI flag bypassed
+    # the env check.
+    command: ["python", "-m", "src.graphql_api"]
     ports:
       - "127.0.0.1:4001:4001"   # GraphQL API — loopback only
     environment:
       <<: *common-env
       EDGEGUARD_GRAPHQL_PORT: "4001"
-      EDGEGUARD_GRAPHQL_HOST: "0.0.0.0"
+      EDGEGUARD_GRAPHQL_HOST: ${EDGEGUARD_GRAPHQL_HOST:-0.0.0.0}
+      EDGEGUARD_GRAPHQL_WORKERS: "2"
       # Set to "false" in production to disable the interactive GraphiQL explorer
       EDGEGUARD_GRAPHQL_PLAYGROUND: ${EDGEGUARD_GRAPHQL_PLAYGROUND:-false}
       PYTHONPATH: /app/src

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -89,13 +89,6 @@ services:
       - "127.0.0.1:7687:7687"   # Bolt protocol — loopback only
     environment:
       NEO4J_AUTH: ${NEO4J_USER:-neo4j}/${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
-      # PR-A audit fix (Prod Readiness HIGH): expose user+password as separate
-      # env vars for the writability healthcheck (the Neo4j entrypoint only
-      # consumes NEO4J_AUTH; the healthcheck command needs the parts directly,
-      # and bash parameter expansion (${NEO4J_AUTH%%/*}) is /bin/sh-fragile in
-      # the Neo4j container).
-      EG_NEO4J_USER: ${NEO4J_USER:-neo4j}
-      EG_NEO4J_PASSWORD: ${NEO4J_PASSWORD:?NEO4J_PASSWORD is required}
       NEO4J_PLUGINS: '["apoc"]'
       NEO4J_dbms_security_procedures_unrestricted: "apoc.*"
       NEO4J_dbms_security_procedures_allowlist: "apoc.*"
@@ -137,8 +130,18 @@ services:
       # don't break the healthcheck. Without quoting, e.g. NEO4J_PASSWORD="a&b"
       # would split mid-arg and the healthcheck would fail with a confusing
       # auth error rather than the actual writability test.
+      #
+      # PR-A audit fix (Bugbot LOW on commit 8ab02ac): drop the
+      # EG_NEO4J_USER / EG_NEO4J_PASSWORD aliases that duplicated the
+      # credentials already in NEO4J_AUTH as separate env vars (visible
+      # to every process in the container). Parse NEO4J_AUTH directly
+      # using POSIX shell parameter expansion (``${VAR%%/*}`` =
+      # everything before first ``/``; ``${VAR#*/}`` = everything after
+      # first ``/``). dash supports both per POSIX spec — the prior
+      # comment claiming this was "/bin/sh-fragile" was incorrect.
+      # Result: one fewer copy of the password on disk + in process env.
       test: ["CMD-SHELL",
-             "cypher-shell -u \"$$EG_NEO4J_USER\" -p \"$$EG_NEO4J_PASSWORD\" 'CREATE (n:_HC) DELETE n' || exit 1"]
+             "cypher-shell -u \"$${NEO4J_AUTH%%/*}\" -p \"$${NEO4J_AUTH#*/}\" 'CREATE (n:_HC) DELETE n' || exit 1"]
       interval: 30s
       timeout: 10s
       retries: 5
@@ -335,6 +338,15 @@ services:
       EDGEGUARD_API_WORKERS: "2"
       EDGEGUARD_ENABLE_ADMIN_QUERY: ${EDGEGUARD_ENABLE_ADMIN_QUERY:-false}
       EDGEGUARD_ADMIN_TOKEN: ${EDGEGUARD_ADMIN_TOKEN:-}
+      # PR-A audit fix (Bugbot MED on commit b2c0479): the .env.example
+      # documents EDGEGUARD_ALLOW_UNAUTH=1 as the "LAST RESORT" escape
+      # hatch when an operator wants to bypass the api/graphql safety
+      # check (src/query_api.py:96 + src/graphql_api.py:101). But Compose
+      # only forwards explicitly listed env vars to containers — without
+      # this line, setting EDGEGUARD_ALLOW_UNAUTH=1 in .env had NO effect
+      # and the container kept crashing with the documented RuntimeError.
+      # Forward it explicitly so the documented escape hatch works.
+      EDGEGUARD_ALLOW_UNAUTH: ${EDGEGUARD_ALLOW_UNAUTH:-}
       PYTHONPATH: /app/src
     depends_on:
       neo4j:
@@ -383,6 +395,10 @@ services:
       EDGEGUARD_GRAPHQL_WORKERS: "2"
       # Set to "false" in production to disable the interactive GraphiQL explorer
       EDGEGUARD_GRAPHQL_PLAYGROUND: ${EDGEGUARD_GRAPHQL_PLAYGROUND:-false}
+      # PR-A audit fix (Bugbot MED on commit b2c0479): symmetric with the
+      # api service above — forward EDGEGUARD_ALLOW_UNAUTH so the .env.example
+      # escape hatch documentation actually works for graphql too.
+      EDGEGUARD_ALLOW_UNAUTH: ${EDGEGUARD_ALLOW_UNAUTH:-}
       PYTHONPATH: /app/src
     depends_on:
       neo4j:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -308,9 +308,20 @@ services:
     # reads EDGEGUARD_API_HOST at startup, the safety check refuses to start
     # unless either EDGEGUARD_API_KEY is set OR the host is loopback OR the
     # operator opts in via EDGEGUARD_ALLOW_UNAUTH=1.
+    #
+    # PR-A audit fix (Red Team CRITICAL C1, follow-up): the safety check has
+    # to remain at 0.0.0.0 in compose because Docker port-forwarding from
+    # ``ports: 127.0.0.1:8000:8000`` requires the container app to bind to
+    # 0.0.0.0 (binding to the container's own 127.0.0.1 makes the docker
+    # bridge unable to deliver traffic). To keep ``./install.sh && docker
+    # compose up`` from crashlooping on the safety check, install.sh now
+    # auto-generates a strong EDGEGUARD_API_KEY in .env on first creation
+    # (see ``install.sh:71-100`` and the comment block in .env.example).
+    # Operators who clone + ``docker compose up`` without install.sh hit
+    # the safety check's RuntimeError with an actionable message.
     command: ["python", "-m", "src.query_api"]
     ports:
-      - "127.0.0.1:8000:8000"   # REST API — loopback only; use reverse proxy for external access
+      - "127.0.0.1:8000:8000"   # REST API — host loopback only; use a reverse proxy for external access
     environment:
       <<: *common-env
       EDGEGUARD_API_HOST: ${EDGEGUARD_API_HOST:-0.0.0.0}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -310,6 +310,13 @@ services:
       <<: *common-env
       EDGEGUARD_API_HOST: ${EDGEGUARD_API_HOST:-0.0.0.0}
       EDGEGUARD_API_PORT: "8000"
+      # PR-A audit fix (Bugbot MED on commit 8dde4de): the symmetric
+      # EDGEGUARD_GRAPHQL_WORKERS=2 was set on the graphql service below,
+      # but EDGEGUARD_API_WORKERS was forgotten — the api service would
+      # fall back to the __main__ default of 1, halving the production
+      # throughput posture compared to the pre-refactor ``--workers 2``
+      # CLI flag we removed. Restore parity.
+      EDGEGUARD_API_WORKERS: "2"
       EDGEGUARD_ENABLE_ADMIN_QUERY: ${EDGEGUARD_ENABLE_ADMIN_QUERY:-false}
       EDGEGUARD_ADMIN_TOKEN: ${EDGEGUARD_ADMIN_TOKEN:-}
       PYTHONPATH: /app/src

--- a/install.sh
+++ b/install.sh
@@ -71,6 +71,56 @@ section "Environment configuration"
 if [ ! -f ".env" ]; then
     cp .env.example .env
     warn ".env created from .env.example — fill in NEO4J_PASSWORD, MISP_URL, MISP_API_KEY before starting"
+
+    # PR-A audit fix (Red Team CRITICAL C1): without an EDGEGUARD_API_KEY, the
+    # api / graphql containers refuse to start (the security check at
+    # src/query_api.py:96 rejects an unauthenticated bind on 0.0.0.0). Auto-
+    # generate a strong key on first .env creation so ``./install.sh && docker
+    # compose up`` does not crashloop. Operators who clone + ``docker compose
+    # up`` without install.sh will see the actionable RuntimeError and can set
+    # EDGEGUARD_API_KEY by hand. We do NOT silently set EDGEGUARD_ALLOW_UNAUTH
+    # — that would defeat the safety check entirely.
+    if grep -q "^EDGEGUARD_API_KEY=$" .env 2>/dev/null; then
+        if command -v openssl &>/dev/null; then
+            generated_key="$(openssl rand -hex 32)"
+        elif command -v python3 &>/dev/null; then
+            generated_key="$(python3 -c 'import secrets; print(secrets.token_hex(32))')"
+        else
+            generated_key=""
+        fi
+        if [ -n "$generated_key" ]; then
+            # Portable in-place sed: explicit -i'' (BSD/mac) and -i (GNU) handled by tmp-file rewrite
+            tmp_env="$(mktemp)"
+            awk -v key="$generated_key" '
+                /^EDGEGUARD_API_KEY=$/ { print "EDGEGUARD_API_KEY=" key; next }
+                { print }
+            ' .env > "$tmp_env" && mv "$tmp_env" .env
+            info "Generated random EDGEGUARD_API_KEY (32 bytes hex) — stored in .env"
+        else
+            warn "Neither openssl nor python3 available — leaving EDGEGUARD_API_KEY blank."
+            warn "  api / graphql containers will refuse to start; set EDGEGUARD_API_KEY in .env first."
+        fi
+    fi
+
+    # Same logic for GRAFANA_ADMIN_PASSWORD — compose default is "changeme"
+    # which is a credential-stuffing target. Auto-generate on first .env.
+    if grep -q "^GRAFANA_ADMIN_PASSWORD=changeme$" .env 2>/dev/null; then
+        if command -v openssl &>/dev/null; then
+            generated_grafana="$(openssl rand -base64 24 | tr -d '=+/')"
+        elif command -v python3 &>/dev/null; then
+            generated_grafana="$(python3 -c 'import secrets; print(secrets.token_urlsafe(24))')"
+        else
+            generated_grafana=""
+        fi
+        if [ -n "$generated_grafana" ]; then
+            tmp_env="$(mktemp)"
+            awk -v pw="$generated_grafana" '
+                /^GRAFANA_ADMIN_PASSWORD=changeme$/ { print "GRAFANA_ADMIN_PASSWORD=" pw; next }
+                { print }
+            ' .env > "$tmp_env" && mv "$tmp_env" .env
+            info "Generated random GRAFANA_ADMIN_PASSWORD — stored in .env (visible only in this file)"
+        fi
+    fi
 else
     info ".env already exists"
 fi

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -303,7 +303,7 @@ groups:
 
       - alert: EdgeGuardNeo4jQuerySlow
         expr: |
-          histogram_quantile(0.95, 
+          histogram_quantile(0.95,
             sum(rate(edgeguard_neo4j_query_duration_seconds_bucket[5m])) by (le, query_type)
           ) > 5
         for: 5m
@@ -313,3 +313,71 @@ groups:
         annotations:
           summary: "Neo4j queries are slow"
           description: "{{ $labels.query_type }} queries 95th percentile is over 5 seconds."
+
+  # ================================================================================
+  # Host / Infrastructure Alerts
+  # ================================================================================
+  # PR-A audit fix (Prod Readiness HIGH): node-exporter is scraped by
+  # prometheus.yml (see job ``node-exporter``) but no rule consumed its
+  # output. A 730d baseline can fill 100GB of MISP attachments + airflow
+  # logs unmonitored — Vanko's overnight ran ~8h and was already eating
+  # several GB. Three rules cover the typical disk-full failure modes:
+  # imminent (5%), warning (15%), and inode exhaustion (which can hit
+  # before bytes-free does on filesystems with many small files like
+  # airflow_logs).
+  - name: edgeguard_host_disk
+    rules:
+      - alert: EdgeGuardDiskFree15Pct
+        expr: |
+          (
+            node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|devtmpfs"}
+            / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|devtmpfs"}
+          ) < 0.15
+        for: 10m
+        labels:
+          severity: warning
+          component: host
+        annotations:
+          summary: "Disk free below 15% on {{ $labels.mountpoint }}"
+          description: |
+            {{ $labels.mountpoint }} on {{ $labels.instance }} is at
+            {{ $value | humanizePercentage }} free. The next baseline run
+            (~50-100GB across MISP + Neo4j + airflow_logs) will likely
+            trigger DiskFree5Pct. Action: prune airflow_logs older than 30d
+            or expand the volume.
+
+      - alert: EdgeGuardDiskFree5Pct
+        expr: |
+          (
+            node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|devtmpfs"}
+            / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|devtmpfs"}
+          ) < 0.05
+        for: 2m
+        labels:
+          severity: critical
+          component: host
+        annotations:
+          summary: "Disk free CRITICAL: below 5% on {{ $labels.mountpoint }}"
+          description: |
+            {{ $labels.mountpoint }} on {{ $labels.instance }} is at
+            {{ $value | humanizePercentage }} free. Neo4j will enter
+            read-only mode soon (which the writability healthcheck will
+            detect — but writes already fail). Pause all collectors:
+            ``edgeguard dag pause``. Then prune or expand.
+
+      - alert: EdgeGuardInodesFree10Pct
+        expr: |
+          (
+            node_filesystem_files_free{fstype!~"tmpfs|overlay|devtmpfs"}
+            / node_filesystem_files{fstype!~"tmpfs|overlay|devtmpfs"}
+          ) < 0.10
+        for: 10m
+        labels:
+          severity: warning
+          component: host
+        annotations:
+          summary: "Inodes free below 10% on {{ $labels.mountpoint }}"
+          description: |
+            {{ $labels.mountpoint }} has {{ $value | humanizePercentage }}
+            inodes free. airflow_logs creates many small files; ext4
+            volumes can exhaust inodes well before bytes. Prune logs.

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -751,4 +751,8 @@ if __name__ == "__main__":
         workers = int(os.getenv("EDGEGUARD_GRAPHQL_WORKERS", "1"))
     except (ValueError, TypeError):
         workers = 1
-    uvicorn.run("graphql_api:app", host=host, port=port, reload=False, workers=workers)
+    # PR-A audit fix (Bugbot MED on commit ce37238): use ``"src.graphql_api:app"``
+    # so uvicorn's worker reimport resolves regardless of PYTHONPATH. Same
+    # reasoning as src/query_api.py:1170 — the bare ``"graphql_api:app"``
+    # only works when PYTHONPATH includes /app/src.
+    uvicorn.run("src.graphql_api:app", host=host, port=port, reload=False, workers=workers)

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -743,4 +743,12 @@ if __name__ == "__main__":
     except (ValueError, TypeError):
         port = 4001
     host = os.getenv("EDGEGUARD_GRAPHQL_HOST", "127.0.0.1")
-    uvicorn.run("graphql_api:app", host=host, port=port, reload=False)
+    # PR-A audit fix (Red Team HIGH): docker-compose's ``graphql`` service now
+    # invokes ``python -m src.graphql_api`` so the EDGEGUARD_GRAPHQL_HOST env-var
+    # safety check actually gates the bind (parity with the REST API). Multi-worker
+    # config moves to EDGEGUARD_GRAPHQL_WORKERS so production posture matches.
+    try:
+        workers = int(os.getenv("EDGEGUARD_GRAPHQL_WORKERS", "1"))
+    except (ValueError, TypeError):
+        workers = 1
+    uvicorn.run("graphql_api:app", host=host, port=port, reload=False, workers=workers)

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -453,6 +453,14 @@ class Neo4jClient:
         except neo4j_exceptions.AuthError as e:
             logger.error(f"Neo4j authentication failed: {e}")
             self._connection_healthy = False
+            # PR-A audit fix (Bug Hunter HIGH H1): close + null-out the driver
+            # before returning. ``self.driver = GraphDatabase.driver(...)`` at
+            # line 435 ALREADY assigned a live driver before the verify
+            # ``session.run`` raised. Returning False without closing leaks the
+            # driver's connection pool. Operationally certain to bite during
+            # MISP password rotation: every retry creates a fresh driver,
+            # exhausting fds within the 5h baseline timeout.
+            self._safe_close_driver()
             return False
         except (
             neo4j_exceptions.ServiceUnavailable,
@@ -461,11 +469,33 @@ class Neo4jClient:
             TimeoutError,
         ):
             self._connection_healthy = False
+            # Same leak shape as AuthError above — even though the retry
+            # decorator will re-call ``connect()`` and overwrite ``self.driver``,
+            # the previous driver instance leaks unless we explicitly close it
+            # here before re-raising.
+            self._safe_close_driver()
             raise  # let @retry_with_backoff handle transient errors
         except Exception as e:
             logger.error(f"Neo4j connection failed: {type(e).__name__}: {e}")
             self._connection_healthy = False
+            self._safe_close_driver()
             return False
+
+    def _safe_close_driver(self) -> None:
+        """Close the driver if alive and null it out. No-raise.
+
+        Used by ``connect()``'s exception branches (PR-A audit fix; Bug Hunter
+        HIGH H1). The neo4j-python-driver's ``Driver.close()`` is idempotent
+        but can raise on a half-initialised driver, so we wrap defensively.
+        """
+        drv = self.driver
+        self.driver = None  # null first so a re-call to connect() doesn't see a half-closed driver
+        if drv is None:
+            return
+        try:
+            drv.close()
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug("Best-effort close on failed-connect driver raised: %s", exc)
 
     def close(self) -> None:
         """Close connection safely."""

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -1167,4 +1167,14 @@ if __name__ == "__main__":
 
     logger.info(f"[START] Starting EdgeGuard Query API on {host}:{port} (workers={workers})")
 
-    uvicorn.run("query_api:app", host=host, port=port, reload=reload, workers=workers, log_level="info")
+    # PR-A audit fix (Bugbot MED on commit ce37238): the previous
+    # ``uvicorn.run("query_api:app", ...)`` import string relied on
+    # ``PYTHONPATH=/app/src`` being set so uvicorn's worker reimport could
+    # resolve the bare module name. Compose + the Docker image both set
+    # PYTHONPATH, but if this module is invoked via ``python -m
+    # src.query_api`` from a context without that PYTHONPATH (local dev
+    # without venv activate, ad-hoc test harness), uvicorn's worker
+    # reimport raises ``ModuleNotFoundError: query_api``. ``"src.query_api:app"``
+    # works regardless of PYTHONPATH because it matches the actual module
+    # path under the project root.
+    uvicorn.run("src.query_api:app", host=host, port=port, reload=reload, workers=workers, log_level="info")

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -1150,7 +1150,21 @@ if __name__ == "__main__":
     except (ValueError, TypeError):
         port = 8000
     reload = os.getenv("EDGEGUARD_API_RELOAD", "false").lower() == "true"
+    # PR-A audit fix (Red Team HIGH): the docker-compose ``api`` service now
+    # invokes ``python -m src.query_api`` (instead of ``python -m uvicorn ...
+    # --host 0.0.0.0 --workers 2``) so the EDGEGUARD_API_HOST env-var safety
+    # check at lines 88-102 actually gates the bind. ``EDGEGUARD_API_WORKERS``
+    # restores the multi-worker config (default 1 to match the prior reload-safe
+    # default; compose sets =2 for production posture). Reload mode forces 1
+    # worker because uvicorn's reload + workers are mutually exclusive.
+    try:
+        workers = int(os.getenv("EDGEGUARD_API_WORKERS", "1"))
+    except (ValueError, TypeError):
+        workers = 1
+    if reload and workers > 1:
+        logger.warning("EDGEGUARD_API_RELOAD=true forces EDGEGUARD_API_WORKERS=1 (uvicorn limitation)")
+        workers = 1
 
-    logger.info(f"[START] Starting EdgeGuard Query API on {host}:{port}")
+    logger.info(f"[START] Starting EdgeGuard Query API on {host}:{port} (workers={workers})")
 
-    uvicorn.run("query_api:app", host=host, port=port, reload=reload, log_level="info")
+    uvicorn.run("query_api:app", host=host, port=port, reload=reload, workers=workers, log_level="info")

--- a/src/requirements.txt
+++ b/src/requirements.txt
@@ -1,35 +1,18 @@
-# EdgeGuard src/ Requirements
-# Install with: pip install -r src/requirements.txt
-# (or install from the root requirements.txt which is the canonical file)
+# EdgeGuard src/ Requirements (alias for the root requirements.txt)
 #
-# Version policy: ~= compatible-release pins — allows patch upgrades only.
+# PR-A audit fix (Dependency HIGH/MED-1): this file used to maintain its own
+# independent set of pins, including ``apache-airflow[postgres]~=2.11`` —
+# while the root requirements.txt was correctly upgraded to ``~=3.2`` to
+# clear 18+ Airflow 2.x CVEs. Anyone running
+#   pip install -r src/requirements.txt
+# (which the previous header even encouraged) would silently re-install the
+# CVE-laden Airflow 2.x. Same drift risk applied to neo4j/requests/etc.
+#
+# Now this file just delegates to the root manifest. There is one source of
+# truth for production deps; tightening the root pins propagates here for free.
+#
+# Install:
+#   pip install -r requirements.txt   (from project root — preferred)
+#   pip install -r src/requirements.txt   (from project root — same result)
 
-# ── Core ─────────────────────────────────────────────────────────────────────
-neo4j~=5.27
-requests~=2.32
-pandas~=2.2
-python-dateutil~=2.9
-urllib3~=2.3
-
-# ── Data collection ──────────────────────────────────────────────────────────
-pymisp~=2.4
-# Correct PyPI package for AlienVault OTX SDK (otx-api is a different, unrelated package)
-OTXv2~=1.5
-
-# ── STIX 2.1 support ─────────────────────────────────────────────────────────
-stix2~=3.0
-
-# ── Airflow orchestration ────────────────────────────────────────────────────
-# Pinned to 2.x — Airflow 3.0 has breaking API/operator changes.
-# Prefer root requirements.txt; [postgres] matches docker-compose Airflow metadata (PostgreSQL).
-apache-airflow[postgres]~=2.11
-
-# ── Monitoring & Metrics ─────────────────────────────────────────────────────
-prometheus-client~=0.21
-
-# ── Utilities ────────────────────────────────────────────────────────────────
-pyyaml~=6.0
-
-# ── Testing (optional) ───────────────────────────────────────────────────────
-pytest~=8.3
-pytest-cov~=6.0
+-r ../requirements.txt

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -916,6 +916,22 @@ class EdgeGuardPipeline:
         # to slip in. Stale-lock recovery (the "PID is gone" case) still
         # uses the read-then-unlink-then-retry pattern below — but the
         # final lock acquisition itself is atomic.
+        def _read_lock_pid(path: str) -> Optional[int]:
+            """Read the PID stored in the pipeline lock file, or None on any error.
+
+            PR-A audit fix (Bug Hunter HIGH H2): used by ``_cleanup_lock``
+            to verify the lock still belongs to THIS process before
+            unlinking. Mirrors the read-then-compare-pid pattern in
+            ``baseline_lock.release_baseline_lock``. Returns None for
+            any read or parse error — caller treats None as "don't
+            unlink" (safer than treating it as match).
+            """
+            try:
+                with open(path) as fh:
+                    return int(fh.read().strip())
+            except (OSError, ValueError):
+                return None
+
         def _try_atomic_lock_acquire(path: str) -> bool:
             """Single atomic create-or-fail attempt.
 
@@ -1060,9 +1076,25 @@ class EdgeGuardPipeline:
             baseline_lock_held = True
 
         def _cleanup_lock(*_args):
+            # PR-A audit fix (Bug Hunter HIGH H2): only remove the lock file
+            # if it still belongs to THIS process. Earlier code did a blind
+            # ``os.remove(lock_path)`` — but the stale-PID recovery path
+            # (lines 1027-1032) lets a competing process unlink-and-re-acquire
+            # the same lock. Without the PID check, this process's atexit
+            # handler then unlinks the OTHER process's freshly-acquired lock,
+            # opening a window where a third invocation can also acquire.
+            # Two pipelines run concurrently, racing MERGE. Mirrors the
+            # release_baseline_lock pattern in src/baseline_lock.py.
             try:
-                if os.path.exists(lock_path):
+                pid = _read_lock_pid(lock_path)
+                if pid is not None and pid == os.getpid():
                     os.remove(lock_path)
+                elif pid is not None:
+                    logger.warning(
+                        "Not removing pipeline lock: sentinel pid=%s != current pid=%s",
+                        pid,
+                        os.getpid(),
+                    )
             except OSError:
                 pass
             if baseline_lock_held:

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -1068,18 +1068,15 @@ class EdgeGuardPipeline:
 
             if not acquire_baseline_lock():
                 # Another baseline is already running — refuse to start.
-                # Bugbot LOW (PR-A audit on bbe02cd): apply the SAME PID
-                # check here that ``_cleanup_lock`` (defined a few lines
-                # below) uses. Otherwise the abort path would unlink the
-                # OTHER process's lock — exactly the race the
-                # ``_read_lock_pid`` helper was added to prevent. The
-                # helper is defined later in the same method, so we
-                # inline the same check here.
-                try:
-                    with open(lock_path) as fh:
-                        existing_pid = int(fh.read().strip())
-                except (OSError, ValueError):
-                    existing_pid = None
+                # Bugbot LOW (PR-A audit on f60e213 + 329559e): use the
+                # ``_read_lock_pid`` helper rather than re-inlining the
+                # PID-check logic. Despite its definition appearing
+                # earlier-in-source than ``_cleanup_lock``, ``_read_lock_pid``
+                # IS in scope here — both inner functions and the
+                # ``acquire_baseline_lock`` failure path are in the same
+                # ``run()`` body, and Python resolves nested-function names
+                # via the enclosing scope at call time.
+                existing_pid = _read_lock_pid(lock_path)
                 if existing_pid == os.getpid():
                     try:
                         os.remove(lock_path)

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -1076,18 +1076,27 @@ class EdgeGuardPipeline:
                 # ``acquire_baseline_lock`` failure path are in the same
                 # ``run()`` body, and Python resolves nested-function names
                 # via the enclosing scope at call time.
+                # PR-A audit fix (Bugbot LOW on commit 8ab02ac): the previous
+                # ``if existing_pid == os.getpid()`` else-branch fired with
+                # ``existing_pid=None`` (lock missing/unreadable) and logged
+                # a misleading "sentinel pid=None != current pid=X" — implying
+                # a PID mismatch when the real cause was a missing/corrupt
+                # file. Mirror ``_cleanup_lock``'s explicit None-guard so
+                # the only warning fires on a genuine PID mismatch.
                 existing_pid = _read_lock_pid(lock_path)
-                if existing_pid == os.getpid():
+                if existing_pid is not None and existing_pid == os.getpid():
                     try:
                         os.remove(lock_path)
                     except OSError:
                         pass
-                else:
+                elif existing_pid is not None:
                     logger.warning(
                         "Not removing pipeline lock on baseline-acquire failure: sentinel pid=%s != current pid=%s",
                         existing_pid,
                         os.getpid(),
                     )
+                # else: existing_pid is None — lock missing/unreadable;
+                # don't remove and don't warn (no actionable information).
                 return False
             baseline_lock_held = True
 

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -1068,10 +1068,29 @@ class EdgeGuardPipeline:
 
             if not acquire_baseline_lock():
                 # Another baseline is already running — refuse to start.
+                # Bugbot LOW (PR-A audit on bbe02cd): apply the SAME PID
+                # check here that ``_cleanup_lock`` (defined a few lines
+                # below) uses. Otherwise the abort path would unlink the
+                # OTHER process's lock — exactly the race the
+                # ``_read_lock_pid`` helper was added to prevent. The
+                # helper is defined later in the same method, so we
+                # inline the same check here.
                 try:
-                    os.remove(lock_path)
-                except OSError:
-                    pass
+                    with open(lock_path) as fh:
+                        existing_pid = int(fh.read().strip())
+                except (OSError, ValueError):
+                    existing_pid = None
+                if existing_pid == os.getpid():
+                    try:
+                        os.remove(lock_path)
+                    except OSError:
+                        pass
+                else:
+                    logger.warning(
+                        "Not removing pipeline lock on baseline-acquire failure: sentinel pid=%s != current pid=%s",
+                        existing_pid,
+                        os.getpid(),
+                    )
                 return False
             baseline_lock_held = True
 

--- a/tests/test_pr_a_ship_blockers.py
+++ b/tests/test_pr_a_ship_blockers.py
@@ -1,0 +1,242 @@
+"""
+Regression tests for PR-A audit ship-blockers.
+
+These tests pin the runtime fixes that came from the 7-agent comprehensive
+audit. The fixes themselves are small (3-10 LOC each) but the failure modes
+are silent and operationally certain to bite — pin via tests so they can't
+regress.
+
+Coverage:
+    - **Bug Hunter HIGH H1**: ``Neo4jClient.connect()`` must close + null
+      ``self.driver`` on every exception branch (auth, transient, generic).
+      The previous code assigned ``self.driver`` BEFORE the verify
+      ``session.run()`` raised — the failed-connect path returned False with
+      a live driver still attached, and every retry leaked another driver.
+      Operationally certain to bite during MISP password rotation: 5+ retries
+      across the 5h baseline timeout would exhaust file descriptors or
+      neo4j connection-pool slots.
+    - **Bug Hunter HIGH H2**: ``run_pipeline.py``'s ``_cleanup_lock``
+      atexit handler must check the lock's PID before unlinking. The
+      previous blind ``os.remove`` opened a window where Process A's
+      atexit could delete Process B's freshly-acquired lock, letting
+      Process C also acquire — two pipelines run concurrently, racing
+      MERGE. Mirrors the PID-check pattern in
+      ``baseline_lock.release_baseline_lock``.
+
+Other PR-A fixes (compose auth bypass, healthchecks, memory defaults,
+requirements alias, GHA SHA pins, disk-free alerts) are config/yaml
+changes pinned by their own filetype tests or by manual ``docker compose
+config`` validation (not unit-testable).
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, "src")
+
+
+# ---------------------------------------------------------------------------
+# Bug Hunter HIGH H1 — driver leak on Neo4j connect-failure paths
+# ---------------------------------------------------------------------------
+
+
+class TestNeo4jConnectDriverLeak:
+    """Every failed-connect exception branch in ``Neo4jClient.connect()``
+    MUST close + null the driver before returning/re-raising.
+
+    The previous code only set ``self._connection_healthy = False`` —
+    leaving ``self.driver`` (assigned at line 435 BEFORE the verify
+    ``session.run`` raised) attached to a live but unverified driver.
+    Symptoms in production:
+      - ``MISP password rotation`` → 5+ retries → 5+ leaked drivers →
+        ``OSError: too many open files`` mid-baseline.
+      - The next ``Neo4jClient()`` call's ``connect()`` overwrote
+        ``self.driver`` without closing the prior — leak compounded.
+
+    Tests use a mock ``GraphDatabase.driver`` that returns a tracked
+    driver mock; we assert ``.close()`` is called on it whenever
+    ``connect()`` returns False or re-raises.
+    """
+
+    def _import_client_with_mocks(self):
+        """Re-import neo4j_client with mocked GraphDatabase + neo4j_exceptions."""
+        # Defer to the real module; we only need to patch the driver factory.
+        import neo4j_client as nc
+
+        return nc
+
+    def test_auth_error_closes_driver(self):
+        nc = self._import_client_with_mocks()
+        client = nc.Neo4jClient()
+        fake_driver = MagicMock()
+        # Make the verify ``session.run`` raise AuthError.
+        fake_session = MagicMock()
+        fake_session.run.side_effect = nc.neo4j_exceptions.AuthError("bad password")
+        fake_driver.session.return_value.__enter__ = lambda s: fake_session
+        fake_driver.session.return_value.__exit__ = lambda s, *a: None
+
+        with patch.object(nc.GraphDatabase, "driver", return_value=fake_driver):
+            ok = client.connect()
+
+        assert ok is False
+        # The leak guard:
+        fake_driver.close.assert_called_once()
+        # And the attribute is nulled so a re-call to connect() doesn't see
+        # a half-closed driver:
+        assert client.driver is None
+        assert client._connection_healthy is False
+
+    def test_generic_exception_closes_driver(self):
+        nc = self._import_client_with_mocks()
+        client = nc.Neo4jClient()
+        fake_driver = MagicMock()
+        fake_session = MagicMock()
+        # Some random non-retryable error — falls into the generic except.
+        fake_session.run.side_effect = ValueError("bad query")
+        fake_driver.session.return_value.__enter__ = lambda s: fake_session
+        fake_driver.session.return_value.__exit__ = lambda s, *a: None
+
+        with patch.object(nc.GraphDatabase, "driver", return_value=fake_driver):
+            ok = client.connect()
+
+        assert ok is False
+        fake_driver.close.assert_called_once()
+        assert client.driver is None
+
+    def test_transient_error_closes_driver_then_reraises(self):
+        nc = self._import_client_with_mocks()
+        client = nc.Neo4jClient()
+        fake_driver = MagicMock()
+        fake_session = MagicMock()
+        # ServiceUnavailable is in the re-raise branch (handled by
+        # @retry_with_backoff at the next layer up).
+        fake_session.run.side_effect = nc.neo4j_exceptions.ServiceUnavailable("svc down")
+        fake_driver.session.return_value.__enter__ = lambda s: fake_session
+        fake_driver.session.return_value.__exit__ = lambda s, *a: None
+
+        with patch.object(nc.GraphDatabase, "driver", return_value=fake_driver):
+            # @retry_with_backoff will retry MAX_RETRIES (5) times then raise.
+            # Each retry closes its own driver (no leak across retries).
+            with pytest.raises(nc.neo4j_exceptions.ServiceUnavailable):
+                client.connect()
+
+        # close() was called at LEAST once per retry attempt
+        assert fake_driver.close.call_count >= 1
+        assert client.driver is None
+
+    def test_safe_close_driver_helper_is_idempotent(self):
+        """``_safe_close_driver`` must be no-raise + safe to call when
+        ``self.driver`` is already None."""
+        nc = self._import_client_with_mocks()
+        client = nc.Neo4jClient()
+        client.driver = None
+        # Must not raise:
+        client._safe_close_driver()
+        assert client.driver is None
+
+    def test_safe_close_driver_swallows_close_exceptions(self):
+        """If the underlying driver.close() raises, the helper logs at
+        debug and returns — does not propagate. Otherwise the leak-guard
+        in connect() would itself break the connect() exception path."""
+        nc = self._import_client_with_mocks()
+        client = nc.Neo4jClient()
+        bad_driver = MagicMock()
+        bad_driver.close.side_effect = RuntimeError("close failed")
+        client.driver = bad_driver
+        # Must not raise:
+        client._safe_close_driver()
+        assert client.driver is None
+        bad_driver.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Bug Hunter HIGH H2 — pipeline lock PID race
+# ---------------------------------------------------------------------------
+
+
+class TestPipelineLockPidCheck:
+    """``_cleanup_lock`` (the atexit handler) must verify the lock file's
+    PID matches the current process before unlinking.
+
+    Without the check, the stale-PID recovery path in ``_run_with_lock``
+    (lines 1027-1032) lets a competing process unlink-and-re-acquire the
+    same lock — and then THIS process's atexit handler unlinks the OTHER
+    process's freshly-acquired lock, opening a window for a third
+    invocation to also acquire. Two pipelines run concurrently.
+
+    The fix uses a new ``_read_lock_pid`` helper that mirrors the
+    ``baseline_lock.release_baseline_lock`` pattern. We assert:
+      1. The helper exists and is invoked from ``_cleanup_lock``.
+      2. ``_cleanup_lock`` does NOT call ``os.remove`` when the PID
+         doesn't match (use file-source scan since the helper is
+         defined inline inside the method).
+    """
+
+    def _pipeline_source(self) -> str:
+        import run_pipeline
+
+        # _cleanup_lock + _read_lock_pid are defined inline inside the
+        # ``EdgeGuardPipeline.run`` method (the public entry point).
+        return inspect.getsource(run_pipeline.EdgeGuardPipeline.run)
+
+    def test_read_lock_pid_helper_is_defined(self):
+        src = self._pipeline_source()
+        assert "def _read_lock_pid(" in src, "_read_lock_pid helper must be defined inline in _run_with_lock"
+
+    def test_cleanup_lock_calls_read_lock_pid_before_remove(self):
+        src = self._pipeline_source()
+        assert "_read_lock_pid(lock_path)" in src, "_cleanup_lock must call _read_lock_pid before unlinking"
+
+    def test_cleanup_lock_compares_pid_to_current(self):
+        src = self._pipeline_source()
+        # The fix uses ``pid == os.getpid()`` to gate the remove.
+        assert "os.getpid()" in src
+        # And the legacy blind-remove pattern must NOT appear in
+        # _cleanup_lock — the unconditional ``os.remove(lock_path)``
+        # was the bug.
+        # We can't grep for "os.remove(lock_path)" globally because
+        # the acquire path also unlinks on stale-PID recovery; instead
+        # we slice to the _cleanup_lock body.
+        cleanup_start = src.find("def _cleanup_lock(")
+        cleanup_end = src.find("\n        atexit.register", cleanup_start)
+        assert cleanup_start > 0 and cleanup_end > cleanup_start
+        cleanup_body = src[cleanup_start:cleanup_end]
+        # The remove inside _cleanup_lock MUST be guarded by a pid==current check
+        assert "pid == os.getpid()" in cleanup_body, "_cleanup_lock body must guard os.remove with pid==os.getpid()"
+
+    def test_read_lock_pid_returns_none_on_unreadable(self, tmp_path):
+        """The helper itself: returns None for missing file, malformed
+        contents, or any I/O error. None is the safer default — caller
+        treats None as 'don't unlink'."""
+
+        # Re-import the module to access the inner function. Since
+        # _read_lock_pid is defined inside _run_with_lock, we can't import
+        # it directly — instead, replicate its body here as a smoke test
+        # of the same logic.
+        def _read_lock_pid(path: str):
+            try:
+                with open(path) as fh:
+                    return int(fh.read().strip())
+            except (OSError, ValueError):
+                return None
+
+        # Missing file
+        assert _read_lock_pid(str(tmp_path / "nonexistent.lock")) is None
+        # Empty file
+        empty = tmp_path / "empty.lock"
+        empty.write_text("")
+        assert _read_lock_pid(str(empty)) is None
+        # Malformed
+        bad = tmp_path / "bad.lock"
+        bad.write_text("not-a-pid\n")
+        assert _read_lock_pid(str(bad)) is None
+        # Valid
+        good = tmp_path / "good.lock"
+        good.write_text(f"{os.getpid()}\n")
+        assert _read_lock_pid(str(good)) == os.getpid()

--- a/tests/test_pr_a_ship_blockers.py
+++ b/tests/test_pr_a_ship_blockers.py
@@ -22,6 +22,15 @@ Coverage:
       Process C also acquire — two pipelines run concurrently, racing
       MERGE. Mirrors the PID-check pattern in
       ``baseline_lock.release_baseline_lock``.
+    - **Red Team CRITICAL C1** (round-2 follow-up): ``install.sh`` must
+      auto-generate ``EDGEGUARD_API_KEY`` when .env is created from
+      .env.example with an empty key. Without this the api / graphql
+      containers crashloop on first ``docker compose up`` (the safety
+      check at ``src/query_api.py:96`` refuses to bind 0.0.0.0 without
+      either an API key or an explicit ``EDGEGUARD_ALLOW_UNAUTH=1`` opt-
+      in). Auto-gen keeps the safety check intact while making the
+      install path frictionless. Same logic for ``GRAFANA_ADMIN_PASSWORD``
+      to avoid shipping the literal ``changeme`` default.
 
 Other PR-A fixes (compose auth bypass, healthchecks, memory defaults,
 requirements alias, GHA SHA pins, disk-free alerts) are config/yaml
@@ -240,3 +249,106 @@ class TestPipelineLockPidCheck:
         good = tmp_path / "good.lock"
         good.write_text(f"{os.getpid()}\n")
         assert _read_lock_pid(str(good)) == os.getpid()
+
+
+# ---------------------------------------------------------------------------
+# Red Team CRITICAL C1 — install.sh auto-generates EDGEGUARD_API_KEY so
+# fresh ``./install.sh && docker compose up`` does not crashloop on the
+# query_api.py safety check.
+# ---------------------------------------------------------------------------
+
+
+class TestInstallShAutogeneratesApiKey:
+    """install.sh must populate EDGEGUARD_API_KEY (and rotate
+    GRAFANA_ADMIN_PASSWORD off the literal "changeme") when creating
+    .env from .env.example. Otherwise the api / graphql containers
+    crashloop and the operator copy-pastes ``EDGEGUARD_ALLOW_UNAUTH=1``
+    out of the error message — defeating the safety check entirely.
+    """
+
+    @staticmethod
+    def _project_root() -> str:
+        # tests/ lives one level under project root
+        return os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
+
+    def test_install_sh_contains_api_key_autogen_block(self):
+        """The install.sh source must contain the .env-edit block that
+        replaces the empty EDGEGUARD_API_KEY with a generated value.
+        Pinned via source-grep because the alternative — actually running
+        install.sh in a tmpdir — pulls in the docker stage."""
+        path = os.path.join(self._project_root(), "install.sh")
+        with open(path) as fh:
+            src = fh.read()
+        # The grep that detects the empty default
+        assert 'grep -q "^EDGEGUARD_API_KEY=$" .env' in src, (
+            "install.sh must detect an empty EDGEGUARD_API_KEY before substituting"
+        )
+        # At least one of the two key generators (must accept either ordering)
+        assert "openssl rand -hex 32" in src or "secrets.token_hex(32)" in src, (
+            "install.sh must offer openssl OR python3 fallback for key generation"
+        )
+        # The actual replacement must rewrite the empty assignment
+        assert 'print "EDGEGUARD_API_KEY=" key' in src, (
+            "install.sh must print the substituted EDGEGUARD_API_KEY=<value> line"
+        )
+
+    def test_install_sh_rotates_default_grafana_password(self):
+        """``changeme`` is a credential-stuffing target — install.sh must
+        replace it with a generated value when creating .env."""
+        path = os.path.join(self._project_root(), "install.sh")
+        with open(path) as fh:
+            src = fh.read()
+        assert "GRAFANA_ADMIN_PASSWORD=changeme" in src, (
+            "install.sh must explicitly target the literal default to substitute"
+        )
+        assert "GRAFANA_ADMIN_PASSWORD=" in src
+
+    def test_env_example_documents_api_key_requirement(self):
+        """The .env.example comment block must tell manual-install
+        operators (those who skip install.sh) that the api/graphql
+        containers will refuse to start with an empty key."""
+        path = os.path.join(self._project_root(), ".env.example")
+        with open(path) as fh:
+            content = fh.read()
+        assert "REFUSE TO START" in content, ".env.example must warn that empty EDGEGUARD_API_KEY blocks startup"
+        # The three fix paths must all be documented
+        assert "install.sh" in content
+        assert "openssl rand -hex 32" in content
+        assert "EDGEGUARD_ALLOW_UNAUTH" in content
+
+    def test_awk_substitution_actually_replaces_the_key(self, tmp_path):
+        """Behavioural test: feed an .env-shaped string with an empty
+        EDGEGUARD_API_KEY through the same awk command install.sh uses,
+        and assert the output has the generated value substituted."""
+        import subprocess
+
+        env_input = (
+            "# leading comment\n"
+            "NEO4J_PASSWORD=changeme\n"
+            "EDGEGUARD_API_KEY=\n"
+            "GRAFANA_ADMIN_PASSWORD=changeme\n"
+            "TRAILING=value\n"
+        )
+        env_file = tmp_path / ".env"
+        env_file.write_text(env_input)
+
+        result = subprocess.run(
+            [
+                "awk",
+                "-v",
+                "key=GENERATED_KEY_VALUE",
+                '/^EDGEGUARD_API_KEY=$/ { print "EDGEGUARD_API_KEY=" key; next } { print }',
+                str(env_file),
+            ],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        out = result.stdout
+        assert "EDGEGUARD_API_KEY=GENERATED_KEY_VALUE" in out
+        # Other lines untouched
+        assert "NEO4J_PASSWORD=changeme" in out
+        assert "GRAFANA_ADMIN_PASSWORD=changeme" in out
+        assert "TRAILING=value" in out
+        # No accidental duplicate / empty key line
+        assert out.count("EDGEGUARD_API_KEY=") == 1


### PR DESCRIPTION
## Summary

**PR-A** of a 4-PR sequence implementing findings from a proactive 7-agent audit (Red Team, Bug Hunter, Cross-Checker, Maintainer Dev, Prod Readiness, Devil's Advocate, Dependency). 8 small independent fixes that **must land before the next baseline run**.

| Severity | Source | Fix | Effort |
|---|---|---|---|
| 🚨 HIGH | Red Team | docker-compose `--host 0.0.0.0` bypassed A6 auth check → REST + GraphQL booted **without auth** | 5 lines |
| 🔴 HIGH | Prod Readiness | Neo4j healthcheck was port-only — passed in disk-full read-only mode | 3 lines |
| 🔴 HIGH | Prod Readiness | `NEO4J_CONTAINER_MEMORY_LIMIT` default 4g (docs say 32g) — fresh-clone OOMs on first baseline | 1 line |
| 🔴 HIGH | Dependency | `src/requirements.txt` still pinned Airflow 2.x with 18+ CVEs | aliased to root |
| 🔴 HIGH | Dependency | GHA pinned to floating @v4 / @v5 — `tj-actions/changed-files` March 2025 attack proves exploitable | 4 SHA pins |
| 🔴 HIGH | Bug Hunter H2 | Pipeline-lock cleanup blindly `os.remove`s — opens concurrent-pipeline race | ~15 lines + helper |
| 🔴 HIGH | Bug Hunter H1 | Driver leak on Neo4j auth failure — operationally certain to bite during MISP password rotation | helper + 3 call-sites |
| 🔴 HIGH | Prod Readiness | No disk-free Prometheus alerts despite node-exporter scraped — 730d baseline can fill 100GB unmonitored | 3 alert rules |

Plus airflow_postgres memory limit 512m → 2g (Prod Readiness MED).

## Why a comprehensive audit, not reactive fixing

The previous workflow was: ship → bugbot finds something → fix reactively → repeat. The 7-agent proactive pass found ~100 findings; this PR addresses the 8 the audit classified as ship-blockers. The remaining findings are scoped into PR-B (supply chain refresh) and PR-C (CLI ↔ DAG parity + fresh-baseline; the audit revealed the original 3-PR plan was scoped against ONE drift point when there are actually three).

Devil's Advocate's pushback: the team has been over-engineering some abstractions; the audit's value is largely in catching THIS kind of bug (driver leak, lock race, healthcheck lying) — not in the fancy refactors.

## Test plan

- [x] `ruff format --check src/ tests/`
- [x] `ruff check src/ tests/`
- [x] `mypy src/`
- [x] `pytest tests/` — **707 passed, 3 skipped, 0 regressions** (was 696; +11 from PR-A's 9 new tests + 2 baseline)
- [x] 9 new regression tests in `tests/test_pr_a_ship_blockers.py` covering the two runtime fixes (driver leak + lock PID race)
- [ ] Bugbot review
- [ ] Manual `docker compose config` validation of the compose changes (yaml-only fixes aren't unit-testable)

## What is NOT in this PR (subsequent PRs)

- **PR-B**: Supply chain refresh (5 monitoring images 14-29 months old, trivy image scan in CI, Flask 2 tracking issue)
- **PR-C**: CLI ↔ DAG parity + fresh-baseline (CLI never runs enrichment_jobs, CLI never invokes build_relationships, baseline_dag has no fresh_baseline knob, plus the destructive baseline_clean task, plus the CLI wrapper, plus the probes module re-introduced slimmer with consumer alongside)
- **PR-D** (deferred to v2): test-pinning rewrite (165+ literal-string assertions across 4 test files; debt cleanup, not blocking)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes API/GraphQL startup and bind/auth gating, plus alters Docker Compose healthchecks and memory limits that can affect availability and deployment behavior.
> 
> **Overview**
> **Security hardening:** Updates Docker/Compose to start REST/GraphQL via `python -m src.query_api` / `src.graphql_api` (not uvicorn CLI) so the existing bind/auth safety checks can’t be bypassed, adds worker-count envs, and ensures `EDGEGUARD_ALLOW_UNAUTH` is actually forwarded to containers as the documented escape hatch.
> 
> **Operational fixes:** Replaces Neo4j’s port-only healthcheck with a `cypher-shell` write/delete probe, bumps default memory limits for Neo4j and Airflow Postgres, and adds Prometheus host disk/inode alerts.
> 
> **Supply chain / reliability:** Pins GitHub Actions to immutable SHAs, makes `src/requirements.txt` delegate to root `requirements.txt` to avoid dependency drift, auto-generates `EDGEGUARD_API_KEY` (and rotates Grafana’s default password) on first `.env` creation, and fixes runtime leaks/races by closing Neo4j drivers on failed connects and guarding pipeline-lock cleanup by PID (with new regression tests).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e596bb3afad54ae66b365117c585c7af772c3a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->