### PR TITLE
feat(security): PR-I — warn-everywhere + Prometheus observability for MISP tag-impersonation defense

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,14 @@ EdgeGuard **intentionally** uses **deterministic identity and merge rules** (Neo
 - **Trivy supply-chain gate re-tightening** — see [Issue #52](../../issues/52) (re-tighten airflow image scan to HIGH+CRITICAL once apache/airflow upstream catches up)
 - **Wipe loop simplification** — see [Issue #54](../../issues/54) (replace string-match + page-advancement state machine with tag-based filter)
 
+#### 🛡️ Security roadmap — MISP trust boundary
+
+Staged defense-in-depth for untrusted MISP inputs. Full design + threat model in [`docs/SECURITY_ROADMAP.md`](docs/SECURITY_ROADMAP.md).
+
+- ✅ **Tier 1 — Defense machinery (PR #44).** Creator-org allowlist check with Unicode-aware name normalization (NFKC + casefold), strict UUID validation, and log-injection-safe rejection logging. Rejections increment `edgeguard_source_truthful_creator_rejected_total`.
+- 🚧 **Tier 2 — Observability for the disabled state (PR-I, this cycle).** Defense-disabled state is now always visible: startup WARNING log fires in **all** envs (previously prod/staging only, which silently accepted the default `EDGEGUARD_ENV=dev`) + Prometheus gauge `edgeguard_misp_tag_impersonation_defense_disabled` exposes the state to alert rules. See [`docs/PROMETHEUS_SETUP.md`](docs/PROMETHEUS_SETUP.md) for the suggested alert rule.
+- 📋 **Tier 3 — Fail-closed boot refusal (planned, post-Tier 2).** After operators have had a deployment cycle to configure the allowlists, `EDGEGUARD_ENV ∈ {prod, staging}` will flip to boot-refusal: the process refuses to start unless an allowlist is configured OR `EDGEGUARD_ALLOW_UNTRUSTED_MISP=1` is set explicitly. Closes the "forgot to configure" footgun at deploy time.
+
 The phased plan: **PR-F1** landed the easy + fast audit fixes; **PR-F2** lands BACKUP.md + the backup-timestamp gate (the Airflow-side baseline lock was de-scoped after Bugbot caught two architectural flaws — proper redesign tracked in [Issue #57](../../issues/57)). Next we work through the remaining In-Progress items above. The README will gain "📋 Planned" sections for **Cloud deployment** (Aura Neo4j + cloud MISP + K8s) and **Regular monitoring & incremental SLOs** once the local-operational hardening lands and we shift focus to those scopes.
 
 ---

--- a/docs/PROMETHEUS_SETUP.md
+++ b/docs/PROMETHEUS_SETUP.md
@@ -258,6 +258,34 @@ sum by (reason) (
 
 **When neither allowlist env var is configured (the default), the trust check is BYPASSED and this counter never increments.** Pre-release / dev environments see no behavior change.
 
+### Defense-disabled state gauge (PR-I, 2026-04)
+
+Added to make the "defense configured OFF" state observable to alert rules, not just to the startup log. See [`SECURITY_ROADMAP.md`](SECURITY_ROADMAP.md) for the full threat-model background and the Tier 3 fail-closed plan.
+
+| Metric | Type | Labels | Description |
+|--------|------|--------|-------------|
+| `edgeguard_misp_tag_impersonation_defense_disabled` | Gauge | — | `1` when both allowlist env vars are empty (defense BYPASSED, all source-truthful claims accepted); `0` when at least one allowlist is populated (defense ACTIVE). Read once at metrics-server boot; operators must restart the metrics server to pick up an env-var change. |
+
+**Suggested alert rule:**
+
+```yaml
+- alert: EdgeGuardMispTagImpersonationDefenseDisabled
+  expr: edgeguard_misp_tag_impersonation_defense_disabled == 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: MISP tag-impersonation defense is disabled
+    description: |
+      EdgeGuard is accepting source-truthful claims from MISP attributes
+      without verifying the creator organization. Configure
+      EDGEGUARD_TRUSTED_MISP_ORG_UUIDS and/or
+      EDGEGUARD_TRUSTED_MISP_ORG_NAMES to enable the defense, then
+      restart the metrics server. See docs/SECURITY_ROADMAP.md.
+```
+
+This alert is a **backstop** for the startup `WARNING` log that fires on every process boot when the defense is disabled — catches cases where operators have filtered / suppressed the log aggregator.
+
 ## Using Metrics in Code
 
 ### Recording Collection

--- a/docs/SECURITY_ROADMAP.md
+++ b/docs/SECURITY_ROADMAP.md
@@ -1,0 +1,163 @@
+# EdgeGuard Security Roadmap
+
+This document tracks EdgeGuard's **trust-boundary** defenses — the
+controls that protect the knowledge graph against hostile or
+misconfigured upstream feeds. It is a staged roadmap, not a finished
+design: each tier raises the bar one step without breaking existing
+operators.
+
+## Threat model in one paragraph
+
+EdgeGuard ingests data from MISP, which acts as the single source of
+truth for indicators, malware, threat actors, techniques, tactics,
+tools, and CVE vulnerability data. **MISP is not trusted by default**:
+anyone with write access to the MISP instance (a federated peer, a
+compromised user, a misconfigured community feed) can create events
+and attach tags such as `original_source:nvd` or
+`edgeguard:source:vt`. Without an additional check, the source-truthful
+timestamp pipeline (PR #41) would treat those forged tags as
+authoritative — corrupting `MIN(r.source_reported_first_at)` exports to
+ResilMesh. The **MISP tag-impersonation defense** (PR #44, Chip 5e) is
+the trust-boundary control that fixes this.
+
+## The defense
+
+The defense is implemented in `src/source_trust.py` and exposed via
+two environment variables:
+
+| Env var | Effect |
+|---|---|
+| `EDGEGUARD_TRUSTED_MISP_ORG_UUIDS` | CSV of `Orgc.uuid` values that are trusted to publish source-truthful attributes |
+| `EDGEGUARD_TRUSTED_MISP_ORG_NAMES` | CSV of `Orgc.name` values (NFKC-normalized + casefolded) trusted to publish source-truthful attributes |
+
+When at least one of these is populated, every MISP attribute that
+carries a `original_source:*` or `edgeguard:source:*` tag has its
+**parent event's `Orgc` (creator organization)** checked against the
+allowlist. Non-matching events' claims are dropped and counted via
+`edgeguard_source_truthful_creator_rejected_total`.
+
+When **both** env vars are empty, the defense is **DISABLED** — all
+claims are accepted. This is the "backward-compat" path for
+operators who have not yet configured the allowlist.
+
+## Roadmap tiers
+
+### ✅ Tier 1 — Defense machinery (shipped, PR #44)
+
+- `source_trust.py` implements the creator-org allowlist check
+- Unicode-aware name normalization (NFKC + casefold) defeats
+  homoglyph attacks
+- Strict UUID validation defeats free-text spoofing
+- Log-injection-safe rejection logging (truncated, newline-stripped
+  `Orgc.name`)
+- `edgeguard_source_truthful_creator_rejected_total` Prometheus
+  counter fires on every rejection
+
+### 🚧 Tier 2 — Observability for the disabled state (this PR, PR-I)
+
+When the defense is configured OFF (both allowlists empty), the
+state is now **always visible** — not silent.
+
+- **Startup log signal (all envs):**
+  - `INFO` line when the defense is ACTIVE: `MISP tag-impersonation
+    defense ACTIVE (EDGEGUARD_ENV=prod, trusted_uuids=3,
+    trusted_names=0).`
+  - `WARNING` line when the defense is DISABLED, including the
+    dev environment (which is the default):
+    `MISP tag-impersonation defense is DISABLED (EDGEGUARD_ENV=dev)
+    — all source-truthful claims accepted without creator-org
+    verification...`
+
+- **Prometheus gauge:**
+  `edgeguard_misp_tag_impersonation_defense_disabled`
+  - Value `1` → defense DISABLED
+  - Value `0` → defense ENABLED
+  - Labelless by design; read once at metrics-server boot
+
+**Why widen from the prior prod/staging-only warning:**
+`EDGEGUARD_ENV` defaults to `dev` in `src/config.py:17`. Under the
+original gating (PR #44's `_warn_if_disabled_in_prod`), a brand-new
+deployment would silently inherit "defense off + no warning" until an
+operator remembered to flip the env var. Every new installation
+shipped with a silent gap. PR-I closes that by emitting the warning
+in **every** env and exposing the state via a gauge that any alert
+rule can catch.
+
+**Suggested alert rule** (see `docs/PROMETHEUS_SETUP.md`):
+
+```yaml
+- alert: EdgeGuardMispTagImpersonationDefenseDisabled
+  expr: edgeguard_misp_tag_impersonation_defense_disabled == 1
+  for: 5m
+  labels:
+    severity: warning
+  annotations:
+    summary: MISP tag-impersonation defense is disabled
+    description: |
+      EdgeGuard accepts source-truthful claims from MISP attributes
+      without verifying the creator organization. Any MISP user or
+      federated peer can spoof source_id values and corrupt
+      source_reported_first_at aggregates. Configure
+      EDGEGUARD_TRUSTED_MISP_ORG_UUIDS and/or
+      EDGEGUARD_TRUSTED_MISP_ORG_NAMES to enable the defense, then
+      restart the metrics server. See docs/SECURITY_ROADMAP.md.
+```
+
+### 📋 Tier 3 — Fail-closed boot refusal (planned, post-Tier 2)
+
+After operators have had a deployment cycle to configure the
+allowlists (signalled by the Tier 2 log + gauge), the
+`EDGEGUARD_ENV ∈ {prod, staging, production, stage}` default will
+flip to **fail-closed**: the process refuses to boot unless EITHER
+an allowlist is configured OR
+`EDGEGUARD_ALLOW_UNTRUSTED_MISP=1` is set explicitly as an opt-out.
+
+Rationale:
+- Boot refusal is self-documenting — operators can't accidentally
+  deploy without making a conscious trust decision
+- Log warnings can be missed; Prometheus alerts can be unwired;
+  boot refusal cannot be missed
+- Dev loop keeps the current warn-on-empty ergonomics (no friction
+  for local stacks where MISP runs inside the same compose network)
+- Opt-out flag preserves escape hatch for operators with legitimate
+  untrusted-MISP use cases (e.g. a known-curated community MISP
+  they've explicitly decided to trust as a whole)
+
+Tier 3 will land as its own PR after Tier 2 has had enough operator
+exposure to surface any unexpected interaction.
+
+## Operator checklist
+
+1. **Find your EdgeGuard collector's `Orgc.uuid`.** In MISP, go to
+   *Administration → List Organisations → [your org] → UUID*. Copy
+   the canonical 8-4-4-4-12 hex string.
+
+2. **Set the env var.** In your `.env` or deployment config:
+   ```
+   EDGEGUARD_TRUSTED_MISP_ORG_UUIDS=11111111-2222-3333-4444-555555555555
+   # For multiple trusted orgs (e.g. after org migration, or multi-tenant):
+   EDGEGUARD_TRUSTED_MISP_ORG_UUIDS=uuid-of-primary,uuid-of-backup
+   ```
+
+3. **Restart the collector and metrics server.** Both processes read
+   the env var at boot.
+
+4. **Verify.** Check the log for
+   `MISP tag-impersonation defense ACTIVE` (INFO) and the gauge
+   for value `0`:
+   ```
+   curl -s http://localhost:8001/metrics | \
+     grep edgeguard_misp_tag_impersonation_defense_disabled
+   # Should report value 0
+   ```
+
+5. **(Recommended)** Add the alert rule from `PROMETHEUS_SETUP.md`.
+
+## Cross-references
+
+- `src/source_trust.py` — defense implementation
+- `src/metrics_server.py` — Prometheus gauge wiring
+- `tests/test_source_trust.py` — 47 tests covering both the decision
+  logic and the new PR-I observability
+- `docs/PROMETHEUS_SETUP.md` — full metrics reference + alert rules
+- `.env.example` — env var templates

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -207,6 +207,57 @@ SYNC_EVENTS_INDEX_TOTAL = Gauge(
     "Total events returned by MISP events index for the most recent sync run",
 )
 
+# PR-I (2026-04-20 multi-agent audit Red Team #4): MISP tag-impersonation
+# defense can be configured OFF (both allowlists empty). Prior to PR-I,
+# that state was signalled only by a startup log line that fired ONLY in
+# prod/staging — which silently accepted the default dev env.  This
+# gauge mirrors the defense's configured state at metrics-server boot:
+#
+#   value 0 → defense ENABLED (at least one allowlist populated)
+#   value 1 → defense DISABLED (all source-truthful claims accepted)
+#
+# Suggested alert rule (see docs/PROMETHEUS_SETUP.md):
+#
+#   ALERT EdgeGuardMispTagImpersonationDefenseDisabled
+#     IF edgeguard_misp_tag_impersonation_defense_disabled == 1
+#     FOR 5m
+#     LABELS { severity="warning" }
+#
+# Labelless by design: alert rules care about "is it on?", not
+# "what kind of allowlist?". If operators later need config-audit
+# gauges (count of trusted uuids / names, per-env breakdown), those
+# land as separate metrics — one gauge per question.
+MISP_TAG_IMPERSONATION_DEFENSE_DISABLED = Gauge(
+    "edgeguard_misp_tag_impersonation_defense_disabled",
+    "MISP tag-impersonation defense: 1 = disabled (all source claims accepted "
+    "without creator-org verification), 0 = enabled. Set EDGEGUARD_TRUSTED_MISP_ORG_UUIDS "
+    "and/or EDGEGUARD_TRUSTED_MISP_ORG_NAMES to enable. See docs/SECURITY_ROADMAP.md.",
+)
+
+
+def _initialize_misp_defense_gauge() -> None:
+    """Populate the MISP_TAG_IMPERSONATION_DEFENSE_DISABLED gauge from
+    source_trust's current state. Called once at module load.
+
+    The gauge reflects env-var state AT METRICS-SERVER BOOT; an operator
+    who changes the env vars must restart the metrics-server process
+    for the gauge to update. This matches the semantics of every other
+    config-derived gauge in this file (e.g. NEO4J_POOL_SIZE, which is
+    also read-once-at-boot). Documented in docs/SECURITY_ROADMAP.md.
+    """
+    try:
+        from source_trust import is_trust_check_configured
+    except ImportError:  # pragma: no cover — defensive; source_trust is always present
+        # source_trust module not available in the environment metrics
+        # is running in — safer to report ``disabled`` so operators
+        # notice that something is off than to stay silent.
+        MISP_TAG_IMPERSONATION_DEFENSE_DISABLED.set(1)
+        return
+    MISP_TAG_IMPERSONATION_DEFENSE_DISABLED.set(0 if is_trust_check_configured() else 1)
+
+
+_initialize_misp_defense_gauge()
+
 NEO4J_QUERIES = Counter("edgeguard_neo4j_queries_total", "Total Neo4j queries executed", ["query_type", "status"])
 
 NEO4J_QUERY_DURATION = Histogram(

--- a/src/source_trust.py
+++ b/src/source_trust.py
@@ -209,27 +209,68 @@ _TRUSTED_CREATOR_ORG_NAMES: FrozenSet[str] = _parse_csv_env_names("EDGEGUARD_TRU
 
 
 # PR #44 audit M1 (Devil's Advocate / Prod Readiness): when the
-# defense is disabled in a production-like environment, log a
-# WARNING at module import so the misconfiguration is loud, not
-# silent. Operators who deliberately want the bypass in dev/staging
-# / EDGEGUARD_ENV unset see nothing.
-def _warn_if_disabled_in_prod() -> None:
-    env = os.getenv("EDGEGUARD_ENV", "").strip().lower()
-    prod_envs = {"prod", "production", "staging", "stage"}
-    if env in prod_envs and not (_TRUSTED_CREATOR_ORG_UUIDS or _TRUSTED_CREATOR_ORG_NAMES):
+# defense is disabled, log a WARNING at module import so the
+# misconfiguration is loud, not silent.
+#
+# PR-I (2026-04-20 multi-agent audit Red Team #4): the original
+# implementation gated the warning on ``EDGEGUARD_ENV ∈ {prod,
+# staging}``. That meant dev — which is ``EDGEGUARD_ENV``'s default
+# in ``config.py`` — silently accepted the disabled-defense state
+# without any log signal at all. Every new deployment inherited
+# "defense off + no warning" until an operator remembered to flip
+# the env var. Widen the warning to fire in ALL envs: humans see
+# the WARNING once per process in the log, and the companion
+# Prometheus gauge ``edgeguard_misp_tag_impersonation_defense_disabled``
+# (set in ``src/metrics_server.py``) exposes the state to alert
+# rules so a missed log line can't mask a production gap.
+#
+# An accompanying planned change (see docs/SECURITY_ROADMAP.md) will
+# flip the ``prod``/``staging`` default to fail-closed — refuse to
+# boot unless the allowlists are configured OR
+# ``EDGEGUARD_ALLOW_UNTRUSTED_MISP=1`` is set explicitly. That
+# requires an operator-migration window which this observability
+# layer provides.
+def _log_defense_state() -> None:
+    env = os.getenv("EDGEGUARD_ENV", "").strip().lower() or "unset"
+    uuid_count = len(_TRUSTED_CREATOR_ORG_UUIDS)
+    name_count = len(_TRUSTED_CREATOR_ORG_NAMES)
+    if _TRUSTED_CREATOR_ORG_UUIDS or _TRUSTED_CREATOR_ORG_NAMES:
+        logger.info(
+            "MISP tag-impersonation defense ACTIVE (EDGEGUARD_ENV=%s, trusted_uuids=%d, trusted_names=%d).",
+            env,
+            uuid_count,
+            name_count,
+        )
+    else:
         logger.warning(
-            "EDGEGUARD_ENV=%r BUT MISP tag-impersonation defense is DISABLED — "
-            "set EDGEGUARD_TRUSTED_MISP_ORG_UUIDS (recommended) and/or "
-            "EDGEGUARD_TRUSTED_MISP_ORG_NAMES to your EdgeGuard collector "
-            "org's identifier(s). Without the allowlist, any MISP user / "
-            "federated peer can spoof source_id='nvd' and silently corrupt "
-            "MIN(r.source_reported_first_at). See src/source_trust.py and "
-            ".env.example for details.",
+            "MISP tag-impersonation defense is DISABLED (EDGEGUARD_ENV=%s) — "
+            "all source-truthful claims accepted without creator-org "
+            "verification. Set EDGEGUARD_TRUSTED_MISP_ORG_UUIDS "
+            "(recommended) and/or EDGEGUARD_TRUSTED_MISP_ORG_NAMES to "
+            "your EdgeGuard collector org's identifier(s). Without the "
+            "allowlist, any MISP user / federated peer can spoof "
+            "source_id='nvd' and silently corrupt "
+            "MIN(r.source_reported_first_at). Planned: fail-closed in "
+            "prod/staging — see docs/SECURITY_ROADMAP.md. Gauge: "
+            "edgeguard_misp_tag_impersonation_defense_disabled.",
             env,
         )
 
 
-_warn_if_disabled_in_prod()
+_log_defense_state()
+
+
+def is_trust_check_configured() -> bool:
+    """Public: ``True`` iff at least one allowlist env var is non-empty.
+
+    Exposed as a public API (no leading underscore) so other modules —
+    notably ``src/metrics_server.py`` which mirrors this state into the
+    ``edgeguard_misp_tag_impersonation_defense_disabled`` Prometheus
+    gauge — can read it without reaching into private names. The
+    private ``_trust_check_configured`` alias is retained for
+    backward-compat with existing callers inside this module.
+    """
+    return _trust_check_configured()
 
 
 # Trust-check decision reasons (also appears as the ``reason`` Prometheus

--- a/tests/test_source_trust.py
+++ b/tests/test_source_trust.py
@@ -548,40 +548,217 @@ def test_h3_log_injection_handles_none_orgc():
 
 
 def test_m1_prod_env_without_allowlist_logs_warning(monkeypatch, caplog):
-    """PR #44 audit M1 (Devil's Advocate / Prod Readiness): when
-    EDGEGUARD_ENV is prod-like AND neither allowlist is configured,
+    """PR #44 audit M1 (Devil's Advocate / Prod Readiness) +
+    PR-I (2026-04-20 Red Team): when an allowlist is NOT configured,
     a WARNING MUST be logged at module-import time so the silent
-    misconfiguration is loud."""
+    misconfiguration is loud. PR-I widened this from prod-only to
+    every env (see ``TestDefenseStateLogging`` below) so the default
+    EDGEGUARD_ENV=dev does not silently bypass the signal."""
     import logging
 
     caplog.set_level(logging.WARNING, logger="source_trust")
     monkeypatch.setenv("EDGEGUARD_ENV", "production")
     monkeypatch.delenv("EDGEGUARD_TRUSTED_MISP_ORG_UUIDS", raising=False)
     monkeypatch.delenv("EDGEGUARD_TRUSTED_MISP_ORG_NAMES", raising=False)
-    # _reload_env does NOT re-trigger the warn; call it explicitly.
+    # _reload_env does NOT re-trigger the log; call it explicitly.
     import source_trust
 
     source_trust._reload_env()
-    source_trust._warn_if_disabled_in_prod()
+    source_trust._log_defense_state()
     assert any("DISABLED" in rec.message and "production" in rec.message.lower() for rec in caplog.records), (
         f"Expected WARNING when EDGEGUARD_ENV=production + no allowlist; got: {[r.message for r in caplog.records]}"
     )
 
 
-def test_m1_dev_env_without_allowlist_does_not_log_warning(monkeypatch, caplog):
-    """The opposite: in dev/test/no-env, the warning MUST stay quiet
-    so operators on local laptops aren't spammed."""
-    import logging
+# ---------------------------------------------------------------------------
+# PR-I — Option A + Prometheus observability for the tag-impersonation
+# defense.  The old prod-only warning gate meant the default
+# ``EDGEGUARD_ENV=dev`` shipped with the defense DISABLED and zero log
+# signal — every new deployment silently inherited the gap until an
+# operator remembered to set the env var.  PR-I widens the warning to
+# fire in all envs (human-facing signal) AND exposes the state via the
+# ``edgeguard_misp_tag_impersonation_defense_disabled`` Prometheus
+# gauge (machine-facing signal for alert rules).
+# ---------------------------------------------------------------------------
 
-    caplog.set_level(logging.WARNING, logger="source_trust")
-    monkeypatch.setenv("EDGEGUARD_ENV", "dev")
-    monkeypatch.delenv("EDGEGUARD_TRUSTED_MISP_ORG_UUIDS", raising=False)
-    monkeypatch.delenv("EDGEGUARD_TRUSTED_MISP_ORG_NAMES", raising=False)
-    import source_trust
 
-    source_trust._reload_env()
-    source_trust._warn_if_disabled_in_prod()
-    assert not any("DISABLED" in rec.message for rec in caplog.records)
+class TestDefenseStateLogging:
+    """Every env-value × allowlist-state combination MUST land on the
+    right log level.  The test matrix:
+
+      | env        | allowlist | expected  |
+      |------------|-----------|-----------|
+      | dev        | empty     | WARNING   |
+      | prod       | empty     | WARNING   |
+      | (unset)    | empty     | WARNING   |
+      | dev        | populated | INFO      |
+      | prod       | populated | INFO      |
+    """
+
+    @staticmethod
+    def _reload_and_log(monkeypatch, *, env: str, uuids: str = "", names: str = "") -> None:
+        monkeypatch.setenv("EDGEGUARD_ENV", env)
+        monkeypatch.setenv("EDGEGUARD_TRUSTED_MISP_ORG_UUIDS", uuids)
+        monkeypatch.setenv("EDGEGUARD_TRUSTED_MISP_ORG_NAMES", names)
+        import source_trust
+
+        source_trust._reload_env()
+        source_trust._log_defense_state()
+
+    def test_dev_env_empty_allowlist_logs_warning(self, monkeypatch, caplog):
+        """The PR-I regression pin: ``EDGEGUARD_ENV=dev`` (the default)
+        with no allowlist used to be silent — which meant every new
+        deployment shipped with the defense off and no log telling
+        the operator so. Must now log a WARNING."""
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="source_trust")
+        self._reload_and_log(monkeypatch, env="dev")
+        assert any("DISABLED" in rec.message for rec in caplog.records if rec.levelno == logging.WARNING), (
+            f"PR-I: dev + empty allowlist MUST emit a WARNING. "
+            f"Got: {[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    def test_unset_env_empty_allowlist_logs_warning(self, monkeypatch, caplog):
+        """``EDGEGUARD_ENV`` not set at all — still must warn."""
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="source_trust")
+        monkeypatch.delenv("EDGEGUARD_ENV", raising=False)
+        monkeypatch.setenv("EDGEGUARD_TRUSTED_MISP_ORG_UUIDS", "")
+        monkeypatch.setenv("EDGEGUARD_TRUSTED_MISP_ORG_NAMES", "")
+        import source_trust
+
+        source_trust._reload_env()
+        source_trust._log_defense_state()
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING and "DISABLED" in r.message]
+        assert warns, f"unset env + empty allowlist MUST emit WARNING; got: {[r.message for r in caplog.records]}"
+        # And the message must report the env as ``unset`` (not as the empty string, which is unreadable).
+        assert "unset" in warns[0].message.lower()
+
+    def test_prod_env_populated_uuid_logs_info_not_warning(self, monkeypatch, caplog):
+        """Defense ACTIVE → INFO log, never WARNING. Captures the
+        positive-case confirmation signal operators want to see."""
+        import logging
+
+        caplog.set_level(logging.INFO, logger="source_trust")
+        self._reload_and_log(
+            monkeypatch,
+            env="production",
+            uuids="11111111-1111-1111-1111-111111111111",
+        )
+        infos = [r for r in caplog.records if r.levelno == logging.INFO and "ACTIVE" in r.message]
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert infos, f"prod + configured allowlist MUST emit INFO 'ACTIVE'; got: {[r.message for r in caplog.records]}"
+        assert not warns, (
+            f"prod + configured allowlist MUST NOT emit WARNING; got WARNINGs: {[r.message for r in warns]}"
+        )
+        # And the INFO line must carry the count of trusted uuids/names so
+        # operators can sanity-check their config from the log.
+        assert "trusted_uuids=1" in infos[0].message
+        assert "trusted_names=0" in infos[0].message
+
+    def test_dev_env_populated_name_logs_info_not_warning(self, monkeypatch, caplog):
+        """Same positive-case check but for name-based allowlist in dev
+        — PR-I doesn't change this path, just verifies it still works."""
+        import logging
+
+        caplog.set_level(logging.INFO, logger="source_trust")
+        self._reload_and_log(monkeypatch, env="dev", names="EdgeGuard Collectors")
+        infos = [r for r in caplog.records if r.levelno == logging.INFO and "ACTIVE" in r.message]
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert infos, f"dev + configured allowlist MUST emit INFO; got: {[r.message for r in caplog.records]}"
+        assert not warns
+
+    def test_is_trust_check_configured_public_api_exists(self):
+        """PR-I exposed ``_trust_check_configured`` as a public
+        ``is_trust_check_configured`` helper so ``metrics_server``
+        doesn't need to reach into private names when wiring up the
+        Prometheus gauge.  Must exist + must agree with the private
+        implementation."""
+        import source_trust
+
+        assert hasattr(source_trust, "is_trust_check_configured"), (
+            "PR-I expected public helper ``is_trust_check_configured`` on source_trust"
+        )
+        # Parity with the private implementation — both should agree.
+        assert source_trust.is_trust_check_configured() == source_trust._trust_check_configured()
+
+
+class TestMispTagImpersonationDefenseGauge:
+    """PR-I (2026-04-20): ``edgeguard_misp_tag_impersonation_defense_disabled``
+    is the alert-rule-facing observable for the defense state. Gauge
+    semantics: 1 = disabled (fail-open), 0 = enabled. Labelless by
+    design — alert rules only need the boolean.
+    """
+
+    @staticmethod
+    def _reinit_gauge(monkeypatch, *, uuids: str = "", names: str = "") -> None:
+        """Set the allowlist env vars, reload ``source_trust``, then
+        call ``metrics_server._initialize_misp_defense_gauge`` to
+        refresh the gauge cell from the new state."""
+        monkeypatch.setenv("EDGEGUARD_TRUSTED_MISP_ORG_UUIDS", uuids)
+        monkeypatch.setenv("EDGEGUARD_TRUSTED_MISP_ORG_NAMES", names)
+        import source_trust
+
+        source_trust._reload_env()
+        import metrics_server
+
+        metrics_server._initialize_misp_defense_gauge()
+
+    def test_gauge_is_one_when_defense_disabled(self, monkeypatch):
+        """Empty allowlist → gauge reports 1 (disabled). This is the
+        state an alert rule like ``defense_disabled == 1 FOR 5m``
+        fires on."""
+        self._reinit_gauge(monkeypatch)
+        from metrics_server import MISP_TAG_IMPERSONATION_DEFENSE_DISABLED
+
+        assert _counter_value(MISP_TAG_IMPERSONATION_DEFENSE_DISABLED) == 1.0
+
+    def test_gauge_is_zero_when_defense_enabled_by_uuid(self, monkeypatch):
+        """Populated UUID allowlist → gauge reports 0 (enabled)."""
+        self._reinit_gauge(monkeypatch, uuids="11111111-1111-1111-1111-111111111111")
+        from metrics_server import MISP_TAG_IMPERSONATION_DEFENSE_DISABLED
+
+        assert _counter_value(MISP_TAG_IMPERSONATION_DEFENSE_DISABLED) == 0.0
+
+    def test_gauge_is_zero_when_defense_enabled_by_name(self, monkeypatch):
+        """Populated NAME allowlist (no UUID) → gauge reports 0."""
+        self._reinit_gauge(monkeypatch, names="EdgeGuard Collectors")
+        from metrics_server import MISP_TAG_IMPERSONATION_DEFENSE_DISABLED
+
+        assert _counter_value(MISP_TAG_IMPERSONATION_DEFENSE_DISABLED) == 0.0
+
+    def test_gauge_is_labelless(self):
+        """Alert-rule simplicity is a feature: gauge MUST be labelless
+        so rules can be written as ``metric == 1`` not ``metric{...}
+        == 1``. Guards against well-intentioned future diffs that
+        add a ``state`` label and break existing alert rules."""
+        from metrics_server import MISP_TAG_IMPERSONATION_DEFENSE_DISABLED
+
+        # prometheus_client Gauge exposes labelnames; empty tuple means
+        # no labels.
+        assert MISP_TAG_IMPERSONATION_DEFENSE_DISABLED._labelnames == ()
+
+    def test_gauge_name_follows_edgeguard_prefix_convention(self):
+        """All EdgeGuard metrics use the ``edgeguard_`` prefix. Guards
+        against accidental naming drift (``misp_*``, ``trust_*``, etc.)."""
+        from metrics_server import MISP_TAG_IMPERSONATION_DEFENSE_DISABLED
+
+        # prometheus_client Gauge stores the full name in ``_name``.
+        assert MISP_TAG_IMPERSONATION_DEFENSE_DISABLED._name.startswith("edgeguard_")
+        assert MISP_TAG_IMPERSONATION_DEFENSE_DISABLED._name == "edgeguard_misp_tag_impersonation_defense_disabled"
+
+    def test_gauge_appears_in_generate_latest_output(self, monkeypatch):
+        """End-to-end: after initialization, the gauge must appear in
+        the ``/metrics`` endpoint output so Prometheus can scrape it.
+        Mirrors the pattern at
+        ``test_creator_rejected_counter_appears_in_generate_latest_output``."""
+        self._reinit_gauge(monkeypatch)
+        from prometheus_client import REGISTRY, generate_latest
+
+        payload = generate_latest(REGISTRY).decode()
+        assert "edgeguard_misp_tag_impersonation_defense_disabled" in payload
 
 
 def test_m2_no_extract_callsite_in_src_omits_event_info():


### PR DESCRIPTION
## Summary

Audit-driven observability pass for the MISP tag-impersonation defense (PR #44, Chip 5e). The prior "defense disabled" warning fired only when `EDGEGUARD_ENV ∈ {prod, staging}`, but `EDGEGUARD_ENV` defaults to `dev` in `src/config.py:17` — so every new deployment shipped with the defense off AND zero log signal until an operator remembered to flip the env var.

This PR implements **Tier 2** of the staged security roadmap documented in [`docs/SECURITY_ROADMAP.md`](docs/SECURITY_ROADMAP.md):

- 🛡️ **Tier 1** — Defense machinery (PR #44, ✅ shipped)
- 🛡️ **Tier 2** — Observability for the disabled state (**this PR**, 🚧 now)
- 🛡️ **Tier 3** — Fail-closed boot refusal in prod/staging (📋 planned, separate PR)

**No enforcement change** — this is purely an observability layer. Defense machinery behavior is unchanged.

## What it does

### Log signal — all envs

`_warn_if_disabled_in_prod()` renamed `_log_defense_state()` and widened:

- **Defense ENABLED** → `INFO`: `MISP tag-impersonation defense ACTIVE (EDGEGUARD_ENV=..., trusted_uuids=N, trusted_names=M).`
- **Defense DISABLED** → `WARNING` (every env) with full remediation guidance + forward reference to Tier 3.

### Prometheus gauge

New labelless gauge exposed from `src/metrics_server.py`:

```
edgeguard_misp_tag_impersonation_defense_disabled
  = 1 when defense is disabled
  = 0 when defense is enabled
```

Backstops the log in case operators have filtered the log aggregator.

**Suggested alert rule** (see `docs/PROMETHEUS_SETUP.md`):
```yaml
- alert: EdgeGuardMispTagImpersonationDefenseDisabled
  expr: edgeguard_misp_tag_impersonation_defense_disabled == 1
  for: 5m
  labels:
    severity: warning
```

### Public API

`source_trust._trust_check_configured()` → `source_trust.is_trust_check_configured()` (public). Keeps metrics-server out of private-name territory AND leaves `source_trust.py` free of any `prometheus_client` dependency — dependency direction flows FROM metrics TO trust, not the other way.

## Design decisions (all recorded in commit message)

- **Warn once per process.** Standard practice; operators deduplicate via log aggregation. Gauge is the alerting signal.
- **Labelless gauge.** One gauge per question. Config-audit metrics (count of trusted uuids, etc.) are YAGNI.
- **Gauge in `metrics_server.py`, not `source_trust.py`.** Clean dependency direction.

## Files

| File | Change |
|---|---|
| `src/source_trust.py` | +53 / -20 — rename + widen `_log_defense_state`, expose public `is_trust_check_configured` |
| `src/metrics_server.py` | +51 — new gauge + initializer |
| `tests/test_source_trust.py` | +198 / -13 — +11 new tests (5 logging-state, 6 gauge) + 1 updated M1 test |
| `docs/SECURITY_ROADMAP.md` | **new** — staged trust-boundary roadmap, threat model, operator checklist |
| `docs/PROMETHEUS_SETUP.md` | +28 — gauge documented + alert rule |
| `README.md` | +4 — new 🛡️ Security roadmap subsection |

## Test plan

- [x] 47 tests pass in `tests/test_source_trust.py` (35 existing + 12 new/updated)
- [x] 5 new `TestDefenseStateLogging` tests — dev/prod/unset env × empty/populated allowlist matrix
- [x] 6 new `TestMispTagImpersonationDefenseGauge` tests — value at 1/0, labelless contract, name prefix, `/metrics` output visibility
- [x] `ruff format --check` ✓
- [x] `ruff check` ✓
- [x] `mypy src/` ✓
- [x] `pytest tests/` — **1002 passed, 3 skipped** (+10 from 992)
- [x] Manual smoke: gauge = 1.0 + WARNING fires when env vars empty

## Related

- Multi-agent audit (2026-04-20) — Red Team #4 + Devil's Advocate findings
- PR #44 (Chip 5e) — original defense machinery (Tier 1)
- Tier 3 fail-closed — queued as separate PR per staged-rollout plan
- PR #69 (F9) + PR #70 (G1) — other audit follow-ups (merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to observability (startup logging + a new Prometheus gauge) and test/docs updates, without altering the underlying trust-check enforcement behavior.
> 
> **Overview**
> Makes the **MISP tag-impersonation defense “disabled” state non-silent** by logging it at process startup in *all* environments (and logging `INFO` when active), instead of warning only in prod/staging.
> 
> Adds a new labelless Prometheus gauge, `edgeguard_misp_tag_impersonation_defense_disabled`, initialized at metrics-server boot from a new public `source_trust.is_trust_check_configured()` helper, with expanded tests and documentation (including a new `docs/SECURITY_ROADMAP.md` and an alert-rule example in `docs/PROMETHEUS_SETUP.md`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8fce152caf643d46b1271d7b67fc548618ef4952. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->