### PR TITLE
fix(audit): PR-M3a+b — two CRITICAL merge-determinism bugs (MD-C1 + RI-S4-Decay)

### DIFF
--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -88,22 +88,57 @@ def decay_ioc_confidence(neo4j_client) -> Dict:
                     RETURN count(n) AS affected
                     """
                     desc = f"{label} retired (>{min_days}d)"
+                    # Retire path is idempotent via the ``n.active = true``
+                    # guard in WHERE — already-retired nodes skip. No
+                    # ``last_decayed_tier`` gating needed here.
+                    params = {"min_days": min_days, "max_days": max_days, "mult": multiplier}
                 else:
+                    # PR-M3b §8-RI-S4-Decay: gate by ``last_decayed_tier`` so
+                    # the multiplicative decay fires AT MOST ONCE per tier
+                    # transition per node.  The prior query had no idempotency
+                    # marker: every enrichment run matched the same nodes in
+                    # the same tier and re-applied the multiplier, so a
+                    # node sitting in the 180-365d tier for 100 daily runs
+                    # got ``confidence × 0.70^100`` ≈ 0 (floored at 0.10)
+                    # within ~7 runs.  All indicators in the tier collapsed
+                    # to the 0.10 floor long before aging out — losing all
+                    # discriminatory power for filtering / ranking.
+                    #
+                    # Fix: each tier gets a unique label (``"<min>-<max>"``
+                    # format, stable across runs) stored on the node as
+                    # ``n.last_decayed_tier``. The WHERE clause excludes
+                    # nodes already decayed at this tier; the SET clause
+                    # updates the marker so the next run is a no-op.  When
+                    # a node AGES INTO the next tier, ``last_decayed_tier``
+                    # differs from the new tier label → decay fires once
+                    # for the new tier and updates the marker.  Net: each
+                    # node sees at most one decay application per tier
+                    # boundary crossed, matching the semantic intent
+                    # documented in the function docstring.
                     cypher = f"""
                     MATCH (n:{label})
                     WHERE n.last_updated IS NOT NULL
                       AND n.confidence_score IS NOT NULL
                       AND duration.between(n.last_updated, datetime()).days >= $min_days
                       AND duration.between(n.last_updated, datetime()).days < $max_days
+                      AND (n.last_decayed_tier IS NULL OR n.last_decayed_tier <> $tier_label)
                     SET n.confidence_score = CASE
                             WHEN n.confidence_score * $mult < 0.10 THEN 0.10
                             ELSE round(n.confidence_score * $mult * 100) / 100
-                        END
+                        END,
+                        n.last_decayed_tier = $tier_label,
+                        n.last_decayed_at = datetime()
                     RETURN count(n) AS affected
                     """
                     desc = f"{label} decayed ({min_days}–{max_days}d, ×{multiplier})"
+                    tier_label = f"{label.lower()}-{min_days}-{max_days}"
+                    params = {
+                        "min_days": min_days,
+                        "max_days": max_days,
+                        "mult": multiplier,
+                        "tier_label": tier_label,
+                    }
 
-                params = {"min_days": min_days, "max_days": max_days, "mult": multiplier}
                 result = session.run(cypher, timeout=NEO4J_READ_TIMEOUT, **params)
                 record = result.single()
                 count = record["affected"] if record else 0

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2465,17 +2465,33 @@ class Neo4jClient:
             return False
 
     def create_indicator_vulnerability_relationship(
-        self, indicator_value: str, cve_id: str, source_id: str = "misp"
+        self,
+        indicator_value: str,
+        cve_id: str,
+        source_id: str = "misp",
+        indicator_type: Optional[str] = None,
     ) -> bool:
         """Create INDICATES/EXPLOITS relationship: Indicator -> Vulnerability or CVE.
 
         Matches the Indicator by value (any type) and links to both Vulnerability
         and CVE nodes (NVD-rich items are stored under the CVE label), cross-source.
