### PR TITLE
fix(baseline): PR-F4 — sequence tier1 collectors to halve MISP write pressure

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2129,7 +2129,15 @@ baseline_clean_task = PythonOperator(
 )
 
 
-# Tier 1 — Core intelligence (rate-limited APIs). ALL_DONE: one failure doesn't block others.
+# Tier 1 — Core intelligence (rate-limited APIs).
+#
+# **trigger_rule = ALL_DONE (deliberate, preserved across PR-F4):** each
+# tier-1 collector hits a DIFFERENT external API (CISA's, MITRE's, OTX's,
+# NVD's). When one source's API has a transient outage, the OTHER three
+# should still run — losing 1/4 of a baseline is much better than losing
+# all of it. ALL_DONE is what gives us that multi-source resilience.
+# Do NOT change to ALL_SUCCESS without explicit discussion: that would
+# cascade-skip downstream collectors on any single-source flake.
 #
 # PR-F4 (2026-04-20, Vanko's overnight baseline observation): collectors
 # now run **SEQUENTIALLY** (cisa → mitre → otx → nvd) instead of in
@@ -2155,15 +2163,21 @@ baseline_clean_task = PythonOperator(
 #   collectors complete in <1min combined, so the real cost is OTX+NVD
 #   no longer overlapping (~3h+5h = 8h vs. previous max(3h, 5h) = 5h).
 #
-# **Order rationale:** small collectors first (cisa ~14s, mitre ~28s)
-# so we get a fast signal if the chain has any problem (auth issue,
-# MISP completely down) before sinking ~3-5 hours into OTX or NVD.
+# **Order rationale (cisa → mitre → otx → nvd):** the order is mostly
+# aesthetic — small-first reads more naturally in the Airflow grid view.
+# It does NOT give us automatic fast-fail because the ALL_DONE trigger
+# rule (correctly preserved for multi-source resilience above) means
+# downstream tasks run regardless of upstream success/failure. Operators
+# monitoring a live run can intervene manually if CISA fails fast and
+# the failure looks chain-wide (MISP completely down), but this is an
+# operator-discretion benefit, not a DAG-automatic one. The real value
+# of PR-F4 is halved MISP write concurrency; the order is incidental.
 #
 # **What this DOES NOT fix:** the per-event-grows-with-size cost on a
 # single oversized event (MISP edit-event loads the entire event for
 # dedup; cost grows linearly with existing attribute count). That's the
 # architectural fix tracked separately — event partitioning by date
-# range so no single event exceeds ~20K attributes.
+# range so no single event exceeds ~20K attributes (Issue #61).
 #
 # Tier2 stays parallel: those 6 feeds are individually tiny (<5K attrs
 # each), don't trigger the failure-mode-2 oversized-event problem, and
@@ -2195,9 +2209,12 @@ with TaskGroup("tier1_core", dag=baseline_dag, default_args={"trigger_rule": Tri
     )
 
     # PR-F4: sequential dependency chain inside the TaskGroup.
-    # cisa (~14s) → mitre (~28s) → otx (~3h) → nvd (~5h). Small ones
-    # first for fast failure signal; heavies serialized to halve the
-    # MISP write concurrency that triggered the 14.7% NVD loss.
+    # cisa (~14s) → mitre (~28s) → otx (~3h) → nvd (~5h). The order is
+    # mostly aesthetic; the real value is halving the MISP write
+    # concurrency that triggered the 14.7% NVD loss. ALL_DONE trigger
+    # rule (set on the TaskGroup default_args above) is preserved so a
+    # single-source API flake doesn't cascade-skip the rest of tier1 —
+    # see the comment block above the TaskGroup for full reasoning.
     bl_cisa >> bl_mitre >> bl_otx >> bl_nvd
 
 # Tier 2 — Reputation & bulk feeds (parallel after Tier 1).

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1697,7 +1697,13 @@ baseline_dag = DAG(
     start_date=_DAG_START_DATE,
     catchup=False,
     max_active_runs=1,  # Only one baseline at a time
-    dagrun_timeout=timedelta(hours=32),  # Worst-case: 26h (full collection + sync + retries) + buffer
+    # Worst-case wall time: tier1 sequential (cisa 14s + mitre 28s + otx ~3h
+    # + nvd ~5h ≈ 8h) + tier2 parallel (~2h) + full_sync (~6h) +
+    # build_rels (~5h) + enrich (~5h) = ~26h realistic, ~31h with a single
+    # retry on the longest task. 32h cap leaves ~1-6h of headroom; if real
+    # runs trend longer post-PR-F4 (sequential tier1 added ~3h), bump this
+    # via a follow-up rather than letting Airflow hard-kill at the cap.
+    dagrun_timeout=timedelta(hours=32),
     is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
 )
@@ -2124,6 +2130,44 @@ baseline_clean_task = PythonOperator(
 
 
 # Tier 1 — Core intelligence (rate-limited APIs). ALL_DONE: one failure doesn't block others.
+#
+# PR-F4 (2026-04-20, Vanko's overnight baseline observation): collectors
+# now run **SEQUENTIALLY** (cisa → mitre → otx → nvd) instead of in
+# parallel. Rationale:
+#
+#   The 2026-04-19 overnight 730-day baseline run hit ~14.7% MISP push
+#   failure rate on NVD (13,620 of 92,620 attributes lost as silent HTTP
+#   500s) when all four tier1 collectors hammered MISP simultaneously.
+#   Bravo's investigation (Slack 2026-04-20 01:09 UTC) traced this to
+#   PHP-FPM worker exhaustion in MISP's AppModel.php under concurrent
+#   write load — symptom is ``Cannot use a scalar value as an array``
+#   warnings + 500s on edit-event calls.
+#
+#   The push-batch chunking (``EDGEGUARD_MISP_PUSH_BATCH_SIZE``, default
+#   500) and inter-batch throttle (``EDGEGUARD_MISP_BATCH_THROTTLE_SEC``,
+#   default 5s) were already in place — they bound per-request size but
+#   not per-event total size, and don't address concurrent writers.
+#
+#   Sequencing tier1 cuts the simultaneous-writer count from 4 → 1
+#   without any MISP server changes (the upstream image is fragile and
+#   not under our control). Trade-off: total runtime grows by ~30-60min
+#   (CISA + MITRE no longer overlap with OTX/NVD), but those small
+#   collectors complete in <1min combined, so the real cost is OTX+NVD
+#   no longer overlapping (~3h+5h = 8h vs. previous max(3h, 5h) = 5h).
+#
+# **Order rationale:** small collectors first (cisa ~14s, mitre ~28s)
+# so we get a fast signal if the chain has any problem (auth issue,
+# MISP completely down) before sinking ~3-5 hours into OTX or NVD.
+#
+# **What this DOES NOT fix:** the per-event-grows-with-size cost on a
+# single oversized event (MISP edit-event loads the entire event for
+# dedup; cost grows linearly with existing attribute count). That's the
+# architectural fix tracked separately — event partitioning by date
+# range so no single event exceeds ~20K attributes.
+#
+# Tier2 stays parallel: those 6 feeds are individually tiny (<5K attrs
+# each), don't trigger the failure-mode-2 oversized-event problem, and
+# their parallel write pressure on MISP is negligible vs tier1's heavies.
 with TaskGroup("tier1_core", dag=baseline_dag, default_args={"trigger_rule": TriggerRule.ALL_DONE}) as baseline_tier1:
     bl_otx = PythonOperator(
         task_id="collect_otx",
@@ -2149,6 +2193,12 @@ with TaskGroup("tier1_core", dag=baseline_dag, default_args={"trigger_rule": Tri
         execution_timeout=timedelta(hours=2),
         dag=baseline_dag,
     )
+
+    # PR-F4: sequential dependency chain inside the TaskGroup.
+    # cisa (~14s) → mitre (~28s) → otx (~3h) → nvd (~5h). Small ones
+    # first for fast failure signal; heavies serialized to halve the
+    # MISP write concurrency that triggered the 14.7% NVD loss.
+    bl_cisa >> bl_mitre >> bl_otx >> bl_nvd
 
 # Tier 2 — Reputation & bulk feeds (parallel after Tier 1).
 # ALL_DONE: Tier 1 tasks have no data dependency on each other; OTX (or NVD) failure must not
@@ -2294,9 +2344,11 @@ baseline_complete = BashOperator(
 # ─────────────────────────────────────────────────────────────────────────────
 
 
-# Dependency chain (PR-C audit fix Cross-Checker HIGH H3):
+# Dependency chain (PR-C audit fix Cross-Checker HIGH H3,
+# updated PR-F4 — tier1 is now sequential, see TaskGroup comment above):
 # health → clean (no-op unless fresh_baseline=true conf) → start → tier1
-# (parallel) → tier2 (parallel) → full_sync → build_rels → enrich → done
+# (cisa→mitre→otx→nvd serial) → tier2 (parallel) → full_sync → build_rels
+# → enrich → done
 (
     baseline_misp_health
     >> baseline_clean_task

--- a/docs/AIRFLOW_DAGS.md
+++ b/docs/AIRFLOW_DAGS.md
@@ -180,6 +180,14 @@ the `dag_run.conf` JSON when triggered:
 
 **Task chain:** `baseline_misp_health` → `baseline_clean` (no-op or wipe) → `baseline_start` → `tier1_core` → `tier2_extended` → `tier3_low_freq` → `baseline_full_neo4j_sync` → `baseline_build_relationships` → `baseline_enrichment` → `baseline_complete`.
 
+> **Note (PR-F4, 2026-04-20):** the four tier-1 collectors inside
+> `tier1_core` run **sequentially** (`cisa → mitre → otx → nvd`),
+> not in parallel. This was changed after the 2026-04-19 overnight
+> baseline run lost ~14.7% of NVD attributes to MISP HTTP 500s under
+> concurrent-write pressure. See [AIRFLOW_DAG_DESIGN.md § Tier 1 collectors — sequential](AIRFLOW_DAG_DESIGN.md#tier-1-collectors--sequential-pr-f4-2026-04-20)
+> for the full rationale + trade-off (~3h longer wall time, halved
+> MISP write concurrency). Tier 2 stays parallel.
+
 **`baseline_clean` task semantics (introduced in PR-C):**
 
 - Reads `dag_run.conf.fresh_baseline`. Accepts Python `True`, integer `1`, or strings `"true"`/`"True"`/`"1"`/`"yes"`/`"on"` (case- and whitespace-insensitive). Anything else (including the explicit-falsy strings `"false"`/`"0"`) is treated as additive — a typo in the JSON config does NOT trigger destruction.

--- a/docs/AIRFLOW_DAG_DESIGN.md
+++ b/docs/AIRFLOW_DAG_DESIGN.md
@@ -14,7 +14,7 @@ EdgeGuard runs **6 specialized DAGs** — each source group has its own schedule
 │  ┌─────────────────────────────────────────────────────────────────────┐    │
 │  │  edgeguard_baseline  (MANUAL TRIGGER ONLY — run once)               │    │
 │  │  misp_health → baseline_start                                        │    │
-│  │    → tier1 [otx, nvd, cisa, mitre] (parallel, limit=unlimited)      │    │
+│  │    → tier1 cisa → mitre → otx → nvd  (SEQUENTIAL, PR-F4)             │    │
 │  │    → tier2 [abuseipdb, threatfox, urlhaus, cybercure,                │    │
 │  │             feodo, sslbl] (parallel)                                 │    │
 │  │    → full_neo4j_sync → build_relationships                           │    │
@@ -90,6 +90,35 @@ All tasks have explicit `execution_timeout` values to prevent hung workers from 
 _Baseline OTX/NVD, `build_relationships`, and `run_enrichment_jobs` were
 bumped from 3h → 5h in 2026-04 after baseline re-runs on the merged
 #20/#22/#24 scope repeatedly hit the 3h ceiling._
+
+### Tier 1 collectors — sequential (PR-F4, 2026-04-20)
+
+The four tier-1 baseline collectors run **sequentially** inside the
+`tier1_core` TaskGroup, in the order **`cisa → mitre → otx → nvd`**. They
+were originally parallel; the change was made after the 2026-04-19
+overnight 730-day baseline run lost ~14.7% of NVD attributes (13,620 of
+92,620) to MISP HTTP 500 errors caused by PHP-FPM worker exhaustion when
+all four collectors hammered MISP simultaneously (`AppModel.php`
+"Cannot use a scalar value as an array" warnings cascading into 5xx
+responses on edit-event calls).
+
+**Order rationale:** small collectors first (CISA ~14s, MITRE ~28s) so a
+chain-wide failure (auth issue, MISP completely down) surfaces in <1
+minute rather than after sinking ~3-5 hours into OTX/NVD.
+
+**Trade-off:** total tier-1 wall time grows from `max(otx, nvd) ≈ 5h` to
+`cisa + mitre + otx + nvd ≈ 8h`. The ~3h cost buys halved MISP write
+concurrency without any MISP server changes.
+
+**What this DOES NOT fix:** the per-event-grows-with-size cost on a
+single oversized event (MISP `edit-event` loads the entire event for
+dedup; cost grows linearly with existing attribute count). That's an
+architectural fix tracked separately — event partitioning by date range
+so no single event exceeds ~20K attributes.
+
+**Tier 2 stays parallel** — the 6 reputation feeds are individually tiny
+(<5K attrs each), don't trigger the oversized-event failure mode, and
+their parallel write pressure on MISP is negligible compared to OTX/NVD.
 
 ---
 

--- a/docs/AIRFLOW_DAG_DESIGN.md
+++ b/docs/AIRFLOW_DAG_DESIGN.md
@@ -102,9 +102,14 @@ all four collectors hammered MISP simultaneously (`AppModel.php`
 "Cannot use a scalar value as an array" warnings cascading into 5xx
 responses on edit-event calls).
 
-**Order rationale:** small collectors first (CISA ~14s, MITRE ~28s) so a
-chain-wide failure (auth issue, MISP completely down) surfaces in <1
-minute rather than after sinking ~3-5 hours into OTX/NVD.
+**Order rationale:** the order is mostly aesthetic — small-first
+(CISA ~14s, MITRE ~28s) reads more naturally in the Airflow grid view.
+It does **not** give automatic fast-fail: the TaskGroup keeps its
+`trigger_rule = ALL_DONE` (preserved from the parallel design) so a
+single-source API flake doesn't cascade-skip the rest of tier-1 — losing
+1/4 of a baseline is much better than losing all of it. The real value
+of PR-F4 is **halved MISP write concurrency**, which is independent of
+the collector ordering.
 
 **Trade-off:** total tier-1 wall time grows from `max(otx, nvd) ≈ 5h` to
 `cisa + mitre + otx + nvd ≈ 8h`. The ~3h cost buys halved MISP write
@@ -113,8 +118,9 @@ concurrency without any MISP server changes.
 **What this DOES NOT fix:** the per-event-grows-with-size cost on a
 single oversized event (MISP `edit-event` loads the entire event for
 dedup; cost grows linearly with existing attribute count). That's an
-architectural fix tracked separately — event partitioning by date range
-so no single event exceeds ~20K attributes.
+architectural fix tracked separately — see [Issue #61](../../issues/61)
+for event partitioning by date range so no single event exceeds
+~20K attributes.
 
 **Tier 2 stays parallel** — the 6 reputation feeds are individually tiny
 (<5K attrs each), don't trigger the oversized-event failure mode, and

--- a/tests/test_pr_f4_tier1_sequential.py
+++ b/tests/test_pr_f4_tier1_sequential.py
@@ -252,12 +252,21 @@ class TestRationaleIsDiscoverable:
         src = _read_dag_source()
         # The comment block above the final ``baseline_misp_health >> ...``
         # chain must reference PR-F4 and the sequential ordering.
+        #
+        # Bugbot LOW (commit 4dff17c): the previous version computed an
+        # ``end`` variable via ``src.find("(", ...)`` but never used it
+        # — dead code with a magic-number ``idx + 600`` slice instead.
+        # Fixed by anchoring on the actual chain-block start
+        # (``\n(\n    baseline_misp_health``) so the snippet covers the
+        # full comment block but not unrelated downstream content.
         idx = src.find("# Dependency chain")
         assert idx > 0
-        end = src.find("(", idx + len("# Dependency chain"))
-        # The PR reference + ordering note are within ~6 comment lines
-        # of the start of the dependency-chain block.
-        snippet = src[idx : idx + 600]
+        # The chain expression starts with ``(\n    baseline_misp_health``
+        # on its own line, after the comment block. Anchor on that to
+        # bound the snippet honestly (no magic numbers).
+        end = src.find("(\n    baseline_misp_health", idx)
+        assert end > idx, "could not find the end of the dependency-chain comment block"
+        snippet = src[idx:end]
         assert "PR-F4" in snippet, "dependency-chain comment must reference PR-F4"
         assert "sequential" in snippet.lower() or "serial" in snippet.lower(), (
             "dependency-chain comment must call out the sequential ordering"

--- a/tests/test_pr_f4_tier1_sequential.py
+++ b/tests/test_pr_f4_tier1_sequential.py
@@ -1,0 +1,199 @@
+"""
+Regression tests for PR-F4 — tier1_core baseline collectors are sequential.
+
+Background
+----------
+
+The 2026-04-19 overnight 730-day baseline run (manual run started
+~22:47 UTC) lost ~14.7% of NVD attributes (13,620 of 92,620) to MISP
+HTTP 500 errors. Bravo's investigation traced the failure to PHP-FPM
+worker exhaustion in MISP's ``AppModel.php`` under concurrent-write
+load when all four tier-1 collectors hammered MISP simultaneously.
+
+PR-F4 sequences the four tier-1 collectors (CISA → MITRE → OTX → NVD)
+inside the ``tier1_core`` TaskGroup so MISP only ever sees one
+heavy-write source at a time. Order rationale: small collectors first
+(CISA ~14s, MITRE ~28s) so a chain-wide failure surfaces in <1 minute
+rather than after sinking ~3-5 hours into OTX or NVD.
+
+What this DOES NOT fix
+----------------------
+
+The per-event-grows-with-size cost on a single oversized MISP event.
+``edit-event`` loads the entire event for dedup; cost grows linearly
+with existing attribute count. That's an architectural fix tracked
+separately — event partitioning by date range so no single event
+exceeds ~20K attributes.
+
+What these tests pin
+--------------------
+
+  - The four tier-1 task IDs still exist (``collect_cisa``,
+    ``collect_mitre``, ``collect_otx``, ``collect_nvd``)
+  - The dependency edges are present in the SOURCE in the right order
+  - Tier-2 stays parallel (no edges added between tier-2 tasks)
+  - The DAG-level dependency-chain comment + module docstring still
+    reference the new ordering (so future readers don't re-introduce
+    the parallel pattern by accident)
+
+These tests are SOURCE-PINS rather than runtime-loaded DAG inspections
+on purpose — the runtime path requires importing Airflow at test time,
+which is heavier than necessary to pin a one-line dependency contract.
+The matching ``test_baseline_dag_timeouts.py`` already does the same
+pattern for execution_timeout assertions.
+"""
+
+from __future__ import annotations
+
+import re
+
+DAG_PATH = "dags/edgeguard_pipeline.py"
+
+
+def _read_dag_source() -> str:
+    with open(DAG_PATH) as fh:
+        return fh.read()
+
+
+def _tier1_block(src: str) -> str:
+    """Extract just the ``tier1_core`` TaskGroup body (from the
+    ``with TaskGroup(...)`` line to the next blank line followed by
+    a top-level ``# Tier 2`` comment)."""
+    start = src.find('with TaskGroup("tier1_core"')
+    assert start > 0, "tier1_core TaskGroup not found in DAG source"
+    end = src.find("# Tier 2", start)
+    assert end > start, "could not find tier2 boundary after tier1_core"
+    return src[start:end]
+
+
+# ---------------------------------------------------------------------------
+# Sequential dependency chain inside tier1_core
+# ---------------------------------------------------------------------------
+
+
+class TestTier1SequentialChain:
+    def test_all_four_tier1_collectors_still_defined(self):
+        """The four collector task IDs MUST still exist — the change
+        is only in their dependency edges, not their identities."""
+        block = _tier1_block(_read_dag_source())
+        for task_id in ("collect_cisa", "collect_mitre", "collect_otx", "collect_nvd"):
+            assert f'task_id="{task_id}"' in block, f"tier1_core lost the {task_id} task"
+
+    def test_sequential_chain_present_in_source(self):
+        """The dependency chain ``cisa >> mitre >> otx >> nvd`` (in that
+        exact order) MUST be present inside the tier1_core TaskGroup.
+
+        We accept either the compact one-liner or a multi-line variant
+        with extra whitespace — the contract is the directional ordering.
+        """
+        block = _tier1_block(_read_dag_source())
+        # Normalize whitespace so the regex matches both the one-liner
+        # and any future multi-line variants.
+        normalized = re.sub(r"\s+", " ", block)
+        assert re.search(
+            r"bl_cisa\s*>>\s*bl_mitre\s*>>\s*bl_otx\s*>>\s*bl_nvd",
+            normalized,
+        ), "PR-F4 contract: tier1 collectors must be chained cisa >> mitre >> otx >> nvd inside tier1_core"
+
+    def test_no_unintended_parallel_chains_remain(self):
+        """Defensive: no ``[bl_otx, bl_nvd, ...]`` list-form parallel
+        spec should be left over (would create a hidden parallel edge
+        that contradicts the sequential chain)."""
+        block = _tier1_block(_read_dag_source())
+        # Look for any list-of-bl_* expression that would represent
+        # parallel scheduling (e.g. ``[bl_otx, bl_nvd] >> ...`` or
+        # ``... >> [bl_otx, bl_nvd]``)
+        list_form = re.findall(r"\[\s*bl_(?:otx|nvd|cisa|mitre)[^\]]*\]", block)
+        assert not list_form, (
+            f"found leftover parallel-list form for tier1 collectors: {list_form!r} — "
+            "PR-F4 requires the chain form (cisa >> mitre >> otx >> nvd)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 stays parallel (defensive — make sure we didn't accidentally
+# serialize tier2 too)
+# ---------------------------------------------------------------------------
+
+
+class TestTier2StaysParallel:
+    """Bravo's analysis: tier2 feeds (~6 collectors, each <5K attrs) are
+    individually tiny and don't trigger the oversized-event failure mode.
+    Their parallel write pressure on MISP is negligible. Keep them parallel."""
+
+    def test_no_sequential_chain_among_tier2_tasks(self):
+        src = _read_dag_source()
+        start = src.find('with TaskGroup(\n    "tier2_feeds"')
+        if start < 0:
+            # Tolerate the one-line variant
+            start = src.find('with TaskGroup("tier2_feeds"')
+        assert start > 0, "tier2_feeds TaskGroup not found"
+        end = src.find("baseline_full_sync_task", start)
+        assert end > start
+        block = src[start:end]
+        # The 6 tier2 task IDs MUST exist.
+        for task_id in (
+            "collect_abuseipdb",
+            "collect_threatfox",
+            "collect_urlhaus",
+            "collect_cybercure",
+            "collect_feodo",
+            "collect_sslblacklist",
+        ):
+            assert f'task_id="{task_id}"' in block, f"tier2_feeds lost {task_id}"
+        # No ``bl_<tier2> >> bl_<tier2>`` chain edges expected.
+        normalized = re.sub(r"\s+", " ", block)
+        chain = re.search(
+            r"bl_(?:abuseipdb|threatfox|urlhaus|cybercure|feodo|sslblacklist)"
+            r"\s*>>\s*"
+            r"bl_(?:abuseipdb|threatfox|urlhaus|cybercure|feodo|sslblacklist)",
+            normalized,
+        )
+        assert chain is None, (
+            f"tier2 feeds should remain parallel; found a sequential edge: {chain.group(0)!r}. "
+            "PR-F4 sequenced tier1 only — tier2 stays parallel per the design."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Comment + docstring traceability — keep the rationale discoverable so
+# the next maintainer doesn't re-introduce parallel scheduling thinking
+# "why isn't this parallel?"
+# ---------------------------------------------------------------------------
+
+
+class TestRationaleIsDiscoverable:
+    def test_dependency_chain_comment_mentions_pr_f4(self):
+        """The top-of-DAG dependency-chain comment must mention PR-F4
+        and the new ordering so the next reader doesn't have to git-blame."""
+        src = _read_dag_source()
+        # The comment block above the final ``baseline_misp_health >> ...``
+        # chain must reference PR-F4 and the sequential ordering.
+        idx = src.find("# Dependency chain")
+        assert idx > 0
+        end = src.find("(", idx + len("# Dependency chain"))
+        # The PR reference + ordering note are within ~6 comment lines
+        # of the start of the dependency-chain block.
+        snippet = src[idx : idx + 600]
+        assert "PR-F4" in snippet, "dependency-chain comment must reference PR-F4"
+        assert "sequential" in snippet.lower() or "serial" in snippet.lower(), (
+            "dependency-chain comment must call out the sequential ordering"
+        )
+
+    def test_tier1_taskgroup_comment_explains_why(self):
+        """The TaskGroup itself must carry a comment explaining the
+        14.7% NVD-loss observation, so future readers see WHY the
+        sequencing exists before they consider 'optimizing' it back
+        to parallel."""
+        src = _read_dag_source()
+        block_idx = src.find('with TaskGroup("tier1_core"')
+        assert block_idx > 0
+        # Look at the ~2KB block ABOVE the TaskGroup line (inline comment)
+        preceding = src[max(0, block_idx - 2500) : block_idx]
+        assert "PR-F4" in preceding, "tier1_core needs a PR-F4 comment block above it"
+        # The rationale should mention the actual incident metric so
+        # future readers understand the cost of regressing this.
+        assert "14.7" in preceding or "13,620" in preceding or "MISP" in preceding, (
+            "tier1_core comment must reference the underlying MISP-write-pressure "
+            "incident (the 14.7% NVD loss / PHP-FPM worker exhaustion)"
+        )

--- a/tests/test_pr_f4_tier1_sequential.py
+++ b/tests/test_pr_f4_tier1_sequential.py
@@ -12,9 +12,19 @@ load when all four tier-1 collectors hammered MISP simultaneously.
 
 PR-F4 sequences the four tier-1 collectors (CISA → MITRE → OTX → NVD)
 inside the ``tier1_core`` TaskGroup so MISP only ever sees one
-heavy-write source at a time. Order rationale: small collectors first
-(CISA ~14s, MITRE ~28s) so a chain-wide failure surfaces in <1 minute
-rather than after sinking ~3-5 hours into OTX or NVD.
+heavy-write source at a time. The order is mostly aesthetic; the real
+value is halved MISP write concurrency. The TaskGroup keeps its
+``trigger_rule=ALL_DONE`` (preserved from the parallel design) so a
+single-source API flake doesn't cascade-skip the rest of tier-1 —
+losing 1/4 of a baseline is much better than losing all of it.
+
+Bugbot Medium-severity finding on commit 8403511 caught an earlier
+version of this docstring + the DAG comment block claiming the
+sequential chain gave automatic fast-fail behavior. That was wrong:
+ALL_DONE means downstream tasks run regardless of upstream
+success/failure. The misleading "fast failure signal before sinking
+3-5 hours into OTX/NVD" claim has been removed; the order is now
+documented honestly as aesthetic.
 
 What this DOES NOT fix
 ----------------------
@@ -152,6 +162,79 @@ class TestTier2StaysParallel:
         assert chain is None, (
             f"tier2 feeds should remain parallel; found a sequential edge: {chain.group(0)!r}. "
             "PR-F4 sequenced tier1 only — tier2 stays parallel per the design."
+        )
+
+
+# ---------------------------------------------------------------------------
+# ALL_DONE trigger rule preserved (Bugbot Medium on commit 8403511)
+# ---------------------------------------------------------------------------
+
+
+class TestAllDoneTriggerRulePreserved:
+    """Bugbot Medium-severity finding on PR-F4 commit 8403511: an earlier
+    version of the comment block claimed sequential ordering gave us a
+    "fast failure signal" — but the TaskGroup ``trigger_rule=ALL_DONE``
+    means downstream tasks run regardless of upstream success/failure,
+    defeating that claim.
+
+    The fix: keep ALL_DONE (multi-source resilience — a CISA-API flake
+    must NOT cascade-skip MITRE/OTX/NVD), drop the misleading fast-fail
+    claim, and pin the trigger rule + its rationale so the next reader
+    doesn't quietly switch to ALL_SUCCESS thinking it's an upgrade.
+    """
+
+    def test_tier1_taskgroup_uses_all_done_trigger_rule(self):
+        """The TaskGroup ``default_args`` MUST set
+        ``trigger_rule=TriggerRule.ALL_DONE`` — switching to ALL_SUCCESS
+        would cascade-skip downstream collectors on any single-source
+        API flake (CISA flake → MITRE/OTX/NVD all skipped). That's a
+        regression in multi-source resilience."""
+        src = _read_dag_source()
+        # Find the tier1_core TaskGroup constructor line.
+        m = re.search(
+            r'with TaskGroup\("tier1_core",[^)]*default_args\s*=\s*\{([^}]*)\}',
+            src,
+        )
+        assert m is not None, "could not locate tier1_core TaskGroup default_args"
+        default_args_blob = m.group(1)
+        assert "TriggerRule.ALL_DONE" in default_args_blob, (
+            "tier1_core default_args MUST set trigger_rule=TriggerRule.ALL_DONE — "
+            "ALL_SUCCESS would cascade-skip downstream collectors on single-source flakes"
+        )
+
+    def test_taskgroup_comment_explains_why_all_done_is_preserved(self):
+        """The TaskGroup comment block MUST explain WHY ALL_DONE is
+        preserved (multi-source resilience), so a future maintainer
+        doesn't quietly 'fix' it to ALL_SUCCESS thinking the sequential
+        chain implies fast-fail semantics."""
+        src = _read_dag_source()
+        block_idx = src.find('with TaskGroup("tier1_core"')
+        assert block_idx > 0
+        preceding = src[max(0, block_idx - 3000) : block_idx]
+        assert "ALL_DONE" in preceding, "tier1_core comment must explain the preserved ALL_DONE trigger rule"
+        assert "ALL_SUCCESS" in preceding, (
+            "tier1_core comment must explicitly warn against switching to ALL_SUCCESS "
+            "(the 'do not change without explicit discussion' clause)"
+        )
+        # Multi-source resilience is the rationale — must be discoverable.
+        assert "different external API" in preceding.lower() or "multi-source" in preceding.lower(), (
+            "tier1_core comment must surface the multi-source-resilience rationale for keeping ALL_DONE"
+        )
+
+    def test_no_overclaiming_fast_failure_signal_in_comments(self):
+        """Defensive: the misleading claim from the original PR-F4
+        comment ("fast failure signal before sinking 3-5 hours into
+        OTX or NVD") was inaccurate given ALL_DONE — downstream tasks
+        run anyway. Make sure that exact phrasing doesn't creep back in
+        on a future doc edit. (We allow the word "fast" in other contexts;
+        the specific anti-pattern is claiming the SEQUENTIAL CHAIN gives
+        automatic fast-fail.)"""
+        src = _read_dag_source()
+        # The exact phrase Bugbot flagged — pin against literal regression.
+        assert "before sinking ~3-5 hours" not in src, (
+            "removed by Bugbot fix on PR-F4 — the ALL_DONE trigger rule means "
+            "downstream tasks run regardless of upstream failure, so the chain "
+            "does NOT short-circuit on early-task failure"
         )
 
 


### PR DESCRIPTION
## Summary

Sequences the four tier-1 baseline collectors inside the `tier1_core` TaskGroup (`cisa → mitre → otx → nvd`) instead of running them in parallel. This halves the concurrent-writer count hitting MISP at any given moment, addressing the **14.7% NVD-attribute loss** observed during the 2026-04-19 overnight 730-day baseline run.

## Why

Bravo's investigation of the overnight run found:
- **13,620 of 92,620 NVD attributes lost** to MISP HTTP 500 errors
- Root cause: PHP-FPM worker exhaustion in MISP's `AppModel.php` under concurrent-write load
- Symptom: `Cannot use a scalar value as an array` warnings cascading into 5xx on `edit-event` calls
- Existing chunking (`EDGEGUARD_MISP_PUSH_BATCH_SIZE=500`, `EDGEGUARD_MISP_BATCH_THROTTLE_SEC=5.0`) bounds per-request size and inter-batch pacing — but neither addresses concurrent writers, and neither addresses the per-event-grows-with-size cost on a single oversized event

Sequencing tier1 cuts simultaneous writers from 4 → 1 without any MISP server changes (the upstream `harvarditsecurity/misp` image is fragile and not under our control).

## Order rationale

**Small collectors first** (CISA ~14s, MITRE ~28s) so a chain-wide failure (auth issue, MISP completely down) surfaces in <1 minute rather than after sinking ~3-5 hours into OTX or NVD.

## Trade-off

| | Before (parallel) | After (sequential) |
|---|---|---|
| Tier-1 wall time | `max(otx, nvd) ≈ 5h` | `cisa + mitre + otx + nvd ≈ 8h` |
| MISP concurrent writers | 4 | 1 |
| Expected NVD loss rate | ~14.7% (observed) | TBD — should drop substantially |

Updated the `baseline_dag.dagrun_timeout` comment to reflect the new worst-case math (~26h realistic, ~31h with one retry; still under the 32h cap with ~1-6h headroom).

## What this DOES NOT fix

The **per-event-grows-with-size cost** on a single oversized MISP event. `edit-event` loads the entire event for dedup; cost grows linearly with existing attribute count. That's an architectural fix tracked separately — event partitioning by date range so no single event exceeds ~20K attributes (follow-up issue forthcoming).

**Tier 2 stays parallel** — the 6 reputation feeds are individually tiny (<5K attrs each), don't trigger the oversized-event failure mode, and parallel write pressure on MISP is negligible vs tier1's heavies.

## Files

| File | Change |
|---|---|
| `dags/edgeguard_pipeline.py` | Sequential chain inside `tier1_core` TaskGroup + comment block + dependency-chain comment update + dagrun_timeout-comment refresh |
| `docs/AIRFLOW_DAG_DESIGN.md` | ASCII-art update + new "Tier 1 collectors — sequential" section with full rationale |
| `docs/AIRFLOW_DAGS.md` | Note in baseline-task-chain section cross-linking the design doc |
| `tests/test_pr_f4_tier1_sequential.py` | **new** — 6 source-pin regression tests |

## Test plan

- [x] All 4 tier-1 task IDs preserved (`collect_cisa`, `collect_mitre`, `collect_otx`, `collect_nvd`)
- [x] Sequential chain `cisa >> mitre >> otx >> nvd` present in DAG source
- [x] No leftover parallel list-form (`[bl_otx, bl_nvd, ...]`)
- [x] Tier 2 stays parallel (no `bl_<tier2> >> bl_<tier2>` edges)
- [x] Top-of-DAG dependency-chain comment references PR-F4 + sequential
- [x] `tier1_core` TaskGroup carries an inline comment explaining the 14.7% NVD-loss incident (so future readers see WHY before "optimizing" back to parallel)
- [x] `ruff format --check src/ dags/ tests/` ✓
- [x] `ruff check src/ dags/ tests/` ✓
- [x] `mypy src/ scripts/ --ignore-missing-imports` (CI's exact command) ✓
- [x] `pytest tests/` — **830 passed, 3 skipped, 0 failures** (was 824 — 6 new tests added)

## Follow-ups (will be filed as separate issues after merge)

1. **Event partitioning for large sources** — the architectural fix for the per-event-size problem this PR doesn't solve
2. **Per-batch failure visibility / metric** — surface "MISP push success rate" so future X% silent loss isn't invisible
3. **Resumable NVD pagination** — don't restart from window 0 on `IncompleteRead`

## Related

- PR #56 (PR-F2) + PR #59 (PR-F3) — backup-gate work
- Issue #57 — Airflow-aware lock primitive (de-scoped from PR-F2)
- Bravo's investigation — Slack thread 2026-04-20 01:09 UTC and 8:18 AM update

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Airflow dependency scheduling for the baseline run, increasing wall-clock runtime and potentially affecting operational expectations; logic is straightforward but impacts a long-running, production-critical DAG.
> 
> **Overview**
> Makes the `edgeguard_baseline` DAG run tier-1 collectors **sequentially** (`cisa → mitre → otx → nvd`) instead of in parallel, while explicitly preserving `trigger_rule=ALL_DONE` so single-source API flakes don’t cascade-skip other tier-1 sources.
> 
> Updates baseline runtime/timeout rationale and operator docs to reflect the new sequencing and expected longer wall time, and adds source-pin regression tests to ensure tier-1 ordering stays serialized and tier-2 collectors remain parallel.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 390c358b2273b5571974ec23117af9e8327ccac6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->