### PR TITLE
feat(safety): PR-F6 — parent-DAG liveness check (orphan-process safeguard, Issue #65)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -292,6 +292,27 @@ AIRFLOW_CONN_NEO4J_DEFAULT=
 # from memory pressure / transient 5xx before re-issuing the fetch. Default 15.0.
 # EDGEGUARD_MISP_RETRY_COOLDOWN_SEC=15.0
 
+# PR-F6 (Issue #65): parent-DAG liveness check — orphan-process safeguard
+# ─────────────────────────────────────────────────────────────────────────────
+# When a baseline DAG run is marked failed (e.g., one tier-1 collector fails),
+# Airflow does NOT auto-kill in-flight tasks of the same run. Without this
+# safeguard, a long-running ``collect_nvd`` subprocess can keep pushing to MISP
+# for hours after the DAG was marked dead — the exact failure mode that produced
+# Event 19 + 72K-CVE duplication on 2026-04-19. The safeguard polls the Airflow
+# REST API between MISP push batches and exits the collector cleanly when the
+# parent dag_run is no longer in 'running' or 'queued' state.
+#
+# Master switch (default: true). Set to false ONLY for direct CLI runs that
+# bypass Airflow OR for offline testing where Airflow API isn't reachable.
+# EDGEGUARD_PARENT_DAG_LIVENESS_CHECK=true
+#
+# Minimum seconds between actual API probes (default 60). The callback is
+# called every batch (every ~5s due to MISP throttle), but the API is only
+# probed once per interval to avoid hammering Airflow with thousands of calls
+# per hour. Lower this for faster orphan detection (cost: more API calls);
+# raise it to reduce Airflow API load on tight clusters.
+# EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC=60
+
 # Cross-process baseline mutex — prevents a manual `edgeguard baseline` run from
 # racing the scheduled incremental DAG. Both honor the same sentinel file.
 # Default: checkpoints/baseline_in_progress.lock under EDGEGUARD_BASE_DIR.

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1933,7 +1933,40 @@ def run_baseline_collector(collector_name: str, collector_class, context=None, *
     from collectors.misp_writer import MISPWriter
 
     limit, baseline_days = get_baseline_config(context=context)
-    writer = MISPWriter()
+
+    # PR-F6 (Issue #65, orphan-process safeguard): install a parent-DAG
+    # liveness callback so the collector exits cleanly if its parent
+    # dag_run is marked failed mid-flight. Without this, a
+    # ``collect_nvd`` subprocess from a failed run can keep pushing to
+    # MISP for hours after Airflow has marked the run dead — the exact
+    # failure mode that produced Event 19 / 72K-CVE duplication on
+    # 2026-04-19. Callback is None when the env flag
+    # EDGEGUARD_PARENT_DAG_LIVENESS_CHECK is disabled OR when context
+    # doesn't carry dag_id/run_id (e.g., direct CLI invocation
+    # bypassing Airflow) — in either case, push_items behaves as
+    # before. See ``src/parent_dag_liveness.py`` for the full design.
+    liveness_cb = None
+    try:
+        from parent_dag_liveness import make_liveness_callback
+
+        dag_id_for_check = ""
+        run_id_for_check = ""
+        if context:
+            dag_obj = context.get("dag")
+            run_obj = context.get("dag_run")
+            if dag_obj is not None:
+                dag_id_for_check = getattr(dag_obj, "dag_id", "") or ""
+            if run_obj is not None:
+                run_id_for_check = getattr(run_obj, "run_id", "") or ""
+        liveness_cb = make_liveness_callback(dag_id_for_check, run_id_for_check)
+    except ImportError as e:
+        logger.warning(
+            "[BASELINE] parent_dag_liveness import failed (%s) — orphan-process safeguard "
+            "INACTIVE for this run. Failed-DAG cleanup falls back to manual `edgeguard dag kill`.",
+            e,
+        )
+
+    writer = MISPWriter(liveness_callback=liveness_cb)
     logger.info(f"[BASELINE] Starting {collector_name} — limit={limit or 'unlimited'}, baseline_days={baseline_days}")
 
     return run_collector_with_metrics(

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -835,6 +835,58 @@ def run_collector_with_metrics(
         # Already logged and metrics updated above (collector success=false path).
         raise
     except Exception as e:
+        # PR-F6 follow-up (Bugbot Medium on commit 5f1f44d): the
+        # orphan-process safeguard's clean-exit signal
+        # (``AbortedByDagFailureException``) MUST NOT be classified
+        # as catastrophic by the generic handler below — that would
+        # emit a ``[CRITICAL] HARD-FAILED`` Slack alert + bump
+        # ``pipeline_errors_total``, the OPPOSITE of "clean exit".
+        # Caught here at the same level as AirflowException so the
+        # orchestration short-circuits BEFORE the transient /
+        # catastrophic split runs.
+        #
+        # Lazy import to avoid creating a hard dependency at module
+        # load time — the parent_dag_liveness module is loaded lazily
+        # inside run_baseline_collector for the same reason.
+        try:
+            from parent_dag_liveness import AbortedByDagFailureException
+        except ImportError:
+            AbortedByDagFailureException = None  # type: ignore[assignment,misc]
+
+        if AbortedByDagFailureException is not None and isinstance(e, AbortedByDagFailureException):
+            duration = time.time() - start_time
+            from collectors.collector_utils import make_skipped_optional_source
+
+            logger.info(
+                "[%s] Aborted by parent-DAG safeguard (state=%r) after %.2fs: %s. "
+                "Clean exit between batches per PR-F6 design — no half-write to MISP/Neo4j. "
+                "Treating as task-success-skipped so downstream tier-1 collectors "
+                "are not blocked by ALL_DONE; the parent DAG run is already terminal "
+                "regardless.",
+                collector_name,
+                e.state,
+                duration,
+                e,
+            )
+            if METRICS_SERVER_AVAILABLE:
+                try:
+                    record_collection(collector_name, "global", 0, "skipped")
+                except Exception as me:  # noqa: BLE001
+                    logger.debug(f"metric emit failed (parent_dag_aborted skip): {me}")
+                try:
+                    record_collection_duration(collector_name, "global", duration)
+                except Exception as me:  # noqa: BLE001
+                    logger.debug(f"metric emit failed (parent_dag_aborted duration): {me}")
+                try:
+                    record_collector_skip(collector_name, "parent_dag_aborted")
+                except Exception as me:  # noqa: BLE001
+                    logger.debug(f"metric emit failed (parent_dag_aborted skip-reason): {me}")
+            return make_skipped_optional_source(
+                collector_name,
+                skip_reason=f"parent dag_run state={e.state!r} — orphan-process safeguard aborted cleanly (PR-F6)",
+                skip_reason_class="parent_dag_aborted",
+            )
+
         # PR #35: distinguish TRANSIENT external errors (network, upstream
         # 5xx, DNS, SSL handshake, timeout) from CATASTROPHIC bugs
         # (TypeError, ImportError, programming mistakes). The user policy

--- a/docs/AIRFLOW_DAG_DESIGN.md
+++ b/docs/AIRFLOW_DAG_DESIGN.md
@@ -126,6 +126,59 @@ for event partitioning by date range so no single event exceeds
 (<5K attrs each), don't trigger the oversized-event failure mode, and
 their parallel write pressure on MISP is negligible compared to OTX/NVD.
 
+### Parent-DAG liveness check (PR-F6, Issue #65, 2026-04-20)
+
+The four tier-1 baseline collectors install a **parent-DAG liveness
+callback** that polls the Airflow REST API between MISP push batches
+and exits cleanly if the parent `dag_run` is no longer in `running`
+or `queued` state. This closes the **orphan-collector-process gap**
+that produced Event 19 + 72,479-CVE duplication on 2026-04-19:
+
+> A failed `edgeguard_baseline` DAG run kept its `collect_nvd` Python
+> subprocess alive for 12+ hours after Airflow marked the run failed.
+> The orphan eventually pushed 78,313 attributes to MISP **after** the
+> next manual run's `baseline_clean` had already wiped MISP.
+
+**Root cause**: when a DAG run is marked `failed` (because *another*
+task in the same run failed), Airflow does NOT auto-kill in-flight
+tasks of that run. The collector keeps running in its worker
+subprocess until it finishes naturally or hits its 5h timeout.
+
+**The fix**: between MISP push batches (already throttled 5s by
+`EDGEGUARD_MISP_BATCH_THROTTLE_SEC`), the collector calls a callback
+that probes the Airflow REST API (rate-limited to one probe per
+60s). If the parent `dag_run` is in any terminal state, the callback
+raises `AbortedByDagFailureException` — the **current batch finishes**
+its write to MISP cleanly, the **next batch never starts**.
+
+**Trade-offs**:
+- ✅ Clean exit between batches → no half-written MISP events
+- ✅ Fail-OPEN → transient Airflow API blip doesn't false-kill the collector
+- ✅ Per-collector opt-in via `EDGEGUARD_PARENT_DAG_LIVENESS_CHECK` (default `true` for baseline)
+- ✅ Low overhead (~1 small HTTP call per minute)
+- ⚠️ Up to 60s lag between DAG-marked-failed and collector-noticing (configurable via `EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC`)
+
+**Operator visibility**: when the safeguard fires, you'll see this in the collector log:
+
+```
+WARNING [PARENT_DAG_DEAD] dag_run=edgeguard_baseline/manual__2026-04-19T22:46:59
+        observed state='failed' — aborting collector cleanly. Orphan-process
+        safeguard (PR-F6) prevented late writes to MISP/Neo4j.
+```
+
+Grep `PARENT_DAG_DEAD` in your DAG logs to find every aborted-by-parent-failure
+event. If you see it firing on healthy runs, your Airflow API is unreachable
+from the collector worker (check `AIRFLOW_WEBSERVER_URL` env).
+
+**What this DOES NOT do**: the safeguard runs collector-side, so it
+can't help if the collector itself is wedged (e.g., blocked in a
+syscall, in a non-MISP loop). For those cases, the existing
+`execution_timeout` per task remains the backstop. Combine the two
+for defense-in-depth.
+
+See [`src/parent_dag_liveness.py`](../src/parent_dag_liveness.py) for
+the full module documentation.
+
 ---
 
 ## Baseline DAG — How to Use

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -17,7 +17,7 @@ import time
 from contextlib import contextmanager
 from datetime import datetime, timezone
 from functools import wraps
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 import requests
 import urllib3
@@ -290,7 +290,13 @@ class MISPWriter:
     # but does not change behavior for any existing input.
     SOURCE_TAGS = source_registry.source_to_misp_tag_map()
 
-    def __init__(self, url: str = None, api_key: str = None, verify_ssl: bool = None):
+    def __init__(
+        self,
+        url: str = None,
+        api_key: str = None,
+        verify_ssl: bool = None,
+        liveness_callback: Optional[Callable[[], None]] = None,
+    ):
         """
         Initialize MISP writer.
 
@@ -298,6 +304,13 @@ class MISPWriter:
             url: MISP instance URL (defaults to config.MISP_URL)
             api_key: MISP API key (defaults to config.MISP_API_KEY)
             verify_ssl: Whether to verify SSL certificates (defaults to config.SSL_VERIFY)
+            liveness_callback: PR-F6 (Issue #65) — optional zero-arg callable
+                invoked between MISP push batches. Should raise
+                ``AbortedByDagFailureException`` (or any exception) to
+                signal the collector to abort cleanly. Used for the
+                parent-DAG-liveness orphan-process safeguard. ``None``
+                (default) preserves legacy behavior — push_items runs
+                to completion regardless of parent-DAG state.
         """
         self.url = url or MISP_URL
         self.api_key = api_key or MISP_API_KEY
@@ -327,6 +340,10 @@ class MISPWriter:
             "errors": 0,
             "attrs_skipped_existing": 0,
         }
+        # PR-F6 (Issue #65): per-batch parent-DAG liveness callback.
+        # ``None`` = no check (legacy / incremental DAGs); a callable
+        # = check before each batch. See src/parent_dag_liveness.py.
+        self.liveness_callback = liveness_callback
 
     def _restsearch_events_for_name(self, event_name: str) -> List[Any]:
         """Call ``/events/restSearch``; returns the ``response`` list (may need exact-info filtering)."""
@@ -1306,6 +1323,30 @@ class MISPWriter:
                 # Throttle between batches (skip only the very first batch of the first event)
                 if (i > 0 or processed_batches > 0) and batch_throttle > 0:
                     time.sleep(batch_throttle)
+
+                # PR-F6 (Issue #65): parent-DAG liveness check BEFORE the
+                # next push. If the parent dag_run has been marked failed
+                # (e.g., a sibling task failed), the callback raises
+                # ``AbortedByDagFailureException`` to exit the collector
+                # cleanly between batches — no half-written events. The
+                # callback is rate-limited internally (default 60s
+                # between actual API probes), so calling it every batch
+                # is cheap. ``None`` (the default) preserves legacy
+                # behavior — push_items runs to completion regardless.
+                # Re-raises ANY exception from the callback so callers
+                # can distinguish parent-DAG-died from other failures.
+                #
+                # ``getattr`` (not ``self.``) is deliberate: existing tests
+                # construct MISPWriter via ``__new__`` to bypass __init__
+                # for test-isolation reasons (see
+                # tests/test_incremental_dedup.py). The new
+                # ``liveness_callback`` attribute would otherwise be
+                # missing on those instances and crash push_items. The
+                # defensive ``getattr`` keeps the legacy test pattern
+                # working without requiring every test to opt-in.
+                liveness_cb = getattr(self, "liveness_callback", None)
+                if liveness_cb is not None:
+                    liveness_cb()
 
                 # Progress logging
                 processed_batches += 1

--- a/src/parent_dag_liveness.py
+++ b/src/parent_dag_liveness.py
@@ -1,0 +1,301 @@
+"""
+EdgeGuard — Parent-DAG liveness check (PR-F6, Issue #65)
+=========================================================
+
+Closes the **orphan collector process** gap surfaced by Bravo's
+2026-04-19 / 2026-04-20 baseline investigation. Recap:
+
+  - A failed ``edgeguard_baseline`` DAG run kept its ``collect_nvd``
+    Python subprocess alive for 12+ hours after Airflow marked the
+    run failed.
+  - The orphan eventually pushed 78,313 attributes to MISP **after**
+    the next manual run's ``baseline_clean`` had already wiped MISP.
+  - Root cause: when a DAG run is marked ``failed`` (because *another*
+    task failed), Airflow does NOT auto-kill in-flight tasks of the
+    same run. The collector kept running in its worker subprocess
+    until it finished naturally.
+
+Design
+------
+
+This module provides a **collector-side liveness check** — the
+collector polls the Airflow REST API between MISP push batches and
+exits cleanly if its parent ``dag_run`` is no longer in a runnable
+state. The check fires from inside ``MISPWriter.push_items`` (which
+already throttles 5s between batches), so the per-batch overhead is
+one small HTTP call + zero added latency.
+
+Why this shape (vs. the alternatives considered in Issue #65):
+
+  - **Clean exit between batches** — the current batch finishes its
+    write to MISP; the NEXT batch never starts. No half-written events.
+  - **Fail-OPEN** — if the Airflow API is briefly unavailable, the
+    check returns "alive" rather than aggressively killing the
+    collector on a transient blip. The orphan window is bounded by
+    the collector's own ``execution_timeout`` regardless.
+  - **Per-collector opt-in** — controlled by
+    ``EDGEGUARD_PARENT_DAG_LIVENESS_CHECK`` (default ``true`` for
+    baseline; collectors choose whether to install the callback).
+  - **No Airflow internals plumbing** — uses the public REST API the
+    rest of EdgeGuard already depends on (``src/airflow_client.py``).
+
+Public API
+----------
+
+  - :class:`AbortedByDagFailureException` — raised by the callback
+    when the parent dag_run is no longer runnable. Catchable by
+    callers that want to log + clean up before re-raising.
+  - :func:`is_dag_run_alive(dag_id, run_id)` — pure probe; returns
+    ``True`` when the run is in ``running`` or ``queued`` state,
+    ``False`` for terminal states (``success``, ``failed``,
+    ``upstream_failed``, ``skipped``, ``removed``). Fail-OPEN: returns
+    ``True`` on any probe error so transient API blips don't false-kill.
+  - :func:`make_liveness_callback(dag_id, run_id, *, throttle_sec)` —
+    returns a closure ``() -> None`` that raises
+    ``AbortedByDagFailureException`` if the parent is dead. Suitable
+    as ``MISPWriter.push_items``' per-batch ``liveness_callback``.
+    Internally rate-limits to ``throttle_sec`` between actual API
+    calls (default 60s) so high-frequency batch pushes don't hammer
+    the Airflow API.
+
+Env flags
+---------
+
+  - ``EDGEGUARD_PARENT_DAG_LIVENESS_CHECK`` (default ``true``) —
+    master switch. When ``false``, ``make_liveness_callback`` returns
+    ``None`` and the collector never polls.
+  - ``EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC`` (default ``60``) —
+    minimum time between actual API calls. The callback is still
+    *called* every batch, but only *probes* once per interval.
+
+See also
+--------
+
+  - ``src/collectors/misp_writer.py`` — calls the callback between batches
+  - ``dags/edgeguard_pipeline.py:run_baseline_collector`` — installs
+    the callback for the 4 tier-1 baseline collectors
+  - ``docs/AIRFLOW_DAG_DESIGN.md`` § "Parent-DAG liveness check" — operator-facing doc
+  - Issue #65 — the original design discussion
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+# DAG run states that mean "still runnable, keep going". Anything else
+# (success, failed, upstream_failed, skipped, removed, ...) is a signal
+# to abort. Per Airflow REST API docs:
+# https://airflow.apache.org/docs/apache-airflow/stable/rest-api-ref.html#operation/get_dag_runs
+_ALIVE_STATES = frozenset({"running", "queued"})
+
+# Default rate-limit for actual API calls. The callback is called every
+# batch (every ~5s due to MISPWriter throttle), but probing every 5s
+# would generate ~720 API calls per hour-long collector run. 60s is the
+# right balance: catches an orphan within ~1 minute of its parent DAG
+# dying, doesn't hammer the API.
+_DEFAULT_THROTTLE_SEC = 60.0
+
+# Env flags
+_ENV_ENABLED = "EDGEGUARD_PARENT_DAG_LIVENESS_CHECK"
+_ENV_THROTTLE = "EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC"
+
+
+# ---------------------------------------------------------------------------
+# Exception
+# ---------------------------------------------------------------------------
+
+
+class AbortedByDagFailureException(Exception):
+    """Raised by the per-batch liveness callback when the parent
+    ``dag_run`` is no longer in a runnable state.
+
+    Distinct exception type so callers (collectors, tests) can
+    distinguish "parent DAG died, exit cleanly" from "MISP write
+    actually failed, retry/fail loud". Carries the dag_id, run_id,
+    and observed state for the structured log line.
+    """
+
+    def __init__(self, dag_id: str, run_id: str, state: Optional[str]):
+        self.dag_id = dag_id
+        self.run_id = run_id
+        self.state = state
+        super().__init__(
+            f"Parent dag_run {dag_id}/{run_id} is no longer runnable "
+            f"(observed state: {state!r}); aborting collector cleanly. "
+            "This is the PR-F6 orphan-process safeguard — see "
+            "docs/AIRFLOW_DAG_DESIGN.md § 'Parent-DAG liveness check'."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_enabled() -> bool:
+    """Return True when the liveness check is enabled by env flag.
+
+    Default is ON — operators must explicitly set the flag to ``false``
+    to disable. This is the safe default: if you forget to opt in, you
+    get protected anyway.
+    """
+    raw = os.environ.get(_ENV_ENABLED, "true").strip().lower()
+    return raw in {"1", "true", "yes", "on"}
+
+
+def _throttle_seconds() -> float:
+    """Return the configured throttle interval (seconds between actual
+    API calls). Default 60s. Invalid values fall back to default."""
+    raw = os.environ.get(_ENV_THROTTLE, "").strip()
+    if not raw:
+        return _DEFAULT_THROTTLE_SEC
+    try:
+        val = float(raw)
+        if val < 0:
+            return _DEFAULT_THROTTLE_SEC
+        return val
+    except (ValueError, TypeError):
+        logger.warning("Ignoring invalid %s=%r; using default %ss", _ENV_THROTTLE, raw, _DEFAULT_THROTTLE_SEC)
+        return _DEFAULT_THROTTLE_SEC
+
+
+def is_dag_run_alive(dag_id: str, run_id: str) -> bool:
+    """Probe the Airflow REST API: is ``dag_id/run_id`` still in a
+    runnable state (``running`` or ``queued``)?
+
+    Returns
+    -------
+    True
+        Run is in ``running`` or ``queued`` state, OR the probe failed
+        (fail-OPEN — a transient API blip should NOT cause us to
+        false-kill an in-flight collector).
+    False
+        Run is in a terminal state (``success``, ``failed``,
+        ``upstream_failed``, etc.) per the Airflow API response.
+
+    Notes
+    -----
+    Imports ``airflow_client._get`` lazily to avoid a hard dependency at
+    module-import time (the parent_dag_liveness module is loaded by
+    collectors that may not have ``requests`` installed in some test
+    environments).
+    """
+    if not dag_id or not run_id:
+        # Defensive: can't probe without identifiers. Fail-OPEN.
+        return True
+    try:
+        from airflow_client import _get  # lazy
+    except ImportError as e:
+        logger.debug("airflow_client not importable (%s) — fail-OPEN", e)
+        return True
+    try:
+        result = _get(f"/dags/{dag_id}/dagRuns/{run_id}")
+    except Exception as e:
+        # Belt-and-suspenders: _get already catches everything and
+        # returns ``{"error": ...}``, but defend against future changes
+        # to its contract. Fail-OPEN on any unexpected exception.
+        logger.debug("Liveness probe raised unexpectedly (%s) — fail-OPEN", e)
+        return True
+    if "error" in result:
+        # API unreachable / 4xx / 5xx — fail-OPEN.
+        logger.debug("Liveness probe API error: %s — fail-OPEN", result.get("error"))
+        return True
+    state = result.get("state")
+    return state in _ALIVE_STATES
+
+
+def make_liveness_callback(
+    dag_id: str,
+    run_id: str,
+    *,
+    throttle_sec: Optional[float] = None,
+) -> Optional[Callable[[], None]]:
+    """Build a per-batch callback that raises
+    :class:`AbortedByDagFailureException` when the parent dag_run is
+    no longer runnable.
+
+    Returns ``None`` when the env flag
+    ``EDGEGUARD_PARENT_DAG_LIVENESS_CHECK`` is disabled OR when
+    ``dag_id`` / ``run_id`` are empty — in either case the caller
+    should skip installing a callback and behave as before.
+
+    The returned callback rate-limits its actual API probes to one
+    per ``throttle_sec`` (default 60s). Calling the callback at a
+    higher frequency is cheap (a single ``time.monotonic()`` check).
+
+    Parameters
+    ----------
+    dag_id
+        The Airflow DAG ID (e.g., ``"edgeguard_baseline"``).
+    run_id
+        The Airflow dag_run ID (e.g., ``"manual__2026-04-19T22:46:59"``).
+    throttle_sec
+        Minimum seconds between real API probes. Defaults to the
+        ``EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC`` env value (default 60).
+    """
+    if not _is_enabled():
+        logger.info(
+            "Parent-DAG liveness check DISABLED (%s != true) — orphan-process safeguard inactive.",
+            _ENV_ENABLED,
+        )
+        return None
+    if not dag_id or not run_id:
+        logger.info(
+            "Parent-DAG liveness check skipped (no dag_id/run_id available); "
+            "orphan-process safeguard not installed for this collector run."
+        )
+        return None
+
+    throttle = throttle_sec if throttle_sec is not None else _throttle_seconds()
+    logger.info(
+        "Parent-DAG liveness check ENABLED for dag_run=%s/%s (throttle=%.1fs).",
+        dag_id,
+        run_id,
+        throttle,
+    )
+
+    # Closure state — separate variables (single-element lists) so mypy
+    # can keep distinct types per slot. ``time.monotonic`` is the right
+    # clock here (immune to wall-clock jumps from NTP / DST).
+    last_probe_at: list[float] = [0.0]
+
+    def _callback() -> None:
+        now = time.monotonic()
+        if now - last_probe_at[0] < throttle:
+            return  # within rate limit, skip
+        last_probe_at[0] = now
+        if is_dag_run_alive(dag_id, run_id):
+            return
+        # Probe came back as terminal — fetch the actual state for the
+        # exception message. is_dag_run_alive returned False, so the
+        # API call succeeded AND the state is not in _ALIVE_STATES.
+        # Re-fetch defensively (cheap; happens once per run, on death).
+        observed_state: Optional[str] = None
+        try:
+            from airflow_client import _get  # lazy
+
+            result = _get(f"/dags/{dag_id}/dagRuns/{run_id}")
+            if isinstance(result, dict) and "error" not in result:
+                observed_state = result.get("state")
+        except Exception:
+            pass
+        logger.warning(
+            "[PARENT_DAG_DEAD] dag_run=%s/%s observed state=%r — aborting collector cleanly. "
+            "Orphan-process safeguard (PR-F6) prevented late writes to MISP/Neo4j.",
+            dag_id,
+            run_id,
+            observed_state,
+        )
+        raise AbortedByDagFailureException(dag_id, run_id, observed_state)
+
+    return _callback

--- a/src/parent_dag_liveness.py
+++ b/src/parent_dag_liveness.py
@@ -169,9 +169,73 @@ def _throttle_seconds() -> float:
         return _DEFAULT_THROTTLE_SEC
 
 
+def _probe_dag_run_state(dag_id: str, run_id: str) -> Optional[str]:
+    """Return the raw Airflow ``dag_run`` state string, or ``None`` on
+    any probe failure.
+
+    Bugbot LOW (PR-F6 commit 2159292): the previous design called
+    Airflow twice on parent-death (once via ``is_dag_run_alive`` for the
+    bool, once again from the callback for the message text). That
+    doubled the API load on death detection AND introduced a TOCTOU
+    gap — if state flipped between the two calls, the exception's
+    ``observed_state`` could contradict the trigger. Refactored: a
+    single probe returns the state, both ``is_dag_run_alive`` and the
+    callback consume that one result.
+
+    Returns
+    -------
+    str
+        The raw state from Airflow (e.g., ``"running"``, ``"queued"``,
+        ``"success"``, ``"failed"``, ``"upstream_failed"``).
+    None
+        Probe failed for any reason (missing identifiers, API
+        unreachable, non-dict response, error envelope from
+        ``airflow_client._get``, unexpected exception). Callers MUST
+        treat ``None`` as fail-OPEN — a transient API blip should NOT
+        false-kill an in-flight collector.
+
+    Notes
+    -----
+    Imports ``airflow_client._get`` lazily to avoid a hard dependency at
+    module-import time (the parent_dag_liveness module is loaded by
+    collectors that may not have ``requests`` installed in some test
+    environments).
+    """
+    if not dag_id or not run_id:
+        # Defensive: can't probe without identifiers. Treat as
+        # fail-OPEN at the caller (return None signals "unknown").
+        return None
+    try:
+        from airflow_client import _get  # lazy
+    except ImportError as e:
+        logger.debug("airflow_client not importable (%s) — probe returns None", e)
+        return None
+    try:
+        result = _get(f"/dags/{dag_id}/dagRuns/{run_id}")
+    except Exception as e:
+        # Belt-and-suspenders: _get already catches everything and
+        # returns ``{"error": ...}``, but defend against future changes
+        # to its contract.
+        logger.debug("Liveness probe raised unexpectedly (%s) — probe returns None", e)
+        return None
+    if not isinstance(result, dict):
+        logger.debug("Liveness probe non-dict response (%r) — probe returns None", type(result))
+        return None
+    if "error" in result:
+        # API unreachable / 4xx / 5xx
+        logger.debug("Liveness probe API error: %s — probe returns None", result.get("error"))
+        return None
+    state = result.get("state")
+    return str(state) if state else None
+
+
 def is_dag_run_alive(dag_id: str, run_id: str) -> bool:
     """Probe the Airflow REST API: is ``dag_id/run_id`` still in a
     runnable state (``running`` or ``queued``)?
+
+    Thin wrapper around :func:`_probe_dag_run_state` that collapses
+    the state string to a bool. Fail-OPEN preserved (``None`` from
+    the probe → ``True`` here).
 
     Returns
     -------
@@ -182,35 +246,10 @@ def is_dag_run_alive(dag_id: str, run_id: str) -> bool:
     False
         Run is in a terminal state (``success``, ``failed``,
         ``upstream_failed``, etc.) per the Airflow API response.
-
-    Notes
-    -----
-    Imports ``airflow_client._get`` lazily to avoid a hard dependency at
-    module-import time (the parent_dag_liveness module is loaded by
-    collectors that may not have ``requests`` installed in some test
-    environments).
     """
-    if not dag_id or not run_id:
-        # Defensive: can't probe without identifiers. Fail-OPEN.
-        return True
-    try:
-        from airflow_client import _get  # lazy
-    except ImportError as e:
-        logger.debug("airflow_client not importable (%s) — fail-OPEN", e)
-        return True
-    try:
-        result = _get(f"/dags/{dag_id}/dagRuns/{run_id}")
-    except Exception as e:
-        # Belt-and-suspenders: _get already catches everything and
-        # returns ``{"error": ...}``, but defend against future changes
-        # to its contract. Fail-OPEN on any unexpected exception.
-        logger.debug("Liveness probe raised unexpectedly (%s) — fail-OPEN", e)
-        return True
-    if "error" in result:
-        # API unreachable / 4xx / 5xx — fail-OPEN.
-        logger.debug("Liveness probe API error: %s — fail-OPEN", result.get("error"))
-        return True
-    state = result.get("state")
+    state = _probe_dag_run_state(dag_id, run_id)
+    if state is None:
+        return True  # fail-OPEN
     return state in _ALIVE_STATES
 
 
@@ -264,38 +303,45 @@ def make_liveness_callback(
         throttle,
     )
 
-    # Closure state — separate variables (single-element lists) so mypy
-    # can keep distinct types per slot. ``time.monotonic`` is the right
-    # clock here (immune to wall-clock jumps from NTP / DST).
-    last_probe_at: list[float] = [0.0]
+    # Closure state — ``time.monotonic`` is the right clock here
+    # (immune to wall-clock jumps from NTP / DST). Initialize to
+    # ``-inf`` so the FIRST callback invocation always probes
+    # regardless of system uptime.
+    #
+    # Bugbot LOW (PR-F6 commit 2159292): the previous initializer
+    # ``0.0`` interacted badly with ``time.monotonic()`` returning
+    # seconds-since-boot on Linux. On a freshly-booted host where
+    # uptime < throttle (default 60s), ``now - 0.0 < throttle`` was
+    # ``True`` so the FIRST probe was silently skipped — leaving the
+    # safeguard inactive during early system uptime. ``-inf`` makes
+    # the first probe always fire.
+    last_probe_at: list[float] = [float("-inf")]
 
     def _callback() -> None:
         now = time.monotonic()
         if now - last_probe_at[0] < throttle:
             return  # within rate limit, skip
         last_probe_at[0] = now
-        if is_dag_run_alive(dag_id, run_id):
+        # Single probe — get the raw state once. Bugbot LOW
+        # (PR-F6 commit 2159292): the previous design called Airflow
+        # twice on death (is_dag_run_alive for the bool, then again
+        # for the message text), doubling API load AND introducing
+        # a TOCTOU gap. Now we consume one probe result for both
+        # the alive/dead decision and the exception's state field.
+        state = _probe_dag_run_state(dag_id, run_id)
+        if state is None:
+            # Fail-OPEN — transient API blip, assume alive
             return
-        # Probe came back as terminal — fetch the actual state for the
-        # exception message. is_dag_run_alive returned False, so the
-        # API call succeeded AND the state is not in _ALIVE_STATES.
-        # Re-fetch defensively (cheap; happens once per run, on death).
-        observed_state: Optional[str] = None
-        try:
-            from airflow_client import _get  # lazy
-
-            result = _get(f"/dags/{dag_id}/dagRuns/{run_id}")
-            if isinstance(result, dict) and "error" not in result:
-                observed_state = result.get("state")
-        except Exception:
-            pass
+        if state in _ALIVE_STATES:
+            return  # alive
+        # Confirmed terminal state — abort the collector cleanly
         logger.warning(
             "[PARENT_DAG_DEAD] dag_run=%s/%s observed state=%r — aborting collector cleanly. "
             "Orphan-process safeguard (PR-F6) prevented late writes to MISP/Neo4j.",
             dag_id,
             run_id,
-            observed_state,
+            state,
         )
-        raise AbortedByDagFailureException(dag_id, run_id, observed_state)
+        raise AbortedByDagFailureException(dag_id, run_id, state)
 
     return _callback

--- a/src/parent_dag_liveness.py
+++ b/src/parent_dag_liveness.py
@@ -45,11 +45,6 @@ Public API
   - :class:`AbortedByDagFailureException` — raised by the callback
     when the parent dag_run is no longer runnable. Catchable by
     callers that want to log + clean up before re-raising.
-  - :func:`is_dag_run_alive(dag_id, run_id)` — pure probe; returns
-    ``True`` when the run is in ``running`` or ``queued`` state,
-    ``False`` for terminal states (``success``, ``failed``,
-    ``upstream_failed``, ``skipped``, ``removed``). Fail-OPEN: returns
-    ``True`` on any probe error so transient API blips don't false-kill.
   - :func:`make_liveness_callback(dag_id, run_id, *, throttle_sec)` —
     returns a closure ``() -> None`` that raises
     ``AbortedByDagFailureException`` if the parent is dead. Suitable
@@ -229,28 +224,13 @@ def _probe_dag_run_state(dag_id: str, run_id: str) -> Optional[str]:
     return str(state) if state else None
 
 
-def is_dag_run_alive(dag_id: str, run_id: str) -> bool:
-    """Probe the Airflow REST API: is ``dag_id/run_id`` still in a
-    runnable state (``running`` or ``queued``)?
-
-    Thin wrapper around :func:`_probe_dag_run_state` that collapses
-    the state string to a bool. Fail-OPEN preserved (``None`` from
-    the probe → ``True`` here).
-
-    Returns
-    -------
-    True
-        Run is in ``running`` or ``queued`` state, OR the probe failed
-        (fail-OPEN — a transient API blip should NOT cause us to
-        false-kill an in-flight collector).
-    False
-        Run is in a terminal state (``success``, ``failed``,
-        ``upstream_failed``, etc.) per the Airflow API response.
-    """
-    state = _probe_dag_run_state(dag_id, run_id)
-    if state is None:
-        return True  # fail-OPEN
-    return state in _ALIVE_STATES
+# Bugbot LOW (PR-F6 commit 5f1f44d): the public ``is_dag_run_alive``
+# bool wrapper was removed — it had no production callers after the
+# single-probe refactor (the callback uses ``_probe_dag_run_state``
+# directly to get the raw state string for the exception). External
+# consumers wanting a bool can still call ``_probe_dag_run_state``
+# and check ``state in _ALIVE_STATES`` themselves; per YAGNI we don't
+# carry a speculative public API.
 
 
 def make_liveness_callback(

--- a/tests/test_pr_f6_parent_dag_liveness.py
+++ b/tests/test_pr_f6_parent_dag_liveness.py
@@ -1,0 +1,442 @@
+"""
+Regression tests for PR-F6 — parent-DAG liveness check (Issue #65).
+
+Background
+----------
+
+Bravo's 2026-04-19 / 2026-04-20 baseline investigation surfaced the
+**deepest production-readiness gap** uncovered to date: a failed
+``edgeguard_baseline`` DAG run kept its ``collect_nvd`` Python
+subprocess alive for 12+ hours after Airflow marked the run failed.
+The orphan eventually pushed 78,313 attributes to MISP **after** the
+next manual run's ``baseline_clean`` had wiped MISP. This was the
+root cause of Event 19 + the 72,479-CVE duplication.
+
+PR-F6 closes the gap with a **collector-side liveness check**: the
+collector polls the Airflow REST API between MISP push batches and
+exits cleanly if its parent ``dag_run`` is no longer in a runnable
+state. Fail-OPEN on probe errors so transient API blips don't
+false-kill in-flight collectors.
+
+What these tests pin
+--------------------
+
+  - ``is_dag_run_alive`` returns True for ``running``/``queued``,
+    False for terminal states, True (fail-OPEN) on any probe error
+  - ``make_liveness_callback`` returns None when disabled by env flag
+    OR when dag_id/run_id are empty (degrades gracefully)
+  - The returned callback raises ``AbortedByDagFailureException`` when
+    the parent is dead
+  - The callback is rate-limited (throttle window) so high-frequency
+    batch pushes don't hammer the Airflow API
+  - ``MISPWriter.push_items`` calls the callback between batches
+  - Source-pin: ``run_baseline_collector`` installs the callback
+    from the Airflow context
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, "src")
+sys.path.insert(0, "dags")
+
+
+# ---------------------------------------------------------------------------
+# is_dag_run_alive — the API probe
+# ---------------------------------------------------------------------------
+
+
+class TestIsDagRunAlive:
+    """The pure probe: True for runnable states, False for terminal,
+    True (fail-OPEN) on any error."""
+
+    def test_running_state_is_alive(self):
+        from parent_dag_liveness import is_dag_run_alive
+
+        with patch("airflow_client._get", return_value={"state": "running"}):
+            assert is_dag_run_alive("dag_x", "run_y") is True
+
+    def test_queued_state_is_alive(self):
+        from parent_dag_liveness import is_dag_run_alive
+
+        with patch("airflow_client._get", return_value={"state": "queued"}):
+            assert is_dag_run_alive("dag_x", "run_y") is True
+
+    @pytest.mark.parametrize(
+        "terminal_state",
+        ["success", "failed", "upstream_failed", "skipped", "removed", "shutdown", "no_status"],
+    )
+    def test_terminal_states_are_dead(self, terminal_state):
+        """Anything not in {running, queued} is treated as dead. Be
+        deliberately conservative — Airflow's state vocabulary may
+        grow; we'd rather mis-classify a new state as dead than as
+        alive (a false-dead just exits cleanly; a false-alive is the
+        original bug we're fixing)."""
+        from parent_dag_liveness import is_dag_run_alive
+
+        with patch("airflow_client._get", return_value={"state": terminal_state}):
+            assert is_dag_run_alive("dag_x", "run_y") is False, f"state {terminal_state!r} should be considered dead"
+
+    def test_api_error_is_fail_open(self):
+        """Bravo's 2026-04-19 incident: the collector ran for 12h after
+        DAG death. We want orphan detection — but a transient Airflow
+        API blip should NOT cause us to false-kill an actively-running
+        collector. Fail-OPEN: probe failure → assume alive."""
+        from parent_dag_liveness import is_dag_run_alive
+
+        with patch("airflow_client._get", return_value={"error": "Cannot connect to Airflow"}):
+            assert is_dag_run_alive("dag_x", "run_y") is True
+
+    def test_api_exception_is_fail_open(self):
+        """Even if airflow_client._get itself raises (defensive: its
+        contract is to never raise, but defend against future changes)."""
+        from parent_dag_liveness import is_dag_run_alive
+
+        with patch("airflow_client._get", side_effect=RuntimeError("unexpected")):
+            assert is_dag_run_alive("dag_x", "run_y") is True
+
+    def test_empty_dag_id_or_run_id_is_fail_open(self):
+        """Degrade gracefully when the caller can't supply identifiers
+        (e.g., direct CLI invocation outside Airflow). No probe should
+        be made; return True so the legacy path keeps working."""
+        from parent_dag_liveness import is_dag_run_alive
+
+        # Should not even attempt the probe
+        with patch("airflow_client._get", side_effect=AssertionError("should not be called")):
+            assert is_dag_run_alive("", "run_y") is True
+            assert is_dag_run_alive("dag_x", "") is True
+            assert is_dag_run_alive("", "") is True
+
+
+# ---------------------------------------------------------------------------
+# make_liveness_callback — the closure factory
+# ---------------------------------------------------------------------------
+
+
+class TestMakeLivenessCallback:
+    def test_returns_none_when_disabled_by_env(self, monkeypatch):
+        """The master switch ``EDGEGUARD_PARENT_DAG_LIVENESS_CHECK=false``
+        must completely disable the callback (returns None). Used for
+        offline tests + direct CLI runs that bypass Airflow."""
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "false")
+        assert make_liveness_callback("dag_x", "run_y") is None
+
+    def test_returns_none_when_dag_id_or_run_id_empty(self, monkeypatch):
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        assert make_liveness_callback("", "run_y") is None
+        assert make_liveness_callback("dag_x", "") is None
+
+    def test_returns_callable_when_enabled(self, monkeypatch):
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        cb = make_liveness_callback("dag_x", "run_y")
+        assert cb is not None
+        assert callable(cb)
+
+    def test_default_enabled_when_env_unset(self, monkeypatch):
+        """Safe default: ON. If you forget to set the env var, you get
+        protected anyway. Operators must explicitly disable."""
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.delenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", raising=False)
+        assert make_liveness_callback("dag_x", "run_y") is not None
+
+    def test_callback_is_noop_when_parent_alive(self, monkeypatch):
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        # Throttle 0 so the probe fires on first call
+        cb = make_liveness_callback("dag_x", "run_y", throttle_sec=0)
+        with patch("airflow_client._get", return_value={"state": "running"}):
+            cb()  # must not raise
+
+    def test_callback_raises_when_parent_dead(self, monkeypatch, caplog):
+        """The whole point: when the parent DAG is dead, the callback
+        raises ``AbortedByDagFailureException`` so the caller exits
+        cleanly between batches."""
+        from parent_dag_liveness import AbortedByDagFailureException, make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        cb = make_liveness_callback("dag_x", "run_y", throttle_sec=0)
+
+        with (
+            patch("airflow_client._get", return_value={"state": "failed"}),
+            caplog.at_level(logging.WARNING),
+        ):
+            with pytest.raises(AbortedByDagFailureException) as excinfo:
+                cb()
+
+        assert excinfo.value.dag_id == "dag_x"
+        assert excinfo.value.run_id == "run_y"
+        assert excinfo.value.state == "failed"
+        # Operator-facing log line MUST carry the grep marker
+        msg = " ".join(r.message for r in caplog.records if r.levelno >= logging.WARNING)
+        assert "[PARENT_DAG_DEAD]" in msg
+        assert "dag_x" in msg and "run_y" in msg
+
+    def test_callback_throttles_actual_api_calls(self, monkeypatch):
+        """The callback is called every batch (every ~5s), but the
+        actual API probe must respect the throttle interval. Pin this
+        contract — without it, a fast collector would generate
+        thousands of API calls per hour."""
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        # 60-second throttle
+        cb = make_liveness_callback("dag_x", "run_y", throttle_sec=60)
+
+        call_count = {"n": 0}
+
+        def fake_get(*args, **kwargs):
+            call_count["n"] += 1
+            return {"state": "running"}
+
+        with patch("airflow_client._get", side_effect=fake_get):
+            # Fire the callback 100 times in quick succession
+            for _ in range(100):
+                cb()
+
+        # First call probes; subsequent calls within the 60s window do not.
+        assert call_count["n"] == 1, f"expected 1 actual probe in the throttle window; got {call_count['n']}"
+
+    def test_callback_re_probes_after_throttle_expires(self, monkeypatch):
+        """After the throttle interval elapses, the next callback call
+        triggers a fresh probe. Use throttle_sec=0 + monotonic mock to
+        simulate elapsed time deterministically."""
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        cb = make_liveness_callback("dag_x", "run_y", throttle_sec=0)
+
+        call_count = {"n": 0}
+
+        def fake_get(*args, **kwargs):
+            call_count["n"] += 1
+            return {"state": "running"}
+
+        with patch("airflow_client._get", side_effect=fake_get):
+            cb()
+            cb()
+            cb()
+
+        # throttle=0 means every call probes
+        assert call_count["n"] == 3
+
+
+# ---------------------------------------------------------------------------
+# AbortedByDagFailureException — message structure
+# ---------------------------------------------------------------------------
+
+
+class TestExceptionMessage:
+    def test_exception_carries_diagnostic_fields(self):
+        from parent_dag_liveness import AbortedByDagFailureException
+
+        exc = AbortedByDagFailureException("d", "r", "failed")
+        assert exc.dag_id == "d"
+        assert exc.run_id == "r"
+        assert exc.state == "failed"
+        # Operator-facing message must reference the design doc so
+        # an operator who hits this in a log can find the rationale
+        assert "AIRFLOW_DAG_DESIGN.md" in str(exc)
+        assert "PR-F6" in str(exc)
+
+
+# ---------------------------------------------------------------------------
+# MISPWriter integration — the callback fires between batches
+# ---------------------------------------------------------------------------
+
+
+class TestMISPWriterCallbackIntegration:
+    """``MISPWriter.push_items`` MUST invoke the liveness callback
+    before each batch. We test by injecting a fake callback that
+    raises after batch N, then asserting that exactly N batches
+    completed (no half-write of batch N+1)."""
+
+    def test_callback_invoked_between_batches_and_raises_exit(self):
+        """Pin the contract: callback is called inside the batch loop
+        and any exception propagates out cleanly. Source-pin only —
+        runtime test of MISPWriter requires MISP fixtures we don't
+        want to set up here."""
+        with open("src/collectors/misp_writer.py") as fh:
+            src = fh.read()
+        # The push_items batch loop MUST invoke the liveness callback
+        # (accept either ``self.liveness_callback`` direct or the
+        # defensive ``getattr(self, "liveness_callback", ...)`` form
+        # — see test_push_items_uses_defensive_getattr_for_callback
+        # below for why we prefer getattr).
+        idx = src.find("def push_items(")
+        assert idx > 0
+        end = src.find("\n    def ", idx + 1)
+        body = src[idx:end]
+        assert "liveness_callback" in body, "push_items must invoke the liveness_callback inside the batch loop"
+        # The marker comment must mention PR-F6 / Issue #65 for
+        # discoverability — future readers see WHY
+        assert "PR-F6" in body or "Issue #65" in body, (
+            "push_items batch loop must reference PR-F6 / Issue #65 in a comment"
+        )
+
+    def test_push_items_uses_defensive_getattr_for_callback(self):
+        """Pin the defensive ``getattr`` (not ``self.``) access pattern.
+
+        ``tests/test_incremental_dedup.py`` constructs MISPWriter via
+        ``MISPWriter.__new__(MISPWriter)`` to bypass __init__ for
+        test-isolation. Without ``getattr``'s default-None fallback,
+        push_items crashes with AttributeError on those instances.
+        This test pins that we don't quietly regress to
+        ``self.liveness_callback`` and re-break the legacy pattern.
+        """
+        with open("src/collectors/misp_writer.py") as fh:
+            src = fh.read()
+        idx = src.find("def push_items(")
+        assert idx > 0
+        end = src.find("\n    def ", idx + 1)
+        body = src[idx:end]
+        assert 'getattr(self, "liveness_callback"' in body, (
+            "push_items must use ``getattr(self, 'liveness_callback', None)`` so "
+            "instances created via ``MISPWriter.__new__`` (test-isolation "
+            "pattern in test_incremental_dedup.py) don't crash on missing attribute"
+        )
+
+    def test_misp_writer_constructor_accepts_liveness_callback(self):
+        """Source-pin: the constructor MUST take the optional kwarg.
+        Without it, callers can't install the callback and the safeguard
+        is structurally impossible."""
+        with open("src/collectors/misp_writer.py") as fh:
+            src = fh.read()
+        idx = src.find("def __init__(")
+        assert idx > 0
+        end = src.find("\n", src.find('"""', idx))
+        # Look at the function signature (first 800 chars)
+        sig = src[idx : idx + 800]
+        assert "liveness_callback" in sig, "MISPWriter.__init__ must accept liveness_callback kwarg"
+
+
+# ---------------------------------------------------------------------------
+# DAG wiring — run_baseline_collector installs the callback
+# ---------------------------------------------------------------------------
+
+
+class TestDagWiring:
+    """``run_baseline_collector`` (the central entry point for the 4
+    tier-1 baseline collectors) MUST construct the callback from the
+    Airflow context and pass it to MISPWriter."""
+
+    def test_run_baseline_collector_constructs_callback_from_context(self):
+        with open("dags/edgeguard_pipeline.py") as fh:
+            src = fh.read()
+        idx = src.find("def run_baseline_collector(")
+        assert idx > 0
+        end = src.find("\ndef ", idx + 1)
+        body = src[idx:end]
+        # Must import the helper
+        assert "from parent_dag_liveness import make_liveness_callback" in body, (
+            "run_baseline_collector must import make_liveness_callback"
+        )
+        # Must read dag_id + run_id from context
+        assert "context" in body and 'getattr(dag_obj, "dag_id"' in body, "must pull dag_id from the Airflow context"
+        assert 'getattr(run_obj, "run_id"' in body, "must pull run_id from the Airflow context"
+        # Must pass to MISPWriter
+        assert "MISPWriter(liveness_callback=" in body, "must pass the callback into MISPWriter constructor"
+
+    def test_run_baseline_collector_handles_missing_module_gracefully(self):
+        """If parent_dag_liveness is missing (e.g., partial deploy),
+        run_baseline_collector must NOT crash — degrade to legacy
+        behavior with a WARNING log."""
+        with open("dags/edgeguard_pipeline.py") as fh:
+            src = fh.read()
+        idx = src.find("def run_baseline_collector(")
+        assert idx > 0
+        end = src.find("\ndef ", idx + 1)
+        body = src[idx:end]
+        assert "ImportError" in body, (
+            "run_baseline_collector must catch ImportError so a missing "
+            "parent_dag_liveness module doesn't crash the DAG"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Env-flag plumbing
+# ---------------------------------------------------------------------------
+
+
+class TestEnvFlags:
+    @pytest.mark.parametrize("val", ["true", "1", "yes", "on", "TRUE", "True"])
+    def test_enabled_truthy_values(self, monkeypatch, val):
+        from parent_dag_liveness import _is_enabled
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", val)
+        assert _is_enabled() is True
+
+    @pytest.mark.parametrize("val", ["false", "0", "no", "off", "FALSE"])
+    def test_enabled_falsy_values(self, monkeypatch, val):
+        from parent_dag_liveness import _is_enabled
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", val)
+        assert _is_enabled() is False
+
+    def test_enabled_default_is_true(self, monkeypatch):
+        """Safe default — operators must opt OUT, not opt IN."""
+        from parent_dag_liveness import _is_enabled
+
+        monkeypatch.delenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", raising=False)
+        assert _is_enabled() is True
+
+    def test_throttle_default_is_60(self, monkeypatch):
+        from parent_dag_liveness import _throttle_seconds
+
+        monkeypatch.delenv("EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC", raising=False)
+        assert _throttle_seconds() == 60.0
+
+    def test_throttle_respects_env(self, monkeypatch):
+        from parent_dag_liveness import _throttle_seconds
+
+        monkeypatch.setenv("EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC", "30")
+        assert _throttle_seconds() == 30.0
+
+    def test_throttle_falls_back_on_invalid(self, monkeypatch):
+        from parent_dag_liveness import _throttle_seconds
+
+        monkeypatch.setenv("EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC", "not-a-number")
+        assert _throttle_seconds() == 60.0
+
+    def test_throttle_negative_falls_back(self, monkeypatch):
+        from parent_dag_liveness import _throttle_seconds
+
+        monkeypatch.setenv("EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC", "-5")
+        assert _throttle_seconds() == 60.0
+
+
+# ---------------------------------------------------------------------------
+# Documentation traceability
+# ---------------------------------------------------------------------------
+
+
+class TestDocsExist:
+    def test_env_example_documents_both_flags(self):
+        with open(".env.example") as fh:
+            content = fh.read()
+        assert "EDGEGUARD_PARENT_DAG_LIVENESS_CHECK" in content
+        assert "EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC" in content
+        # Operator-facing rationale must reference the incident
+        assert "Issue #65" in content or "PR-F6" in content
+        assert "Event 19" in content or "orphan" in content.lower()
+
+    def test_design_doc_references_pr_f6(self):
+        with open("docs/AIRFLOW_DAG_DESIGN.md") as fh:
+            content = fh.read()
+        assert "PR-F6" in content or "Issue #65" in content, (
+            "AIRFLOW_DAG_DESIGN.md must document the PR-F6 / Issue #65 "
+            "parent-DAG liveness check so operators see WHY collectors "
+            "may exit early on a sibling-task failure"
+        )

--- a/tests/test_pr_f6_parent_dag_liveness.py
+++ b/tests/test_pr_f6_parent_dag_liveness.py
@@ -253,6 +253,108 @@ class TestExceptionMessage:
 
 
 # ---------------------------------------------------------------------------
+# Bugbot LOW fixes (commit 2159292) — pin the regressions so they don't
+# come back: (a) first probe must fire on freshly-booted hosts, (b) the
+# callback must NOT make a redundant second API call on parent-death.
+# ---------------------------------------------------------------------------
+
+
+class TestBugbotLOWRegressions:
+    """Pin the three Bugbot LOW findings on PR-F6 commit 2159292:
+    1. First probe skipped on hosts where time.monotonic() < throttle
+       (boot-time bug — initialize last_probe_at to -inf, not 0.0).
+    2. Silent ``except Exception: pass`` — eliminated by single-probe
+       refactor (no second API call → no second except block to mishandle).
+    3. Redundant API re-fetch on death — eliminated by single-probe
+       refactor; ``_probe_dag_run_state`` returns state once.
+    """
+
+    def test_first_probe_fires_on_freshly_booted_host(self, monkeypatch):
+        """``last_probe_at`` initializer MUST be -inf (or equivalent),
+        not 0.0. On Linux ``time.monotonic()`` returns seconds-since-boot;
+        with init=0.0 and a 60s throttle, the first probe was skipped
+        for the first 60s of system uptime — leaving the safeguard
+        inactive on early boot."""
+        from parent_dag_liveness import make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        # Big throttle so a buggy 0.0 initializer would skip the first probe
+        cb = make_liveness_callback("dag_x", "run_y", throttle_sec=10_000)
+
+        call_count = {"n": 0}
+
+        def fake_get(*args, **kwargs):
+            call_count["n"] += 1
+            return {"state": "running"}
+
+        with patch("airflow_client._get", side_effect=fake_get):
+            cb()  # MUST probe on first call regardless of system uptime
+
+        assert call_count["n"] == 1, (
+            "first callback invocation must always probe (Bugbot LOW: "
+            "init=0.0 + monotonic-since-boot caused first-N-seconds skip)"
+        )
+
+    def test_no_redundant_api_call_on_parent_death(self, monkeypatch):
+        """The pre-fix design called Airflow twice on death: once via
+        ``is_dag_run_alive`` for the bool, then again from the callback
+        to fetch the state for the exception message. The refactor uses
+        a single ``_probe_dag_run_state`` call. Pin one-call-per-death."""
+        from parent_dag_liveness import AbortedByDagFailureException, make_liveness_callback
+
+        monkeypatch.setenv("EDGEGUARD_PARENT_DAG_LIVENESS_CHECK", "true")
+        cb = make_liveness_callback("dag_x", "run_y", throttle_sec=0)
+
+        call_count = {"n": 0}
+
+        def fake_get(*args, **kwargs):
+            call_count["n"] += 1
+            return {"state": "failed"}
+
+        with patch("airflow_client._get", side_effect=fake_get):
+            with pytest.raises(AbortedByDagFailureException) as excinfo:
+                cb()
+
+        # CRITICAL: exactly ONE API call per probe-and-die, not two.
+        # Doubling the API load on every death detection — and the
+        # TOCTOU gap that came with it — was the third Bugbot LOW.
+        assert call_count["n"] == 1, f"callback must make exactly ONE API call per probe-and-die; got {call_count['n']}"
+        # Exception's observed state matches the single-probe result
+        assert excinfo.value.state == "failed"
+
+    def test_probe_dag_run_state_returns_state_string(self, monkeypatch):
+        """``_probe_dag_run_state`` is the new single-probe primitive.
+        Returns the raw state string on success, None on any failure."""
+        from parent_dag_liveness import _probe_dag_run_state
+
+        with patch("airflow_client._get", return_value={"state": "failed"}):
+            assert _probe_dag_run_state("d", "r") == "failed"
+
+        with patch("airflow_client._get", return_value={"state": "running"}):
+            assert _probe_dag_run_state("d", "r") == "running"
+
+    def test_probe_dag_run_state_returns_none_on_failure(self, monkeypatch):
+        """Probe failure → None (callers MUST treat as fail-OPEN)."""
+        from parent_dag_liveness import _probe_dag_run_state
+
+        # Empty identifiers
+        assert _probe_dag_run_state("", "r") is None
+        assert _probe_dag_run_state("d", "") is None
+        # API error envelope
+        with patch("airflow_client._get", return_value={"error": "Cannot connect"}):
+            assert _probe_dag_run_state("d", "r") is None
+        # Unexpected exception
+        with patch("airflow_client._get", side_effect=RuntimeError("boom")):
+            assert _probe_dag_run_state("d", "r") is None
+        # Non-dict response
+        with patch("airflow_client._get", return_value="not-a-dict"):
+            assert _probe_dag_run_state("d", "r") is None
+        # Missing state field
+        with patch("airflow_client._get", return_value={"other": "data"}):
+            assert _probe_dag_run_state("d", "r") is None
+
+
+# ---------------------------------------------------------------------------
 # MISPWriter integration — the callback fires between batches
 # ---------------------------------------------------------------------------
 

--- a/tests/test_pr_f6_parent_dag_liveness.py
+++ b/tests/test_pr_f6_parent_dag_liveness.py
@@ -21,8 +21,8 @@ false-kill in-flight collectors.
 What these tests pin
 --------------------
 
-  - ``is_dag_run_alive`` returns True for ``running``/``queued``,
-    False for terminal states, True (fail-OPEN) on any probe error
+  - ``_probe_dag_run_state`` returns the raw state string on success,
+    None on any probe failure (fail-OPEN — caller treats None as alive)
   - ``make_liveness_callback`` returns None when disabled by env flag
     OR when dag_id/run_id are empty (degrades gracefully)
   - The returned callback raises ``AbortedByDagFailureException`` when
@@ -47,75 +47,12 @@ sys.path.insert(0, "dags")
 
 
 # ---------------------------------------------------------------------------
-# is_dag_run_alive — the API probe
-# ---------------------------------------------------------------------------
-
-
-class TestIsDagRunAlive:
-    """The pure probe: True for runnable states, False for terminal,
-    True (fail-OPEN) on any error."""
-
-    def test_running_state_is_alive(self):
-        from parent_dag_liveness import is_dag_run_alive
-
-        with patch("airflow_client._get", return_value={"state": "running"}):
-            assert is_dag_run_alive("dag_x", "run_y") is True
-
-    def test_queued_state_is_alive(self):
-        from parent_dag_liveness import is_dag_run_alive
-
-        with patch("airflow_client._get", return_value={"state": "queued"}):
-            assert is_dag_run_alive("dag_x", "run_y") is True
-
-    @pytest.mark.parametrize(
-        "terminal_state",
-        ["success", "failed", "upstream_failed", "skipped", "removed", "shutdown", "no_status"],
-    )
-    def test_terminal_states_are_dead(self, terminal_state):
-        """Anything not in {running, queued} is treated as dead. Be
-        deliberately conservative — Airflow's state vocabulary may
-        grow; we'd rather mis-classify a new state as dead than as
-        alive (a false-dead just exits cleanly; a false-alive is the
-        original bug we're fixing)."""
-        from parent_dag_liveness import is_dag_run_alive
-
-        with patch("airflow_client._get", return_value={"state": terminal_state}):
-            assert is_dag_run_alive("dag_x", "run_y") is False, f"state {terminal_state!r} should be considered dead"
-
-    def test_api_error_is_fail_open(self):
-        """Bravo's 2026-04-19 incident: the collector ran for 12h after
-        DAG death. We want orphan detection — but a transient Airflow
-        API blip should NOT cause us to false-kill an actively-running
-        collector. Fail-OPEN: probe failure → assume alive."""
-        from parent_dag_liveness import is_dag_run_alive
-
-        with patch("airflow_client._get", return_value={"error": "Cannot connect to Airflow"}):
-            assert is_dag_run_alive("dag_x", "run_y") is True
-
-    def test_api_exception_is_fail_open(self):
-        """Even if airflow_client._get itself raises (defensive: its
-        contract is to never raise, but defend against future changes)."""
-        from parent_dag_liveness import is_dag_run_alive
-
-        with patch("airflow_client._get", side_effect=RuntimeError("unexpected")):
-            assert is_dag_run_alive("dag_x", "run_y") is True
-
-    def test_empty_dag_id_or_run_id_is_fail_open(self):
-        """Degrade gracefully when the caller can't supply identifiers
-        (e.g., direct CLI invocation outside Airflow). No probe should
-        be made; return True so the legacy path keeps working."""
-        from parent_dag_liveness import is_dag_run_alive
-
-        # Should not even attempt the probe
-        with patch("airflow_client._get", side_effect=AssertionError("should not be called")):
-            assert is_dag_run_alive("", "run_y") is True
-            assert is_dag_run_alive("dag_x", "") is True
-            assert is_dag_run_alive("", "") is True
-
-
-# ---------------------------------------------------------------------------
 # make_liveness_callback — the closure factory
 # ---------------------------------------------------------------------------
+# (The previous TestIsDagRunAlive class was deleted in the Bugbot LOW fix
+# — ``is_dag_run_alive`` had no production callers after the single-probe
+# refactor and was removed per YAGNI. The probe-result matrix is now
+# tested via ``TestBugbotLOWRegressions::test_probe_dag_run_state_*``.)
 
 
 class TestMakeLivenessCallback:
@@ -427,6 +364,83 @@ class TestMISPWriterCallbackIntegration:
 # ---------------------------------------------------------------------------
 # DAG wiring — run_baseline_collector installs the callback
 # ---------------------------------------------------------------------------
+
+
+class TestRunCollectorWithMetricsCleanSkipPath:
+    """Bugbot Medium (PR-F6 commit 5f1f44d): ``AbortedByDagFailureException``
+    must NOT be classified as catastrophic by ``run_collector_with_metrics``.
+
+    Without the fix, the orphan-process safeguard's clean-exit signal
+    propagated into the generic ``except Exception`` handler → emitted
+    a ``[CRITICAL] HARD-FAILED`` Slack alert + bumped
+    ``pipeline_errors_total`` — the OPPOSITE of "clean exit". Operators
+    would see a CRITICAL alert exactly when the safeguard worked correctly.
+
+    Fix: catch the exception at the same level as ``AirflowException``
+    in ``run_collector_with_metrics`` and translate to a clean
+    skipped-source result.
+    """
+
+    def test_run_collector_with_metrics_catches_abort_exception(self):
+        """Source-pin: ``run_collector_with_metrics`` MUST have a
+        dedicated except branch for ``AbortedByDagFailureException``
+        BEFORE the generic ``except Exception`` block — otherwise the
+        catastrophic classification fires."""
+        with open("dags/edgeguard_pipeline.py") as fh:
+            src = fh.read()
+        idx = src.find("def run_collector_with_metrics(")
+        assert idx > 0
+        end = src.find("\ndef ", idx + 1)
+        body = src[idx:end]
+        assert "AbortedByDagFailureException" in body, (
+            "run_collector_with_metrics must reference AbortedByDagFailureException"
+        )
+        # The handling MUST appear BEFORE the generic catastrophic split.
+        # Specifically: the abort must be checked inside the except Exception
+        # handler at the TOP (before the transient/catastrophic split).
+        abort_idx = body.find("AbortedByDagFailureException")
+        catastrophic_idx = body.find("HARD-FAILED")
+        assert abort_idx < catastrophic_idx, (
+            "AbortedByDagFailureException handling must precede the catastrophic alert path"
+        )
+
+    def test_run_collector_with_metrics_returns_skipped_for_abort(self):
+        """The abort branch must return a ``make_skipped_optional_source``
+        result so the Airflow task stays GREEN (no upstream_failed
+        propagation) and downstream tier-1 collectors aren't blocked."""
+        with open("dags/edgeguard_pipeline.py") as fh:
+            src = fh.read()
+        idx = src.find("def run_collector_with_metrics(")
+        assert idx > 0
+        end = src.find("\ndef ", idx + 1)
+        body = src[idx:end]
+        assert "make_skipped_optional_source" in body
+        assert "parent_dag_aborted" in body, (
+            "skip_reason_class must be 'parent_dag_aborted' so operators can grep / "
+            "Prometheus can label the skip reason distinctly from transient_external_error"
+        )
+
+    def test_no_critical_slack_alert_on_abort_path(self):
+        """Defensive: the abort branch MUST NOT call ``send_slack_alert``
+        for the [CRITICAL] HARD-FAILED message. The whole point of the
+        Bugbot fix is to suppress that misleading alert."""
+        with open("dags/edgeguard_pipeline.py") as fh:
+            src = fh.read()
+        idx = src.find("def run_collector_with_metrics(")
+        assert idx > 0
+        end = src.find("\ndef ", idx + 1)
+        body = src[idx:end]
+        # Find the abort handling block
+        abort_branch_start = body.find("AbortedByDagFailureException is not None and isinstance")
+        assert abort_branch_start > 0
+        # The abort branch should end before "PR #35: distinguish TRANSIENT"
+        abort_branch_end = body.find("PR #35: distinguish TRANSIENT", abort_branch_start)
+        assert abort_branch_end > abort_branch_start
+        abort_block = body[abort_branch_start:abort_branch_end]
+        assert "HARD-FAILED" not in abort_block, (
+            "abort branch must NOT emit the [CRITICAL] HARD-FAILED alert — that "
+            "would defeat the entire 'clean exit' design"
+        )
 
 
 class TestDagWiring:


### PR DESCRIPTION
## Summary

Closes the **deepest production-readiness gap** uncovered by Bravo's 2026-04-19 / 2026-04-20 baseline investigation: **orphan collector processes that outlive their failed Airflow DAG runs**.

## The incident this fixes

> A failed `edgeguard_baseline` DAG run kept its `collect_nvd` Python subprocess alive for **12+ hours after Airflow marked the run failed**. The orphan eventually pushed 78,313 attributes to MISP **after** the next manual run's `baseline_clean` had already wiped MISP. This was the root cause of Event 19 + the 72,479-CVE duplication observed in production.

**Root cause** (Airflow architectural): when a DAG run is marked `failed` (because *another* task in the same run failed), Airflow does NOT auto-kill in-flight tasks of that run. The collector keeps running in its worker subprocess until it finishes naturally or hits its 5h `execution_timeout`.

## How PR-F6 fixes it

A **collector-side liveness check** between MISP push batches:

1. Collector starts, gets parent `dag_id` + `run_id` from Airflow context
2. Builds a callback via `make_liveness_callback(dag_id, run_id)`
3. `MISPWriter.push_items` invokes the callback before each batch
4. Callback rate-limits to 1 actual API probe per 60s (cheap)
5. If probe shows parent in any terminal state → raise `AbortedByDagFailureException`
6. Current batch finishes its write to MISP cleanly; **next batch never starts**

Per-call cost: ~1 small HTTP call per minute. Catches orphans within ~1 minute of parent death without hammering the Airflow API.

## Why Option B (vs. A/C/D from Issue #65)

| Property | Option A (SIGTERM) | Option C (lock-file reaper) | **Option B (this PR)** |
|---|---|---|---|
| Half-write risk | High (kills mid-batch) | Medium (race) | **Zero** (clean exit between batches) |
| Airflow process-model dependency | High | Low | **None** |
| Test isolation | Hard | Hard | **Easy** (mock API, fake state) |
| Implementation complexity | High | Medium | **Low** (~250 LOC) |
| Latency to abort | <1s | Up to interval | Up to 60s (configurable) |

## Operator-visibility

When the safeguard fires, the collector log shows:

```
WARNING [PARENT_DAG_DEAD] dag_run=edgeguard_baseline/manual__2026-04-19T22:46:59
        observed state='failed' — aborting collector cleanly. Orphan-process
        safeguard (PR-F6) prevented late writes to MISP/Neo4j.
```

Grep `PARENT_DAG_DEAD` in DAG logs to find every aborted-by-parent-failure event.

## Configuration

| Env var | Default | Purpose |
|---|---|---|
| `EDGEGUARD_PARENT_DAG_LIVENESS_CHECK` | `true` | Master switch (safe default ON; ops must explicitly opt out) |
| `EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC` | `60` | Min seconds between actual API probes |

## What this DOES NOT do

The safeguard runs collector-side, so it can't help if the collector itself is wedged (blocked syscall, non-MISP loop). The existing per-task `execution_timeout` remains the backstop. **Defense-in-depth: combine the two.**

## Files changed

| File | Change |
|---|---|
| `src/parent_dag_liveness.py` | **new** ~250 LOC — `AbortedByDagFailureException`, `is_dag_run_alive`, `make_liveness_callback`, env-flag plumbing |
| `src/collectors/misp_writer.py` | `__init__` accepts `liveness_callback`; `push_items` invokes it before each batch via defensive `getattr` (preserves test-isolation pattern in `test_incremental_dedup.py`) |
| `dags/edgeguard_pipeline.py` | `run_baseline_collector` constructs callback from context; ImportError handled (degrades to legacy on missing module) |
| `.env.example` | Documents both new env flags + incident rationale |
| `docs/AIRFLOW_DAG_DESIGN.md` | New section "Parent-DAG liveness check (PR-F6, Issue #65)" with incident recap, design rationale, trade-offs, operator-visibility |
| `tests/test_pr_f6_parent_dag_liveness.py` | **new** 44 tests covering probe matrix / callback factory matrix / exception contract / MISPWriter integration source-pin / DAG wiring source-pin / env flag matrix / docs traceability |

## Test plan

- [x] Probe matrix: running/queued → alive, all terminal states → dead, API errors → fail-OPEN, missing IDs → fail-OPEN
- [x] Factory matrix: env-disabled → None, missing dag_id/run_id → None, default-on
- [x] Callback raises `AbortedByDagFailureException` with structured fields when parent dies
- [x] Throttle prevents API hammering (100 calls in window → 1 probe)
- [x] Throttle expires correctly (re-probes after interval)
- [x] Exception message references PR-F6 + design doc (operator can find rationale from log)
- [x] `MISPWriter.__init__` accepts `liveness_callback` kwarg (source-pin)
- [x] `push_items` invokes callback inside batch loop (source-pin)
- [x] **Defensive `getattr` pattern pinned** — prevents future regression that would break `test_incremental_dedup.py`'s `__new__` test pattern
- [x] `run_baseline_collector` constructs callback from context (source-pin) + handles ImportError gracefully
- [x] Env flag matrix (true/1/yes/on truthy; false/0/no/off falsy; default true; invalid throttle → 60s fallback)
- [x] Documentation traceability (.env.example + AIRFLOW_DAG_DESIGN.md reference PR-F6)
- [x] `ruff format --check` ✓
- [x] `ruff check` ✓
- [x] `mypy src/ scripts/ --ignore-missing-imports` ✓
- [x] `pytest tests/` — **921 passed, 3 skipped, 0 failures** (was 877 — +44 new tests)

## Related

- Issue #65 — original design discussion (4 options laid out; this PR ships Option B)
- PR #60 (PR-F4) — sequenced tier-1 collectors (concurrent-write fix; surfaced this gap)
- PR #64 (PR-F5) — DAG conf validation + doctor --memory (operator-visibility hardening)
- Issue #61 — MISP event partitioning (the architectural fix for cross-event duplication that orphans contributed to)
- Issue #57 — Airflow-aware baseline lock (companion design issue)
- Bravo's investigation — Slack thread 2026-04-20 11:58 AM (Brussels)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core MISP write loop and Airflow baseline orchestration/exception handling, which could affect ingestion completion semantics if misconfigured. Mitigated by fail-open behavior on API probe failures and explicit opt-out env flags.
> 
> **Overview**
> Adds an orphan-process safeguard for baseline collectors: a new `parent_dag_liveness` module builds a rate-limited callback that polls the Airflow REST API and raises `AbortedByDagFailureException` when the parent `dag_run` leaves `running`/`queued`.
> 
> Wires the callback into baseline runs by passing it from `run_baseline_collector` into `MISPWriter`, which now invokes it between MISP push batches; `edgeguard_pipeline.run_collector_with_metrics` also special-cases this exception to return a clean *skipped* result (no CRITICAL alert/"hard-fail" metrics). Documentation and `.env.example` add the two new flags (`EDGEGUARD_PARENT_DAG_LIVENESS_CHECK`, `EDGEGUARD_LIVENESS_CHECK_INTERVAL_SEC`), and new regression tests pin the callback, throttling, wiring, and doc traceability.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 53c6cbba89939b9393dfaec0f7df02916f3b7681. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->