### PR TITLE
fix(audit): PR-G1 — baseline-killer defensive fixes (P0-3 + P0-4 + P0-5)

### DIFF
--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -535,11 +535,23 @@ class NVDCollector:
                 # resume. Read ``current_page`` to match the writer, and fall
                 # back to ``max(pages)`` for extra robustness if the schema
                 # ever diverges.
-                total_batches_done = int(
-                    checkpoint.get("current_page")
-                    or (max(checkpoint.get("pages") or [0]) if checkpoint.get("pages") else 0)
-                    or 0
-                )
+                #
+                # PR-G1 Bugbot round-2 (Low): a fresh baseline run AFTER a
+                # previously-completed one must start the counter at 0, not
+                # at the prior run's final value. The resume-detection
+                # branch below is skipped when ``completed=True``, so we
+                # have to reset explicitly here.  The old formula naturally
+                # reset because it recomputed from loop variables; the
+                # monotonic counter needs the operator-facing invariant
+                # made explicit.
+                if checkpoint.get("completed"):
+                    total_batches_done = 0
+                else:
+                    total_batches_done = int(
+                        checkpoint.get("current_page")
+                        or (max(checkpoint.get("pages") or [0]) if checkpoint.get("pages") else 0)
+                        or 0
+                    )
                 if not checkpoint.get("completed") and checkpoint.get("nvd_window_idx") is not None:
                     start_wi = int(checkpoint["nvd_window_idx"])
                     resume_index = int(checkpoint.get("nvd_start_index", 0))

--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -515,11 +515,24 @@ class NVDCollector:
                 checkpoint = get_source_checkpoint("nvd")
                 start_wi = 0
                 resume_index = 0
+                # PR-G1 Bug Hunter audit (HIGH): the old ``page`` formula was
+                # ``wi * 5000 + (idx // batch_size) + 1`` with ``batch_size =
+                # 2000`` — the hard-coded ``5000`` multiplier made the page
+                # counter jump from e.g. ~60 (end of window 0) to 5001
+                # (start of window 1), so ``edgeguard baseline status``
+                # reported meaningless pages. Replace with a monotonic
+                # per-API-call batch counter. ``page`` is display-only —
+                # resume uses ``nvd_window_idx`` + ``nvd_start_index`` — so
+                # seeding the counter from the checkpoint keeps the display
+                # approximately correct across restarts without affecting
+                # resume correctness.
+                total_batches_done = int(checkpoint.get("page", 0) or 0)
                 if not checkpoint.get("completed") and checkpoint.get("nvd_window_idx") is not None:
                     start_wi = int(checkpoint["nvd_window_idx"])
                     resume_index = int(checkpoint.get("nvd_start_index", 0))
                     if start_wi >= len(windows):
                         start_wi, resume_index = 0, 0
+                        total_batches_done = 0
                     else:
                         logger.info(
                             f"  Resuming baseline at window {start_wi + 1}/{len(windows)}, startIndex={resume_index}"
@@ -559,9 +572,10 @@ class NVDCollector:
                             f"(unique CVE rows: {len(all_cves)})"
                         )
                         next_idx = idx + len(cves)
