### PR TITLE
fix(audit): PR-K1 — baseline resume robustness (§2-3 + §2-1 + §1-8)

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2240,15 +2240,33 @@ baseline_misp_health = PythonOperator(
 def _baseline_start_summary(**context):
     """Print baseline config at run-time so it shows clearly in the Airflow log.
 
-    Always clears baseline checkpoints (page counters) so collectors start
-    from page 1. Incremental state (OTX modified_since cursor, MITRE ETag)
-    is preserved by default — pass ``clear_checkpoints: "all"`` in
-    dag_run.conf to wipe those too.
+    PR-K1 §1-8: the old contract cleared baseline checkpoints on EVERY
+    run — including additive ones. That killed the resume path that
+    ``update_source_checkpoint`` was designed to provide: if a tier-1
+    collector fails at page 50 of a 730-day run, the next retry
+    should start from page 51, NOT page 1. Unconditional clearing
+    meant operators paid the full baseline cost again on every
+    interruption + resume.
+
+    The fix: only wipe checkpoints on **fresh-baseline** runs. The
+    fresh-baseline path's own ``_baseline_clean`` task already wipes
+    via ``_wipe_checkpoints()`` *before* this task runs, so
+    ``_baseline_start_summary`` is now **read-only on checkpoint
+    state** (never writes to it). Additive baselines preserve
+    whatever checkpoint state is on disk, enabling proper resume.
+
+    Operators who WANT to wipe on an additive run can do so by hand
+    (``rm checkpoints/baseline_checkpoint.json``) before triggering
+    the DAG. The DAG will no longer silently wipe on their behalf.
+
+    Incremental state (OTX modified_since cursor, MITRE ETag) is
+    never touched by this task — it flows through the
+    fresh-baseline branch via ``_wipe_checkpoints()`` in
+    ``baseline_clean.py`` with its own opt-in (``clear_checkpoints:
+    "all"`` in the DAG conf). See PR-K1 §2-8 for the cursor
+    handoff details.
     """
     limit, baseline_days = get_baseline_config(context)
-
-    # Clear baseline checkpoints so collectors start fresh (page 1, not stale page 80)
-    from baseline_checkpoint import clear_checkpoint
 
     # PR-C v2 audit fix (Bugbot HIGH on commit 951b163, same-pattern as
     # _baseline_clean below): ``dag_run.conf`` can be ``None`` in Airflow 3.x
@@ -2262,12 +2280,17 @@ def _baseline_start_summary(**context):
     # operators trace the full sequence of conf-consumption sites).
     _validate_baseline_dag_conf(conf, source_label="_baseline_start_summary")
 
-    include_incremental = str(conf.get("clear_checkpoints", "")).lower() == "all"
-    clear_checkpoint(include_incremental=include_incremental)
-    if include_incremental:
-        logger.info("[BASELINE] Cleared ALL checkpoints (baseline + incremental state)")
+    # PR-K1 §1-8: NO checkpoint clearing here. Fresh-baseline runs
+    # already had their checkpoints wiped by ``_baseline_clean``.
+    # Additive runs must preserve checkpoint state for resume.
+    is_fresh_baseline = str(conf.get("fresh_baseline", "")).lower() in ("true", "1", "yes")
+    if is_fresh_baseline:
+        logger.info("[BASELINE] Fresh-baseline: checkpoints already cleared by _baseline_clean task (PR-K1 §1-8)")
     else:
-        logger.info("[BASELINE] Cleared baseline checkpoints (incremental cursors preserved)")
+        logger.info(
+            "[BASELINE] Additive baseline: preserving checkpoints for resume (PR-K1 §1-8). "
+            "To wipe checkpoints, trigger with dag_run.conf={'fresh_baseline': 'true'}."
+        )
 
     logger.info("=" * 55)
     logger.info("EdgeGuard BASELINE Collection Started")

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1828,7 +1828,15 @@ _KNOWN_BASELINE_CONF_KEYS = frozenset(
         "baseline_days",  # historical depth (consumed by get_baseline_config)
         "baseline_collection_limit",  # legacy per-source cap (back-compat)
         "collection_limit",  # current per-source cap (SSoT)
-        "clear_checkpoints",  # "all" wipes incremental cursors too (consumed by _baseline_start_summary)
+        # PR-K1 Bugbot round-2 (Medium): the ``clear_checkpoints`` key
+        # used to be consumed by ``_baseline_start_summary`` to choose
+        # between baseline-only and full wipe. PR-K1 §1-8 removed that
+        # consumption (additive baselines must preserve checkpoints
+        # for resume), so the key is now a no-op everywhere — including
+        # the fresh-baseline path, since ``baseline_clean.py::_wipe_checkpoints``
+        # always wipes unconditionally with ``include_incremental=True``.
+        # Removing the key from the allowlist surfaces stale operator
+        # docs as a typo-warning instead of silently accepting it.
     }
 )
 
@@ -2260,11 +2268,13 @@ def _baseline_start_summary(**context):
     the DAG. The DAG will no longer silently wipe on their behalf.
 
     Incremental state (OTX modified_since cursor, MITRE ETag) is
