### PR TITLE
fix(audit): PR-K3 §1-4 — bounded-memory subprocess streaming for build_relationships

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1702,20 +1702,55 @@ check_neo4j_quality_task = BashOperator(
 
 
 def run_build_relationships(**context):
-    """Run build_relationships.py after sync to create/refresh graph links."""
-    import subprocess
+    """Run build_relationships.py after sync to create/refresh graph links.
 
-    result = subprocess.run(
-        ["python3", os.path.join(BASE_DIR, "src", "build_relationships.py")],
-        capture_output=True,
-        text=True,
-        timeout=18000,  # 5 hours — aligned with execution_timeout (bumped from 3h
-        # after baseline re-runs hit the ceiling on the merged #20/#22/#24 scope)
+    PR-K3 §1-4: use the streaming helper so the child's 5-hour output
+    is logged line-by-line as it arrives instead of buffered in
+    parent memory until exit. On a 344K-node graph with 12 APOC
+    link queries each emitting progress logs, the old
+    ``capture_output=True`` path accumulated tens of MB of buffered
+    text — a real OOM risk on 8 GB Airflow workers, especially when
+    ``NEO4J_TX_MEMORY_MAX`` is also bumped to 8 g. The streaming
+    helper caps memory at ``DEFAULT_TAIL_LINES`` (200 lines
+    retained for error-context) and enforces the 5h timeout with
+    a SIGTERM-then-SIGKILL escalation so APOC transactions get a
+    chance to roll back cleanly.
+    """
+    from subprocess_streaming import (
+        SubprocessStreamTimeout,
+        run_with_streaming_output,
     )
-    if result.returncode != 0:
-        logger.error(f"build_relationships failed:\n{result.stderr}")
-        raise AirflowException(f"build_relationships.py exited with code {result.returncode}")
-    logger.info(result.stdout)
+
+    try:
+        returncode, tail = run_with_streaming_output(
+            ["python3", os.path.join(BASE_DIR, "src", "build_relationships.py")],
+            timeout=18000,  # 5 hours — aligned with execution_timeout (bumped
+            # from 3h after baseline re-runs hit the ceiling on the merged
+            # #20/#22/#24 scope). Same deadline as before PR-K3.
+            child_logger=logger,
+            line_prefix="[build_relationships] ",
+        )
+    except SubprocessStreamTimeout as exc:
+        # The helper already logged the SIGTERM/SIGKILL escalation;
+        # fail the task loudly so Airflow surfaces the timeout.
+        raise AirflowException(f"build_relationships.py exceeded deadline: {exc}") from exc
+
+    if returncode != 0:
+        # PR-K3: tail is a pre-bounded list of the last 200 lines,
+        # already streamed to the Airflow task log above. Re-emit a
+        # concise summary so the exception message includes enough
+        # context for operators eyeballing the task view. Full stderr
+        # is in the task log as INFO lines from the streaming reader.
+        logger.error(
+            "build_relationships failed with exit code %d. Tail (last %d lines streamed above):\n%s",
+            returncode,
+            len(tail),
+            "\n".join(tail),
+        )
+        raise AirflowException(f"build_relationships.py exited with code {returncode}")
+    # Success: output already streamed to the task log line-by-line
+    # by the helper; no final stdout dump needed.
+    logger.info("[build_relationships] complete (exit 0)")
 
 
 def run_enrichment_jobs(**context):

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -1554,12 +1554,21 @@ class EdgeGuardPipeline:
             # SIGTERM-then-SIGKILL escalation so APOC transactions
             # get a chance to roll back cleanly.
             logger.info("\n[TARGET] Step 5b: build_relationships (CLI parity with DAG)...")
-            try:
-                from subprocess_streaming import (
-                    SubprocessStreamTimeout,
-                    run_with_streaming_output,
-                )
+            # PR-K3 Bugbot round-1 (Medium): import OUTSIDE the try block.
+            # If the import itself fails (e.g. module missing from deployment),
+            # a ModuleNotFoundError fires — but Python would then try to
+            # evaluate ``except SubprocessStreamTimeout as e:`` which
+            # references the un-imported name, raising NameError that
+            # propagates PAST the ``except Exception`` fallback. Bugbot
+            # caught this bypassing the CLI's degraded-mode guarantee.
+            # The DAG site already had the import outside ``try``; this
+            # brings the CLI site into parity.
+            from subprocess_streaming import (
+                SubprocessStreamTimeout,
+                run_with_streaming_output,
+            )
 
+            try:
                 br_returncode, br_tail = run_with_streaming_output(
                     [sys.executable, os.path.join(os.path.dirname(__file__), "build_relationships.py")],
                     timeout=18000,  # 5h, matches DAG's run_build_relationships

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -1542,56 +1542,75 @@ class EdgeGuardPipeline:
         if baseline:
             # Step 5b: build_relationships (12 cross-entity link queries).
             # Subprocess-isolated to match the DAG's invocation shape.
+            #
+            # PR-K3 §1-4: use the streaming helper so the child's 5-hour
+            # output is logged line-by-line as it arrives instead of
+            # buffered in parent memory until exit. Same OOM concern
+            # as on the DAG side — the old ``capture_output=True`` path
+            # accumulated tens of MB of log text across the 12 APOC
+            # queries. The helper caps memory at
+            # ``DEFAULT_TAIL_LINES`` (200 lines retained for
+            # error-context) and enforces the 5h timeout with a
+            # SIGTERM-then-SIGKILL escalation so APOC transactions
+            # get a chance to roll back cleanly.
             logger.info("\n[TARGET] Step 5b: build_relationships (CLI parity with DAG)...")
             try:
-                import subprocess
-
-                br_result = subprocess.run(
-                    [sys.executable, os.path.join(os.path.dirname(__file__), "build_relationships.py")],
-                    capture_output=True,
-                    text=True,
-                    timeout=18000,  # 5h, matches DAG's run_build_relationships
-                    check=False,
+                from subprocess_streaming import (
+                    SubprocessStreamTimeout,
+                    run_with_streaming_output,
                 )
-                if br_result.returncode == 0:
+
+                br_returncode, br_tail = run_with_streaming_output(
+                    [sys.executable, os.path.join(os.path.dirname(__file__), "build_relationships.py")],
+                    timeout=18000,  # 5h, matches DAG's run_build_relationships
+                    child_logger=logger,
+                    line_prefix="[build_relationships] ",
+                )
+                if br_returncode == 0:
                     logger.info("   [OK] build_relationships complete")
                 else:
                     # PR-C v2 audit fix (Cross-Checker B2, comprehensive
                     # 7-agent audit): the previous comment claimed "same
                     # behavior as the DAG", but the DAG actually raises
                     # ``AirflowException`` on non-zero exit (see
-                    # ``dags/edgeguard_pipeline.py``: ``run_build_relationships``
-                    # at lines 1618-1633). The CLI deliberately diverges —
-                    # local operators want a "degraded-mode finish" rather
-                    # than a hard abort that loses Step 5c enrichment too.
-                    # Acknowledge the asymmetry explicitly so the parity
-                    # claim isn't a lie.
+                    # ``dags/edgeguard_pipeline.py``: ``run_build_relationships``).
+                    # The CLI deliberately diverges — local operators
+                    # want a "degraded-mode finish" rather than a hard
+                    # abort that loses Step 5c enrichment too.
                     #
-                    # Operator hint: the graph edges from build_relationships
-                    # (12 link queries: IMPLEMENTS_TECHNIQUE, TARGETS,
-                    # AFFECTS, ...) will be MISSING. Re-run
-                    # ``python src/build_relationships.py`` standalone to
-                    # complete the graph.
-                    # Production-test audit fix (Devil's Advocate + Maintainer
-                    # corroborated, post-PR-C-merge): emit structured log with
-                    # ``extra={"degraded": True}`` instead of setting an
-                    # instance-attribute marker that no caller actually read.
-                    # The previous ``self._build_relationships_degraded`` attr
-                    # was write-only — only test-framework grep referenced it,
-                    # zero production callers. Structured logs are cloud-
-                    # portable (Datadog/CloudWatch/etc. can route on the
-                    # ``degraded`` extra field), the attribute was not.
+                    # Operator hint: the graph edges from
+                    # build_relationships (12 link queries:
+                    # IMPLEMENTS_TECHNIQUE, TARGETS, AFFECTS, ...) will
+                    # be MISSING. Re-run ``python src/build_relationships.py``
+                    # standalone to complete the graph.
+                    #
+                    # Structured log with ``extra={"degraded": True}`` is
+                    # cloud-portable (Datadog/CloudWatch/etc. can route
+                    # on the ``degraded`` extra field).
+                    #
+                    # PR-K3: ``br_tail`` is the pre-bounded deque of the
+                    # last 200 lines streamed (already logged line-by-line
+                    # above). Joining the last ~10 gives the operator
+                    # enough context in the summary log without a second
+                    # full-stderr dump.
+                    tail_context = "\n".join(br_tail[-10:]) if br_tail else "(no output captured)"
                     logger.warning(
                         "   [WARN] build_relationships exited with code %d. "
                         "Graph is in DEGRADED MODE (link edges missing). "
                         "DAG would have raised AirflowException; CLI continues "
                         "to allow Step 5c enrichment to run. "
                         "Re-run ``python src/build_relationships.py`` standalone to repair. "
-                        "stderr (last 500 chars): %s",
-                        br_result.returncode,
-                        (br_result.stderr or "")[-500:],
+                        "Last 10 lines:\n%s",
+                        br_returncode,
+                        tail_context,
                         extra={"degraded": True, "step": "build_relationships"},
                     )
+            except SubprocessStreamTimeout as e:
+                logger.warning(
+                    "   [WARN] build_relationships timed out: %s. Graph in DEGRADED MODE.",
+                    e,
+                    extra={"degraded": True, "step": "build_relationships"},
+                )
             except Exception as e:
                 logger.warning(
                     "   [WARN] build_relationships skipped: %s",

--- a/src/subprocess_streaming.py
+++ b/src/subprocess_streaming.py
@@ -43,17 +43,60 @@ multiplexed stderr) should continue using ``subprocess.run`` directly.
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 import threading
 import time
 from collections import deque
 from typing import List, Sequence, Tuple
 
-# Default: keep the last 200 lines of child output for error-context
-# logging if the child exits non-zero. At ~200 bytes/line average this
-# caps memory at ~40 KB, vs. the unbounded buffer the ``capture_output``
+# Default: keep the last 2000 lines of child output for error-context
+# logging if the child exits non-zero.  At ~200 bytes/line average this
+# caps memory at ~400 KB — still negligible on an 8 GB Airflow worker
+# (0.005% of RAM), vs. the unbounded buffer the ``capture_output``
 # path accumulated over 5-hour runs.
-DEFAULT_TAIL_LINES = 200
+#
+# Why 2000 (not 200): a Python stack trace is 10-30 lines, but an APOC
+# nested-exception chain can run 50-100 lines, a multi-query cascade
+# failure easily 200+, and a Neo4j transaction retry storm with nested
+# error details 100-200.  200 lines was operator-diagnostic-tight even
+# for common failure classes.  2000 gives 10x the context at the same
+# trivial memory footprint.
+#
+# **Operator override:** ``EDGEGUARD_SUBPROCESS_TAIL_LINES`` env var
+# lets operators tune without a code change — e.g. raise to 20000
+# (~4 MB) for a particularly gnarly diagnosis session, or drop to
+# 500 on memory-constrained workers.  Non-integer or <=0 values fall
+# back to the 2000-line default with a warning log.
+_DEFAULT_TAIL_LINES_CONST = 2000
+
+
+def _resolve_default_tail_lines() -> int:
+    """Resolve ``DEFAULT_TAIL_LINES`` from the env var with a safe
+    fallback. Called once at module load."""
+    raw = os.getenv("EDGEGUARD_SUBPROCESS_TAIL_LINES", "").strip()
+    if not raw:
+        return _DEFAULT_TAIL_LINES_CONST
+    try:
+        value = int(raw)
+    except ValueError:
+        logging.getLogger(__name__).warning(
+            "EDGEGUARD_SUBPROCESS_TAIL_LINES=%r is not an integer; using default=%d.",
+            raw,
+            _DEFAULT_TAIL_LINES_CONST,
+        )
+        return _DEFAULT_TAIL_LINES_CONST
+    if value <= 0:
+        logging.getLogger(__name__).warning(
+            "EDGEGUARD_SUBPROCESS_TAIL_LINES=%d must be > 0; using default=%d.",
+            value,
+            _DEFAULT_TAIL_LINES_CONST,
+        )
+        return _DEFAULT_TAIL_LINES_CONST
+    return value
+
+
+DEFAULT_TAIL_LINES = _resolve_default_tail_lines()
 
 # Grace window between SIGTERM and SIGKILL when a child exceeds its
 # deadline. 30 seconds matches the sysadmin-folk-wisdom default (long

--- a/src/subprocess_streaming.py
+++ b/src/subprocess_streaming.py
@@ -140,10 +140,18 @@ def _drain_output(
         try:
             if proc.stdout is not None:
                 proc.stdout.close()
-        except Exception:
-            # Stdout already closed by the subprocess module on
-            # process exit — harmless.
-            pass
+        except (ValueError, OSError) as exc:
+            # Expected: stdout already closed by subprocess module on
+            # process exit (``ValueError: I/O operation on closed file``)
+            # or pipe already torn down (``OSError``). Log at DEBUG so
+            # operators who need traceability still see it but normal
+            # runs don't get noise.
+            #
+            # PR-K3 Bugbot round-2 (Low): the prior ``except Exception: pass``
+            # violated the project's bare-except-with-pass review rule.
+            # Narrowing + DEBUG log preserves the close-is-harmless
+            # invariant while meeting the audit contract.
+            logging.getLogger(__name__).debug("stdout close on exiting child: %s", exc, exc_info=True)
 
 
 def run_with_streaming_output(

--- a/src/subprocess_streaming.py
+++ b/src/subprocess_streaming.py
@@ -217,6 +217,15 @@ def run_with_streaming_output(
             elapsed,
         )
         proc.terminate()
+        # PR-K3 Bugbot round-1 (Low): track whether SIGKILL actually
+        # fired so the exception message reflects reality. Previously
+        # the message unconditionally said ``SIGTERM + grace → SIGKILL``
+        # even when SIGTERM alone succeeded within the grace window,
+        # which in an APOC-heavy workload could trigger unnecessary
+        # data-integrity investigations (SIGTERM → clean rollback;
+        # SIGKILL → transactions may be interrupted mid-commit). The
+        # distinction matters to operators.
+        sigkill_sent = False
         try:
             proc.wait(timeout=SIGTERM_GRACE_SECONDS)
         except subprocess.TimeoutExpired:
@@ -226,13 +235,23 @@ def run_with_streaming_output(
                 SIGTERM_GRACE_SECONDS,
             )
             proc.kill()
+            sigkill_sent = True
             # SIGKILL cannot be caught; wait() returns promptly.
             proc.wait()
         reader.join(timeout=5)
-        raise SubprocessStreamTimeout(
-            f"child exceeded timeout={timeout}s (elapsed={elapsed:.1f}s); "
-            f"SIGTERM + {SIGTERM_GRACE_SECONDS}s grace → SIGKILL"
-        ) from None
+        if sigkill_sent:
+            msg = (
+                f"child exceeded timeout={timeout}s (elapsed={elapsed:.1f}s); "
+                f"SIGTERM + {SIGTERM_GRACE_SECONDS}s grace → SIGKILL "
+                f"(child did not exit within grace; transactions may be interrupted)"
+            )
+        else:
+            msg = (
+                f"child exceeded timeout={timeout}s (elapsed={elapsed:.1f}s); "
+                f"exited cleanly after SIGTERM within {SIGTERM_GRACE_SECONDS}s grace "
+                f"(no SIGKILL)"
+            )
+        raise SubprocessStreamTimeout(msg) from None
 
     # Clean exit: drain the reader and return.
     reader.join(timeout=5)

--- a/src/subprocess_streaming.py
+++ b/src/subprocess_streaming.py
@@ -1,0 +1,196 @@
+"""
+Bounded-memory subprocess runner for long-lived child processes.
+
+PR-K3 §1-4 — addresses the flow-audit finding that
+``subprocess.run(..., capture_output=True, timeout=18000)`` was
+being used for ``build_relationships.py`` in both the Airflow DAG
+and the CLI baseline path. ``capture_output=True`` buffers the
+ENTIRE child stdout + stderr in the parent's memory until the child
+exits — on a 5-hour APOC-heavy run against a 344K-node graph, the
+buffer grows to tens of megabytes of log text and adds real OOM
+risk on the 8GB Airflow worker (especially when
+``NEO4J_TX_MEMORY_MAX`` is also bumped).
+
+The helper in this module replaces ``capture_output=True`` with a
+streaming read: a daemon thread drains the child's merged
+stdout/stderr line-by-line into the parent's logger, the main
+thread waits for exit with a deadline, and on timeout the helper
+sends ``SIGTERM``, grants a 30s grace window, then escalates to
+``SIGKILL``. A bounded ``deque`` retains the last N lines for
+error-context logging on failure — no unbounded buffer.
+
+## Why a separate module (not inlined)
+
+PR-L's regression tests (``tests/test_tier1_sequential_robustness.py``)
+source-pin that ``src/run_pipeline.py`` has no ``threading.Thread``
+— part of the tier-1 sequential-execution robustness guarantee.
+Putting the reader thread in a dedicated module keeps that pin
+happy: the CLI's ``run_pipeline.py`` only *calls* the helper, never
+spawns raw threads itself.
+
+## Scope
+
+Designed specifically for ``build_relationships.py``-shaped children:
+- Long-running (minutes to hours)
+- Emit progress logs frequently (so line-by-line streaming is useful)
+- Single-threaded reader suffices (no multiplexing needed)
+- Timeout is a hard deadline (SIGTERM → 30s grace → SIGKILL)
+
+Callers who need different semantics (short-running, binary output,
+multiplexed stderr) should continue using ``subprocess.run`` directly.
+"""
+
+from __future__ import annotations
+
+import logging
+import subprocess
+import threading
+import time
+from collections import deque
+from typing import List, Sequence, Tuple
+
+# Default: keep the last 200 lines of child output for error-context
+# logging if the child exits non-zero. At ~200 bytes/line average this
+# caps memory at ~40 KB, vs. the unbounded buffer the ``capture_output``
+# path accumulated over 5-hour runs.
+DEFAULT_TAIL_LINES = 200
+
+# Grace window between SIGTERM and SIGKILL when a child exceeds its
+# deadline. 30 seconds matches the sysadmin-folk-wisdom default (long
+# enough for the child to flush buffers + cleanly abort APOC
+# transactions; short enough that operators aren't waiting forever).
+SIGTERM_GRACE_SECONDS = 30
+
+
+class SubprocessStreamTimeout(Exception):
+    """Raised when the child did not exit within the deadline.
+
+    Distinct from ``subprocess.TimeoutExpired`` so callers can react
+    specifically to the streaming-helper's timeout + escalation
+    behavior (SIGTERM-then-SIGKILL) without catching broader
+    ``subprocess`` errors."""
+
+
+def _drain_output(
+    proc: subprocess.Popen,
+    tail_buf: deque,
+    child_logger: logging.Logger,
+    line_prefix: str,
+) -> None:
+    """Read child stdout line-by-line (merged stderr), log each at INFO,
+    retain last N in the bounded deque.
+
+    Runs in a daemon thread so the main thread can continue waiting
+    on the child's exit while output streams in parallel. ``bufsize=1``
+    on the ``Popen`` (text mode + line-buffered) ensures
+    ``readline()`` returns as soon as the child emits a newline.
+    """
+    try:
+        assert proc.stdout is not None, "caller must have set stdout=PIPE"
+        for raw in iter(proc.stdout.readline, ""):
+            line = raw.rstrip()
+            if not line:
+                continue
+            child_logger.info("%s%s", line_prefix, line)
+            tail_buf.append(line)
+    finally:
+        try:
+            if proc.stdout is not None:
+                proc.stdout.close()
+        except Exception:
+            # Stdout already closed by the subprocess module on
+            # process exit — harmless.
+            pass
+
+
+def run_with_streaming_output(
+    cmd: Sequence[str],
+    timeout: float,
+    child_logger: logging.Logger,
+    *,
+    tail_lines: int = DEFAULT_TAIL_LINES,
+    line_prefix: str = "[child] ",
+) -> Tuple[int, List[str]]:
+    """Run ``cmd`` as a subprocess, stream its output to
+    ``child_logger``, and return ``(returncode, tail_lines_list)``.
+
+    - ``cmd``: argv list passed to ``subprocess.Popen``.
+    - ``timeout``: hard deadline in seconds. On exceed, the child
+      receives ``SIGTERM``, then after
+      :data:`SIGTERM_GRACE_SECONDS` escalates to ``SIGKILL``. The
+      helper then raises :class:`SubprocessStreamTimeout` so the
+      caller can distinguish this from a clean non-zero exit.
+    - ``child_logger``: every line emitted by the child is logged at
+      INFO level. Pass the caller's module logger so Airflow's
+      task-log routing works naturally.
+    - ``tail_lines``: bound on the retained-line buffer for
+      error-context. Capped even on successful runs — caller can
+      decide whether to surface the tail (typically only on
+      non-zero exit).
+    - ``line_prefix``: tag prepended to every logged line so
+      operators can distinguish child output from parent context.
+
+    Returns ``(returncode, tail)`` where ``tail`` is a list of the
+    last ``tail_lines`` lines (order preserved, oldest→newest).
+
+    Raises :class:`SubprocessStreamTimeout` on deadline exceed
+    (after the SIGTERM/SIGKILL escalation). Any other
+    ``subprocess``-layer exception propagates unchanged so the
+    caller can handle (missing binary, EACCES, etc.) with existing
+    logic.
+    """
+    tail_buf: deque = deque(maxlen=max(1, tail_lines))
+
+    # ``bufsize=1`` + ``text=True`` gives line-buffered UTF-8
+    # readline(); ``errors="replace"`` keeps a child that emits
+    # invalid bytes (e.g. an APOC exception that logs a raw
+    # un-escaped byte) from crashing the reader thread.
+    proc = subprocess.Popen(  # noqa: S603 — argv list, not shell=True
+        list(cmd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,
+        errors="replace",
+    )
+
+    reader = threading.Thread(
+        target=_drain_output,
+        args=(proc, tail_buf, child_logger, line_prefix),
+        daemon=True,
+        name=f"stream-reader-pid{proc.pid}",
+    )
+    reader.start()
+
+    start = time.monotonic()
+    try:
+        proc.wait(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        elapsed = time.monotonic() - start
+        child_logger.error(
+            "%schild exceeded timeout=%ss (elapsed=%.1fs); sending SIGTERM",
+            line_prefix,
+            timeout,
+            elapsed,
+        )
+        proc.terminate()
+        try:
+            proc.wait(timeout=SIGTERM_GRACE_SECONDS)
+        except subprocess.TimeoutExpired:
+            child_logger.error(
+                "%sSIGTERM did not exit in %ds; escalating to SIGKILL",
+                line_prefix,
+                SIGTERM_GRACE_SECONDS,
+            )
+            proc.kill()
+            # SIGKILL cannot be caught; wait() returns promptly.
+            proc.wait()
+        reader.join(timeout=5)
+        raise SubprocessStreamTimeout(
+            f"child exceeded timeout={timeout}s (elapsed={elapsed:.1f}s); "
+            f"SIGTERM + {SIGTERM_GRACE_SECONDS}s grace → SIGKILL"
+        ) from None
+
+    # Clean exit: drain the reader and return.
+    reader.join(timeout=5)
+    return proc.returncode, list(tail_buf)

--- a/tests/test_pr_c_cli_dag_parity.py
+++ b/tests/test_pr_c_cli_dag_parity.py
@@ -207,13 +207,22 @@ class TestCliDagParity:
         return inspect.getsource(run_pipeline.EdgeGuardPipeline._run_pipeline_inner)
 
     def test_cli_baseline_invokes_build_relationships(self):
-        # CLI baseline path must call build_relationships.py via subprocess
+        # CLI baseline path must call build_relationships.py as a subprocess
         # (matches the DAG's invocation shape — same script, same timeout).
         src = self._pipeline_inner_source()
         # Gated on `if baseline:` to avoid surprising incremental runs
         assert "build_relationships.py" in src
-        # Subprocess invocation (matches the DAG's run_build_relationships shape)
-        assert "subprocess.run" in src
+        # Subprocess invocation must be present. PR-K3 §1-4 (2026-04-20
+        # flow audit) replaced the old ``subprocess.run(capture_output=True)``
+        # — which buffered 5h of stdout in parent memory — with
+        # ``run_with_streaming_output()`` from ``src/subprocess_streaming.py``
+        # (which wraps ``subprocess.Popen`` with line-by-line draining).
+        # Either form satisfies the "is invoked as a subprocess" contract
+        # this test pins.
+        assert "subprocess.run" in src or "run_with_streaming_output" in src, (
+            "CLI baseline must invoke build_relationships.py as a subprocess "
+            "(either subprocess.run directly or via run_with_streaming_output helper)"
+        )
 
     def test_cli_baseline_invokes_run_all_enrichment_jobs(self):
         # CLI baseline path must call enrichment_jobs.run_all_enrichment_jobs

--- a/tests/test_pr_k3_subprocess_streaming.py
+++ b/tests/test_pr_k3_subprocess_streaming.py
@@ -211,7 +211,14 @@ class TestSourcePinsCaptureOutputGone:
         so source-pins don't false-positive on prose that explains
         what was removed. We're not parsing Python syntax; a simple
         state-machine over line-by-line text is enough for the
-        narrow 'code-only' view we need."""
+        narrow 'code-only' view we need.
+
+        PR-K3 Bugbot round-1 (Low): previously the single-line
+        docstring branch only ``break``ed the inner ``for`` loop but
+        never set a skip flag — control fell through to
+        ``out.append(raw)`` and the line was included anyway.
+        An explicit ``skip_this_line`` flag makes the intent match
+        the behaviour."""
         out = []
         in_doc = False
         doc_quote: str = ""
@@ -223,16 +230,20 @@ class TestSourcePinsCaptureOutputGone:
                     doc_quote = ""
                 continue
             # Detect triple-quoted docstring start (either """ or ''')
+            skip_this_line = False
             for quote in ('"""', "'''"):
                 if stripped.startswith(quote):
-                    # Single-line docstring ("""...""") — also skip
+                    # Single-line docstring ("""...""") — skip the line.
+                    # Multi-line — enter doc mode, skip subsequent lines
+                    # until the closing quote.
                     rest = stripped[len(quote) :]
                     if quote in rest:
-                        break  # single-line, skip this line and move on
-                    in_doc = True
-                    doc_quote = quote
+                        skip_this_line = True
+                    else:
+                        in_doc = True
+                        doc_quote = quote
                     break
-            if in_doc:
+            if skip_this_line or in_doc:
                 continue
             if stripped.startswith("#"):
                 continue
@@ -366,3 +377,155 @@ class TestDefaultTailLinesIsGenerous:
         importlib.reload(subprocess_streaming)
         assert subprocess_streaming.DEFAULT_TAIL_LINES == 2000
         assert any("must be > 0" in rec.message for rec in caplog.records)
+
+
+# ===========================================================================
+# Bugbot round-1 follow-up findings (Medium + 2 Low)
+# ===========================================================================
+
+
+class TestImportOutsideTryBlock:
+    """PR-K3 Bugbot round-1 (Medium): ``from subprocess_streaming
+    import ...`` MUST be OUTSIDE the ``try`` block in ``run_pipeline.py``
+    Step 5b. If the import is inside ``try`` and fails, the
+    ``except SubprocessStreamTimeout as e:`` clause references an
+    un-imported name → NameError propagates PAST the
+    ``except Exception`` fallback, breaking the CLI's degraded-mode
+    guarantee.
+
+    The DAG site already had it outside; this pin enforces parity."""
+
+    def test_subprocess_streaming_imported_outside_try(self):
+        """The import must precede the ``try:`` block, not be inside it."""
+        cli_src = (REPO_ROOT / "src" / "run_pipeline.py").read_text()
+        marker = "Step 5b: build_relationships"
+        idx = cli_src.find(marker)
+        assert idx > 0
+        block = cli_src[idx : idx + 6000]
+
+        # Find the import statement
+        import_line = "from subprocess_streaming import"
+        import_idx = block.find(import_line)
+        assert import_idx > 0, f"could not find {import_line!r} in Step 5b region"
+
+        # Find the first try: block AFTER the marker
+        try_idx = block.find("try:", 0)
+        assert try_idx > 0, "could not find try block in Step 5b region"
+
+        # The import MUST come before the try, not inside it.
+        assert import_idx < try_idx, (
+            "PR-K3 Bugbot round-1 (Medium): subprocess_streaming import must be "
+            "OUTSIDE the try block. If the import fails inside try, NameError on "
+            "the except clause bypasses the degraded-mode handler."
+        )
+
+
+class TestTimeoutMessageReflectsActualEscalation:
+    """PR-K3 Bugbot round-1 (Low): ``SubprocessStreamTimeout`` message
+    MUST distinguish between (a) child exited cleanly after SIGTERM
+    within grace window and (b) child required SIGKILL escalation.
+    Operators eyeballing the AirflowException need the right signal
+    for whether to investigate APOC transaction integrity."""
+
+    def test_clean_sigterm_message_does_not_claim_sigkill(self, caplog):
+        """A child that handles SIGTERM cleanly within the grace
+        window MUST get a message that says ``no SIGKILL`` — NOT a
+        message that claims SIGKILL was sent."""
+        import logging
+
+        from subprocess_streaming import (
+            SubprocessStreamTimeout,
+            run_with_streaming_output,
+        )
+
+        caplog.set_level(logging.INFO)
+        child_logger = logging.getLogger("test_clean_sigterm_msg")
+
+        # Child that handles SIGTERM by exiting cleanly (Python's
+        # default behavior: SIGTERM → KeyboardInterrupt-like).
+        child_code = "import time\ntime.sleep(10)\n"
+        with pytest.raises(SubprocessStreamTimeout) as exc_info:
+            run_with_streaming_output(
+                [sys.executable, "-u", "-c", child_code],
+                timeout=0.3,
+                child_logger=child_logger,
+            )
+
+        msg = str(exc_info.value)
+        # The cleaner outcome — child exited within grace window — must NOT
+        # claim SIGKILL was sent.
+        assert "no SIGKILL" in msg, (
+            f"timeout message must reflect that SIGKILL was NOT sent when child "
+            f"exited cleanly within grace window; got: {msg!r}"
+        )
+        # The misleading old message format must not return.
+        assert "→ SIGKILL" not in msg, (
+            f"timeout message must not unconditionally claim SIGKILL when SIGTERM succeeded; got: {msg!r}"
+        )
+
+    def test_timeout_message_distinguishes_sigterm_vs_sigkill_paths(self):
+        """Source-pin: the helper MUST track whether ``proc.kill()``
+        actually fired and emit different messages for the two cases.
+        Guards against a future refactor reverting to the unconditional-
+        SIGKILL message."""
+        helper_src = (SRC / "subprocess_streaming.py").read_text()
+        # The two distinct messages must exist
+        assert "no SIGKILL" in helper_src, "helper must emit a 'no SIGKILL' message when SIGTERM alone was sufficient"
+        # And the SIGKILL escalation message must remain for the actual escalation path
+        assert "→ SIGKILL" in helper_src
+        # A boolean tracking flag must be set inside the SIGKILL branch
+        assert "sigkill_sent" in helper_src, (
+            "helper must track whether SIGKILL was actually sent, not just always claim it was"
+        )
+
+
+class TestStripDocstringsHandlesSingleLine:
+    """PR-K3 Bugbot round-1 (Low): the test-helper
+    ``_strip_docstrings_and_comments`` MUST actually skip single-line
+    docstrings (e.g. ``\"\"\"text\"\"\"`` on one line). Previously the
+    inner ``break`` exited the for loop without setting any skip
+    flag, so the line was appended to the output anyway."""
+
+    def test_single_line_docstring_is_actually_stripped(self):
+        # Construct source with a single-line docstring that mentions
+        # a forbidden pattern; if the stripper doesn't actually skip
+        # it, our other source-pin tests would false-positive.
+        from tests.test_pr_k3_subprocess_streaming import TestSourcePinsCaptureOutputGone
+
+        source_with_singleline_doc = (
+            'def some_func():\n    """This docstring mentions subprocess.run but is only prose."""\n    return 42\n'
+        )
+        stripped = TestSourcePinsCaptureOutputGone._strip_docstrings_and_comments(source_with_singleline_doc)
+        assert "subprocess.run" not in stripped, (
+            "single-line docstring must be skipped; if it leaks through, source-pin tests could false-positive on prose"
+        )
+
+    def test_multi_line_docstring_still_stripped(self):
+        """Sanity: the multi-line case the helper handled correctly
+        before MUST still work."""
+        from tests.test_pr_k3_subprocess_streaming import TestSourcePinsCaptureOutputGone
+
+        source_with_multiline_doc = (
+            "def some_func():\n"
+            '    """\n'
+            "    This multi-line docstring also mentions subprocess.run.\n"
+            '    """\n'
+            "    return 42\n"
+        )
+        stripped = TestSourcePinsCaptureOutputGone._strip_docstrings_and_comments(source_with_multiline_doc)
+        assert "subprocess.run" not in stripped
+
+    def test_actual_code_lines_kept(self):
+        """Non-docstring, non-comment code MUST still appear in the
+        stripped output — otherwise the source-pin tests can't see
+        anything."""
+        from tests.test_pr_k3_subprocess_streaming import TestSourcePinsCaptureOutputGone
+
+        source = '"""Module docstring"""\n# A line comment\nx = 1\ny = subprocess.run(cmd)\n'
+        stripped = TestSourcePinsCaptureOutputGone._strip_docstrings_and_comments(source)
+        # Real code must survive
+        assert "x = 1" in stripped
+        assert "subprocess.run(cmd)" in stripped
+        # Module docstring + comment must be gone
+        assert "Module docstring" not in stripped
+        assert "A line comment" not in stripped

--- a/tests/test_pr_k3_subprocess_streaming.py
+++ b/tests/test_pr_k3_subprocess_streaming.py
@@ -298,3 +298,71 @@ class TestSourcePinsCaptureOutputGone:
         assert "proc.terminate()" in code_only, "helper must send SIGTERM first"
         assert "proc.kill()" in code_only, "helper must escalate to SIGKILL after grace window"
         assert "SIGTERM_GRACE_SECONDS" in code_only, "helper must use the documented grace constant"
+
+
+# ===========================================================================
+# Default tail-lines cap + env-var override
+# ===========================================================================
+
+
+class TestDefaultTailLinesIsGenerous:
+    """PR-K3 bumped the default from 200 to 2000 lines after operator
+    concern that 200 was too few for common APOC failure modes.
+    Verify the generous default AND the env-var override path so
+    operators can tune per-deployment if needed."""
+
+    def test_default_is_at_least_2000_lines(self):
+        """The default retained-tail cap MUST be at least 2000 lines.
+        200 was operator-diagnostic-tight for APOC nested-exception
+        chains; 2000 gives 10x context at ~400KB memory (0.005% of
+        an 8GB worker)."""
+        # Import fresh so we don't pick up a prior test's env override.
+        import importlib
+
+        import subprocess_streaming
+
+        importlib.reload(subprocess_streaming)
+        assert subprocess_streaming.DEFAULT_TAIL_LINES >= 2000, (
+            f"DEFAULT_TAIL_LINES must be >= 2000 for operator-facing "
+            f"diagnostic context; got {subprocess_streaming.DEFAULT_TAIL_LINES}"
+        )
+
+    def test_env_var_override_honored(self, monkeypatch):
+        """Operators can raise the tail-line cap via
+        ``EDGEGUARD_SUBPROCESS_TAIL_LINES`` without a code change.
+        Useful for debugging a particularly verbose failure class."""
+        import importlib
+
+        monkeypatch.setenv("EDGEGUARD_SUBPROCESS_TAIL_LINES", "7777")
+        import subprocess_streaming
+
+        importlib.reload(subprocess_streaming)
+        assert subprocess_streaming.DEFAULT_TAIL_LINES == 7777
+
+    def test_env_var_invalid_falls_back_to_default(self, monkeypatch, caplog):
+        """Non-integer env var MUST fall back to the hard-coded default
+        with a clear warning, not crash the import."""
+        import importlib
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="subprocess_streaming")
+        monkeypatch.setenv("EDGEGUARD_SUBPROCESS_TAIL_LINES", "not-an-int")
+        import subprocess_streaming
+
+        importlib.reload(subprocess_streaming)
+        assert subprocess_streaming.DEFAULT_TAIL_LINES == 2000
+        assert any("not an integer" in rec.message for rec in caplog.records)
+
+    def test_env_var_non_positive_falls_back_to_default(self, monkeypatch, caplog):
+        """Zero or negative env var must also fall back — not clamp
+        to 0 (which would disable tail retention entirely)."""
+        import importlib
+        import logging
+
+        caplog.set_level(logging.WARNING, logger="subprocess_streaming")
+        monkeypatch.setenv("EDGEGUARD_SUBPROCESS_TAIL_LINES", "0")
+        import subprocess_streaming
+
+        importlib.reload(subprocess_streaming)
+        assert subprocess_streaming.DEFAULT_TAIL_LINES == 2000
+        assert any("must be > 0" in rec.message for rec in caplog.records)

--- a/tests/test_pr_k3_subprocess_streaming.py
+++ b/tests/test_pr_k3_subprocess_streaming.py
@@ -1,0 +1,300 @@
+"""
+PR-K3 §1-4 — bounded-memory subprocess streaming for build_relationships.
+
+Regression coverage for ``src/subprocess_streaming.py`` and the two
+call sites that use it (DAG ``run_build_relationships`` + CLI
+``run_pipeline.py`` Step 5b).
+
+## The bug
+
+Both call sites used
+``subprocess.run(..., capture_output=True, timeout=18000)``. On a
+344K-node graph with 12 APOC link queries, the child emits tens of
+MB of progress logs over a 5-hour run. ``capture_output=True``
+buffers the ENTIRE child stdout + stderr in the parent's memory
+until the child exits — real OOM risk on 8 GB Airflow workers,
+especially when ``NEO4J_TX_MEMORY_MAX`` is also bumped to 8 g.
+
+## The fix
+
+Replace with a streaming helper that:
+
+- Spawns the child with ``stdout=PIPE, stderr=STDOUT, bufsize=1``
+  (line-buffered, merged streams)
+- Drains output line-by-line in a daemon thread, logging each line
+  at INFO and appending to a bounded ``deque(maxlen=200)`` for
+  error-context
+- Waits for exit with the same 5h deadline
+- On timeout: sends ``SIGTERM``, waits 30s, escalates to ``SIGKILL``
+- Returns ``(returncode, tail_lines_list)``
+
+Memory cap: ~40 KB (200 lines × ~200 bytes/line average) vs. the
+unbounded buffer.
+
+## Tests
+
+Behavioural (using a small Python subprocess as a stand-in for
+``build_relationships.py``):
+- Streaming: lines are logged as they arrive, not buffered
+- Success path: returncode=0 returned, tail populated
+- Failure path: non-zero returncode returned, tail has last N lines
+- Timeout: SubprocessStreamTimeout raised after SIGTERM/SIGKILL
+  escalation
+
+Source-pins (guard against a future refactor reverting to
+capture_output=True):
+- DAG ``run_build_relationships`` uses the helper, not subprocess.run
+- CLI Step 5b uses the helper, not subprocess.run
+- Helper's tail buffer is bounded (``deque(maxlen=...)``)
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# Behavioural tests — the streaming helper
+# ===========================================================================
+
+
+class TestStreamingHelperBehavior:
+    """Drive the helper with small Python subprocesses that emit
+    deterministic output. We don't need the real
+    ``build_relationships.py`` — we need to verify the helper itself."""
+
+    def test_streams_lines_to_logger_as_they_arrive(self, caplog):
+        """The whole point of PR-K3: lines from the child must reach
+        the parent logger incrementally, not be buffered until the
+        child exits. Use a child that sleeps BETWEEN prints so we
+        can verify lines arrive out-of-order with the helper's
+        wait() — the reader thread must be draining in parallel."""
+        from subprocess_streaming import run_with_streaming_output
+
+        caplog.set_level(logging.INFO)
+        child_logger = logging.getLogger("test_streaming")
+
+        # Child prints 3 lines with small delays in between. flush=True
+        # on each print + python -u for line-buffering means they hit
+        # the parent's pipe immediately.
+        child_code = "import sys, time\nfor i in range(3):\n    print(f'line-{i}', flush=True)\n    time.sleep(0.05)\n"
+        start = time.monotonic()
+        returncode, tail = run_with_streaming_output(
+            [sys.executable, "-u", "-c", child_code],
+            timeout=10.0,
+            child_logger=child_logger,
+            line_prefix="[child] ",
+        )
+        elapsed = time.monotonic() - start
+
+        assert returncode == 0
+        assert tail == ["line-0", "line-1", "line-2"]
+        # Sanity: the run took at least the cumulative sleep time,
+        # proving we actually waited for the child (not a fast-path
+        # that collected stdout buffered).
+        assert elapsed >= 0.15, f"expected >=0.15s for 3× 50ms sleeps, got {elapsed}"
+
+        # Every line must appear in caplog with the prefix.
+        streamed = [rec.message for rec in caplog.records if "[child]" in rec.message]
+        assert any("line-0" in m for m in streamed)
+        assert any("line-1" in m for m in streamed)
+        assert any("line-2" in m for m in streamed)
+
+    def test_success_path_returns_zero_and_tail(self):
+        """Clean exit with output → ``(0, tail_lines)``."""
+        from subprocess_streaming import run_with_streaming_output
+
+        child_logger = logging.getLogger("test_streaming_success")
+        returncode, tail = run_with_streaming_output(
+            [sys.executable, "-c", "print('ok')"],
+            timeout=10.0,
+            child_logger=child_logger,
+        )
+        assert returncode == 0
+        assert tail == ["ok"]
+
+    def test_failure_path_returns_non_zero_and_tail(self):
+        """Non-zero exit → ``(returncode, tail)`` (no exception)."""
+        from subprocess_streaming import run_with_streaming_output
+
+        child_logger = logging.getLogger("test_streaming_failure")
+        returncode, tail = run_with_streaming_output(
+            [sys.executable, "-c", "import sys; print('bye'); sys.exit(7)"],
+            timeout=10.0,
+            child_logger=child_logger,
+        )
+        assert returncode == 7
+        assert tail == ["bye"]
+
+    def test_tail_buffer_is_bounded(self):
+        """The retained-line deque MUST be capped at ``tail_lines``.
+        Proves the PR-K3 memory-cap guarantee."""
+        from subprocess_streaming import run_with_streaming_output
+
+        child_logger = logging.getLogger("test_streaming_bounded")
+        # Child prints 500 lines; ask helper to retain only 50.
+        child_code = "for i in range(500):\n    print(f'line-{i}')\n"
+        returncode, tail = run_with_streaming_output(
+            [sys.executable, "-u", "-c", child_code],
+            timeout=15.0,
+            child_logger=child_logger,
+            tail_lines=50,
+        )
+        assert returncode == 0
+        assert len(tail) == 50, f"tail must be capped at tail_lines=50; got {len(tail)}"
+        # And it must be the LAST 50 (not the first 50).
+        assert tail[0] == "line-450"
+        assert tail[-1] == "line-499"
+
+    def test_timeout_sends_sigterm_then_raises(self, caplog):
+        """A child that exceeds the deadline gets SIGTERM'd; if it
+        exits within the grace window the helper raises
+        ``SubprocessStreamTimeout``. We use a child that handles
+        SIGTERM politely so the SIGKILL escalation path is NOT
+        exercised here (separate test for that)."""
+        from subprocess_streaming import (
+            SubprocessStreamTimeout,
+            run_with_streaming_output,
+        )
+
+        caplog.set_level(logging.INFO)
+        child_logger = logging.getLogger("test_streaming_timeout")
+
+        # Child sleeps longer than our deadline but handles SIGTERM
+        # cleanly (the default: ``signal.SIGTERM`` → KeyboardInterrupt-
+        # like termination in Python, non-zero exit).
+        child_code = "import time\ntime.sleep(10)\n"
+        start = time.monotonic()
+        with pytest.raises(SubprocessStreamTimeout) as exc_info:
+            run_with_streaming_output(
+                [sys.executable, "-u", "-c", child_code],
+                timeout=0.5,  # very short deadline
+                child_logger=child_logger,
+            )
+        elapsed = time.monotonic() - start
+
+        assert "exceeded timeout" in str(exc_info.value)
+        # Helper should have escalated quickly — deadline 0.5s + some
+        # buffer for process cleanup. Allow generous upper bound to
+        # avoid flakes on slow CI.
+        assert elapsed < 5.0, f"timeout escalation took too long: {elapsed}s"
+        # The SIGTERM log should have fired.
+        assert any("sending SIGTERM" in rec.message for rec in caplog.records), (
+            f"expected 'sending SIGTERM' log; got {[r.message for r in caplog.records]}"
+        )
+
+
+# ===========================================================================
+# Source-pins — guard against refactor reverting to capture_output=True
+# ===========================================================================
+
+
+class TestSourcePinsCaptureOutputGone:
+    """Neither of the two call sites may re-introduce
+    ``capture_output=True`` on the 18000-second deadline. That's the
+    exact pattern PR-K3 replaced because it buffers 5 hours of stdout
+    in parent memory."""
+
+    @staticmethod
+    def _strip_docstrings_and_comments(source: str) -> str:
+        """Remove ``# ...`` line-comments AND triple-quoted docstrings
+        so source-pins don't false-positive on prose that explains
+        what was removed. We're not parsing Python syntax; a simple
+        state-machine over line-by-line text is enough for the
+        narrow 'code-only' view we need."""
+        out = []
+        in_doc = False
+        doc_quote: str = ""
+        for raw in source.splitlines():
+            stripped = raw.lstrip()
+            if in_doc:
+                if doc_quote in stripped:
+                    in_doc = False
+                    doc_quote = ""
+                continue
+            # Detect triple-quoted docstring start (either """ or ''')
+            for quote in ('"""', "'''"):
+                if stripped.startswith(quote):
+                    # Single-line docstring ("""...""") — also skip
+                    rest = stripped[len(quote) :]
+                    if quote in rest:
+                        break  # single-line, skip this line and move on
+                    in_doc = True
+                    doc_quote = quote
+                    break
+            if in_doc:
+                continue
+            if stripped.startswith("#"):
+                continue
+            out.append(raw)
+        return "\n".join(out)
+
+    def test_dag_run_build_relationships_uses_helper(self):
+        """DAG site: ``run_build_relationships`` MUST call the
+        streaming helper, NOT ``subprocess.run(capture_output=True)``."""
+        dag_src = (REPO_ROOT / "dags" / "edgeguard_pipeline.py").read_text()
+        start = dag_src.find("def run_build_relationships")
+        assert start > 0
+        end = dag_src.find("\ndef ", start + 1)
+        body = dag_src[start:end]
+        code_only = self._strip_docstrings_and_comments(body)
+
+        # New code path must use the helper.
+        assert "run_with_streaming_output(" in code_only, (
+            "PR-K3: run_build_relationships must call run_with_streaming_output"
+        )
+        # Old bad pattern — the specific call that buffered 5h of
+        # stdout in parent memory. If `subprocess.run(` appears in
+        # live code of this function body, something regressed.
+        assert "subprocess.run(" not in code_only, (
+            "PR-K3: run_build_relationships must not revert to subprocess.run(...) — "
+            "that's the 5h-memory-buffer pattern the PR closed"
+        )
+        # The SubprocessStreamTimeout branch must be present so timeouts are handled.
+        assert "SubprocessStreamTimeout" in code_only
+
+    def test_cli_step_5b_uses_helper(self):
+        """CLI site: ``run_pipeline.py`` Step 5b MUST call the
+        streaming helper."""
+        cli_src = (REPO_ROOT / "src" / "run_pipeline.py").read_text()
+        # Locate Step 5b — uniquely identified by the log marker.
+        marker = "Step 5b: build_relationships"
+        idx = cli_src.find(marker)
+        assert idx > 0, "could not find Step 5b marker in run_pipeline.py"
+        # Grab the next ~120 lines of context.
+        block = cli_src[idx : idx + 6000]
+        code_only = self._strip_docstrings_and_comments(block)
+
+        assert "run_with_streaming_output(" in code_only, "PR-K3: Step 5b must call run_with_streaming_output"
+        assert "subprocess.run(" not in code_only, "PR-K3: Step 5b must not revert to subprocess.run(...)"
+        # Degraded-mode log must still be there — CLI divergence from DAG preserved.
+        assert "DEGRADED MODE" in code_only
+
+    def test_helper_uses_bounded_deque(self):
+        """The helper's tail buffer MUST be a bounded ``deque(maxlen=...)``
+        — otherwise the memory-cap guarantee of PR-K3 evaporates."""
+        helper_src = (SRC / "subprocess_streaming.py").read_text()
+        code_only = "\n".join(line for line in helper_src.splitlines() if not line.lstrip().startswith("#"))
+        assert "deque(maxlen=" in code_only, (
+            "subprocess_streaming.py tail buffer must use deque(maxlen=...) to cap memory"
+        )
+
+    def test_helper_escalates_sigterm_to_sigkill(self):
+        """Source-pin the SIGTERM → 30s grace → SIGKILL escalation
+        so a future refactor can't silently remove the graceful-abort
+        window (APOC needs time to roll back transactions on SIGTERM)."""
+        helper_src = (SRC / "subprocess_streaming.py").read_text()
+        code_only = "\n".join(line for line in helper_src.splitlines() if not line.lstrip().startswith("#"))
+        assert "proc.terminate()" in code_only, "helper must send SIGTERM first"
+        assert "proc.kill()" in code_only, "helper must escalate to SIGKILL after grace window"
+        assert "SIGTERM_GRACE_SECONDS" in code_only, "helper must use the documented grace constant"


### PR DESCRIPTION
## Summary

Closes flow-audit finding §1-4. Replaces `subprocess.run(..., capture_output=True, timeout=18000)` with a bounded-memory streaming helper to eliminate OOM risk on long `build_relationships.py` runs.

## The bug

Both Airflow DAG (`run_build_relationships`) and CLI baseline (`run_pipeline.py` Step 5b) used:

```python
subprocess.run(
    ["python3", "build_relationships.py"],
    capture_output=True,
    text=True,
    timeout=18000,
)
```

`capture_output=True` buffers ENTIRE child stdout + stderr in parent memory until the child exits. On a 344K-node graph, 12 APOC link queries over 5 hours → tens of MB of accumulated log text.

**Real OOM risk** on 8 GB Airflow workers, especially when `NEO4J_TX_MEMORY_MAX=8g` is also bumped.

## The fix

New module `src/subprocess_streaming.py` with `run_with_streaming_output()`:

- Spawns child with `stdout=PIPE, stderr=STDOUT, bufsize=1, text=True, errors="replace"` (merged streams, line-buffered, crash-resistant on bad bytes)
- Daemon thread drains output line-by-line, logs each at INFO, retains last N in a bounded `deque(maxlen=200)`
- Main thread waits for exit with 5h deadline
- On timeout: `SIGTERM` → 30s grace → `SIGKILL` (APOC rollback window)
- Returns `(returncode, tail_lines_list)`

**Memory cap: ~40 KB** (200 lines × ~200 bytes/line) vs. the prior unbounded buffer. ~1000× reduction at worst case.

## Why a separate module

PR-L's regression suite source-pins `src/run_pipeline.py` has no `threading.Thread` (part of the tier-1 sequential guarantee). Putting the reader thread in `src/subprocess_streaming.py` preserves that pin: the CLI only *calls* the helper.

## Files

| File | Change |
|---|---|
| `src/subprocess_streaming.py` | **new** — 196 LOC helper + docs |
| `dags/edgeguard_pipeline.py::run_build_relationships` | use helper; `SubprocessStreamTimeout` → `AirflowException` |
| `src/run_pipeline.py` Step 5b | use helper; degraded-mode path preserved |
| `tests/test_pr_k3_subprocess_streaming.py` | **new** — 9 tests |
| `tests/test_pr_c_cli_dag_parity.py` | update `test_cli_baseline_invokes_build_relationships` to accept either call shape |

## Test matrix

**`TestStreamingHelperBehavior` (5, behavioral):**
- Lines stream to parent logger as they arrive (proves parallel reader thread)
- Success → `(0, tail)`
- Failure → `(non-zero, tail)` (no exception)
- Tail buffer bounded: 500 child lines × `tail_lines=50` → exactly 50 retained, last-N
- Timeout escalation: SIGTERM sent, `SubprocessStreamTimeout` raised, <5s for 0.5s deadline

**`TestSourcePinsCaptureOutputGone` (4, pins):**
- DAG function body has no `subprocess.run(` (code-only strip)
- CLI Step 5b block has no `subprocess.run(`, `DEGRADED MODE` log preserved
- Helper uses `deque(maxlen=)` (memory-cap pin)
- Helper has SIGTERM → grace → SIGKILL escalation (pin against "simplification")

## Test plan

- [x] Target suite: 9/9 pass
- [x] Full suite: **1011 passed, 3 skipped, 0 failures**
- [x] Updated `test_cli_baseline_invokes_build_relationships` — preserves the "invoked as subprocess" invariant while accepting the new caller shim
- [x] `ruff format --check` ✓
- [x] `ruff check` ✓
- [x] `mypy src/` ✓

## Operator-facing impact

| Scenario | Before | After |
|---|---|---|
| 5h build_relationships run | Tens of MB buffered until exit | Streams to log immediately; ~40 KB tail |
| Child hangs past 5h | `TimeoutExpired` after 5h, no graceful abort | SIGTERM + 30s grace + SIGKILL |
| Child fails mid-run | Full stderr dumped at end | Lines in task log as they happen + summary tail |
| Child outputs bad bytes | decode error crashes reader | `errors="replace"` keeps reader alive |

## Related

- Flow audit: `docs/flow_audits/01_baseline_sequence.md` §1-4 (in PR-K #73)
- PR-K1 (#75), PR-K2 (#76) — other Tier-A resume/data-integrity fixes, independent of this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how long-running `build_relationships.py` is executed and timed out in both Airflow and CLI, including SIGTERM/SIGKILL escalation; mistakes could cause premature termination or altered operator diagnostics. Scope is localized and backed by new regression tests, reducing overall risk.
> 
> **Overview**
> **Replaces buffered `subprocess.run(capture_output=True)` execution of `build_relationships.py` with a bounded-memory, line-streaming runner** to prevent parent-process OOM during multi-hour runs.
> 
> Adds `src/subprocess_streaming.py` helper that streams merged stdout/stderr to the caller logger, retains only a configurable last-N line tail, and enforces the existing 5h deadline with SIGTERM→grace→SIGKILL escalation. Airflow’s `run_build_relationships` now fails with `AirflowException` on timeout/non-zero exit using the streamed tail for context, while the CLI baseline path preserves “degraded mode” behavior and logs a short tail summary.
> 
> Updates and adds tests to pin the new call shape, validate streaming/timeout behavior, and guard against regressions back to `capture_output=True`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8416786de64421e9b6ab70a2dcbc1523545c8402. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->