+                        total_batches_done += 1
                         update_source_checkpoint(
                             "nvd",
-                            page=wi * 5000 + (idx // batch_size) + 1,
+                            page=total_batches_done,
                             items_collected=len(all_cves),
                             extra={"nvd_window_idx": wi, "nvd_start_index": next_idx},
                         )
@@ -585,7 +599,12 @@ class NVDCollector:
                 logger.info(f"  Baseline complete: {len(vulnerabilities)} CVEs collected")
                 update_source_checkpoint(
                     "nvd",
-                    page=len(windows) * 5000,
+                    # PR-G1 Bug Hunter audit (HIGH): was ``len(windows) * 5000``
+                    # — a meaningless product of window count and a stale
+                    # batch_size constant. Use the actual monotonic
+                    # per-API-call batch counter so the final checkpoint
+                    # reports the real number of NVD calls made.
+                    page=total_batches_done,
                     items_collected=len(vulnerabilities),
                     completed=True,
                 )

--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -526,7 +526,20 @@ class NVDCollector:
                 # seeding the counter from the checkpoint keeps the display
                 # approximately correct across restarts without affecting
                 # resume correctness.
-                total_batches_done = int(checkpoint.get("page", 0) or 0)
+                #
+                # PR-G1 Bugbot round-1 (Medium): ``update_source_checkpoint``
+                # persists the ``page`` kwarg under ``entry["current_page"]``
+                # (``baseline_checkpoint.py:135``) — NOT under ``"page"``. The
+                # original seed expression ``checkpoint.get("page", 0)`` would
+                # always return 0, so the counter never actually recovered on
+                # resume. Read ``current_page`` to match the writer, and fall
+                # back to ``max(pages)`` for extra robustness if the schema
+                # ever diverges.
+                total_batches_done = int(
+                    checkpoint.get("current_page")
+                    or (max(checkpoint.get("pages") or [0]) if checkpoint.get("pages") else 0)
+                    or 0
+                )
                 if not checkpoint.get("completed") and checkpoint.get("nvd_window_idx") is not None:
                     start_wi = int(checkpoint["nvd_window_idx"])
                     resume_index = int(checkpoint.get("nvd_start_index", 0))

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1528,12 +1528,25 @@ class MISPToNeo4jSync:
             # Check if this is a MITRE tactic (format: "TA0001: Initial Access")
             #
             # PR-G1 Bug Hunter audit (HIGH): same three defects as the tool
-            # branch above. STIX 2.1 has no first-class ``tactic`` SDO —
-            # MITRE tactics are most commonly modelled as ``x-mitre-tactic``
-            # (ATT&CK's own custom type) but for maximum consumer compat
-            # we emit an ``attack-pattern`` SDO (mirroring the technique
-            # branch) and mark the MITRE kind under ``x_edgeguard_mitre_kind``
-            # so downstream code that cares can distinguish.
+            # branch above.
+            #
+            # PR-G1 Bugbot round-2 (Medium): initial rewrite used
+            # ``"type": "attack-pattern"`` for tactics — which turned out
+            # to be strictly worse than the prior broken state:
+            # ``run_pipeline.py::load_stix21_to_neo4j`` (line ~567) routes
+            # ALL ``attack-pattern`` objects to ``merge_technique()`` and
+            # handles tactics only under ``"x-mitre-tactic"`` (line ~592).
+            # So the "fix" silently created Technique nodes from Tactic
+            # data (previously tactics were silently dropped because the
+            # non-standard ``"type": "tactic"`` matched no consumer
+            # branch). Misclassification beats silent drop.
+            #
+            # The correct type is MITRE ATT&CK's own custom type
+            # ``x-mitre-tactic`` (STIX 2.1 §3.6 custom-object convention),
+            # which the consumer already handles correctly. The
+            # ``x_edgeguard_mitre_kind`` marker stays as a secondary
+            # disambiguator for any code that cares, but the type alone
+            # is now authoritative.
             tactic_match = re.match(r"^(TA\d{4}):\s*(.+)$", value)
             if tactic_match:
                 tactic_id = tactic_match.group(1)
@@ -1546,9 +1559,9 @@ class MISPToNeo4jSync:
                     }
                 ]
                 stix_obj = {
-                    "type": "attack-pattern",
+                    "type": "x-mitre-tactic",
                     "spec_version": "2.1",
-                    "id": f"attack-pattern--{attr_uuid}",
+                    "id": f"x-mitre-tactic--{attr_uuid}",
                     "name": tactic_name,
                     "description": attr.get("comment", ""),
                     "external_references": tactic_external_refs,

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1464,6 +1464,28 @@ class MISPToNeo4jSync:
                 return stix_obj
 
             # Check if this is a MITRE tool (format: "S0001: Mimikatz")
+            #
+            # PR-G1 Bug Hunter audit (HIGH): this branch and the tactic branch
+            # below had three compounding defects:
+            #
+            #   1. ``tag`` was an undefined name at this scope — the only
+            #      binding was the loop variable ``for tag in attr_tags`` at
+            #      line ~1327, which leaks out only if the loop body ran at
+            #      least once. Empty ``attr_tags`` → NameError at runtime,
+            #      crashing the STIX export for the whole event.
+            #   2. The returned dict had no ``id`` field, so the caller's
+            #      ``object_refs.append(stix_obj["id"])`` raised KeyError on
+            #      every single MITRE tool attribute regardless of tags.
+            #   3. Top-level fields ``mitre_id`` / ``zone`` / ``source`` /
+            #      ``confidence_score`` are not valid STIX 2.1 SDO fields,
+            #      so any downstream STIX parser would reject the bundle.
+            #
+            # The rewrite mirrors the technique branch above: a proper STIX
+            # 2.1 ``tool`` SDO with ``external_references`` carrying the
+            # MITRE ATT&CK ID, EdgeGuard-specific metadata under the
+            # ``x_edgeguard_*`` prefix per the STIX 2.1 custom-property
+            # convention (§3.1.1 of the spec), and ``labels`` populated from
+            # the zone extraction already done above (in-scope here).
             tool_match = re.match(r"^(S\d{4}):\s*(.+)$", value)
             if tool_match:
                 tool_id = tool_match.group(1)
@@ -1482,33 +1504,59 @@ class MISPToNeo4jSync:
                         description = tail or description
                     except (ValueError, TypeError, json.JSONDecodeError):
                         pass
-                return {
+                external_refs = [
+                    {
+                        "source_name": "mitre-attack",
+                        "external_id": tool_id,
+                        "url": f"https://attack.mitre.org/software/{tool_id}/",
+                    }
+                ]
+                stix_obj: dict = {
                     "type": "tool",
-                    "mitre_id": tool_id,
+                    "spec_version": "2.1",
+                    "id": f"tool--{attr_uuid}",
                     "name": tool_name,
                     "description": description,
-                    "uses_techniques": uses_techniques,
-                    "tag": tag,
-                    "zone": ["global"],
-                    "source": [tag],
-                    "confidence_score": 0.95,
+                    "external_references": external_refs,
                 }
+                if labels:
+                    stix_obj["labels"] = labels
+                if uses_techniques:
+                    stix_obj["x_edgeguard_uses_techniques"] = uses_techniques
+                return stix_obj
 
             # Check if this is a MITRE tactic (format: "TA0001: Initial Access")
+            #
+            # PR-G1 Bug Hunter audit (HIGH): same three defects as the tool
+            # branch above. STIX 2.1 has no first-class ``tactic`` SDO —
+            # MITRE tactics are most commonly modelled as ``x-mitre-tactic``
+            # (ATT&CK's own custom type) but for maximum consumer compat
+            # we emit an ``attack-pattern`` SDO (mirroring the technique
+            # branch) and mark the MITRE kind under ``x_edgeguard_mitre_kind``
+            # so downstream code that cares can distinguish.
             tactic_match = re.match(r"^(TA\d{4}):\s*(.+)$", value)
             if tactic_match:
                 tactic_id = tactic_match.group(1)
                 tactic_name = tactic_match.group(2).strip()
-                return {
-                    "type": "tactic",
-                    "mitre_id": tactic_id,
+                tactic_external_refs = [
+                    {
+                        "source_name": "mitre-attack",
+                        "external_id": tactic_id,
+                        "url": f"https://attack.mitre.org/tactics/{tactic_id}/",
+                    }
+                ]
+                stix_obj = {
+                    "type": "attack-pattern",
+                    "spec_version": "2.1",
+                    "id": f"attack-pattern--{attr_uuid}",
                     "name": tactic_name,
                     "description": attr.get("comment", ""),
-                    "tag": tag,
-                    "zone": ["global"],
-                    "source": [tag],
-                    "confidence_score": 1.0,
+                    "external_references": tactic_external_refs,
+                    "x_edgeguard_mitre_kind": "tactic",
                 }
+                if labels:
+                    stix_obj["labels"] = labels
+                return stix_obj
 
             # Not a MITRE technique/tool/tactic, treat as unknown indicator
             return None
@@ -2690,7 +2738,13 @@ class MISPToNeo4jSync:
                     success += 1
                 except Exception as e:
                     item_type = item.get("type", "unknown")
-                    item_value = item.get("value", item.get("name", "N/A"))[:50]
+                    # PR-G1 Bug Hunter audit (HIGH): ``dict.get(k, default)``
+                    # returns ``None`` — not the default — when the key exists
+                    # with a None value. ``None[:50]`` then raises TypeError
+                    # INSIDE the error-recovery path, aborting the whole sync
+                    # after most of the work succeeded. Use ``or`` chaining so
+                    # a None-valued key falls through to the next fallback.
+                    item_value = (item.get("value") or item.get("name") or "N/A")[:50]
                     logger.warning(f"[WARN] Error syncing {item_type} ({item_value}): {type(e).__name__}: {e}")
                     errors += 1
 
@@ -2758,7 +2812,11 @@ class MISPToNeo4jSync:
                         else:
                             errors += 1
                     except Exception as e:
-                        cve_id = vuln.get("cve_id", "?")[:20]
+                        # PR-G1 Bug Hunter audit (HIGH): defensive ``or``
+                        # chain — ``get("cve_id", "?")`` returns None (not
+                        # "?") when the key exists with a None value, and
+                        # ``None[:20]`` would crash the error-recovery path.
+                        cve_id = (vuln.get("cve_id") or "?")[:20]
                         logger.warning(f"[WARN] Error syncing plain CVE ({cve_id}): {type(e).__name__}: {e}")
                         errors += 1
 
@@ -2819,7 +2877,11 @@ class MISPToNeo4jSync:
                     else:
                         errors += 1
                 except Exception as e:
-                    actor_name = actor.get("name", "unknown")[:30]
+                    # PR-G1 Bug Hunter audit (HIGH): ``or`` chain guards
+                    # against ``actor.get("name")`` returning None on a
+                    # present-but-null key — see the companion fix in
+                    # ``_sync_single_item`` at ~line 2693.
+                    actor_name = (actor.get("name") or "unknown")[:30]
                     logger.warning(f"[WARN] Error syncing actor ({actor_name}): {type(e).__name__}: {e}")
                     errors += 1
             logger.info(f"  ✓ {len(actors)} actors")
@@ -2836,7 +2898,11 @@ class MISPToNeo4jSync:
                     else:
                         errors += 1
                 except Exception as e:
-                    tool_name = tool.get("name", "unknown")[:30]
+                    # PR-G1 Bug Hunter audit (HIGH): ``or`` chain guards
+                    # against ``tool.get("name")`` returning None on a
+                    # present-but-null key — matches the actor / CVE / item
+                    # sites above.
+                    tool_name = (tool.get("name") or "unknown")[:30]
                     logger.warning(f"[WARN] Error syncing tool ({tool_name}): {type(e).__name__}: {e}")
                     errors += 1
             logger.info(f"  ✓ {len(tools)} tools")

--- a/tests/test_pr_g1_baseline_killers.py
+++ b/tests/test_pr_g1_baseline_killers.py
@@ -325,8 +325,76 @@ class TestNvdCheckpointPageMath:
         # Two call sites must use the new formula (inner + final).
         assert source.count("page=total_batches_done") >= 2
 
-    def test_counter_seeds_from_checkpoint(self, source: str) -> None:
-        """On resume, the counter must seed from the previously-persisted
-        ``page`` so the display stays approximately correct across
-        restarts."""
-        assert 'int(checkpoint.get("page", 0) or 0)' in source
+    def test_counter_seeds_from_current_page_not_page(self, source: str) -> None:
+        """Bugbot round-1 catch: ``update_source_checkpoint`` persists
+        the ``page=`` kwarg under ``entry["current_page"]``
+        (``baseline_checkpoint.py:135``) — NOT under ``"page"``. The
+        seed MUST read ``current_page`` so resume actually recovers
+        the counter; reading ``"page"`` would always return 0 and the
+        counter would restart from scratch on every run."""
+        assert 'checkpoint.get("current_page")' in source, (
+            "seed must read the ``current_page`` key the writer stores, "
+            "not the legacy ``page`` key which always returns 0"
+        )
+        # And the old broken expression must be gone.
+        assert 'int(checkpoint.get("page", 0) or 0)' not in source, (
+            'the original broken seed pinned ``.get("page", 0)`` which '
+            "always returned 0 because the writer persists under "
+            "``current_page`` — Bugbot caught this; don't let it regress"
+        )
+
+    def test_seed_recovers_persisted_page_end_to_end(self, tmp_path, monkeypatch) -> None:
+        """End-to-end: persist a fake NVD checkpoint via the real
+        ``update_source_checkpoint`` API, then read back the value the
+        nvd_collector seed expression would read.  This proves the
+        seed + writer key agree, closing the class of bug Bugbot
+        caught at the source level (writer persists under
+        ``current_page`` but seed was reading ``page``)."""
+        import importlib
+
+        # The checkpoint module stays under the project root by design
+        # (path-traversal guard at baseline_checkpoint.py:34-42), so we
+        # set EDGEGUARD_CHECKPOINT_DIR to a path inside the repo that's
+        # safe to write to. ``tmp_path`` is guaranteed clean per-test.
+        project_root = REPO_ROOT
+        safe_dir = project_root / ".pytest_checkpoint_tmp"
+        safe_dir.mkdir(exist_ok=True)
+        monkeypatch.setenv("EDGEGUARD_CHECKPOINT_DIR", str(safe_dir))
+
+        # Reload so the module re-reads the env var + rebuilds
+        # ``CHECKPOINT_FILE`` at the redirected path.
+        import baseline_checkpoint
+
+        importlib.reload(baseline_checkpoint)
+        try:
+            # Wipe any stale state from a previous test run.
+            if baseline_checkpoint.CHECKPOINT_FILE.exists():
+                baseline_checkpoint.CHECKPOINT_FILE.unlink()
+
+            # Simulate what the NVD collector writes on each batch.
+            baseline_checkpoint.update_source_checkpoint(
+                "nvd",
+                page=42,
+                items_collected=84000,
+                extra={"nvd_window_idx": 3, "nvd_start_index": 4000},
+            )
+
+            # Now read back and apply the nvd_collector's seed expression.
+            ckpt = baseline_checkpoint.get_source_checkpoint("nvd")
+            seeded = int(ckpt.get("current_page") or (max(ckpt.get("pages") or [0]) if ckpt.get("pages") else 0) or 0)
+            assert seeded == 42, (
+                f"seed expression must recover the persisted ``page`` value; got {seeded}. "
+                f"checkpoint keys present: {sorted(ckpt.keys())}"
+            )
+        finally:
+            # Clean up so this test leaves no artefacts in the repo.
+            if baseline_checkpoint.CHECKPOINT_FILE.exists():
+                baseline_checkpoint.CHECKPOINT_FILE.unlink()
+            lock = baseline_checkpoint.CHECKPOINT_FILE.with_suffix(".lock")
+            if lock.exists():
+                lock.unlink()
+            if safe_dir.exists() and not any(safe_dir.iterdir()):
+                safe_dir.rmdir()
+            # Reload the module one more time so subsequent tests see
+            # the normal project-default checkpoint path again.
+            importlib.reload(baseline_checkpoint)

--- a/tests/test_pr_g1_baseline_killers.py
+++ b/tests/test_pr_g1_baseline_killers.py
@@ -148,19 +148,30 @@ class TestStixMitreToolTacticRewrite:
         assert '"external_references"' in tool_block
         assert "mitre-attack" in tool_block
 
-    def test_tactic_branch_returns_valid_stix21_sdo(self, source: str) -> None:
-        """Tactic branch MUST emit an ``attack-pattern`` SDO with
-        ``spec_version`` + ``id`` + ``external_references`` (STIX 2.1
-        has no first-class tactic SDO, so we use ``attack-pattern`` and
-        mark the kind under ``x_edgeguard_mitre_kind``)."""
+    def test_tactic_branch_uses_x_mitre_tactic_not_attack_pattern(self, source: str) -> None:
+        """Bugbot round-2 catch: MITRE tactics MUST be emitted as the
+        ``x-mitre-tactic`` custom type (MITRE ATT&CK STIX extension),
+        not as ``attack-pattern``.
+
+        Why: ``run_pipeline.py::load_stix21_to_neo4j`` routes ALL
+        ``attack-pattern`` objects to ``merge_technique()`` (line ~567)
+        and handles tactics only under ``"x-mitre-tactic"`` (line ~592).
+        If tactics land with type ``attack-pattern``, they get CREATED
+        AS TECHNIQUES — strictly worse than the prior "silently
+        dropped" state."""
         tactic_idx = source.find("if tactic_match:")
         assert tactic_idx > 0
-        # End of block is the next elif/else/return None at function scope
-        # — grab a reasonable window.
         tactic_block = source[tactic_idx : tactic_idx + 2000]
-        assert '"type": "attack-pattern"' in tactic_block
+        # Correct type + id prefix
+        assert '"type": "x-mitre-tactic"' in tactic_block
+        assert '"id": f"x-mitre-tactic--{attr_uuid}"' in tactic_block
+        # Wrong type must not resurface
+        assert '"type": "attack-pattern"' not in tactic_block, (
+            "tactics must NOT be emitted as attack-pattern — the consumer routes that type to merge_technique()"
+        )
+        assert '"id": f"attack-pattern--{attr_uuid}"' not in tactic_block
+        # Common structural requirements
         assert '"spec_version": "2.1"' in tactic_block
-        assert '"id": f"attack-pattern--{attr_uuid}"' in tactic_block
         assert '"x_edgeguard_mitre_kind": "tactic"' in tactic_block
 
     def test_tool_branch_uses_x_edgeguard_for_edgeguard_specific_fields(self, source: str) -> None:
@@ -249,7 +260,11 @@ class TestStixAttributeConversionDoesNotCrash:
 
     def test_tactic_with_empty_tags_returns_valid_stix(self) -> None:
         """Tactic branch was identically broken. Same NameError trigger,
-        same KeyError-on-caller."""
+        same KeyError-on-caller.
+
+        Bugbot round-2 catch: tactics MUST use STIX type
+        ``x-mitre-tactic`` — NOT ``attack-pattern``. The consumer's
+        routing for ``attack-pattern`` goes to ``merge_technique``."""
         syncer = self._make_syncer()
         attr = {
             "type": "text",
@@ -260,12 +275,73 @@ class TestStixAttributeConversionDoesNotCrash:
         }
         result = syncer._attribute_to_stix21(attr, "event-uuid-xyz", event_zones=["global"])
         assert result is not None
-        assert result["type"] == "attack-pattern"
+        assert result["type"] == "x-mitre-tactic"
         assert result["spec_version"] == "2.1"
-        assert result["id"] == "attack-pattern--22222222-2222-2222-2222-222222222222"
+        assert result["id"] == "x-mitre-tactic--22222222-2222-2222-2222-222222222222"
         assert result.get("x_edgeguard_mitre_kind") == "tactic"
         refs = result.get("external_references") or []
         assert any(r.get("external_id") == "TA0001" and r.get("source_name") == "mitre-attack" for r in refs)
+
+    def test_tactic_type_matches_consumer_routing_contract(self) -> None:
+        """Cross-file contract check: the type we emit for tactics in
+        ``_attribute_to_stix21`` MUST match the type the consumer in
+        ``run_pipeline.py::load_stix21_to_neo4j`` routes to
+        ``merge_tactic()``.
+
+        This test guards against a regression like the one Bugbot
+        caught: emitting a type that the consumer routes elsewhere
+        (attack-pattern → merge_technique) silently misclassifies
+        data in Neo4j. The contract is: tactics go through
+        ``x-mitre-tactic``. Period."""
+        syncer = self._make_syncer()
+        attr = {
+            "type": "text",
+            "value": "TA0003: Persistence",
+            "uuid": "dddddddd-dddd-dddd-dddd-dddddddddddd",
+            "Tag": [],
+            "comment": "",
+        }
+        result = syncer._attribute_to_stix21(attr, "event-uuid", event_zones=[])
+        assert result is not None
+
+        # Read the consumer's routing rules from the source.  Note:
+        # run_pipeline.py has two dispatches on ``obj_type ==
+        # "x-mitre-tactic"`` — an upstream id-map populator and the
+        # actual neo4j merger call.  We only need to know that SOME
+        # branch (a) exists for the type we emit, and (b) routes to
+        # ``merge_tactic`` somewhere — not ``merge_technique``.
+        pipeline_src = (REPO_ROOT / "src" / "run_pipeline.py").read_text()
+        assert f'elif obj_type == "{result["type"]}":' in pipeline_src, (
+            f"Tactic type '{result['type']}' has no corresponding branch "
+            f"in run_pipeline.py — emitter and consumer are out of sync. "
+            f"See Bugbot round-2 finding on PR-G1 for why this matters."
+        )
+        # Find EVERY dispatch block for our type and confirm at least
+        # one routes to ``merge_tactic``.  A strict contract: none may
+        # route to ``merge_technique``.
+        type_str = result["type"]
+        dispatch_pattern = f'elif obj_type == "{type_str}":'
+        blocks = []
+        start = 0
+        while True:
+            idx = pipeline_src.find(dispatch_pattern, start)
+            if idx < 0:
+                break
+            # Slice until the next ``elif obj_type ==`` to bound this
+            # dispatch's body.
+            end = pipeline_src.find("elif obj_type ==", idx + len(dispatch_pattern))
+            if end < 0:
+                end = idx + 2000  # tail of function; reasonable cap
+            blocks.append(pipeline_src[idx:end])
+            start = end
+        assert blocks, f"no dispatch blocks for '{type_str}' found"
+        assert any("merge_tactic(" in b for b in blocks), (
+            f"no dispatch for '{type_str}' routes to merge_tactic(); tactics may be silently misrouted"
+        )
+        assert not any("merge_technique(" in b for b in blocks), (
+            f"a dispatch for '{type_str}' routes to merge_technique() — "
+            f"this is the exact misrouting bug Bugbot round-2 caught"
+        )
 
     def test_tool_with_mitre_uses_techniques_comment_parses(self) -> None:
         """The MITRE_USES_TECHNIQUES comment format must still parse,
@@ -341,6 +417,25 @@ class TestNvdCheckpointPageMath:
             'the original broken seed pinned ``.get("page", 0)`` which '
             "always returned 0 because the writer persists under "
             "``current_page`` — Bugbot caught this; don't let it regress"
+        )
+
+    def test_counter_resets_to_zero_on_completed_checkpoint(self, source: str) -> None:
+        """Bugbot round-2 catch: a fresh baseline run AFTER a previously
+        completed one MUST start the counter at 0, not at the prior
+        run's final value.  The seed expression reads ``current_page``
+        unconditionally, and the resume-detection block only runs when
+        ``completed=False``, so the reset for completed checkpoints has
+        to be explicit.
+
+        Source-pin: verify the explicit guard is present."""
+        assert 'if checkpoint.get("completed"):' in source
+        # And the guard's body must reset to 0 (not to the seeded value).
+        # Find the completed-branch and assert the reset is there.
+        idx = source.find('if checkpoint.get("completed"):')
+        assert idx > 0
+        branch = source[idx : idx + 200]
+        assert "total_batches_done = 0" in branch, (
+            "completed-checkpoint branch must explicitly reset the counter to 0 for fresh baseline runs"
         )
 
     def test_seed_recovers_persisted_page_end_to_end(self, tmp_path, monkeypatch) -> None:

--- a/tests/test_pr_g1_baseline_killers.py
+++ b/tests/test_pr_g1_baseline_killers.py
@@ -1,0 +1,332 @@
+"""
+Regression tests for PR-G1 — three baseline-killer defensive fixes from
+the 2026-04-20 comprehensive multi-agent audit.
+
+These fixes all landed as one PR because each is a small defensive patch
+on a path that runs during every baseline / incremental sync:
+
+  * P0-3 (Bug Hunter HIGH) — ``_attribute_to_stix21`` MITRE tool + tactic
+    branches raised NameError on ``tag`` (the loop variable leaked from
+    an earlier branch only when ``attr_tags`` was non-empty), AND
+    returned dicts without an ``id`` field so the caller's
+    ``object_refs.append(stix_obj["id"])`` raised KeyError on every
+    MITRE tool/tactic regardless of tags, AND the returned shape had
+    ``mitre_id`` / ``zone`` / ``source`` / ``confidence_score`` at top
+    level — none of which are valid STIX 2.1 SDO fields.
+
+  * P0-4 (Bug Hunter HIGH) — four ``item.get(k, default)[:N]`` call sites
+    in the error-recovery branches of ``_sync_single_item`` and the
+    CVE / actor / tool batch handlers. ``dict.get(k, default)`` returns
+    ``None`` — not the default — when the key is present with a None
+    value, so ``None[:N]`` crashed the error-recovery path and aborted
+    the whole sync after most of the work had already succeeded.
+
+  * P0-5 (Bug Hunter HIGH) — NVD checkpoint ``page`` was computed as
+    ``wi * 5000 + (idx // batch_size) + 1`` with ``batch_size = 2000``;
+    the hard-coded ``5000`` was a stale constant and made the page
+    counter jump from ~60 (end of window 0) to 5001 (start of window
+    1). ``edgeguard baseline status`` reported meaningless page numbers.
+
+Each fix is source-pinned here against future regression. The STIX
+rewrites are also exercised behaviourally so we know they produce valid
+STIX 2.1 SDOs and don't NameError on empty tags.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, "src")
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ===========================================================================
+# Fix 1 (P0-4): NoneType slicing in error handlers
+# ===========================================================================
+
+
+class TestNoneTypeSlicingInErrorHandlers:
+    """Every ``[:N]`` slice in an except-clause of ``run_misp_to_neo4j.py``
+    MUST guard with ``or`` chaining against a present-but-None key.
+
+    The old ``item.get("value", item.get("name", "N/A"))[:50]`` pattern
+    crashed the error-recovery path itself when the key existed with a
+    None value, aborting the whole sync mid-run (Bug Hunter HIGH)."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (REPO_ROOT / "src" / "run_misp_to_neo4j.py").read_text()
+
+    def test_item_value_fallback_uses_or_chain(self, source: str) -> None:
+        """The catchall branch in the single-item sync loop MUST use
+        ``(item.get("value") or item.get("name") or "N/A")[:50]`` —
+        not the broken ``item.get("value", item.get("name", "N/A"))[:50]``
+        pattern that crashes on present-but-None keys."""
+        good = '(item.get("value") or item.get("name") or "N/A")[:50]'
+        bad = 'item.get("value", item.get("name", "N/A"))[:50]'
+        assert good in source, (
+            "catchall single-item error handler must use or-chain fallback "
+            "so a present-but-None 'value' key doesn't crash the error path"
+        )
+        assert bad not in source, "the broken get(k, default)[:50] pattern must not reappear — see PR-G1 for why"
+
+    def test_plain_cve_error_uses_or_chain(self, source: str) -> None:
+        """Plain-CVE retry except-clause MUST use ``(vuln.get("cve_id")
+        or "?")[:20]``."""
+        assert '(vuln.get("cve_id") or "?")[:20]' in source
+        assert 'vuln.get("cve_id", "?")[:20]' not in source
+
+    def test_actor_error_uses_or_chain(self, source: str) -> None:
+        """Actor batch except-clause MUST use ``(actor.get("name") or
+        "unknown")[:30]``."""
+        assert '(actor.get("name") or "unknown")[:30]' in source
+        assert 'actor.get("name", "unknown")[:30]' not in source
+
+    def test_tool_error_uses_or_chain(self, source: str) -> None:
+        """Tool batch except-clause MUST use ``(tool.get("name") or
+        "unknown")[:30]``."""
+        assert '(tool.get("name") or "unknown")[:30]' in source
+        assert 'tool.get("name", "unknown")[:30]' not in source
+
+    def test_or_chain_actually_handles_none(self) -> None:
+        """Behavioral check: the ``or`` pattern produces a valid string
+        when the key is present with a None value. This is the core
+        guarantee the source-pins above protect."""
+        item = {"value": None, "name": None}
+        # Old broken pattern would raise TypeError here:
+        # (item.get("value", item.get("name", "N/A"))[:50])
+        # New pattern falls through to "N/A":
+        assert (item.get("value") or item.get("name") or "N/A")[:50] == "N/A"
+
+        item_value_set = {"value": "203.0.113.5"}
+        assert (item_value_set.get("value") or item_value_set.get("name") or "N/A")[:50] == "203.0.113.5"
+
+
+# ===========================================================================
+# Fix 2 (P0-3): STIX MITRE tool / tactic branches were broken
+# ===========================================================================
+
+
+class TestStixMitreToolTacticRewrite:
+    """The MITRE tool + tactic branches of ``_attribute_to_stix21`` MUST
+    return valid STIX 2.1 SDOs — not Neo4j-shaped dicts — and MUST NOT
+    reference an undefined ``tag`` name (Bug Hunter HIGH)."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (REPO_ROOT / "src" / "run_misp_to_neo4j.py").read_text()
+
+    def test_tool_branch_does_not_reference_undefined_tag(self, source: str) -> None:
+        """The tool-branch return block MUST NOT include the broken
+        ``"tag": tag`` or ``"source": [tag]`` — ``tag`` is not bound at
+        this scope and raises NameError when ``attr_tags`` is empty."""
+        # The old broken shape had these fields at the top level of the
+        # returned dict.  Make sure neither resurfaces.
+        # Note: ``"source": [tag]`` (with the undefined `tag` name) is
+        # the specific NameError source; grep for it precisely.
+        assert '"source": [tag]' not in source
+        assert '"tag": tag,' not in source
+
+    def test_tool_branch_returns_valid_stix21_tool_sdo(self, source: str) -> None:
+        """The tool-branch return MUST include ``spec_version`` and an
+        ``id`` of the form ``"tool--{attr_uuid}"`` — matching every
+        other SDO branch in the function."""
+        # Find the tool_match block
+        tool_idx = source.find("if tool_match:")
+        assert tool_idx > 0
+        # End of the block = start of the tactic block
+        tactic_idx = source.find("# Check if this is a MITRE tactic", tool_idx)
+        assert tactic_idx > tool_idx
+        tool_block = source[tool_idx:tactic_idx]
+        assert '"type": "tool"' in tool_block
+        assert '"spec_version": "2.1"' in tool_block
+        assert '"id": f"tool--{attr_uuid}"' in tool_block
+        assert '"external_references"' in tool_block
+        assert "mitre-attack" in tool_block
+
+    def test_tactic_branch_returns_valid_stix21_sdo(self, source: str) -> None:
+        """Tactic branch MUST emit an ``attack-pattern`` SDO with
+        ``spec_version`` + ``id`` + ``external_references`` (STIX 2.1
+        has no first-class tactic SDO, so we use ``attack-pattern`` and
+        mark the kind under ``x_edgeguard_mitre_kind``)."""
+        tactic_idx = source.find("if tactic_match:")
+        assert tactic_idx > 0
+        # End of block is the next elif/else/return None at function scope
+        # — grab a reasonable window.
+        tactic_block = source[tactic_idx : tactic_idx + 2000]
+        assert '"type": "attack-pattern"' in tactic_block
+        assert '"spec_version": "2.1"' in tactic_block
+        assert '"id": f"attack-pattern--{attr_uuid}"' in tactic_block
+        assert '"x_edgeguard_mitre_kind": "tactic"' in tactic_block
+
+    def test_tool_branch_uses_x_edgeguard_for_edgeguard_specific_fields(self, source: str) -> None:
+        """``uses_techniques`` is EdgeGuard-specific, not STIX-standard,
+        so it MUST live under the ``x_edgeguard_*`` prefix per STIX 2.1
+        §3.1.1 custom-property convention — NOT as a top-level field."""
+        tool_idx = source.find("if tool_match:")
+        tactic_idx = source.find("# Check if this is a MITRE tactic", tool_idx)
+        tool_block = source[tool_idx:tactic_idx]
+        assert "x_edgeguard_uses_techniques" in tool_block
+        # And the old STIX-illegal top-level ``"uses_techniques":`` must
+        # be gone (would be a top-level dict key, caught by a bare-word
+        # search distinguishing it from the x_edgeguard_ prefix).
+        assert '"uses_techniques":' not in tool_block.replace('"x_edgeguard_uses_techniques":', "")
+
+    def test_tool_branch_does_not_leak_neo4j_fields(self, source: str) -> None:
+        """Top-level ``confidence_score`` / ``zone`` / ``mitre_id`` are
+        Neo4j-internal concerns and aren't valid STIX 2.1 SDO fields."""
+        tool_idx = source.find("if tool_match:")
+        tactic_idx = source.find("# Check if this is a MITRE tactic", tool_idx)
+        tool_block = source[tool_idx:tactic_idx]
+        for bad in ['"confidence_score":', '"zone":', '"mitre_id":']:
+            assert bad not in tool_block, (
+                f"top-level {bad} is invalid STIX 2.1 — move EdgeGuard fields under x_edgeguard_* or drop"
+            )
+
+
+class TestStixAttributeConversionDoesNotCrash:
+    """Behavioral check: exercise ``_attribute_to_stix21`` with inputs
+    that previously crashed (empty ``attr_tags`` on a MITRE tool/tactic)
+    and assert we now get back valid STIX 2.1 SDOs instead of a NameError
+    or a KeyError one level up."""
+
+    def _make_syncer(self):
+        """Build a MISPToNeo4jSync without touching Neo4j or MISP."""
+        # Avoid importing the whole module's side effects — just the class.
+        import importlib
+        from unittest.mock import patch
+
+        with (
+            patch.dict(
+                "os.environ",
+                {
+                    "NEO4J_URI": "bolt://localhost:7687",
+                    "NEO4J_USER": "neo4j",
+                    "NEO4J_PASSWORD": "x",
+                    "MISP_URL": "https://localhost",
+                    "MISP_API_KEY": "x",
+                },
+                clear=False,
+            ),
+            patch("neo4j_client.Neo4jClient") as _,
+        ):
+            mod = importlib.import_module("run_misp_to_neo4j")
+            importlib.reload(mod)
+            # Bypass __init__ to avoid driver wiring — just bind the
+            # method off the class.
+            syncer = mod.MISPToNeo4jSync.__new__(mod.MISPToNeo4jSync)
+            return syncer
+
+    def test_tool_with_empty_tags_returns_valid_stix(self) -> None:
+        """Pre-fix: empty ``attr_tags`` meant the old ``for tag in attr_tags``
+        loop body never ran, ``tag`` was never bound, and ``"tag": tag``
+        raised NameError. Post-fix: branch must return a valid STIX tool
+        SDO with id + spec_version + external_references."""
+        syncer = self._make_syncer()
+        attr = {
+            "type": "text",
+            "value": "S0002: Mimikatz",
+            "uuid": "11111111-1111-1111-1111-111111111111",
+            "Tag": [],  # <-- the NameError trigger
+            "comment": "",
+        }
+        result = syncer._attribute_to_stix21(attr, "event-uuid-abc", event_zones=["global"])
+        assert result is not None
+        assert result["type"] == "tool"
+        assert result["spec_version"] == "2.1"
+        assert result["id"] == "tool--11111111-1111-1111-1111-111111111111"
+        # The caller does ``object_refs.append(result["id"])`` — that
+        # must not KeyError.
+        assert "id" in result
+        # Must have the MITRE ID reference, not a top-level mitre_id.
+        assert "mitre_id" not in result
+        refs = result.get("external_references") or []
+        assert any(r.get("external_id") == "S0002" and r.get("source_name") == "mitre-attack" for r in refs)
+
+    def test_tactic_with_empty_tags_returns_valid_stix(self) -> None:
+        """Tactic branch was identically broken. Same NameError trigger,
+        same KeyError-on-caller."""
+        syncer = self._make_syncer()
+        attr = {
+            "type": "text",
+            "value": "TA0001: Initial Access",
+            "uuid": "22222222-2222-2222-2222-222222222222",
+            "Tag": [],
+            "comment": "",
+        }
+        result = syncer._attribute_to_stix21(attr, "event-uuid-xyz", event_zones=["global"])
+        assert result is not None
+        assert result["type"] == "attack-pattern"
+        assert result["spec_version"] == "2.1"
+        assert result["id"] == "attack-pattern--22222222-2222-2222-2222-222222222222"
+        assert result.get("x_edgeguard_mitre_kind") == "tactic"
+        refs = result.get("external_references") or []
+        assert any(r.get("external_id") == "TA0001" and r.get("source_name") == "mitre-attack" for r in refs)
+
+    def test_tool_with_mitre_uses_techniques_comment_parses(self) -> None:
+        """The MITRE_USES_TECHNIQUES comment format must still parse,
+        with the result stashed under ``x_edgeguard_uses_techniques``
+        (not at top level, per STIX 2.1 custom-property rules)."""
+        syncer = self._make_syncer()
+        attr = {
+            "type": "text",
+            "value": "S0002: Mimikatz",
+            "uuid": "33333333-3333-3333-3333-333333333333",
+            "Tag": [],
+            "comment": 'MITRE_USES_TECHNIQUES:{"t":["T1003","T1056"]}\nFree-form description here',
+        }
+        result = syncer._attribute_to_stix21(attr, "event-uuid-abc", event_zones=["global"])
+        assert result is not None
+        assert result["x_edgeguard_uses_techniques"] == ["T1003", "T1056"]
+        assert "uses_techniques" not in result  # top-level leaked field
+        assert result["description"] == "Free-form description here"
+
+
+# ===========================================================================
+# Fix 3 (P0-5): NVD checkpoint page-numbering
+# ===========================================================================
+
+
+class TestNvdCheckpointPageMath:
+    """NVD baseline MUST NOT use the stale ``wi * 5000`` hard-coded
+    multiplier for ``page`` — it produced nonsense page numbers when
+    ``batch_size = 2000`` (Bug Hunter HIGH)."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (REPO_ROOT / "src" / "collectors" / "nvd_collector.py").read_text()
+
+    def test_old_broken_page_formula_is_gone(self, source: str) -> None:
+        """Neither of the two old broken ``page=`` expressions may
+        appear as a live kwarg — only in the explanatory comment that
+        documents what the audit found. We strip comment lines before
+        checking to avoid a false-positive from our own prose."""
+        code = "\n".join(line for line in source.splitlines() if not line.lstrip().startswith("#"))
+        assert "wi * 5000 + (idx // batch_size) + 1" not in code, (
+            "the old wi*5000-based page kwarg must not reappear in code"
+        )
+        assert "page=len(windows) * 5000" not in code, (
+            "the old final-page expression ``page=len(windows) * 5000`` must not reappear in code"
+        )
+
+    def test_total_batches_counter_exists_and_is_used(self, source: str) -> None:
+        """The replacement is a monotonic per-API-call counter called
+        ``total_batches_done``. It MUST be defined once (seeded from
+        checkpoint), incremented per successful batch, and used as the
+        ``page`` kwarg in BOTH update_source_checkpoint call sites in
+        the baseline block."""
+        assert "total_batches_done" in source
+        assert "total_batches_done += 1" in source
+        assert "page=total_batches_done" in source
+        # Two call sites must use the new formula (inner + final).
+        assert source.count("page=total_batches_done") >= 2
+
+    def test_counter_seeds_from_checkpoint(self, source: str) -> None:
+        """On resume, the counter must seed from the previously-persisted
+        ``page`` so the display stays approximately correct across
+        restarts."""
+        assert 'int(checkpoint.get("page", 0) or 0)' in source


### PR DESCRIPTION
## Summary

Three baseline-killer defensive fixes from the 2026-04-20 comprehensive multi-agent audit, bundled as one PR because each is a small defensive patch on paths that run during every baseline / incremental sync.

## The three fixes

### 1. [Bug Hunter HIGH] STIX MITRE tool + tactic branches were triply broken

`_attribute_to_stix21` at `src/run_misp_to_neo4j.py:1485-1511`:

1. **`NameError` on `tag`** — the variable was only bound as a loop variable in an earlier zone-extraction loop, which leaks out of scope only if the loop body ran at least once. Empty `attr_tags` → `NameError: name 'tag' is not defined`, crashing the STIX export for the entire event.
2. **Missing `id` field** — the returned dicts had no `id`, so the caller's `object_refs.append(stix_obj["id"])` raised `KeyError` on every single MITRE tool/tactic attribute regardless of tags. Broke the STIX export **deterministically**, not intermittently.
3. **Invalid STIX 2.1 shape** — top-level `mitre_id` / `zone` / `source` / `confidence_score` are Neo4j-internal fields, not valid STIX 2.1 SDO properties. Any strict STIX parser would reject the bundle.

**Fix:** rewrote both branches to mirror the adjacent technique branch — proper STIX 2.1 SDOs (`tool` + `attack-pattern`) with `spec_version`, `id = "<type>--{attr_uuid}"`, `external_references` carrying the MITRE ATT&CK ID, and EdgeGuard-specific metadata under `x_edgeguard_*` prefix per STIX 2.1 §3.1.1 custom-property convention. Tactic uses `attack-pattern` (STIX 2.1 has no first-class tactic SDO) marked with `x_edgeguard_mitre_kind = "tactic"`.

### 2. [Bug Hunter HIGH] NoneType slicing in 4 error handlers

`dict.get(key, default)` returns `None` — **not** the default — when the key is present with a None value. Four error-recovery branches then did `[:N]` on the result, turning recoverable errors into fatal `TypeError` crashes that aborted the whole sync after most of the work had already succeeded.

Sites fixed:

| Before | After |
|---|---|
| `item.get("value", item.get("name", "N/A"))[:50]` | `(item.get("value") or item.get("name") or "N/A")[:50]` |
| `vuln.get("cve_id", "?")[:20]` | `(vuln.get("cve_id") or "?")[:20]` |
| `actor.get("name", "unknown")[:30]` | `(actor.get("name") or "unknown")[:30]` |
| `tool.get("name", "unknown")[:30]` | `(tool.get("name") or "unknown")[:30]` |

### 3. [Bug Hunter HIGH] NVD checkpoint page-numbering

`src/collectors/nvd_collector.py:564` computed `page` as `wi * 5000 + (idx // batch_size) + 1` with `batch_size = 2000` — the hard-coded `5000` multiplier made the page counter jump from ~60 (end of window 0) to 5001 (start of window 1). `edgeguard baseline status` reported nonsense page numbers. The final checkpoint write was similarly broken: `page=len(windows) * 5000`.

**Fix:** introduce a monotonic `total_batches_done` counter that increments once per successful NVD API call, seeded from the checkpoint's persisted `page` on resume so the display stays approximately correct across restarts. Resume correctness is unaffected — resume uses `nvd_window_idx` + `nvd_start_index`, not `page`.

## Files

| File | Change |
|---|---|
| `src/run_misp_to_neo4j.py` | +92 / -19 — fixes 1 + 2 |
| `src/collectors/nvd_collector.py` | +21 / -3 — fix 3 |
| `tests/test_pr_g1_baseline_killers.py` | **new** — 16 regression pins |

## Test plan

- [x] 16 new regression-pin tests — all pass
  - [x] 5 source-pin tests on P0-4 `or`-chain replacements (+ 1 behavioral)
  - [x] 5 source-pin tests on P0-3 STIX rewrite (tool + tactic shape + NameError elimination)
  - [x] 3 behavioral tests on P0-3 `_attribute_to_stix21` proving empty `attr_tags` now returns valid STIX 2.1 SDOs (not NameError / KeyError) and that the `MITRE_USES_TECHNIQUES` comment parser still works
  - [x] 3 source-pin tests on P0-5 counter-based page math
- [x] `ruff format --check src/ dags/ tests/` ✓
- [x] `ruff check src/ tests/` ✓
- [x] `mypy src/ --ignore-missing-imports` ✓
- [x] `pytest tests/` — **989 passed, 3 skipped, 0 failures** (+17 from F9's 972)

## Related

- Multi-agent audit (2026-04-20) — 7 specialized agents produced ~97 findings; these three were the Bug Hunter's HIGH-severity baseline-killers
- PR #69 (F9) — quick-wins from the same audit (GraphQL limit clamp, password-leak fix, docs + dead-code cleanup) — **merged**
- Queued follow-ups:
  - **PR-G2** OOM-safe streaming reads for large MISP events (separate PR — larger refactor)
  - **PR-H** observability (task_id Prometheus cardinality clamp + EdgeGuardDAGRunStuck alert rewrite)
  - **Issue #57** Airflow-aware baseline lock design spike — separate architectural track, not a patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect baseline progress checkpointing and STIX object shapes for MITRE tool/tactic exports, which can impact downstream ingestion even though the intent is purely defensive bug fixing. Added regression tests reduce the chance of reintroducing these runtime-crash and misrouting issues.
> 
> **Overview**
> Fixes several baseline-killer runtime issues in core ingestion paths.
> 
> NVD baseline checkpointing now uses a monotonic `total_batches_done` counter (seeded from `current_page` and reset on completed runs) instead of the stale `wi * 5000` math, so `page` reporting reflects real API calls and resumes display sanely.
> 
> MISP→STIX export rewrites MITRE **tool** and **tactic** handling to emit valid STIX 2.1 objects with proper `id`/`spec_version` and `external_references` (tactics as `x-mitre-tactic`), and hardens multiple error-log fallback slices to avoid `None[:N]` crashes.
> 
> Adds `tests/test_pr_g1_baseline_killers.py` to pin these fixes with source-level assertions plus behavioral tests for empty-tag tool/tactic attributes and checkpoint seeding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e526f58692d05e1df7f2d461f620f2ad09aff494. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->