+
+        PR-M3a §5-MD-C1: when ``indicator_type`` is provided, the ``indicator_value``
+        is canonicalized via ``canonicalize_merge_key`` BEFORE the MATCH — matching
+        the canonicalization that ``merge_indicators_batch`` applies before MERGE.
+        Without this, a caller passing ``"DEADBEEF..."`` (mixed case) would MATCH
+        zero nodes because the stored node is at ``"deadbeef..."`` → edge silently
+        dropped. When ``indicator_type`` is None, the raw value is used (backward-
+        compat for callers that haven't been migrated; NOT safe for case-sensitive
+        types — caller takes responsibility).
         """
         if not self.driver:
             return False
 
         ind = nonempty_graph_string(indicator_value)
+        if ind and indicator_type:
+            canon = canonicalize_merge_key("Indicator", {"indicator_type": indicator_type, "value": ind})
+            ind = canon.get("value", ind)
         cve = normalize_cve_id_for_graph(cve_id)
         if not ind or not cve:
             logger.debug("Skipping indicator↔vulnerability link: missing normalized indicator value or CVE id")
@@ -2520,17 +2536,31 @@ class Neo4jClient:
             return False
 
     def create_indicator_malware_relationship(
-        self, indicator_value: str, malware_name: str, source_id: str = "misp"
+        self,
+        indicator_value: str,
+        malware_name: str,
+        source_id: str = "misp",
+        indicator_type: Optional[str] = None,
     ) -> bool:
         """Create INDICATES relationship: Indicator -> Malware.
 
         Matches Malware by name or aliases, cross-source (no tag filter).