-    never touched by this task — it flows through the
-    fresh-baseline branch via ``_wipe_checkpoints()`` in
-    ``baseline_clean.py`` with its own opt-in (``clear_checkpoints:
-    "all"`` in the DAG conf). See PR-K1 §2-8 for the cursor
-    handoff details.
+    never touched by this task. On a fresh-baseline run,
+    ``baseline_clean.py::_wipe_checkpoints()`` wipes EVERYTHING
+    unconditionally (baseline + incremental) — there is no opt-in
+    to preserve incremental cursors on the fresh-baseline path
+    today. PR-K1 §2-8 (the cursor-handoff design) is deferred to a
+    follow-up PR; the existing "fresh-baseline = true clean slate"
+    operator invariant is preserved here.
     """
     limit, baseline_days = get_baseline_config(context)
 
@@ -2323,7 +2333,15 @@ def _baseline_start_summary(**context):
     logger.info("  BASELINE_DAYS             = 730 (2 years, recommended)")
     logger.info("  Or set env on Airflow container (overrides Variables):")
     logger.info("  EDGEGUARD_BASELINE_DAYS=7  EDGEGUARD_BASELINE_COLLECTION_LIMIT=1000")
-    logger.info('  To wipe incremental cursors too: {"clear_checkpoints": "all"}')
+    # PR-K1 Bugbot round-2 (Medium): the previous hint
+    #   ``To wipe incremental cursors too: {"clear_checkpoints": "all"}``
+    # was misleading after PR-K1 §1-8 removed the only consumer of
+    # the ``clear_checkpoints`` key. The fresh-baseline path always
+    # wipes everything via ``_wipe_checkpoints(include_incremental=True)``
+    # in baseline_clean.py — there is no per-key control today.
+    # Surface the actual mechanism instead so operators don't follow
+    # a no-op instruction.
+    logger.info('  Fresh-baseline (wipe Neo4j + MISP + checkpoints): {"fresh_baseline": "true"}')
     logger.info("=" * 55)
 
 

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2283,7 +2283,19 @@ def _baseline_start_summary(**context):
     # PR-K1 §1-8: NO checkpoint clearing here. Fresh-baseline runs
     # already had their checkpoints wiped by ``_baseline_clean``.
     # Additive runs must preserve checkpoint state for resume.
-    is_fresh_baseline = str(conf.get("fresh_baseline", "")).lower() in ("true", "1", "yes")
+    #
+    # PR-K1 Bugbot round-1 (Medium): use the shared
+    # ``_is_truthy_conf_value`` helper (line ~1890) instead of inline
+    # ``str(...).lower() in (...)``. The helper accepts ``"on"``,
+    # strips whitespace, and handles ``True`` / ``int(1)`` explicitly
+    # — mirroring ``_baseline_clean``'s parse exactly. PR-F8 extracted
+    # this helper SPECIFICALLY to prevent drift between the two
+    # truthy-parse sites; re-introducing inline parsing here would
+    # reproduce the exact class of bug the helper was built to prevent
+    # (operator passes ``{"fresh_baseline": "on"}``, ``_baseline_clean``
+    # wipes correctly, but ``_baseline_start_summary`` logs misleading
+    # "preserving checkpoints").
+    is_fresh_baseline = _is_truthy_conf_value(conf.get("fresh_baseline"))
     if is_fresh_baseline:
         logger.info("[BASELINE] Fresh-baseline: checkpoints already cleared by _baseline_clean task (PR-K1 §1-8)")
     else:

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -70,23 +70,95 @@ def _atomic_write(path: Path, data: dict) -> None:
 
 
 def load_checkpoint() -> dict:
-    """Load checkpoint from file. Returns {} on missing or corrupt file."""
+    """Load checkpoint from file. Returns {} on missing or corrupt file.
+
+    Corrupt-file handling (PR-K1 §2-3):  if the on-disk JSON fails to
+    parse (truncated by power loss, SIGKILL mid-write, disk bitrot),
+    the corrupt file is **renamed to
+    ``baseline_checkpoint.json.corrupt.{ISO-timestamp}``** before the
+    empty ``{}`` is returned. This preserves forensic evidence so
+    operators can inspect what went wrong and potentially recover the
+    pre-corruption state by hand (e.g. ``mv
+    baseline_checkpoint.json.corrupt.<ts> baseline_checkpoint.json``
+    after fixing the JSON).
+
+    The log level is ``ERROR`` (not WARN) because the consequence on
+    a 730-day baseline is silent loss of progress — on the next
+    ``update_source_checkpoint`` call, the empty dict gets overwritten
+    with a fresh entry for that source, and every OTHER source's
+    prior progress is irrecoverably gone. Operators MUST see this
+    event in the log.
+    """
     if not CHECKPOINT_FILE.exists():
         return {}
     try:
         with open(CHECKPOINT_FILE, "r") as f:
             return json.load(f)
     except Exception as e:
-        logger.warning("Could not parse checkpoint file %s: %s — starting fresh.", CHECKPOINT_FILE, e)
+        # Preserve the corrupt bytes so the operator can inspect / recover.
+        # Timestamp is UTC-ISO-compact with ``-`` separators — safe for
+        # every filesystem (no colons, no spaces).
+        ts = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+        corrupt_backup = CHECKPOINT_FILE.with_suffix(f".json.corrupt.{ts}")
+        try:
+            CHECKPOINT_FILE.rename(corrupt_backup)
+            preserved_msg = f"preserved as {corrupt_backup.name}"
+        except OSError as rename_err:
+            # Filesystem may be read-only or file may have been removed
+            # between exists() and rename(). Log and continue with empty
+            # state — the original bug (silent fresh start) is still
+            # closed, we just couldn't stash the evidence.
+            preserved_msg = f"could not preserve (rename failed: {rename_err})"
+        logger.error(
+            "CORRUPT CHECKPOINT: %s failed to parse (%s). All per-source "
+            "baseline progress will be LOST on the next update_source_checkpoint "
+            "call unless the corrupt file is recovered. Forensic backup: %s. "
+            "To recover: stop all baseline/incremental runs, inspect the "
+            "corrupt backup, restore it to %s if usable. To force fresh "
+            "start after inspection, delete any remaining baseline_checkpoint.* "
+            "files. (PR-K1 §2-3)",
+            CHECKPOINT_FILE,
+            e,
+            preserved_msg,
+            CHECKPOINT_FILE.name,
+        )
         return {}
 
 
 def save_checkpoint(data: dict) -> None:
-    """Atomically save checkpoint to file."""
+    """Atomically save checkpoint to file.
+
+    PR-K1 §2-1:  write failures now **propagate** instead of being
+    swallowed with a WARN log. The prior silent-fail behavior let an
+    ENOSPC / permission / disk-failure event during a 730-day
+    baseline drift the in-memory counter away from the on-disk state
+    — operators would see the collector "advancing" in logs while
+    ``edgeguard baseline status`` showed hours-old numbers, and on
+    restart the resume would redo enormous chunks.
+
+    Callers (``update_source_checkpoint`` and, transitively, every
+    collector's progress-recording call site) get a loud exception
+    they can handle explicitly. ``update_source_checkpoint`` itself
+    does NOT swallow — if the write fails, the collector should
+    abort so the failure is visible before the sync continues with
+    in-memory state that can't be persisted.
+    """
+    # Log at ERROR level on failure so operators see the event
+    # immediately (checkpoint write is a critical step — silent
+    # failure is exactly what PR-K1 §2-1 closes), then re-raise so
+    # the caller can abort rather than continuing with a stale
+    # on-disk state.
     try:
         _atomic_write(CHECKPOINT_FILE, data)
     except Exception as e:
-        logger.warning("Could not save checkpoint: %s", e)
+        logger.error(
+            "CHECKPOINT WRITE FAILED: %s to %s — in-memory progress will NOT "
+            "be persisted and may be lost on restart. Caller should abort. "
+            "(PR-K1 §2-1)",
+            type(e).__name__,
+            CHECKPOINT_FILE,
+        )
+        raise
 
 
 def get_source_checkpoint(source: str) -> dict:

--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -151,12 +151,20 @@ def save_checkpoint(data: dict) -> None:
     try:
         _atomic_write(CHECKPOINT_FILE, data)
     except Exception as e:
+        # PR-K1 Bugbot round-1 (Low): include ``str(e)`` alongside
+        # ``type(e).__name__`` so operators triaging the alert can
+        # distinguish disk-full (``OSError: [Errno 28] No space left
+        # on device``) from permission-denied (``PermissionError:
+        # [Errno 13] Permission denied``) without having to dig for
+        # the traceback elsewhere. Matches ``load_checkpoint``'s
+        # existing ``logger.warning("... %s: %s", file, e)`` pattern.
         logger.error(
-            "CHECKPOINT WRITE FAILED: %s to %s — in-memory progress will NOT "
+            "CHECKPOINT WRITE FAILED: %s to %s: %s — in-memory progress will NOT "
             "be persisted and may be lost on restart. Caller should abort. "
             "(PR-K1 §2-1)",
             type(e).__name__,
             CHECKPOINT_FILE,
+            e,
         )
         raise
 

--- a/tests/test_pr_k1_baseline_resume_robustness.py
+++ b/tests/test_pr_k1_baseline_resume_robustness.py
@@ -424,3 +424,100 @@ class TestSaveCheckpointLogIncludesExceptionMessage:
         )
         # Type name should still be there too (both, not either/or).
         assert any("OSError" in msg for msg in error_logs)
+
+
+class TestNoStaleClearCheckpointsReferences:
+    """PR-K1 Bugbot round-2 (Medium): when §1-8 removed the only
+    consumer of the ``clear_checkpoints`` conf key from
+    ``_baseline_start_summary``, three stale references survived:
+
+    1. ``_KNOWN_BASELINE_CONF_KEYS`` still listed it, so passing
+       it would silently pass conf-validation (no "did you mean?"
+       warning).
+    2. The ``_baseline_start_summary`` log told operators to pass
+       it for "wipe incremental cursors too" — pure no-op, would
+       mislead operators into thinking cursors were wiped.
+    3. The docstring claimed it "flows through baseline_clean.py
+       with its own opt-in" — but ``_wipe_checkpoints()`` always
+       wipes everything unconditionally; no opt-in exists.
+
+    Pin all three against regression."""
+
+    @pytest.fixture(scope="class")
+    def dag_source(self) -> str:
+        return (REPO_ROOT / "dags" / "edgeguard_pipeline.py").read_text()
+
+    def test_clear_checkpoints_not_in_known_baseline_conf_keys(self, dag_source: str) -> None:
+        """The ``clear_checkpoints`` key MUST be absent from the
+        allowlist. Otherwise an operator passing it gets no warning
+        and silently believes it took effect."""
+        # Find the _KNOWN_BASELINE_CONF_KEYS frozenset literal block.
+        idx = dag_source.find("_KNOWN_BASELINE_CONF_KEYS = frozenset(")
+        assert idx > 0, "_KNOWN_BASELINE_CONF_KEYS not found"
+        # End at the closing of the literal.
+        end = dag_source.find(")", idx + len("_KNOWN_BASELINE_CONF_KEYS = frozenset("))
+        assert end > idx
+        block = dag_source[idx:end]
+        # Strip the explanatory comment block (which may legitimately
+        # mention "clear_checkpoints" as the removed key).
+        active_lines = [
+            line for line in block.splitlines() if not line.lstrip().startswith("#") and "clear_checkpoints" in line
+        ]
+        assert active_lines == [], (
+            f"clear_checkpoints must not appear as an active set member; "
+            f"found: {active_lines}. PR-K1 Bugbot round-2 caught this drift "
+            f"after §1-8 removed the consumer."
+        )
+
+    def test_baseline_start_summary_log_does_not_advertise_clear_checkpoints(self, dag_source: str) -> None:
+        """The operator-facing log MUST NOT tell operators to pass
+        the now-dead ``clear_checkpoints`` conf key. The mention IS
+        allowed in comments (explaining what was removed), but not
+        as live ``logger.info(...)`` text."""
+        # Locate _baseline_start_summary body
+        start = dag_source.find("def _baseline_start_summary")
+        end = dag_source.find("\ndef ", start + 1)
+        body = dag_source[start:end]
+        # Strip comments/docstrings — same code-only view as Bugbot is
+        # complaining about.
+        in_doc = False
+        doc_q = ""
+        live_lines = []
+        for line in body.splitlines():
+            s = line.lstrip()
+            if in_doc:
+                if doc_q in s:
+                    in_doc = False
+                    doc_q = ""
+                continue
+            for q in ('"""', "'''"):
+                if s.startswith(q):
+                    rest = s[len(q) :]
+                    if q in rest:
+                        break  # single-line, skip
+                    in_doc = True
+                    doc_q = q
+                    break
+            if in_doc or s.startswith("#"):
+                continue
+            live_lines.append(line)
+        live_code = "\n".join(live_lines)
+        assert '"clear_checkpoints"' not in live_code, (
+            "live (non-comment, non-docstring) code in _baseline_start_summary "
+            "must not advertise the clear_checkpoints conf key — it's a no-op "
+            "since PR-K1 §1-8."
+        )
+
+    def test_baseline_start_summary_advertises_fresh_baseline_instead(self, dag_source: str) -> None:
+        """The replacement: operators are pointed at
+        ``fresh_baseline: 'true'`` which IS still consumed (by
+        ``_baseline_clean``)."""
+        start = dag_source.find("def _baseline_start_summary")
+        end = dag_source.find("\ndef ", start + 1)
+        body = dag_source[start:end]
+        # The operator-facing instruction line must mention
+        # fresh_baseline as the actual lever.
+        assert "fresh_baseline" in body, (
+            "_baseline_start_summary must point operators at the fresh_baseline conf key as the "
+            "actual control for wiping data — that's the key still consumed by _baseline_clean."
+        )

--- a/tests/test_pr_k1_baseline_resume_robustness.py
+++ b/tests/test_pr_k1_baseline_resume_robustness.py
@@ -1,0 +1,364 @@
+"""
+PR-K1 — Baseline resume robustness regression suite.
+
+Fixes three flow-audit findings that collectively break the
+restart-without-data-loss story for a 730-day baseline:
+
+  * §2-3 — Corrupt checkpoint recovery: the on-disk JSON getting
+    truncated by a power-loss / SIGKILL would silently wipe all
+    per-source baseline progress on next load. Fix: preserve the
+    corrupt bytes as ``baseline_checkpoint.json.corrupt.{timestamp}``
+    and escalate log level to ERROR.
+
+  * §2-1 — ``save_checkpoint`` exception handling: the function
+    swallowed every write error with a WARN log, letting an
+    ENOSPC / permission failure during a 730-day run silently
+    desync the in-memory counter from the on-disk state. Fix:
+    re-raise so callers (and their Prometheus error accounting)
+    can handle it.
+
+  * §1-8 — Additive-baseline checkpoint preservation: the DAG's
+    ``_baseline_start_summary`` task unconditionally called
+    ``clear_checkpoint()`` on every baseline run, including
+    additive ones — killing the resume path that the rest of the
+    checkpoint machinery was built to support. Fix:
+    ``_baseline_start_summary`` no longer touches checkpoint state;
+    the fresh-baseline path still wipes via the separate
+    ``_baseline_clean`` task.
+
+**Intentionally scoped out of PR-K1:** §2-8 (fresh-baseline →
+incremental cursor handoff) needs a design decision about what
+cursor value to set at baseline completion and breaks an existing
+pin-test that encodes the ``true clean slate`` operator invariant.
+The §1-8 fix above ALREADY closes the ADDITIVE-baseline half of
+§2-8 by preserving cursors on additive runs; the remaining
+fresh-baseline-only handoff is deferred to a dedicated PR.
+
+Each fix has behavioural tests that prove the bug is closed, plus
+source-pin tests that guard against silent regressions.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def isolated_checkpoint_dir(tmp_path, monkeypatch):
+    """Redirect ``baseline_checkpoint`` state into a per-test directory.
+
+    The module captures the checkpoint path at import time via
+    ``EDGEGUARD_CHECKPOINT_DIR``. To mutate that, we set the env var
+    + reload the module; we restore afterwards so other tests see the
+    normal project-default path.
+
+    The path-traversal guard requires the dir to be INSIDE the project
+    root, so we use ``tmp_path / "inside_repo"`` placed as a child of
+    the repo. Safer: we use a repo-child dir and clean up.
+    """
+    safe_dir = REPO_ROOT / ".pytest_k1_checkpoint_tmp"
+    safe_dir.mkdir(exist_ok=True)
+    monkeypatch.setenv("EDGEGUARD_CHECKPOINT_DIR", str(safe_dir))
+
+    import baseline_checkpoint
+
+    importlib.reload(baseline_checkpoint)
+
+    yield safe_dir, baseline_checkpoint
+
+    # Cleanup
+    for entry in safe_dir.iterdir():
+        try:
+            entry.unlink()
+        except OSError:
+            pass
+    if safe_dir.exists() and not any(safe_dir.iterdir()):
+        safe_dir.rmdir()
+    # Restore module to normal state
+    monkeypatch.delenv("EDGEGUARD_CHECKPOINT_DIR", raising=False)
+    importlib.reload(baseline_checkpoint)
+
+
+# ===========================================================================
+# §2-3 — Corrupt checkpoint recovery
+# ===========================================================================
+
+
+class TestCorruptCheckpointRecovery:
+    """A corrupt checkpoint JSON MUST be preserved as evidence
+    before ``load_checkpoint`` returns ``{}``. The file rename is
+    the forensic artifact the operator needs to recover from the
+    class of bug where a truncated write wiped two years of
+    baseline progress on the next resume."""
+
+    def test_corrupt_file_preserved_as_timestamped_backup(self, isolated_checkpoint_dir, caplog):
+        """Write a corrupt JSON, call load_checkpoint, assert:
+        (a) function returns ``{}`` (existing contract preserved),
+        (b) corrupt file is gone from the checkpoint path,
+        (c) a ``baseline_checkpoint.json.corrupt.*`` sibling exists
+            with the original corrupt bytes intact,
+        (d) the log event is at ERROR level."""
+        import logging
+
+        safe_dir, bc = isolated_checkpoint_dir
+        corrupt_bytes = b'{"nvd": {"page": 42, "current_page"'  # truncated mid-field
+        bc.CHECKPOINT_FILE.write_bytes(corrupt_bytes)
+
+        caplog.set_level(logging.ERROR, logger="baseline_checkpoint")
+        result = bc.load_checkpoint()
+
+        assert result == {}, "load_checkpoint must still return empty dict on parse failure"
+        assert not bc.CHECKPOINT_FILE.exists(), "corrupt file must be moved out of the way"
+
+        # Find the preserved backup
+        backups = list(safe_dir.glob("baseline_checkpoint.json.corrupt.*"))
+        assert len(backups) == 1, f"expected exactly one .corrupt.* backup; got {backups}"
+        assert backups[0].read_bytes() == corrupt_bytes, "backup bytes must match the original corrupt file"
+
+        # Log must be ERROR level with CORRUPT marker for alert rules
+        assert any(rec.levelno == logging.ERROR and "CORRUPT CHECKPOINT" in rec.message for rec in caplog.records), (
+            f"expected ERROR log; got {[(r.levelname, r.message) for r in caplog.records]}"
+        )
+
+    def test_returns_empty_dict_when_rename_fails(self, isolated_checkpoint_dir, monkeypatch, caplog):
+        """If the rename itself fails (e.g. read-only filesystem),
+        load_checkpoint still returns {} — the primary bug (silent
+        fresh start with no preservation) is logged, and we don't
+        crash because the backup couldn't be taken."""
+        import logging
+        from pathlib import Path as _Path
+
+        _, bc = isolated_checkpoint_dir
+        bc.CHECKPOINT_FILE.write_bytes(b"{not valid json")
+
+        # Force rename to fail
+        original_rename = _Path.rename
+
+        def failing_rename(self, target):  # type: ignore[no-redef]
+            raise OSError("read-only filesystem (simulated)")
+
+        monkeypatch.setattr(_Path, "rename", failing_rename)
+
+        caplog.set_level(logging.ERROR, logger="baseline_checkpoint")
+        try:
+            result = bc.load_checkpoint()
+        finally:
+            monkeypatch.setattr(_Path, "rename", original_rename)
+
+        assert result == {}
+        # Log must mention the rename failure so operators understand why
+        # no backup was stashed.
+        assert any("could not preserve" in rec.message for rec in caplog.records)
+
+    def test_valid_checkpoint_still_loads_normally(self, isolated_checkpoint_dir):
+        """Sanity: the new defensive path must not regress the happy path."""
+        _, bc = isolated_checkpoint_dir
+        bc.save_checkpoint({"nvd": {"current_page": 42, "items_collected": 100}})
+
+        result = bc.load_checkpoint()
+        assert result == {"nvd": {"current_page": 42, "items_collected": 100}}
+
+    def test_source_pins_corrupt_rename_logic(self):
+        """Guard against a future "cleanup" that removes the rename
+        step. The rename behavior must stay in ``load_checkpoint``."""
+        source = (SRC / "baseline_checkpoint.py").read_text()
+        assert "corrupt." in source.lower(), "load_checkpoint must preserve corrupt files with a .corrupt.* suffix"
+        assert "CORRUPT CHECKPOINT" in source, "the ERROR log marker must stay for alert rules"
+        # Explicit: the old silent-warn pattern must not return.
+        assert "starting fresh." not in source, (
+            "the old silent-fresh-start warning pattern must not return — PR-K1 §2-3 escalated it to ERROR "
+            "+ forensic backup"
+        )
+
+
+# ===========================================================================
+# §2-1 — save_checkpoint re-raises on write failure
+# ===========================================================================
+
+
+class TestSaveCheckpointReRaises:
+    """Write failures MUST propagate out of ``save_checkpoint`` so the
+    caller (and its downstream error accounting) can react. The prior
+    silent-WARN behavior let a 730-day baseline silently desync
+    in-memory progress from on-disk state — PR-K1 §2-1."""
+
+    def test_save_failure_propagates_oserror(self, isolated_checkpoint_dir, monkeypatch):
+        """Simulate a disk-full / permission failure during ``_atomic_write``:
+        the exception must reach the caller, not be swallowed."""
+        _, bc = isolated_checkpoint_dir
+
+        def failing_atomic_write(path, data):  # type: ignore[no-redef]
+            raise OSError(28, "No space left on device (simulated)")
+
+        monkeypatch.setattr(bc, "_atomic_write", failing_atomic_write)
+
+        with pytest.raises(OSError) as exc_info:
+            bc.save_checkpoint({"nvd": {"current_page": 42}})
+        assert "No space left on device" in str(exc_info.value)
+
+    def test_save_failure_logs_at_error_level(self, isolated_checkpoint_dir, monkeypatch, caplog):
+        """The write failure must appear in logs at ERROR level with
+        the ``CHECKPOINT WRITE FAILED`` marker so alert rules and
+        operator dashboards can surface it immediately."""
+        import logging
+
+        _, bc = isolated_checkpoint_dir
+
+        def failing_atomic_write(path, data):  # type: ignore[no-redef]
+            raise PermissionError("denied (simulated)")
+
+        monkeypatch.setattr(bc, "_atomic_write", failing_atomic_write)
+
+        caplog.set_level(logging.ERROR, logger="baseline_checkpoint")
+        with pytest.raises(PermissionError):
+            bc.save_checkpoint({"nvd": {}})
+
+        assert any(
+            rec.levelno == logging.ERROR and "CHECKPOINT WRITE FAILED" in rec.message for rec in caplog.records
+        ), f"ERROR log missing; got {[(r.levelname, r.message) for r in caplog.records]}"
+
+    def test_update_source_checkpoint_also_raises(self, isolated_checkpoint_dir, monkeypatch):
+        """Downstream contract: ``update_source_checkpoint`` delegates
+        to ``save_checkpoint``, so it must also raise on write
+        failure. NVD collector's outer try/except then records a
+        collection failure and returns a failed-status response,
+        which is the exact behavior §2-1 wants."""
+        _, bc = isolated_checkpoint_dir
+
+        def failing_atomic_write(path, data):  # type: ignore[no-redef]
+            raise OSError("disk error (simulated)")
+
+        monkeypatch.setattr(bc, "_atomic_write", failing_atomic_write)
+
+        with pytest.raises(OSError):
+            bc.update_source_checkpoint("nvd", page=1, items_collected=10)
+
+    def test_fcntl_lock_released_on_save_exception(self, isolated_checkpoint_dir, monkeypatch):
+        """Critical: the fcntl lock inside update_source_checkpoint
+        MUST be released even when save_checkpoint raises. The
+        ``with open(...)`` context manager closes the fd, which
+        releases the advisory lock automatically — but a regression
+        that restructures the code could break this. Verify by
+        calling update_source_checkpoint twice: first with failing
+        save, then with normal save. The second call must succeed
+        (proves the lock from the first call was released)."""
+        _, bc = isolated_checkpoint_dir
+
+        call_count = {"n": 0}
+        original_atomic_write = bc._atomic_write
+
+        def conditionally_failing(path, data):  # type: ignore[no-redef]
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise OSError("simulated first-call failure")
+            return original_atomic_write(path, data)
+
+        monkeypatch.setattr(bc, "_atomic_write", conditionally_failing)
+
+        with pytest.raises(OSError):
+            bc.update_source_checkpoint("nvd", page=1)
+
+        # Second call must not deadlock (lock was released on the
+        # exception path) and must succeed.
+        bc.update_source_checkpoint("nvd", page=2)
+        result = bc.get_source_checkpoint("nvd")
+        assert result.get("current_page") == 2
+
+    def test_source_pins_no_silent_warn(self):
+        """The old silent-WARN pattern must not return."""
+        source = (SRC / "baseline_checkpoint.py").read_text()
+        # Strip comments (docstrings / explanation) so cautionary
+        # mentions in documentation don't trigger.
+        # The actual code must use ``logger.error`` + ``raise``, not
+        # ``logger.warning`` followed by quiet return.
+        assert "CHECKPOINT WRITE FAILED" in source
+        # The old behavior: ``logger.warning("Could not save checkpoint...``.
+        # Must be gone. Strip docstrings first.
+        # Simplest check: look for the specific old log string literal.
+        assert 'logger.warning("Could not save checkpoint' not in source, (
+            "the old silent-WARN save pattern must not return — PR-K1 §2-1 escalated to ERROR + re-raise"
+        )
+
+
+# ===========================================================================
+# §1-8 — Additive baselines preserve checkpoints
+# ===========================================================================
+
+
+class TestAdditiveBaselinePreservesCheckpoints:
+    """``_baseline_start_summary`` must NOT wipe checkpoints on
+    additive baseline runs. The old code unconditionally cleared
+    — defeating the resume path that the whole checkpoint machinery
+    was built to provide."""
+
+    @pytest.fixture(scope="class")
+    def dag_source(self) -> str:
+        return (REPO_ROOT / "dags" / "edgeguard_pipeline.py").read_text()
+
+    def test_baseline_start_summary_does_not_call_clear_checkpoint(self, dag_source: str) -> None:
+        """Source-pin: the ``_baseline_start_summary`` body must not
+        import or call ``clear_checkpoint``. The fresh-baseline path
+        clears via ``_baseline_clean`` (a separate task); this task
+        has no business wiping on additive runs."""
+        # Extract the _baseline_start_summary function body
+        start = dag_source.find("def _baseline_start_summary")
+        assert start > 0, "_baseline_start_summary function not found"
+        # End at the next top-level def or the EdgeGuard BASELINE marker
+        # (the log line that leads the config printout).
+        end_marker_1 = dag_source.find("\ndef ", start + 1)
+        end_marker_2 = dag_source.find("\n# ", start + 1)
+        end = min(e for e in (end_marker_1, end_marker_2, len(dag_source)) if e > start)
+        body = dag_source[start:end]
+
+        # The active-code region (strip comments) must not call
+        # ``clear_checkpoint(``. We strip comment lines so the
+        # explanatory docstring/comments that MENTION what was
+        # removed don't trigger the pin.
+        code_only = "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+        assert "clear_checkpoint(" not in code_only, (
+            "_baseline_start_summary MUST NOT call clear_checkpoint() — "
+            "additive baselines preserve checkpoints for resume (PR-K1 §1-8). "
+            "The fresh-baseline path clears via _baseline_clean task instead."
+        )
+        # And the import should also be gone (tidy).
+        assert "from baseline_checkpoint import clear_checkpoint" not in code_only, (
+            "_baseline_start_summary no longer needs clear_checkpoint imported"
+        )
+
+    def test_baseline_start_summary_preserves_for_additive_runs(self, dag_source: str) -> None:
+        """The log message MUST state that additive baselines preserve
+        checkpoints — this is the operator-facing signal that resume
+        works."""
+        assert "Additive baseline: preserving checkpoints" in dag_source, (
+            "the additive-baseline log line must say 'preserving checkpoints' so operators know the resume path is live"
+        )
+
+    def test_baseline_start_summary_documents_fresh_baseline_path(self, dag_source: str) -> None:
+        """The log message MUST tell operators how to wipe if they
+        actually wanted a fresh baseline — surface the
+        ``fresh_baseline: true`` conf trigger."""
+        # Extract just the _baseline_start_summary function
+        start = dag_source.find("def _baseline_start_summary")
+        end_marker_1 = dag_source.find("\ndef ", start + 1)
+        end_marker_2 = dag_source.find("\n# ", start + 1)
+        end = min(e for e in (end_marker_1, end_marker_2, len(dag_source)) if e > start)
+        body = dag_source[start:end]
+        # Log message mentions the fresh-baseline conf hint.
+        assert "fresh_baseline" in body, (
+            "_baseline_start_summary must reference the fresh_baseline conf so "
+            "operators know how to opt into wipe behavior"
+        )

--- a/tests/test_pr_k1_baseline_resume_robustness.py
+++ b/tests/test_pr_k1_baseline_resume_robustness.py
@@ -450,14 +450,33 @@ class TestNoStaleClearCheckpointsReferences:
     def test_clear_checkpoints_not_in_known_baseline_conf_keys(self, dag_source: str) -> None:
         """The ``clear_checkpoints`` key MUST be absent from the
         allowlist. Otherwise an operator passing it gets no warning
-        and silently believes it took effect."""
+        and silently believes it took effect.
+
+        PR-K1 Bugbot round-2 Low on THIS test (commit 786e375): the
+        original bracketing used ``dag_source.find(")", idx)`` which
+        matched the first ``)`` — which happened to be INSIDE a
+        comment (``(consumed by _baseline_clean)``) on the first
+        entry's line, not at the actual frozenset closing ``)``. That
+        truncated ``block`` to a single-line view + made the
+        assertion vacuously pass. Fixed by bracketing on the
+        column-0 ``\\n)`` that terminates the frozenset literal —
+        the closing paren lives on its own line by convention
+        (``Black`` / ``ruff format`` enforce this for multi-line
+        calls), so this is robust."""
         # Find the _KNOWN_BASELINE_CONF_KEYS frozenset literal block.
         idx = dag_source.find("_KNOWN_BASELINE_CONF_KEYS = frozenset(")
         assert idx > 0, "_KNOWN_BASELINE_CONF_KEYS not found"
-        # End at the closing of the literal.
-        end = dag_source.find(")", idx + len("_KNOWN_BASELINE_CONF_KEYS = frozenset("))
-        assert end > idx
-        block = dag_source[idx:end]
+        # End at ``\n)`` at column 0 — the frozenset's actual closing
+        # paren on its own line. Any ``)`` inside comments or adjacent
+        # expressions is indented or mid-line, so ``\n)`` disambiguates.
+        end_marker = "\n)"
+        end = dag_source.find(end_marker, idx + len("_KNOWN_BASELINE_CONF_KEYS = frozenset("))
+        assert end > idx, (
+            "could not find ``\\n)`` terminator for _KNOWN_BASELINE_CONF_KEYS — "
+            "frozenset literal may have been reformatted onto one line; update this test"
+        )
+        block = dag_source[idx : end + len(end_marker)]
+
         # Strip the explanatory comment block (which may legitimately
         # mention "clear_checkpoints" as the removed key).
         active_lines = [
@@ -467,6 +486,30 @@ class TestNoStaleClearCheckpointsReferences:
             f"clear_checkpoints must not appear as an active set member; "
             f"found: {active_lines}. PR-K1 Bugbot round-2 caught this drift "
             f"after §1-8 removed the consumer."
+        )
+
+    def test_known_baseline_conf_keys_bracket_captures_all_entries(self, dag_source: str) -> None:
+        """Meta-pin for the test above: ensure the bracketing logic
+        captures ALL set members, not just the first one.  If a
+        reformatting ever collapses the frozenset to a single line
+        (``frozenset({...})``), the ``\\n)`` terminator won't match
+        and the test above will ``assert end > idx`` fail with a
+        clear message — but this test checks the POSITIVE case
+        (the bracket captures the real members) so we catch it."""
+        idx = dag_source.find("_KNOWN_BASELINE_CONF_KEYS = frozenset(")
+        assert idx > 0
+        end = dag_source.find("\n)", idx + len("_KNOWN_BASELINE_CONF_KEYS = frozenset("))
+        block = dag_source[idx : end + len("\n)")]
+        # The bracket must contain all the currently-active conf keys,
+        # not just one. Count them to ensure bracketing is robust.
+        active = {"fresh_baseline", "baseline_days", "baseline_collection_limit", "collection_limit"}
+        present = {k for k in active if f'"{k}"' in block}
+        missing = active - present
+        assert not missing, (
+            f"frozenset bracketing truncated before capturing all entries; "
+            f"missing from block: {missing}. This would vacuously pass the "
+            f"clear_checkpoints-absence test — matches the exact Bugbot "
+            f"round-2 Low finding pattern."
         )
 
     def test_baseline_start_summary_log_does_not_advertise_clear_checkpoints(self, dag_source: str) -> None:

--- a/tests/test_pr_k1_baseline_resume_robustness.py
+++ b/tests/test_pr_k1_baseline_resume_robustness.py
@@ -362,3 +362,65 @@ class TestAdditiveBaselinePreservesCheckpoints:
             "_baseline_start_summary must reference the fresh_baseline conf so "
             "operators know how to opt into wipe behavior"
         )
+
+    def test_baseline_start_uses_shared_is_truthy_helper(self, dag_source: str) -> None:
+        """PR-K1 Bugbot round-1 (Medium): the truthy-check for
+        ``fresh_baseline`` MUST go through ``_is_truthy_conf_value``
+        (not an inline ``str(...).lower() in (...)`` check) so it
+        mirrors ``_baseline_clean``'s parse exactly.
+
+        PR-F8 extracted the helper SPECIFICALLY to prevent this drift:
+        operator passes ``{"fresh_baseline": "on"}`` →
+        ``_baseline_clean`` wipes correctly (helper accepts "on") but
+        inline check in ``_baseline_start_summary`` didn't → operator
+        sees misleading "preserving checkpoints" log. Silent operator
+        confusion."""
+        start = dag_source.find("def _baseline_start_summary")
+        end_marker_1 = dag_source.find("\ndef ", start + 1)
+        end_marker_2 = dag_source.find("\n# ", start + 1)
+        end = min(e for e in (end_marker_1, end_marker_2, len(dag_source)) if e > start)
+        body = dag_source[start:end]
+        code_only = "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+
+        # Must use the shared helper
+        assert "_is_truthy_conf_value(" in code_only, (
+            "fresh_baseline truthy-check must use the shared _is_truthy_conf_value helper "
+            "(extracted in PR-F8 to prevent drift between _baseline_clean and _baseline_start_summary)"
+        )
+        # And must NOT re-introduce the inline pattern
+        assert 'str(conf.get("fresh_baseline", "")).lower() in' not in code_only, (
+            "the inline truthy parse must not return — PR-K1 Bugbot round-1 Medium "
+            "caught the exact drift PR-F8 was designed to prevent"
+        )
+
+
+class TestSaveCheckpointLogIncludesExceptionMessage:
+    """PR-K1 Bugbot round-1 (Low): the CHECKPOINT WRITE FAILED error
+    log MUST include ``str(e)`` (the actual exception message) along
+    with ``type(e).__name__``. Otherwise operators can't distinguish
+    ENOSPC from permission-denied from the alert alone."""
+
+    def test_log_includes_exception_message_not_just_type(self, isolated_checkpoint_dir, monkeypatch, caplog):
+        """Trigger a failure with a distinctive message and verify
+        both the exception type AND the exception message appear in
+        the ERROR log output."""
+        import logging
+
+        _, bc = isolated_checkpoint_dir
+
+        def failing_atomic_write(path, data):  # type: ignore[no-redef]
+            raise OSError(28, "No space left on device — distinctive marker")
+
+        monkeypatch.setattr(bc, "_atomic_write", failing_atomic_write)
+
+        caplog.set_level(logging.ERROR, logger="baseline_checkpoint")
+        with pytest.raises(OSError):
+            bc.save_checkpoint({"nvd": {}})
+
+        error_logs = [rec.message for rec in caplog.records if rec.levelno == logging.ERROR]
+        # Exception message (not just type name) must be in the log.
+        assert any("No space left on device" in msg for msg in error_logs), (
+            f"operator-facing error log must include the exception message, not just the type. Got: {error_logs}"
+        )
+        # Type name should still be there too (both, not either/or).
+        assert any("OSError" in msg for msg in error_logs)


### PR DESCRIPTION
## Summary

Three flow-audit fixes that collectively make the **730-day baseline restartable without data loss**. Each closes a documented silent-failure path that prior multi-agent audits found but couldn't reach.

The user explicitly scoped this work as: *"verify the existing tier-1 sequential mitigation first, then add resume robustness — no new batching/splitting logic."* PR-L (#74) verified the tier-1 foundation; this PR adds the resume layer on top.

## Three fixes

### §2-3 — Corrupt checkpoint preservation (was: silent data loss)

**File:** `src/baseline_checkpoint.py::load_checkpoint`

| Before | After |
|---|---|
| Parse failure → `WARN` log + return `{}` → next save overwrites with skeleton → **all per-source progress wiped** | Rename corrupt file to `.corrupt.{ISO-timestamp}` BEFORE returning `{}` → escalate log to `ERROR` with recovery instructions → forensic backup preserved |

### §2-1 — `save_checkpoint` re-raises (was: silent freeze)

**File:** `src/baseline_checkpoint.py::save_checkpoint`

| Before | After |
|---|---|
| Every disk failure swallowed with `WARN` → in-memory counter advances while disk stays stale → operator sees logs scrolling but `edgeguard baseline status` shows hours-old numbers | `ERROR` log with `CHECKPOINT WRITE FAILED` marker for alert rules + `raise` → caller aborts cleanly. fcntl lock released via `with` context manager. NVD collector's outer try/except surfaces the failure. |

### §1-8 — Additive baseline preserves checkpoints (was: resume killed)

**File:** `dags/edgeguard_pipeline.py::_baseline_start_summary`

| Before | After |
|---|---|
| `clear_checkpoint(...)` called unconditionally on every baseline run → additive baseline lost checkpoint state → if tier-1 collector failed at page 50 of a 730-day run, retry started from page 1 | `_baseline_start_summary` no longer touches checkpoint state. Fresh-baseline path still wipes via separate `_baseline_clean` task. Additive runs preserve disk state. Log explicitly tells operators which path they're on. |

## Intentionally scoped out

- **§2-8** fresh-baseline → incremental cursor handoff: needs design decision on cursor-completion value, breaks an existing pin-test on the operator invariant `fresh-baseline = true clean slate`. The §1-8 fix above ALREADY closes the additive-baseline half of §2-8 by preserving cursors on additive runs. Remaining fresh-baseline-only handoff deferred to dedicated PR.
- **§1-1** baseline lock missing on DAG path: Issue #57, architectural — not a patch.
- **§1-2** MISP events-index `since` filter: PR-K2 (next).
- **§1-4** subprocess stdout streaming: PR-K3.

## Test matrix (12 new tests)

`tests/test_pr_k1_baseline_resume_robustness.py`:

| Class | Tests | What it pins |
|---|---|---|
| `TestCorruptCheckpointRecovery` | 4 | corrupt → backup; rename-failure path; happy path; source-pin |
| `TestSaveCheckpointReRaises` | 5 | OSError propagates; ERROR log; downstream contract; fcntl lock release on exception; source-pin |
| `TestAdditiveBaselinePreservesCheckpoints` | 3 | source-pin no `clear_checkpoint(`; "preserving checkpoints" log; `fresh_baseline` conf reference |

## Test plan

- [x] Target suite: 12/12 pass
- [x] Full suite: **1014 passed, 3 skipped** (+12 from 1002)
- [x] `ruff format --check` ✓
- [x] `ruff check` ✓
- [x] `mypy src/` ✓
- [x] Existing `test_baseline_clean_destructive.py` invariants preserved (the "true clean slate" semantic stays — `_wipe_checkpoints` unchanged)

## Operator-facing impact

| Scenario | Before | After |
|---|---|---|
| Disk full mid-baseline | silent freeze | loud `ERROR` + caller aborts; no silent desync |
| Corrupt JSON on disk | silent data loss on next load | forensic backup + recovery instructions; data preserved as evidence |
| Additive baseline interruption | restart from page 1 | restart from last checkpointed page |

## Related

- Audit findings: `docs/flow_audits/02_checkpoint_state_machine.md` §2-3, §2-1; `docs/flow_audits/01_baseline_sequence.md` §1-8 (in PR-K #73)
- Tier-1 robustness foundation: PR-L (#74) — verified before this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes alter baseline checkpoint persistence and baseline DAG run behavior (when checkpoints are cleared) and now fail fast on checkpoint write issues, which could cause previously “successful” runs to abort; mitigated by extensive new regression tests.
> 
> **Overview**
> Improves baseline *resume robustness* by preserving progress across additive baseline retries and surfacing checkpoint failures loudly.
> 
> `_baseline_start_summary` no longer clears checkpoints on every run; it now preserves checkpoint state for additive baselines and only indicates wiping via the existing `fresh_baseline` path, while removing the dead `clear_checkpoints` conf key from the allowlist and operator log hints.
> 
> `baseline_checkpoint.load_checkpoint` now renames corrupt JSON to a timestamped `.corrupt.*` backup and logs `ERROR`, and `save_checkpoint` now logs `ERROR` and re-raises on write failures instead of silently warning. Adds a dedicated test suite covering corrupt-file preservation, write-failure propagation/logging, and pinning the DAG/config behavior against regression.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4994545b46cb060523c7d71d4f33c2aad20fda01. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->