### PR TITLE
fix(audit): PR-K2 §1-2 — server-side timestamp narrowing on MISP events-index

### DIFF
--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -178,6 +178,27 @@ def _fetch_edgeguard_events_via_requests_index(
     Try MISP event index endpoints (paginated). Returns:
       - list (possibly empty) if an index path responded successfully;
       - None if no index URL worked (caller may fall back to PyMISP/restSearch).
+
+    PR-K2 §1-2 — server-side ``timestamp`` narrowing:
+    when ``since`` is not None, pass ``timestamp = int(since.timestamp())``
+    as a query parameter so MISP narrows the result set on the server side
+    BEFORE pagination. The prior implementation only filtered client-side
+    (``_event_covers_since`` at the post-loop comprehension), which meant
+    a re-triggered baseline against a populated MISP would walk up to
+    ``MISP_EVENTS_INDEX_MAX_PAGES`` × ``MISP_EVENTS_INDEX_PAGE_SIZE``
+    rows of the entire MISP instance (including non-EdgeGuard events
+    from federated peers) before any filtering kicked in. On large
+    deployments the 100-page cap silently truncated — events past page
+    100 never made it to ``full_neo4j_sync``, exactly the
+    ``EdgeGuardSyncCoverageGap`` failure mode the alert was built to
+    catch (the gap was UPSTREAM of the accounting, so the alert never
+    fired).
+
+    The PyMISP and ``/events/restSearch`` fallback paths already use
+    this convention (see lines ~977 + ~997). This brings the index
+    path into parity. Older MISP versions that ignore the ``timestamp``
+    param degrade gracefully — the client-side ``_event_covers_since``
+    filter at the post-loop comprehension stays as defense-in-depth.
     """
     base = misp_base.rstrip("/")
     for path in ("/events/index", "/events"):
@@ -185,9 +206,13 @@ def _fetch_edgeguard_events_via_requests_index(
         path_unusable = False
         for page in range(1, MISP_EVENTS_INDEX_MAX_PAGES + 1):
             try:
+                params: dict = {"limit": MISP_EVENTS_INDEX_PAGE_SIZE, "page": page}
+                # Server-side narrowing — see docstring above for context.
+                if since is not None:
+                    params["timestamp"] = int(since.timestamp())
                 resp = session.get(
                     f"{base}{path}",
-                    params={"limit": MISP_EVENTS_INDEX_PAGE_SIZE, "page": page},
+                    params=params,
                     verify=SSL_VERIFY,
                     timeout=(MISP_CONNECT_TIMEOUT, MISP_REQUEST_TIMEOUT),
                 )

--- a/tests/test_pr_k2_misp_index_since_filter.py
+++ b/tests/test_pr_k2_misp_index_since_filter.py
@@ -1,0 +1,228 @@
+"""
+PR-K2 §1-2 — server-side `timestamp` narrowing on MISP events-index fetch.
+
+Regression coverage for ``_fetch_edgeguard_events_via_requests_index``
+in ``src/run_misp_to_neo4j.py``. The function fetches EdgeGuard
+events from MISP's ``/events/index`` (or ``/events``) endpoint, page
+by page, capped at ``MISP_EVENTS_INDEX_MAX_PAGES``.
+
+The original implementation passed ONLY ``limit`` and ``page`` query
+params — no ``timestamp`` filter — even though the function accepted
+a ``since`` datetime. Filtering happened client-side after the
+pagination loop completed. On a populated MISP (e.g. one that
+federates with peers), this meant the function walked up to
+100 × 500 = 50,000 event rows of the entire instance before any
+filter kicked in. The 100-page cap then silently truncated past
+that — events past page 100 never reached Neo4j sync.
+
+PR-K2 fix: when ``since`` is non-None, pass
+``timestamp = int(since.timestamp())`` as a query param so MISP
+narrows the result set on the server side BEFORE pagination. Same
+convention as the PyMISP and ``/events/restSearch`` fallback paths
+(lines ~977, ~997). The client-side filter stays as defense-in-depth
+for older MISP versions that ignore the param.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(status_code: int = 200, json_payload=None):
+    """Build a fake ``requests.Response``-shaped object for the
+    function under test. Only ``status_code`` and ``json()`` are read."""
+    resp = MagicMock()
+    resp.status_code = status_code
+    resp.json.return_value = json_payload if json_payload is not None else []
+    return resp
+
+
+# ===========================================================================
+# Server-side timestamp narrowing
+# ===========================================================================
+
+
+class TestServerSideTimestampNarrowing:
+    """When ``since`` is non-None, ``params["timestamp"]`` MUST be
+    passed to the MISP GET request so the server narrows the result
+    set before pagination."""
+
+    def test_timestamp_param_present_when_since_given(self, monkeypatch):
+        """Critical positive case: a ``since`` datetime must produce
+        ``params["timestamp"] = int(since.timestamp())`` on every page
+        request — the exact contract the audit fix introduces."""
+        from run_misp_to_neo4j import _fetch_edgeguard_events_via_requests_index
+
+        session = MagicMock()
+        # Return one page with one EdgeGuard-tagged event, then exit
+        # the loop via short-page condition.
+        session.get.return_value = _make_response(200, json_payload=[])
+
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        result = _fetch_edgeguard_events_via_requests_index(
+            session,
+            "https://misp.example.com",
+            since=since,
+        )
+        assert result == []  # empty page → empty filtered list
+
+        # Inspect every call to session.get
+        assert session.get.called
+        for call in session.get.call_args_list:
+            kwargs = call.kwargs
+            params = kwargs.get("params", {})
+            assert "timestamp" in params, (
+                f"every page request MUST carry the timestamp param when since is given; got params={params}"
+            )
+            assert params["timestamp"] == int(since.timestamp()), (
+                f"timestamp param MUST equal int(since.timestamp())={int(since.timestamp())}; got {params['timestamp']}"
+            )
+
+    def test_timestamp_param_absent_when_since_is_none(self, monkeypatch):
+        """Negative case: if no ``since`` provided, no timestamp param
+        on the wire. Preserves the existing fetch-everything contract
+        for fresh-baseline / first-run scenarios."""
+        from run_misp_to_neo4j import _fetch_edgeguard_events_via_requests_index
+
+        session = MagicMock()
+        session.get.return_value = _make_response(200, json_payload=[])
+
+        _fetch_edgeguard_events_via_requests_index(
+            session,
+            "https://misp.example.com",
+            since=None,
+        )
+
+        for call in session.get.call_args_list:
+            params = call.kwargs.get("params", {})
+            assert "timestamp" not in params, f"timestamp param MUST be absent when since=None; got params={params}"
+
+    def test_timestamp_value_is_integer_seconds(self):
+        """The PyMISP and restSearch fallbacks both use ``int(since.timestamp())``
+        — same convention here. A float timestamp would silently change
+        MISP server behavior on some versions."""
+        from run_misp_to_neo4j import _fetch_edgeguard_events_via_requests_index
+
+        session = MagicMock()
+        session.get.return_value = _make_response(200, json_payload=[])
+
+        # Use a since with sub-second precision to force the int() coerce
+        # path to be exercised.
+        since = datetime(2026, 4, 20, 12, 34, 56, 789000, tzinfo=timezone.utc)
+        _fetch_edgeguard_events_via_requests_index(session, "https://misp.example.com", since=since)
+
+        timestamp_value = session.get.call_args_list[0].kwargs["params"]["timestamp"]
+        assert isinstance(timestamp_value, int), (
+            f"timestamp param MUST be an integer (int(since.timestamp())); got {type(timestamp_value).__name__}"
+        )
+
+    def test_limit_and_page_params_still_present(self):
+        """Defensive: the original ``limit`` + ``page`` params MUST stay
+        in place — the new ``timestamp`` is additive."""
+        from run_misp_to_neo4j import (
+            MISP_EVENTS_INDEX_PAGE_SIZE,
+            _fetch_edgeguard_events_via_requests_index,
+        )
+
+        session = MagicMock()
+        session.get.return_value = _make_response(200, json_payload=[])
+
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        _fetch_edgeguard_events_via_requests_index(session, "https://misp.example.com", since=since)
+
+        params = session.get.call_args_list[0].kwargs["params"]
+        assert params.get("limit") == MISP_EVENTS_INDEX_PAGE_SIZE
+        assert params.get("page") == 1
+
+
+# ===========================================================================
+# Source-pin (regex) — guards against silent regression
+# ===========================================================================
+
+
+class TestSourcePinTimestampParam:
+    """Guard against a future refactor that drops the timestamp
+    narrowing. Source-pin so a regression fails CI even before the
+    behavioral tests load the module."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "run_misp_to_neo4j.py").read_text()
+
+    def test_function_passes_timestamp_when_since_given(self, source: str) -> None:
+        """The fix: ``params["timestamp"] = int(since.timestamp())``
+        must appear inside ``_fetch_edgeguard_events_via_requests_index``."""
+        # Locate the function block so we don't accidentally match the
+        # PyMISP fallback's identical line later in the file.
+        start = source.find("def _fetch_edgeguard_events_via_requests_index")
+        assert start > 0, "function not found"
+        # End at the next top-level def
+        end = source.find("\ndef ", start + 1)
+        if end < 0:
+            end = len(source)
+        body = source[start:end]
+
+        assert 'params["timestamp"] = int(since.timestamp())' in body, (
+            "PR-K2 §1-2 fix must include "
+            "``params['timestamp'] = int(since.timestamp())`` inside "
+            "_fetch_edgeguard_events_via_requests_index — server-side "
+            "narrowing on the index endpoint."
+        )
+
+    def test_function_guards_with_since_not_none(self, source: str) -> None:
+        """The ``timestamp`` assignment must be guarded by
+        ``if since is not None:`` so fresh-baseline / first-run
+        callers (since=None) keep their current fetch-everything
+        behavior."""
+        start = source.find("def _fetch_edgeguard_events_via_requests_index")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert "if since is not None:" in body, (
+            "the timestamp narrowing must be conditional on `since is not None` so the no-since "
+            "(fresh-baseline) path doesn't change behavior"
+        )
+
+    def test_old_unfiltered_get_pattern_is_gone(self, source: str) -> None:
+        """The old call site passed ``params={"limit": ..., "page": page}``
+        as a literal dict, with no timestamp. That exact pattern must
+        not return — if a refactor reverts to the literal-dict form,
+        we lose the conditional ``timestamp`` injection."""
+        start = source.find("def _fetch_edgeguard_events_via_requests_index")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+
+        # The literal dict form ``params={"limit": ..., "page": page}``
+        # without an adjacent ``params["timestamp"]`` assignment would
+        # signal a regression. Check that the literal isn't on the
+        # ``session.get`` call line.
+        assert 'params={"limit": MISP_EVENTS_INDEX_PAGE_SIZE, "page": page}' not in body, (
+            "the old single-line literal-dict params form is gone — PR-K2 §1-2 introduced "
+            "a conditional `params` dict with optional timestamp injection"
+        )
+
+    def test_fallback_paths_already_used_timestamp(self, source: str) -> None:
+        """Sanity: the PyMISP + restSearch fallback paths already
+        carried the ``timestamp = int(since.timestamp())`` convention
+        BEFORE PR-K2. The audit's fix brings the index path into
+        parity. If a future refactor breaks the fallback paths, the
+        whole convention is shaky; pin against it."""
+        # Both fallback paths set ``timestamp`` from int(since.timestamp())
+        assert source.count('"timestamp"] = int(since.timestamp())') >= 1, (
+            "fallback paths in the same module must continue using int(since.timestamp()) "
+            "for the timestamp param — convention shared with PR-K2's index-path fix"
+        )

--- a/tests/test_pr_k2_misp_index_since_filter.py
+++ b/tests/test_pr_k2_misp_index_since_filter.py
@@ -220,9 +220,26 @@ class TestSourcePinTimestampParam:
         carried the ``timestamp = int(since.timestamp())`` convention
         BEFORE PR-K2. The audit's fix brings the index path into
         parity. If a future refactor breaks the fallback paths, the
-        whole convention is shaky; pin against it."""
-        # Both fallback paths set ``timestamp`` from int(since.timestamp())
-        assert source.count('"timestamp"] = int(since.timestamp())') >= 1, (
-            "fallback paths in the same module must continue using int(since.timestamp()) "
-            "for the timestamp param — convention shared with PR-K2's index-path fix"
+        whole convention is shaky; pin against it.
+
+        PR-K2 Bugbot round-1 (Low): the original ``>= 1`` threshold
+        was always satisfied because the NEW index-path fix itself
+        matches the pattern — so the test passed even if BOTH
+        fallbacks were deleted, defeating the stated purpose. Scope
+        the grep to EXCLUDE the index-path function body so only the
+        fallback matches count, then require ``>= 2`` (one for
+        PyMISP, one for restSearch)."""
+        # Carve out the index-path function so its occurrence of the
+        # pattern doesn't contribute to the count.
+        index_start = source.find("def _fetch_edgeguard_events_via_requests_index")
+        index_end = source.find("\ndef ", index_start + 1)
+        assert index_start > 0 and index_end > index_start, (
+            "could not bracket _fetch_edgeguard_events_via_requests_index — "
+            "refactor may have split or renamed the function; update this carve-out."
+        )
+        source_excluding_index_path = source[:index_start] + source[index_end:]
+        assert source_excluding_index_path.count('"timestamp"] = int(since.timestamp())') >= 2, (
+            "both fallback paths (PyMISP + restSearch) must continue using int(since.timestamp()) "
+            "for the timestamp param. Counted matches OUTSIDE the new index-path function body, "
+            "so the test can't be vacuously satisfied by the fix it's supposed to guard."
         )


### PR DESCRIPTION
## Summary

Small, isolated, high-impact fix for a **silent-truncation bug** on the MISP events-index fetch path. One function changed (~5 LOC of actual behavior change + guardian comments), 8 new regression tests.

Closes flow-audit finding §1-2.

## The bug

`_fetch_edgeguard_events_via_requests_index` in `src/run_misp_to_neo4j.py` accepts a `since` datetime parameter but passed ONLY `limit` + `page` as query params to MISP. The `since` filter was applied **client-side after the pagination loop completed**.

On a mature MISP deployment (one that federates with peers), this meant:

1. Function walks up to **100 × 500 = 50,000 event rows** of the ENTIRE MISP instance — EdgeGuard + non-EdgeGuard events from federated peers
2. `MISP_EVENTS_INDEX_MAX_PAGES=100` cap silently truncates past that
3. Events past page 100 never reach `full_neo4j_sync`
4. **`EdgeGuardSyncCoverageGap` alert never fires because the gap is UPSTREAM of the accounting**

Exact coverage-gap pattern the alert was designed to catch, invisible to every existing monitoring surface.

## The fix

When `since is not None`, pass `timestamp = int(since.timestamp())` as a query param. MISP narrows server-side before pagination.

**Same convention as the siblings:**
- PyMISP fallback at line ~977: `search_kwargs["timestamp"] = int(since.timestamp())`
- restSearch fallback at line ~997: `rest_body["timestamp"] = int(since.timestamp())`

The index path now has parity with both fallbacks.

**Graceful degradation:** older MISP versions that ignore the `timestamp` param work fine — the existing `_event_covers_since` client-side filter at the post-loop comprehension stays as defense-in-depth.

**No behavior change for `since=None` callers** — fresh-baseline / first-run paths keep the fetch-everything semantic.

## Why not also add `searchall`

The audit finding suggested also passing `searchall="EdgeGuard"` to narrow by the EdgeGuard search term. Held off because:
- `timestamp` is the primary fix (closes the silent-truncation P0)
- `searchall` behavior varies across MISP versions; adding it widens the compatibility surface without addressing the P0
- Client-side `_is_edgeguard_index_event` filter already handles the EdgeGuard narrowing correctly

If `searchall` turns out to meaningfully reduce page counts in practice, it can be its own PR with version-compat testing.

## Test matrix (8 tests)

`tests/test_pr_k2_misp_index_since_filter.py`:

**`TestServerSideTimestampNarrowing` (4, behavioral):**
- `timestamp` param present on every page request when `since` given
- `timestamp` param absent when `since=None`
- `timestamp` value is `int(since.timestamp())` (not float)
- `limit` + `page` params still present (additive fix)

**`TestSourcePinTimestampParam` (4, source-pin):**
- Fix line present inside the function
- Guarded by `if since is not None:`
- Old literal-dict params form absent (catches revert)
- Fallback paths still use `int(since.timestamp())` (shared-contract pin)

## Test plan

- [x] Target suite: 8/8 pass
- [x] Full suite: **1010 passed, 3 skipped** (+8 from 1002; this branch is off main, does NOT include PR-K1's +12)
- [x] `ruff format --check` ✓
- [x] `ruff check` ✓
- [x] `mypy src/` ✓
- [x] No file overlap with PR-K1 (#75) — can merge in either order

## Operator-facing impact

| Scenario | Before | After |
|---|---|---|
| Incremental sync on mature MISP (500+ events) | Walks entire instance per fetch, truncates past page 100 | Server narrows by timestamp, fetches only relevant window |
| Re-triggered baseline | Silent data loss if event count > 50K | No truncation up to `MISP_EVENTS_INDEX_MAX_PAGES` worth of IN-WINDOW events |
| Fresh baseline / empty MISP | Unchanged | Unchanged |
| Old MISP version without timestamp support | Unchanged (client-side filter remains) | Unchanged (graceful degrade) |

## Related

- Audit finding: [`docs/flow_audits/01_baseline_sequence.md` §1-2](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/blob/main/docs/flow_audits/01_baseline_sequence.md) (in PR-K #73)
- PR-K1 (#75) — baseline resume robustness, independent of this PR; zero file overlap
- PR-L (#74) — Tier-1 sequential regression suite, also independent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the event-discovery query behavior used to drive Neo4j sync windows; while scoped, incorrect timestamp handling or MISP version quirks could alter which events are synced. Added tests reduce regression risk but the code path is production-critical.
> 
> **Overview**
> Fixes a silent truncation risk in `_fetch_edgeguard_events_via_requests_index` by adding an optional server-side `timestamp=int(since.timestamp())` query param when `since` is provided, so MISP narrows results before pagination while preserving the `since=None` fetch-all behavior.
> 
> Adds a dedicated regression test suite that asserts the new `timestamp` param contract (present/absent, integer seconds, `limit`/`page` preserved) and source-pins the change to prevent future refactors from dropping the filter or weakening the fallback-path expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d29d6f3ae652853e8e57429652a18c488b1d63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->