+
+        PR-M3a §5-MD-C1: Indicator value canonicalization when
+        ``indicator_type`` is provided. See
+        ``create_indicator_vulnerability_relationship`` for the rationale.
+        Malware name is ALWAYS canonicalized (lowercase + NFC + strip) since
+        Malware natural-key case-sensitivity is fixed by the project schema.
         """
         if not self.driver:
             return False
 
         iv = nonempty_graph_string(indicator_value)
+        if iv and indicator_type:
+            iv = canonicalize_merge_key("Indicator", {"indicator_type": indicator_type, "value": iv}).get("value", iv)
         mn = nonempty_graph_string(malware_name)
+        if mn:
+            mn = canonicalize_merge_key("Malware", {"name": mn}).get("name", mn)
         if not iv or not mn:
             logger.debug("Skipping indicator↔malware link: missing indicator value or malware name")
             return False
@@ -2566,13 +2596,24 @@ class Neo4jClient:
             return False
 
     def create_indicator_sector_relationship(
-        self, indicator_value: str, sector_name: str, source_id: str = "misp"
+        self,
+        indicator_value: str,
+        sector_name: str,
+        source_id: str = "misp",
+        indicator_type: Optional[str] = None,
     ) -> bool:
-        """Create TARGETS relationship: Indicator -> Sector."""
+        """Create TARGETS relationship: Indicator -> Sector.
+
+        PR-M3a §5-MD-C1: Indicator value canonicalization when
+        ``indicator_type`` is provided. See
+        ``create_indicator_vulnerability_relationship`` for the rationale.
+        """
         if not self.driver:
             return False
 
         iv = nonempty_graph_string(indicator_value)
+        if iv and indicator_type:
+            iv = canonicalize_merge_key("Indicator", {"indicator_type": indicator_type, "value": iv}).get("value", iv)
         sec = nonempty_graph_string(sector_name)
         if not iv or not sec:
             logger.debug("Skipping indicator↔sector link: missing indicator value or sector name")
@@ -2739,6 +2780,27 @@ class Neo4jClient:
             rt = rel.get("rel_type")
             fk = rel.get("from_key") or {}
             tk = rel.get("to_key") or {}
+            # PR-M3a §5-MD-C1: canonicalize Indicator / Malware / ThreatActor /
+            # Campaign natural keys via ``canonicalize_merge_key`` BEFORE
+            # appending rows. Without this, ``merge_indicators_batch`` stores
+            # e.g. SHA256 as lowercase (canonicalize_merge_key) but the
+            # relationship MATCH below uses the raw value from ``fk.get("value")``
+            # → mixed-case MISP data (uppercase hash/hostname/domain from some
+            # collectors) produces a row whose MATCH finds no node → edge
+            # SILENTLY DROPPED and _dropped_rels doesn't catch it (it only
+            # counts missing-endpoint rows BEFORE the query runs). Same issue
+            # affects Malware/ThreatActor/Campaign name matches — canonicalize
+            # uniformly so both sides of the MERGE↔MATCH pairing agree.
+            from_type = rel.get("from_type")
+            to_type = rel.get("to_type")
+            if from_type == "Indicator":
+                fk = {**fk, **canonicalize_merge_key("Indicator", fk)}
+            elif from_type in ("Malware", "ThreatActor", "Campaign"):
+                fk = {**fk, **canonicalize_merge_key(from_type, fk)}
+            if to_type == "Indicator":
+                tk = {**tk, **canonicalize_merge_key("Indicator", tk)}
+            elif to_type in ("Malware", "ThreatActor", "Campaign"):
+                tk = {**tk, **canonicalize_merge_key(to_type, tk)}
             conf = rel.get("confidence", 0.5)
             # Originating MISP event id, stamped by parse_attribute /
             # _build_cross_item_relationships. Threaded into each row dict so the

--- a/tests/test_pr_m3ab_merge_determinism.py
+++ b/tests/test_pr_m3ab_merge_determinism.py
@@ -1,0 +1,403 @@
+"""
+PR-M3a + PR-M3b — Tier-A merge-determinism critical-bug fixes.
+
+Two CRITICAL findings from the 2026-04-20 comprehensive audit — each
+would silently corrupt a 730-day baseline graph even if every other
+Tier-A fix landed.
+
+## §5-MD-C1 (PR-M3a) — Indicator value canonicalization
+
+``merge_indicators_batch`` canonicalizes ``value`` via
+``canonicalize_merge_key`` before MERGE (e.g. lowercases SHA256
+hashes + IPv4 + hostnames + domains). But ``create_misp_relationships_batch``
+built row dicts directly from ``fk.get("value")`` — the raw, un-
+canonicalized MISP payload string. For any upstream source that
+emits mixed-case hashes (SHA256 as ``DEADBEEF...``, hostname as
+``Example.Com``), the relationship MATCH finds zero nodes → edge
+SILENTLY DROPPED. ``_dropped_rels`` counter doesn't catch it (only
+counts missing-endpoint rows BEFORE the query runs).
+
+Fix: canonicalize ``fk`` and ``tk`` in the dispatch loop BEFORE row
+append. Also make ``indicator_type`` an optional kwarg on the three
+single-item helpers so STIX-import callers can opt in.
+
+## §8-RI-S4-Decay (PR-M3b) — decay idempotency
+
+The original `decay_ioc_confidence` Cypher had no idempotency marker.
+Every enrichment run matched the same nodes in the same tier and
+re-applied ``× 0.85`` (or ``× 0.70``). A node sitting in the 180-365d
+tier for 100 runs got ``× 0.70^100`` ≈ 0, floored at 0.10, within ~7
+runs. All indicators in a tier collapse to the 0.10 floor — losing
+all discriminatory power for filtering / ranking.
+
+Fix: add ``n.last_decayed_tier`` marker, gate the WHERE clause on it,
+set it in the SET clause. Each node decays AT MOST ONCE per tier
+crossing; subsequent runs are no-ops. When the node ages into the
+next tier, the tier label changes → decay fires once for the new
+tier.
+
+## Test strategy
+
+Both fixes touch Cypher + Python dispatch logic. No live Neo4j in
+unit tests (that's the integration test's job). We use:
+- **Source-pin tests** — regex over the source to verify the fix
+  pattern is present AND the old broken pattern is gone.
+- **Behavioral tests** — mock the Neo4j driver / session, feed
+  specific inputs through ``create_misp_relationships_batch`` /
+  ``decay_ioc_confidence``, assert the Cypher / params sent to the
+  driver reflect the canonicalization / idempotency contract.
+
+Source-pins catch regressions on the code path; behavioral tests
+catch the bug in its actual trigger condition.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# §5-MD-C1 — Indicator value canonicalization
+# ===========================================================================
+
+
+class TestIndicatorCanonicalizationInBatchDispatch:
+    """When ``create_misp_relationships_batch`` builds row dicts for
+    Indicator-from relationships, the Indicator ``value`` MUST be
+    canonicalized via ``canonicalize_merge_key`` so it matches the
+    canonicalized value that ``merge_indicators_batch`` stored on
+    the node. Without this, mixed-case MISP data silently drops
+    edges."""
+
+    def _make_client(self):
+        """Build a ``Neo4jClient`` without connecting.  We don't need
+        a live driver — the dispatch loop runs in Python before any
+        Cypher is sent."""
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        # Satisfy attribute access — the dispatch doesn't touch the driver.
+        client.driver = MagicMock()
+        # Make session.run capture the params dict passed to it
+        self._captured_rows: list = []
+
+        def capture(query, **kwargs):
+            # The batch helper passes ``rows=...``; capture and return
+            # a fake result with .consume() shape.
+            rows = kwargs.get("rows")
+            if rows is not None:
+                self._captured_rows.append((query, list(rows)))
+            result = MagicMock()
+            result.consume.return_value.counters.relationships_created = 0
+            return result
+
+        session = MagicMock()
+        session.run = capture
+        session.__enter__ = lambda s: s
+        session.__exit__ = lambda *a: False
+        client.driver.session.return_value = session
+        return client
+
+    def test_indicates_malware_row_has_canonicalized_value(self):
+        """INDICATES Indicator→Malware: mixed-case SHA256 must be
+        lowercased in the row ``value`` field before reaching the
+        MATCH query."""
+        client = self._make_client()
+
+        relationships = [
+            {
+                "rel_type": "INDICATES",
+                "from_type": "Indicator",
+                "from_key": {"indicator_type": "sha256", "value": "DEADBEEF" * 8},
+                "to_type": "Malware",
+                "to_key": {"name": "Mimikatz"},
+                "confidence": 0.7,
+                "misp_event_id": "42",
+            }
+        ]
+        client.create_misp_relationships_batch(relationships, source_id="nvd")
+
+        # Find the rows captured for the INDICATES Indicator→Malware query.
+        ind_mal_rows = []
+        for query, rows in self._captured_rows:
+            if "INDICATES" in query and "Malware" in query and "i:Indicator" in query:
+                ind_mal_rows.extend(rows)
+
+        assert ind_mal_rows, (
+            f"expected rows captured for INDICATES Ind→Mal; got queries: {[q[:80] for q, _ in self._captured_rows]}"
+        )
+        row = ind_mal_rows[0]
+        # Value must be lowercased (SHA256 is a case-insensitive indicator type)
+        assert row["value"] == ("deadbeef" * 8), (
+            f"PR-M3a §5-MD-C1: Indicator value in INDICATES row must be "
+            f"canonicalized (lowercased for SHA256); got {row['value']!r}"
+        )
+        # Malware name must be lowercased too (name labels are case-insensitive per schema)
+        assert row["malware"] == "mimikatz", f"Malware name must be canonicalized (lowercase); got {row['malware']!r}"
+
+    def test_targets_sector_row_has_canonicalized_value(self):
+        """TARGETS Indicator→Sector: mixed-case IPv4 stays canonical
+        (already lowercase, but run the pipeline to prove no regression)."""
+        client = self._make_client()
+
+        relationships = [
+            {
+                "rel_type": "TARGETS",
+                "from_type": "Indicator",
+                "from_key": {"indicator_type": "domain", "value": "Example.COM"},
+                "to_type": "Sector",
+                "to_key": {"name": "healthcare"},
+                "confidence": 0.6,
+                "misp_event_id": "17",
+            }
+        ]
+        client.create_misp_relationships_batch(relationships, source_id="otx")
+
+        tgt_rows = []
+        for query, rows in self._captured_rows:
+            if "TARGETS" in query and "Sector" in query:
+                tgt_rows.extend(rows)
+
+        assert tgt_rows
+        row = tgt_rows[0]
+        assert row["value"] == "example.com", (
+            f"Domain indicator value must be canonicalized (lowercase); got {row['value']!r}"
+        )
+
+    def test_exploits_cve_row_has_canonicalized_value(self):
+        """EXPLOITS Indicator→CVE: SHA1 of mixed case → lowercased."""
+        client = self._make_client()
+
+        relationships = [
+            {
+                "rel_type": "EXPLOITS",
+                "from_type": "Indicator",
+                "from_key": {"indicator_type": "sha1", "value": "ABCDEF1234567890" * 2 + "BADF00D1"},
+                "to_type": "CVE",
+                "to_key": {"cve_id": "CVE-2024-1234"},
+                "confidence": 0.8,
+                "misp_event_id": "99",
+            }
+        ]
+        client.create_misp_relationships_batch(relationships, source_id="nvd")
+
+        expl_rows = []
+        for query, rows in self._captured_rows:
+            if "EXPLOITS" in query or ("INDICATES" in query and ":CVE" in query):
+                expl_rows.extend(rows)
+            # Newer Cypher may use MATCH(v:CVE/Vulnerability) + MERGE EXPLOITS.
+        # If no direct match yet, look for rows with cve_id + value.
+        if not expl_rows:
+            for _query, rows in self._captured_rows:
+                if any("cve_id" in r for r in rows):
+                    expl_rows.extend([r for r in rows if "cve_id" in r])
+
+        assert expl_rows, f"expected EXPLOITS rows; got queries: {[q[:80] for q, _ in self._captured_rows]}"
+        row = expl_rows[0]
+        # SHA1 is case-insensitive per indicator type rules → must be lowercased.
+        assert row["value"].islower(), (
+            f"PR-M3a §5-MD-C1: SHA1 indicator value must be lowercased before MATCH; got {row['value']!r}"
+        )
+
+
+class TestSingleItemHelpersAcceptIndicatorType:
+    """The three single-item rel helpers grew an optional
+    ``indicator_type`` kwarg in PR-M3a. When the caller provides it,
+    the value is canonicalized via ``canonicalize_merge_key`` before
+    the Cypher runs."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "neo4j_client.py").read_text()
+
+    def test_indicator_vulnerability_helper_accepts_indicator_type(self, source: str) -> None:
+        """``create_indicator_vulnerability_relationship`` signature
+        MUST include ``indicator_type`` kwarg with ``None`` default."""
+        sig_pattern = "def create_indicator_vulnerability_relationship"
+        idx = source.find(sig_pattern)
+        assert idx > 0
+        end = source.find(") -> bool:", idx)
+        signature = source[idx:end]
+        assert "indicator_type" in signature
+        assert "Optional[str] = None" in signature or "indicator_type: Optional[str]" in signature
+
+    def test_indicator_malware_helper_accepts_indicator_type(self, source: str) -> None:
+        idx = source.find("def create_indicator_malware_relationship")
+        end = source.find(") -> bool:", idx)
+        signature = source[idx:end]
+        assert "indicator_type" in signature
+
+    def test_indicator_sector_helper_accepts_indicator_type(self, source: str) -> None:
+        idx = source.find("def create_indicator_sector_relationship")
+        end = source.find(") -> bool:", idx)
+        signature = source[idx:end]
+        assert "indicator_type" in signature
+
+    def test_helpers_call_canonicalize_merge_key_when_type_given(self, source: str) -> None:
+        """All three helpers must invoke ``canonicalize_merge_key`` so
+        the caller's optional type argument actually changes behaviour."""
+        # Count occurrences inside the three helper bodies.  Shortcut:
+        # just verify the pattern appears at least 3 times across the
+        # file's helper definitions (one per helper) in the context
+        # of ``"Indicator"``.
+        assert source.count('canonicalize_merge_key("Indicator",') >= 4, (
+            "expected ``canonicalize_merge_key('Indicator', ...)`` to appear at "
+            "least 4 times (once per single-item helper + once in batch dispatch)"
+        )
+
+
+class TestSourcePinBatchDispatchCanonicalizes:
+    """The dispatch loop in ``create_misp_relationships_batch`` MUST
+    canonicalize ``fk`` and ``tk`` before row append. Source-pin so
+    a future refactor can't silently revert."""
+
+    def test_dispatch_loop_canonicalizes_fk_tk(self) -> None:
+        src = (SRC / "neo4j_client.py").read_text()
+        dispatch_start = src.find("def create_misp_relationships_batch")
+        assert dispatch_start > 0
+        # End at the next top-level `def ` after a reasonable window.
+        dispatch_end = src.find("\n    def ", dispatch_start + 1)
+        body = src[dispatch_start:dispatch_end]
+
+        # The canonicalization block must appear inside the dispatch body.
+        assert 'canonicalize_merge_key("Indicator", fk)' in body, (
+            "PR-M3a §5-MD-C1: dispatch must canonicalize Indicator from_key"
+        )
+        assert 'canonicalize_merge_key("Indicator", tk)' in body, (
+            "PR-M3a §5-MD-C1: dispatch must canonicalize Indicator to_key"
+        )
+        # The canonicalize_merge_key function name is the exact marker
+        # of the fix — if someone deletes that but leaves a comment, this
+        # still fails.
+        pre_fix_marker = 'fk = rel.get("from_key") or {}'
+        # After the fix, the very next lines should include a canonicalize call.
+        idx = body.find(pre_fix_marker)
+        assert idx > 0
+        # Slice the next ~500 chars — should contain the canonicalize call.
+        near = body[idx : idx + 1500]
+        assert "canonicalize_merge_key" in near, (
+            "canonicalize_merge_key must appear IMMEDIATELY after fk/tk assignment in the dispatch loop"
+        )
+
+
+# ===========================================================================
+# §8-RI-S4-Decay — Decay idempotency
+# ===========================================================================
+
+
+class TestDecayIsIdempotentWithinTier:
+    """Each node should decay AT MOST ONCE per tier.  The fix uses
+    ``n.last_decayed_tier`` as an idempotency marker; this test
+    pins the marker's presence in both the WHERE and SET clauses."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def test_where_clause_gates_on_last_decayed_tier(self, source: str) -> None:
+        """WHERE clause must include ``last_decayed_tier`` gate so
+        an already-decayed node in this tier is skipped on subsequent
+        runs."""
+        # Locate the decay helper's non-retire Cypher branch.
+        idx = source.find("def decay_ioc_confidence")
+        assert idx > 0
+        end = source.find("\ndef ", idx + 1)
+        body = source[idx:end]
+        assert "n.last_decayed_tier IS NULL OR n.last_decayed_tier <> $tier_label" in body, (
+            "PR-M3b §8-RI-S4-Decay: WHERE clause must gate on last_decayed_tier so "
+            "the multiplicative decay fires at most once per tier crossing"
+        )
+
+    def test_set_clause_writes_last_decayed_tier(self, source: str) -> None:
+        """SET clause must write ``n.last_decayed_tier`` so next run
+        sees it and skips."""
+        idx = source.find("def decay_ioc_confidence")
+        end = source.find("\ndef ", idx + 1)
+        body = source[idx:end]
+        assert "n.last_decayed_tier = $tier_label" in body
+        assert "n.last_decayed_at = datetime()" in body, (
+            "SET should also stamp last_decayed_at so operators can see when the marker was set"
+        )
+
+    def test_params_include_tier_label(self, source: str) -> None:
+        """The params dict must pass ``tier_label``."""
+        idx = source.find("def decay_ioc_confidence")
+        end = source.find("\ndef ", idx + 1)
+        body = source[idx:end]
+        assert '"tier_label": tier_label' in body, "params must include tier_label so the query can bind it"
+        # Tier label should be derived deterministically from the tier tuple
+        assert 'f"{label.lower()}-{min_days}-{max_days}"' in body
+
+    def test_old_unbounded_multiply_pattern_is_gone(self, source: str) -> None:
+        """The old query's final SET clause had no guard — just
+        ``n.confidence_score = CASE ...``.  After the fix, the SET
+        must include the tier marker.  A regression that re-wrote the
+        query without the guard would restore the non-idempotency."""
+        idx = source.find("def decay_ioc_confidence")
+        end = source.find("\ndef ", idx + 1)
+        body = source[idx:end]
+        # There must be NO decay-non-retire Cypher block that SETs
+        # ``n.confidence_score = CASE`` WITHOUT also setting
+        # ``n.last_decayed_tier``.  Simplest: verify every occurrence of
+        # the CASE expression on confidence_score is within ~400 chars of
+        # a last_decayed_tier SET.
+        pos = 0
+        while True:
+            case_idx = body.find("n.confidence_score = CASE", pos)
+            if case_idx < 0:
+                break
+            # Look 600 chars ahead for the tier marker
+            near = body[case_idx : case_idx + 800]
+            assert "n.last_decayed_tier" in near, (
+                "a SET clause writing confidence_score without also writing "
+                "last_decayed_tier was found — this is the non-idempotency bug "
+                "PR-M3b fixed"
+            )
+            pos = case_idx + 1
+
+
+class TestRetireTierStillIdempotentViaActiveFlag:
+    """The retire tier (>365d) has its own idempotency guard via
+    ``n.active = true`` in the WHERE clause.  PR-M3b should NOT
+    add the ``last_decayed_tier`` marker to the retire branch
+    (it would be dead work and confusing)."""
+
+    def test_retire_branch_does_not_use_last_decayed_tier(self) -> None:
+        """The retire (>365d) branch should NOT touch ``last_decayed_tier``
+        — ``n.active = true`` in WHERE is sufficient idempotency.  Dead
+        work to also set the tier marker.
+
+        We strip comment-only lines before checking so the explanatory
+        comment ("retire path is idempotent via active flag...") doesn't
+        trigger a false-positive."""
+        src = (SRC / "enrichment_jobs.py").read_text()
+        idx = src.find("def decay_ioc_confidence")
+        end = src.find("\ndef ", idx + 1)
+        body = src[idx:end]
+        retire_idx = body.find("if retire:")
+        assert retire_idx > 0
+        else_idx = body.find("else:", retire_idx)
+        retire_block = body[retire_idx:else_idx]
+
+        # Strip comment-only lines from the retire block before checking.
+        code_only_lines = [line for line in retire_block.splitlines() if not line.lstrip().startswith("#")]
+        retire_code_only = "\n".join(code_only_lines)
+        # Retire uses `n.active = true` guard (in active Cypher, not a comment).
+        assert "n.active = true" in retire_code_only
+        # Retire ACTIVE code must NOT reference last_decayed_tier — but
+        # the comment IS allowed to explain why it's not used.
+        assert "last_decayed_tier" not in retire_code_only, (
+            "retire branch's ACTIVE code does not need last_decayed_tier — "
+            "the n.active = true guard provides idempotency. Comments "
+            "explaining this are fine, but the Cypher + params must not "
+            "reference the marker."
+        )


### PR DESCRIPTION
## Summary

Two **Tier-A CRITICAL** findings from the 2026-04-20 comprehensive audit (PR-M #78). Each would silently corrupt a 730-day baseline graph even if every other Tier-A fix landed. Bundled because both are small, isolated, and address the "merge determinism" audit theme.

## §5-MD-C1 (PR-M3a) — Indicator value canonicalization

### The bug

`merge_indicators_batch` canonicalizes `value` via `canonicalize_merge_key` before MERGE — e.g. lowercases SHA256 + IPv4 + hostnames + domains + MD5/SHA1/SHA512/etc. But `create_misp_relationships_batch` built row dicts directly from `fk.get("value")` — the raw, un-canonicalized MISP payload.

For any upstream source that emits mixed-case hashes (`DEADBEEF...`) or hostnames (`Example.Com`):
- MERGE side: Indicator stored at `deadbeef...`
- MATCH side: lookup with `DEADBEEF...` → **zero rows** → **edge silently dropped**
- `_dropped_rels` counter misses it (only counts missing-endpoint rows before the query runs)

### The fix

Canonicalize `fk` and `tk` in the dispatch loop immediately after reading them from the relationship dict. One place, covers all row appends that follow (INDICATES / TARGETS / EXPLOITS / etc.). Also canonicalizes Malware/ThreatActor/Campaign name fields uniformly.

Single-item helpers (`create_indicator_{vulnerability,malware,sector}_relationship`) grew optional `indicator_type: Optional[str] = None` kwarg for opt-in canonicalization.

## §8-RI-S4-Decay (PR-M3b) — Decay idempotency

### The bug

Original `decay_ioc_confidence` Cypher had no idempotency marker. Every enrichment run re-applied `× 0.85` (or `× 0.70`). A node sitting in the 180-365d tier for 100 daily Airflow runs got `confidence × 0.70^100` ≈ 0, floored at 0.10, within **~7 runs**. All indicators in a tier collapse to 0.10 floor — losing all discriminatory power for filtering / ranking / RAG weighting.

### The fix

Add `n.last_decayed_tier` marker. Gate WHERE on it, set it in SET. Tier label derived deterministically as `f"{label.lower()}-{min_days}-{max_days}"`.

Behavior:
- First run: marker is NULL → decay applies once, marker set.
- Subsequent runs in same tier: filter excludes → no-op.
- Node ages into next tier: marker differs from new tier label → decay applies once for new tier.

Retire tier (>365d) unchanged — its `n.active = true` guard is already idempotent.

## Files

| File | Change |
|---|---|
| `src/neo4j_client.py` | +70 / -6 — dispatch canonicalization + 3 helper signatures |
| `src/enrichment_jobs.py` | +39 / -3 — last_decayed_tier gate in decay Cypher |
| `tests/test_pr_m3ab_merge_determinism.py` | **new** — 13 regression tests |

## Test plan

- [x] Target: 13/13 pass
- [x] Full suite: **1069 passed, 3 skipped, 3 xfailed, 0 failures**
- [x] `ruff format --check` ✓ / `ruff check` ✓ / `mypy src/` ✓

## Operator-facing impact on 730d baseline

| Scenario | Before | After |
|---|---|---|
| Mixed-case SHA256 from source X | Edge silently dropped | Edge created correctly |
| Same IOC from CyberCure (UPPER) + AbuseIPDB (lower) | Two Indicator nodes or split edges | One node, all edges attached |
| 180-day-old indicator, 100 enrichment runs | Confidence collapses to 0.10 floor in ~7 runs | Decays once (to ~0.35), stays there until aging into next tier |

## Related

- Audit: `docs/flow_audits/05_merge_determinism.md` §C1; `docs/flow_audits/08_relationship_integrity.md` S4 (in PR-M #78)
- Part of Tier-A fix sprint per operator direction "stop adding improvements, fix bugs in main pipeline"
- Next queued: PR-M1 (collector data loss), PR-M2 (timestamps), PR-M3c (q9 source_id), PR-M3d (Campaign PART_OF), PR-M4 (MISP aggregation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Neo4j write/query paths for relationship creation and confidence decay; mistakes could drop edges or change scores across large datasets, though changes are localized and guarded with new regression tests.
> 
> **Overview**
> Fixes two silent data-corruption issues in the Neo4j pipeline: **relationship creation now canonicalizes natural keys before matching**, and **confidence decay is now idempotent per time tier**.
> 
> Relationship helpers and the `create_misp_relationships_batch` dispatch loop now run `canonicalize_merge_key` for Indicator values (and for Malware/ThreatActor/Campaign names), plus the single-item helpers accept an optional `indicator_type` to enable consistent canonicalization so mixed-case inputs don’t silently fail to match.
> 
> `decay_ioc_confidence` now tracks per-node decay application with `n.last_decayed_tier`/`n.last_decayed_at` and gates the Cypher so multipliers apply at most once per tier transition (retire path remains guarded by `n.active = true`). A new test suite (`tests/test_pr_m3ab_merge_determinism.py`) pins both behaviors via source-pattern and mocked-driver assertions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ceb9a4ef1c2ee7db8a996503e8d4f39f05c14625. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->