### PR TITLE
fix(audit): PR-F3 — backup-gate auto-skip on clean installs (Issue #58)

### DIFF
--- a/docs/BACKUP.md
+++ b/docs/BACKUP.md
@@ -74,6 +74,32 @@ edgeguard fresh-baseline --skip-backup-check    # logs WARNING; not for prod
 The gate logs the bypass at WARNING level so audit-trail readers can see
 when production safety was disabled.
 
+### Auto-skip on clean installs (PR-F3, Issue #58)
+
+The gate also auto-skips when **both data stores are empty** (Neo4j
+EdgeGuard nodes = 0 AND MISP EdgeGuard events = 0). This covers the
+first-time / dev-laptop / CI-bringup workflow: there is nothing to back
+up on a fresh install, so requiring `EDGEGUARD_LAST_BACKUP_AT` for the
+very first `fresh-baseline` would be friction-without-safety.
+
+The auto-skip is logged at **INFO** (not WARNING):
+
+```
+INFO  edgeguard: Backup-timestamp gate auto-skipped on clean install
+      (neo4j_count=0, misp_count=0); EDGEGUARD_LAST_BACKUP_AT not required.
+```
+
+This is deliberately distinct from the WARNING-level `--skip-backup-check`
+audit log: "no data exists" is a different state than "operator chose to
+disable safety". As soon as either store has any EdgeGuard-managed data,
+the gate enforces normally on the next `fresh-baseline` run — the auto-skip
+is a one-time bootstrap, not an ongoing posture.
+
+Checkpoint state is **intentionally excluded** from the auto-skip
+predicate: a leftover `checkpoints/baseline_checkpoint.json` from a prior
+run on a now-emptied graph is exactly the case we want to allow without
+ceremony, and per-collector cursor state is not user-meaningful data.
+
 ## Backup procedures by deployment shape
 
 ### Self-hosted Neo4j (Docker Compose, the default)

--- a/src/edgeguard.py
+++ b/src/edgeguard.py
@@ -2200,8 +2200,33 @@ def cmd_fresh_baseline(args) -> int:
     # ``--skip-backup-check`` is the dev/test escape hatch — emits a
     # WARNING in the log so the bypass is auditable. Production
     # operators should NEVER use this flag.
+    #
+    # PR-F3 audit fix (Issue #58, clean-install UX gap): the gate has
+    # nothing to protect on a fresh install (empty Neo4j + empty MISP),
+    # so requiring ``EDGEGUARD_LAST_BACKUP_AT`` for the very first
+    # ``fresh-baseline`` call is friction-without-safety. Auto-skip the
+    # gate when both data stores are empty — log at INFO (audit-trail
+    # clarity: this is "no data exists", NOT a deliberate safety bypass
+    # like ``--skip-backup-check``). Checkpoint state is intentionally
+    # NOT considered: it's per-collector cursor progress, not user-data,
+    # and a leftover checkpoint file from a prior run on an emptied
+    # graph is exactly the case we want to allow without ceremony.
     if not getattr(args, "skip_backup_check", False):
-        backup_check_result = _check_recent_backup_timestamp()
+        backup_check_result: Optional[str]
+        gate_auto_skipped_clean_install = False
+        if state.neo4j_count == 0 and state.misp_count == 0:
+            info(
+                "Backup-timestamp gate auto-skipped: no existing data to back up "
+                "(clean install — Neo4j EdgeGuard nodes = 0, MISP EdgeGuard events = 0)."
+            )
+            logger.info(
+                "Backup-timestamp gate auto-skipped on clean install "
+                "(neo4j_count=0, misp_count=0); EDGEGUARD_LAST_BACKUP_AT not required."
+            )
+            backup_check_result = None
+            gate_auto_skipped_clean_install = True
+        else:
+            backup_check_result = _check_recent_backup_timestamp()
         if backup_check_result is not None:  # check failed
             print(file=sys.stderr)
             err("FRESH BASELINE — BACKUP GATE FAILED")
@@ -2234,7 +2259,11 @@ def cmd_fresh_baseline(args) -> int:
         # addition to the structured logger.info inside the helper.
         # Helps operators see WHY the gate accepted (and how much window
         # is left) without having to grep the log file.
-        info("Backup-timestamp gate passed (see log for age + remaining window).")
+        # Skip this on the clean-install auto-skip path: the helper never
+        # ran, so there's no age/remaining-window to point at and the
+        # auto-skip ``info(...)`` above is the canonical operator message.
+        if not gate_auto_skipped_clean_install:
+            info("Backup-timestamp gate passed (see log for age + remaining window).")
     else:
         warn("--skip-backup-check passed; bypassing the backup-timestamp gate.")
         warn("This is intended for dev/test only — production runs MUST take a backup first.")

--- a/tests/test_pr_f3_backup_gate_clean_install.py
+++ b/tests/test_pr_f3_backup_gate_clean_install.py
@@ -1,0 +1,277 @@
+"""
+Regression tests for PR-F3 — clean-install ergonomics for the
+``edgeguard fresh-baseline`` backup-timestamp gate (Issue #58).
+
+PR-F2 (#56, merged) added a backup-timestamp gate that refuses to run
+``edgeguard fresh-baseline`` unless ``EDGEGUARD_LAST_BACKUP_AT`` records
+a backup within the freshness window. That's correct for production
+(steady-state) but creates UX friction for the first-time / dev-laptop /
+CI-bringup workflow: on a truly empty install there is **nothing to
+back up**, but the gate would still refuse.
+
+PR-F3 closes the gap by auto-skipping the gate when both data stores
+report zero EdgeGuard-managed objects. The bypass is logged at INFO
+(audit-trail clarity: "no data exists" is a different state than the
+WARNING-level explicit ``--skip-backup-check`` bypass).
+
+This file pins the contract:
+
+    | state                           | EDGEGUARD_LAST_BACKUP_AT | gate behavior          |
+    |---------------------------------|--------------------------|------------------------|
+    | empty Neo4j + empty MISP        | unset                    | AUTO-SKIP (INFO log)   |
+    | empty Neo4j + empty MISP        | recent ISO ts            | helper runs (passes)   |
+    | non-empty (either store)        | unset                    | gate REFUSES (exit 2)  |
+    | non-empty (either store)        | recent ISO ts            | helper runs (passes)   |
+    | --skip-backup-check (any state) | irrelevant               | bypass (WARNING log)   |
+
+Naming: per the PR-F2 docstring recommendation, this is
+``test_<module>_<aspect>.py`` rather than the older ``test_pr_<id>_*``
+pattern; the ``pr_f3`` slug is kept here because the change is scoped
+to a single PR with a clear audit-trail back to Issue #58.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, "src")
+
+
+def _make_state(*, neo4j_count: int, misp_count: int):
+    """Build a ``BaselineState`` with all probes 'reachable' so the
+    pre-flight (``state.all_reachable``) gate doesn't short-circuit
+    before the backup-gate logic we're testing."""
+    from baseline_clean import BaselineState
+
+    return BaselineState(
+        neo4j_count=neo4j_count,
+        neo4j_ok=True,
+        misp_count=misp_count,
+        misp_ok=True,
+        checkpoint_count=0,
+        checkpoint_ok=True,
+    )
+
+
+def _make_args(**overrides):
+    """Build an ``args`` object compatible with ``cmd_fresh_baseline``.
+    ``force=False`` would block on ``input()``; tests that exercise the
+    gate path only need to verify the gate result *before* the
+    confirmation prompt, so we set ``force=True`` to bypass it."""
+    args = MagicMock()
+    args.days = 30
+    args.force = True
+    args.skip_backup_check = False
+    args.dry_run = False
+    args.yes = True
+    for key, value in overrides.items():
+        setattr(args, key, value)
+    return args
+
+
+# ---------------------------------------------------------------------------
+# The three test cases the user explicitly requested in the PR-F3 brief
+# ---------------------------------------------------------------------------
+
+
+class TestCleanInstallAutoSkip:
+    """Empty graph + no backup timestamp → gate auto-skips, INFO log fires."""
+
+    def test_empty_graph_no_timestamp_auto_skips_gate(self, monkeypatch, caplog):
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        empty = _make_state(neo4j_count=0, misp_count=0)
+
+        with (
+            patch("baseline_clean.probe_baseline_state", return_value=empty),
+            patch("edgeguard._trigger_baseline_dag", return_value=(0, "run-1")),
+            caplog.at_level(logging.INFO, logger="edgeguard"),
+        ):
+            ret = edgeguard.cmd_fresh_baseline(_make_args())
+
+        # The gate must NOT fail with exit 2 (no backup) — the auto-skip
+        # path is the whole point of this PR. Any exit code that is NOT 2
+        # means the gate didn't reject (the actual numeric exit depends on
+        # the airflow-trigger mock and confirmation-prompt path; this
+        # assertion is contract, not implementation).
+        assert ret != 2, f"clean install must not be blocked by backup gate; got exit {ret}"
+
+        # The structured log entry MUST surface the auto-skip reason so
+        # operators can grep for it later when wondering "why did the gate
+        # accept on this run".
+        msg = " ".join(rec.message for rec in caplog.records)
+        assert "auto-skipped on clean install" in msg, (
+            f"expected auto-skip log line; got records: {[r.message for r in caplog.records]}"
+        )
+        assert "neo4j_count=0" in msg
+        assert "misp_count=0" in msg
+
+    def test_auto_skip_log_is_info_not_warning(self, monkeypatch, caplog):
+        """Audit-trail clarity: 'no data exists' is NOT a deliberate
+        safety bypass like ``--skip-backup-check`` — the latter is
+        WARNING-level for a reason. Auto-skip is INFO."""
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        empty = _make_state(neo4j_count=0, misp_count=0)
+
+        with (
+            patch("baseline_clean.probe_baseline_state", return_value=empty),
+            patch("edgeguard._trigger_baseline_dag", return_value=(0, "run-1")),
+            caplog.at_level(logging.DEBUG, logger="edgeguard"),
+        ):
+            edgeguard.cmd_fresh_baseline(_make_args())
+
+        auto_skip_records = [r for r in caplog.records if "auto-skipped on clean install" in r.message]
+        assert auto_skip_records, "auto-skip log line must be emitted"
+        for rec in auto_skip_records:
+            assert rec.levelno == logging.INFO, (
+                f"auto-skip must be INFO (got {rec.levelname}); "
+                "WARNING is reserved for the explicit --skip-backup-check path"
+            )
+
+
+class TestPopulatedGraphStillEnforces:
+    """Non-empty graph + no backup timestamp → gate refuses (current behavior)."""
+
+    def test_neo4j_has_data_misp_empty_gate_refuses(self, monkeypatch):
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        populated = _make_state(neo4j_count=42, misp_count=0)
+
+        with patch("baseline_clean.probe_baseline_state", return_value=populated):
+            ret = edgeguard.cmd_fresh_baseline(_make_args())
+
+        assert ret == 2, "non-empty Neo4j must still trigger the gate refusal (exit 2)"
+
+    def test_misp_has_data_neo4j_empty_gate_refuses(self, monkeypatch):
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        populated = _make_state(neo4j_count=0, misp_count=7)
+
+        with patch("baseline_clean.probe_baseline_state", return_value=populated):
+            ret = edgeguard.cmd_fresh_baseline(_make_args())
+
+        assert ret == 2, "non-empty MISP must still trigger the gate refusal (exit 2)"
+
+    def test_both_stores_have_data_gate_refuses(self, monkeypatch):
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        populated = _make_state(neo4j_count=350_000, misp_count=8000)
+
+        with patch("baseline_clean.probe_baseline_state", return_value=populated):
+            ret = edgeguard.cmd_fresh_baseline(_make_args())
+
+        assert ret == 2
+
+
+class TestEmptyGraphRecentTimestampPassesThrough:
+    """Empty graph + recent backup timestamp → gate passes through normal
+    path (the auto-skip short-circuit fires FIRST, but the passthrough
+    is still safe — recent timestamps must never trigger a refusal)."""
+
+    def test_empty_graph_with_recent_timestamp_does_not_refuse(self, monkeypatch, caplog):
+        import edgeguard
+
+        # 1h-old backup, well within the 240h default
+        recent = (datetime.now(timezone.utc) - timedelta(hours=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        monkeypatch.setenv("EDGEGUARD_LAST_BACKUP_AT", recent)
+        empty = _make_state(neo4j_count=0, misp_count=0)
+
+        with (
+            patch("baseline_clean.probe_baseline_state", return_value=empty),
+            patch("edgeguard._trigger_baseline_dag", return_value=(0, "run-1")),
+            caplog.at_level(logging.INFO, logger="edgeguard"),
+        ):
+            ret = edgeguard.cmd_fresh_baseline(_make_args())
+
+        assert ret != 2, "recent timestamp + empty graph must never block"
+
+        # Implementation choice: auto-skip fires first (short-circuit on
+        # empty install). The helper's "gate passed" log must NOT fire
+        # in this case — having BOTH would be confusing in the audit log.
+        msg = " ".join(rec.message for rec in caplog.records)
+        assert "auto-skipped on clean install" in msg
+        assert "Backup-timestamp gate passed: backup is" not in msg, (
+            "auto-skip path must short-circuit BEFORE the helper, so the "
+            "helper's 'gate passed' log should not also fire"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Defensive coverage — the explicit --skip-backup-check flag must keep
+# its WARNING-level audit semantics regardless of empty/non-empty state.
+# ---------------------------------------------------------------------------
+
+
+class TestSkipBackupCheckFlagUnchanged:
+    """``--skip-backup-check`` is the explicit operator-bypass path.
+    PR-F3 must not weaken its WARNING-level audit log just because the
+    auto-skip path now also exists."""
+
+    def test_skip_flag_logs_warning_even_on_clean_install(self, monkeypatch, caplog):
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        empty = _make_state(neo4j_count=0, misp_count=0)
+
+        with (
+            patch("baseline_clean.probe_baseline_state", return_value=empty),
+            patch("edgeguard._trigger_baseline_dag", return_value=(0, "run-1")),
+            caplog.at_level(logging.DEBUG, logger="edgeguard"),
+        ):
+            edgeguard.cmd_fresh_baseline(_make_args(skip_backup_check=True))
+
+        # Must NOT auto-skip (the explicit flag takes precedence — operator
+        # opted in, audit-trail must reflect it).
+        msg = " ".join(rec.message for rec in caplog.records)
+        assert "auto-skipped on clean install" not in msg, (
+            "explicit --skip-backup-check must take precedence over auto-skip"
+        )
+
+    def test_skip_flag_bypasses_gate_when_populated_too(self, monkeypatch):
+        import edgeguard
+
+        monkeypatch.delenv("EDGEGUARD_LAST_BACKUP_AT", raising=False)
+        populated = _make_state(neo4j_count=100, misp_count=50)
+
+        with (
+            patch("baseline_clean.probe_baseline_state", return_value=populated),
+            patch("edgeguard._trigger_baseline_dag", return_value=(0, "run-1")),
+        ):
+            ret = edgeguard.cmd_fresh_baseline(_make_args(skip_backup_check=True))
+
+        # The gate must NOT exit 2 — the bypass flag is the whole point.
+        assert ret != 2, "--skip-backup-check must bypass even on populated installs"
+
+
+# ---------------------------------------------------------------------------
+# Source-pin: the auto-skip branch must be present in cmd_fresh_baseline,
+# AND must use ``state.neo4j_count`` + ``state.misp_count`` (not the
+# ``state.all_zero`` convenience property — checkpoint state is
+# intentionally excluded from this gate).
+# ---------------------------------------------------------------------------
+
+
+class TestAutoSkipSourceContract:
+    def test_auto_skip_branch_uses_neo4j_and_misp_counts_only(self):
+        with open("src/edgeguard.py") as fh:
+            src = fh.read()
+        idx = src.find("def cmd_fresh_baseline(")
+        assert idx > 0
+        end = src.find("\ndef cmd_baseline(", idx)
+        body = src[idx:end]
+        # The condition MUST be neo4j_count == 0 AND misp_count == 0,
+        # NOT state.all_zero (which would also gate on checkpoint state
+        # and reintroduce a different friction case).
+        assert "state.neo4j_count == 0 and state.misp_count == 0" in body, (
+            "PR-F3 contract: auto-skip predicate is data-store counts only"
+        )
+        assert "auto-skipped on clean install" in body, "structured-log marker required for ops grep"


### PR DESCRIPTION
## Summary

Closes the **clean-install UX gap** left by PR-F2 (#56): the backup-timestamp gate now auto-skips when both data stores are empty, so first-time / dev-laptop / CI-bringup `fresh-baseline` runs work without setting `EDGEGUARD_LAST_BACKUP_AT` (there is nothing to back up on an empty install).

The auto-skip is logged at **INFO** (not WARNING). This is deliberately distinct from the WARNING-level `--skip-backup-check` audit log: "no data exists" is a different state than "operator chose to disable safety."

Closes #58.

## Behavior matrix the gate now implements

| state | `EDGEGUARD_LAST_BACKUP_AT` | result |
|---|---|---|
| empty Neo4j + empty MISP | unset | **AUTO-SKIP** (INFO log) |
| empty + recent ISO ts | (any) | AUTO-SKIP (INFO log; short-circuits before helper) |
| non-empty (either store) | unset | gate REFUSES (exit 2) |
| non-empty + recent ts | (recent) | helper runs, gate passes |
| `--skip-backup-check` (any state) | irrelevant | bypass (WARNING log unchanged) |

## Why deferred from PR-F2

PR-F2 was already de-scoped once (the lock-task pair → Issue #57). Folding another change in would have invited a third Bugbot review round on the same PR. Cleaner to ship PR-F2 as the audit-fix-only PR and address the UX gap here.

## Implementation notes

- State is reused from the existing `probe_baseline_state()` call that runs immediately above the gate — no extra round-trip.
- Predicate is `state.neo4j_count == 0 and state.misp_count == 0` (NOT `state.all_zero`, which would also gate on checkpoint state — leftover `baseline_checkpoint.json` from a prior run on an emptied graph is exactly the case we want to allow without ceremony).
- Two log entries on the auto-skip path: an operator-facing `info(...)` (stdout) and a structured `logger.info(...)` with the marker `"auto-skipped on clean install"` for ops grep.
- Suppresses the helper's "gate passed: backup is X.Yh old" log on this path (the helper never ran; double-firing would be confusing in the audit log).
- `--skip-backup-check` still takes precedence — auto-skip is the nothing-to-protect path, the explicit flag is the chose-to-bypass path. Audit-trail levels reflect the difference.

## Files changed

| File | Change |
|---|---|
| `src/edgeguard.py` | +28 LOC in `cmd_fresh_baseline` — auto-skip branch + suppression of stale helper log |
| `tests/test_pr_f3_backup_gate_clean_install.py` | **new** — 9 regression tests pinning the contract |
| `docs/BACKUP.md` | new "Auto-skip on clean installs" subsection (predicate, log-level rationale, checkpoint-exclusion rationale) |

## Test plan

- [x] Empty graph + no timestamp → auto-skip + INFO log fires
- [x] Auto-skip log MUST be INFO not WARNING (audit-trail discipline)
- [x] Neo4j-only populated → gate enforces (exit 2)
- [x] MISP-only populated → gate enforces (exit 2)
- [x] Both populated → gate enforces (exit 2)
- [x] Empty + recent ts → auto-skip short-circuits cleanly (no double log)
- [x] `--skip-backup-check` on clean install → flag wins, no auto-skip
- [x] `--skip-backup-check` on populated install → flag still bypasses
- [x] Source-pin: predicate uses `neo4j_count` + `misp_count` only (not `state.all_zero`)
- [x] `ruff format --check src/ dags/ tests/` ✓
- [x] `ruff check src/ tests/` ✓
- [x] `mypy src/` ✓
- [x] `pytest tests/` — **824 passed, 3 skipped, 0 failures**

## Related

- PR #56 — original PR-F2 backup-gate (this fixes the UX edge case)
- Issue #57 — Airflow-aware lock primitive (also de-scoped from PR-F2)
- Issue #53 — operational hardening backlog

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adjusts the safety gate for the destructive `fresh-baseline` command to skip backup enforcement on empty datastores, so any bug in the “empty” predicate or state probing could unintentionally weaken protections. Coverage is improved with new regression tests, but the change still touches production safety logic.
> 
> **Overview**
> `edgeguard fresh-baseline` now **auto-skips the backup-timestamp gate** when both Neo4j and MISP have zero EdgeGuard-managed data, logging an *INFO* audit line distinct from the explicit WARNING-level `--skip-backup-check` bypass.
> 
> It also suppresses the usual “gate passed” operator message on the auto-skip path to avoid confusing double-logging. Documentation is updated to describe the clean-install behavior and rationale, and a new test suite pins the expected behavior across empty/populated states and bypass flag precedence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4508436005ded05543070ed1dc03f7b9a3a62e3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->