### PR TITLE
fix(audit): PR-M3d — Campaign PART_OF determinism + c.zone stability

### DIFF
--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -17,6 +17,7 @@ import logging
 import os
 import sys
 import time
+from datetime import datetime, timezone
 from typing import Dict
 
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
@@ -159,6 +160,17 @@ def build_campaign_nodes(neo4j_client) -> Dict:
 
     results = {"campaigns_created": 0, "campaigns_updated": 0, "links_created": 0}
 
+    # PR-M3d: capture the run's start time in ISO-8601 with UTC offset.
+    # Passed to Step 3b's prune query as ``$run_start_at`` to distinguish
+    # edges touched by THIS run (``r.updated_at >= $run_start_at``) from
+    # stale edges left over from prior runs' non-deterministic top-100
+    # (``r.updated_at < $run_start_at``).  Python-side capture is
+    # sufficient because Neo4j server-side ``datetime()`` in Step 3a's
+    # SET is monotonic — any value stamped in Step 3a is guaranteed
+    # >= run_start_at (both read the same wall clock; Step 3a runs
+    # after this line by definition).
+    run_start_at = datetime.now(timezone.utc).isoformat()
+
     try:
         with neo4j_client.driver.session() as session:
             # Pre-fetch the names of every qualifying ThreatActor so we can
@@ -228,15 +240,28 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             WITH a, malware_list, i,
                  min(r.source_reported_first_at) AS i_source_first,
                  max(r.source_reported_last_at)  AS i_source_last
+            // PR-M3d §5-MD-C2 (CRITICAL): ``all_zones`` (below) used to be
+            // computed from ``collect(DISTINCT i)[0..100]``, a 100-sample
+            // in Neo4j's internal (non-deterministic) iteration order. On
+            // a Campaign with 500 associated indicators spanning multiple
+            // zones, ``c.zone`` would flap between different subsets of
+            // the full zone set across enrichment runs (e.g. ``["healthcare"]``
+            // on run 1, ``["healthcare","energy"]`` on run 2). Dashboards
+            // filtering ``WHERE 'healthcare' IN c.zone`` saw the campaign
+            // flicker in/out. Fix: compute zones from the FULL active-
+            // indicator set (no slice) — deterministic + semantically
+            // correct (Campaign's zones shouldn't depend on sample size).
+            // The slice was cheap compute defense; the full reduce is O(N)
+            // and trivial even for 10k-indicator campaigns.
             WITH a, malware_list,
                  count(DISTINCT i) AS indicator_total,
-                 collect(DISTINCT i)[0..100] AS indicator_sample,
+                 collect(DISTINCT i) AS all_indicators,
                  min(coalesce(i_source_first, i.first_imported_at)) AS first_seen,
                  max(coalesce(i_source_last,  i.last_updated))      AS last_seen
             WHERE size(malware_list) > 0 AND indicator_total > 0
-            WITH a, malware_list, indicator_total, indicator_sample, first_seen, last_seen,
+            WITH a, malware_list, indicator_total, first_seen, last_seen,
                  apoc.coll.toSet(
-                     reduce(z=[], ind IN indicator_sample | z + coalesce(ind.zone, []))
+                     reduce(z=[], ind IN all_indicators | z + coalesce(ind.zone, []))
                  ) AS all_zones
             MERGE (c:Campaign {{name: a.name + ' Campaign'}})
             ON CREATE SET c.created_at = datetime(),
@@ -319,23 +344,91 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             results["links_created"] += record["links"] if record else 0
             query_pause()
 
-            # Step 3: Link active indicators to their campaigns (sample: up to 100 per campaign)
-            # Using LIMIT inside WITH to avoid huge relationship fans
+            # Step 3a: Link active indicators to their campaigns (top 100 per
+            # campaign by recency).
+            #
+            # PR-M3d §8-RI-S3-Camp (CRITICAL): the old implementation used
+            # ``collect(i)[0..100]`` which returns the first 100 in Neo4j's
+            # internal iteration order — NOT a stable order across runs.
+            # Combined with MERGE's no-delete semantic, PART_OF edges
+            # accumulated monotonically: run N attached {i1..i100}, run N+1
+            # attached {i17..i116}, old 16 kept their edges forever. After
+            # 730 daily runs, a ThreatActor with 10k active indicators had
+            # EVERY single one wired via PART_OF — defeating the 100-cap's
+            # purpose and producing a non-deterministic graph where "is
+            # indicator X PART_OF campaign C?" depended on history, not
+            # current state.
+            #
+            # Fix:
+            # (a) Deterministic ordering via ``ORDER BY i.first_imported_at
+            #     DESC, i.value ASC`` BEFORE the slice. Newest-first with a
+            #     stable tiebreaker on value. Same input graph → same top-
+            #     100 every run.
+            # (b) ``r.updated_at = datetime()`` stamped unconditionally on
+            #     every MERGE so Step 3b below can prune edges that WEREN'T
+            #     touched this run (i.e., indicators that have fallen out
+            #     of the top 100 since the last run).
+            # (c) ``r.created_at`` on ON CREATE for audit-trail.
+            #
+            # Net: PART_OF edges for each Campaign always equal the current
+            # top-100 of active indicators. Reproducible, bounded, matches
+            # the documented "sample: up to 100 per campaign" contract.
             link_indicators = """
             MATCH (c:Campaign)
             MATCH (a:ThreatActor {name: c.actor_name})<-[:ATTRIBUTED_TO]-(m:Malware)<-[:INDICATES]-(i:Indicator)
             WHERE i.active = true
+            WITH c, i
+            ORDER BY i.first_imported_at DESC, i.value ASC
             WITH c, collect(i)[0..100] AS indicators
             UNWIND indicators AS i
             MERGE (i)-[r:PART_OF]->(c)
-            ON CREATE SET r.src_uuid = i.uuid, r.trg_uuid = c.uuid
+            ON CREATE SET r.created_at = datetime(),
+                          r.src_uuid = i.uuid,
+                          r.trg_uuid = c.uuid
             SET r.src_uuid = coalesce(r.src_uuid, i.uuid),
-                r.trg_uuid = coalesce(r.trg_uuid, c.uuid)
+                r.trg_uuid = coalesce(r.trg_uuid, c.uuid),
+                r.updated_at = datetime()
             RETURN count(*) AS links
             """
             result = session.run(link_indicators, timeout=NEO4J_READ_TIMEOUT)
             record = result.single()
             results["links_created"] += record["links"] if record else 0
+            query_pause()
+
+            # Step 3b: Prune stale PART_OF edges — indicators that WERE in a
+            # prior run's top-100 but aren't in THIS run's (aged out, retired,
+            # or displaced by newer active indicators).
+            #
+            # PR-M3d: without this prune, Step 3a's deterministic-top-100
+            # still accumulates across runs (MERGE never removes). We use
+            # ``r.updated_at`` as the freshness marker: every edge touched
+            # by Step 3a above gets ``r.updated_at = datetime()`` (which is
+            # always >= ``$run_start_at`` captured below). Any PART_OF edge
+            # with ``r.updated_at < $run_start_at`` OR ``r.updated_at IS
+            # NULL`` (from pre-fix edges) is stale and gets deleted.
+            #
+            # Edge case: if Step 3a failed mid-run (transaction abort), some
+            # edges may have stale timestamps. Idempotent — next successful
+            # run reconciles.
+            prune_indicators = """
+            MATCH (i:Indicator)-[r:PART_OF]->(c:Campaign)
+            WHERE r.updated_at IS NULL OR r.updated_at < $run_start_at
+            DELETE r
+            RETURN count(r) AS pruned
+            """
+            prune_result = session.run(
+                prune_indicators,
+                run_start_at=run_start_at,
+                timeout=NEO4J_READ_TIMEOUT,
+            )
+            prune_record = prune_result.single()
+            pruned = prune_record["pruned"] if prune_record else 0
+            if pruned:
+                logger.info(
+                    "[CAMPAIGN] pruned %d stale PART_OF edges (aged out of top-100 or pre-fix residue)",
+                    pruned,
+                )
+            results["links_pruned"] = pruned
             query_pause()
 
             # Step 4: Deactivate campaigns whose indicators are all retired

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -407,12 +407,18 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             # with ``r.updated_at < $run_start_at`` OR ``r.updated_at IS
             # NULL`` (from pre-fix edges) is stale and gets deleted.
             #
+            # Type note: ``$run_start_at`` is passed as an ISO-8601 string
+            # from Python (``datetime.now(timezone.utc).isoformat()``).
+            # Neo4j returns NULL when comparing a DateTime to a String, so
+            # we parse it to a temporal via ``datetime($run_start_at)``.
+            # Same pattern as merge_indicators_batch in neo4j_client.py.
+            #
             # Edge case: if Step 3a failed mid-run (transaction abort), some
             # edges may have stale timestamps. Idempotent — next successful
             # run reconciles.
             prune_indicators = """
             MATCH (i:Indicator)-[r:PART_OF]->(c:Campaign)
-            WHERE r.updated_at IS NULL OR r.updated_at < $run_start_at
+            WHERE r.updated_at IS NULL OR r.updated_at < datetime($run_start_at)
             DELETE r
             RETURN count(r) AS pruned
             """
@@ -431,12 +437,26 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             results["links_pruned"] = pruned
             query_pause()
 
-            # Step 4: Deactivate campaigns whose indicators are all retired
+            # Step 4: Deactivate campaigns whose indicators are all retired.
+            #
+            # PR-M3d: must use OPTIONAL MATCH. The old inner-MATCH
+            # (``MATCH (c:Campaign)<-[:PART_OF]-(i:Indicator)``) relied on
+            # stale PART_OF edges to now-retired indicators to detect
+            # all-retired campaigns. After Step 3b prunes those stale
+            # edges, a campaign whose indicators have ALL become inactive
+            # ends up with ZERO PART_OF edges (Step 3a only (re)creates
+            # edges for ``i.active = true``) — the inner MATCH would miss
+            # it entirely and the campaign would remain ``active = true``
+            # as a zombie. OPTIONAL MATCH includes campaigns with no
+            # PART_OF edges, and the explicit check on ``c.active`` avoids
+            # re-setting campaigns already marked inactive.
             logger.info("[DECAY] Deactivating campaigns with no active indicators...")
             cleanup_query = """
-                MATCH (c:Campaign)<-[:PART_OF]-(i:Indicator)
-                WITH c, collect(i.active) AS statuses
-                WHERE NOT any(s IN statuses WHERE s = true)
+                MATCH (c:Campaign)
+                WHERE c.active IS NULL OR c.active = true
+                OPTIONAL MATCH (c)<-[:PART_OF]-(i:Indicator {active: true})
+                WITH c, count(i) AS active_links
+                WHERE active_links = 0
                 SET c.active = false
                 RETURN count(c) as count
             """

--- a/tests/test_pr_m3d_campaign_determinism.py
+++ b/tests/test_pr_m3d_campaign_determinism.py
@@ -1,0 +1,256 @@
+"""
+PR-M3d — Campaign PART_OF determinism + c.zone stability.
+
+Closes TWO findings that share a root cause (non-deterministic
+``collect(DISTINCT i)[0..100]``):
+
+## §8-RI-S3-Camp (CRITICAL) — Campaign PART_OF monotonic growth
+
+``build_campaign_nodes`` Step 3 used ``collect(i)[0..100]`` returning
+the first 100 indicators in Neo4j's internal (non-deterministic)
+iteration order.  Combined with MERGE's no-delete semantic, PART_OF
+edges accumulated across runs: run N attached {i1..i100}, run N+1
+attached {i17..i116}, old 16 kept their edges forever.  After 730
+daily enrichment runs, a ThreatActor with 10k active indicators had
+EVERY single one wired via PART_OF — defeating the 100-cap.
+
+## §5-MD-C2 (CRITICAL) — c.zone flapping
+
+Same root cause. Step 1 computed ``c.zone`` from
+``collect(DISTINCT i)[0..100]`` → non-deterministic subset of zones.
+``c.zone`` flipped between ``["healthcare"]`` on run 1 and
+``["healthcare","energy"]`` on run 2 for the same Campaign.
+
+## Fix
+
+Three-part:
+1. **Step 1:** compute ``all_zones`` from the FULL active-indicator
+   set (no ``[0..100]`` slice).  Deterministic + semantically correct.
+2. **Step 3a:** add ``ORDER BY i.first_imported_at DESC, i.value ASC``
+   before ``collect(i)[0..100]`` so top-100 is stable across runs.
+   Stamp ``r.updated_at = datetime()`` on every MERGE (freshness
+   marker for pruning).
+3. **Step 3b (NEW):** delete PART_OF edges whose ``r.updated_at``
+   predates the run's start (``$run_start_at``) — they're the
+   displaced-from-top-100 residue.  ``$run_start_at`` captured in
+   Python at function start.
+
+## Test strategy
+
+Source-pin the three fix sites + behavioral test with mocked Neo4j
+driver for the prune step's `$run_start_at` param.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# §5-MD-C2 — c.zone computed from full set, not sample
+# ===========================================================================
+
+
+class TestCampaignZoneComputedFromFullSet:
+    """``c.zone`` MUST be computed by reducing over the FULL active-
+    indicator set, not over a non-deterministic 100-sample."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def test_step1_uses_all_indicators_for_zone_reduction(self, source: str) -> None:
+        """Step 1's MERGE block must compute zones from
+        ``reduce(z=[], ind IN all_indicators | ...)`` — iterating the
+        full active set — not from ``indicator_sample[0..100]``."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+
+        # The reduce over all_indicators must be present
+        assert "reduce(z=[], ind IN all_indicators | z + coalesce(ind.zone, []))" in body, (
+            "PR-M3d §5-MD-C2: c.zone must be computed by reducing over "
+            "``all_indicators`` (the FULL active set), not over a 100-sample. "
+            "The old ``indicator_sample[0..100]`` path was non-deterministic."
+        )
+
+    def test_step1_old_indicator_sample_slice_is_gone(self, source: str) -> None:
+        """The ``collect(DISTINCT i)[0..100] AS indicator_sample`` pattern
+        (non-deterministic 100-sample in Step 1) must be absent from the
+        active Cypher. Comments explaining what was removed are fine."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        # Strip comment-only Cypher lines (// ...) and Python comments (#)
+        # before checking.  Simple heuristic: active Cypher lines contain
+        # the pattern and are NOT inside a # comment.
+        active_lines = [
+            line for line in body.splitlines() if not line.lstrip().startswith("#") and "//" not in line.strip()[:3]
+        ]
+        active = "\n".join(active_lines)
+        assert "collect(DISTINCT i)[0..100] AS indicator_sample" not in active, (
+            "old Step 1 indicator_sample slice must not return as active Cypher"
+        )
+
+
+# ===========================================================================
+# §8-RI-S3-Camp — PART_OF edges deterministic + pruned
+# ===========================================================================
+
+
+class TestPartOfEdgesDeterministic:
+    """Step 3a MUST order indicators deterministically before the
+    ``[0..100]`` slice so the same graph state always produces the
+    same top-100."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def test_step3_has_order_by_before_collect(self, source: str) -> None:
+        """The ``ORDER BY i.first_imported_at DESC, i.value ASC``
+        clause MUST appear between the WHERE filter and the
+        ``collect(i)[0..100]`` slice."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        # Look for link_indicators query
+        assert "link_indicators = " in body
+        li_start = body.find("link_indicators = ")
+        li_end = body.find('"""', li_start + 20)  # end of triple-quoted block
+        # Skip the opening triple-quote to find the real end
+        li_end = body.find('"""', li_end + 3)
+        link_block = body[li_start:li_end]
+        assert "ORDER BY i.first_imported_at DESC, i.value ASC" in link_block, (
+            "Step 3 must sort deterministically before the 100-slice"
+        )
+        # Ensure the ORDER BY comes BEFORE the collect
+        order_idx = link_block.find("ORDER BY i.first_imported_at")
+        collect_idx = link_block.find("collect(i)[0..100]")
+        assert order_idx < collect_idx, "ORDER BY must precede collect(i)[0..100]"
+
+    def test_step3a_stamps_r_updated_at(self, source: str) -> None:
+        """Every PART_OF MERGE MUST stamp ``r.updated_at = datetime()``
+        so Step 3b can use it as the freshness marker."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        li_idx = body.find("link_indicators = ")
+        # The link_indicators query block extends roughly 2KB.
+        link_block = body[li_idx : li_idx + 2000]
+        assert "r.updated_at = datetime()" in link_block, (
+            "Step 3a MERGE must stamp r.updated_at so Step 3b can prune stale edges"
+        )
+
+    def test_step3b_prune_query_exists(self, source: str) -> None:
+        """Step 3b MUST delete PART_OF edges whose ``r.updated_at``
+        predates ``$run_start_at`` (or is NULL for pre-fix edges)."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert "prune_indicators = " in body, "Step 3b prune query must be defined"
+        pi_idx = body.find("prune_indicators = ")
+        prune_block = body[pi_idx : pi_idx + 1000]
+        # WHERE clause with the freshness marker check
+        assert "r.updated_at IS NULL OR r.updated_at < $run_start_at" in prune_block, (
+            "prune must gate on r.updated_at < $run_start_at (with NULL-tolerant branch for pre-fix edges)"
+        )
+        # DELETE keyword
+        assert "DELETE r" in prune_block
+
+    def test_function_captures_run_start_at(self, source: str) -> None:
+        """The Python function MUST capture ``run_start_at`` before
+        any Cypher executes so the prune query can filter edges
+        stamped DURING the run from edges stamped BEFORE."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert "run_start_at = datetime.now(timezone.utc).isoformat()" in body, (
+            "run_start_at must be captured with datetime.now(timezone.utc) for UTC+ISO-8601 format"
+        )
+        # Must pass to prune query
+        assert "run_start_at=run_start_at" in body, "prune query must receive run_start_at parameter"
+
+    def test_results_includes_links_pruned(self, source: str) -> None:
+        """Operator-facing: the results dict should report prune count
+        alongside links_created so a 730d baseline can see both."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert 'results["links_pruned"]' in body
+
+
+# ===========================================================================
+# Behavioral test: prune query receives correct params
+# ===========================================================================
+
+
+class TestPruneQueryReceivesRunStartAt:
+    """Mocked-driver behavioral test: assert that the prune query is
+    called with ``run_start_at`` as an ISO string in UTC."""
+
+    def test_prune_query_called_with_run_start_at(self, monkeypatch):
+        """Drive ``build_campaign_nodes`` with a mocked driver and
+        verify the prune query's params include ``run_start_at`` in
+        ISO-8601 UTC format."""
+        import enrichment_jobs
+
+        # Mock session + driver
+        queries_captured: list = []
+
+        def capture_run(query, **kwargs):
+            queries_captured.append((query, kwargs))
+            result = MagicMock()
+            # Return a row with 0 for every aggregate
+            result.single.return_value = {
+                "backfilled": 0,
+                "links": 0,
+                "pruned": 5,  # non-zero so the "pruned X" log fires
+                "count": 0,
+                "campaigns": 0,
+            }
+            # For queries that return iterable results (qualifying_actors_query)
+            result.__iter__ = lambda s: iter([])
+            return result
+
+        session = MagicMock()
+        session.run = capture_run
+        session.__enter__ = lambda s: s
+        session.__exit__ = lambda *a: False
+
+        fake_client = MagicMock()
+        fake_client.driver = MagicMock()
+        fake_client.driver.session.return_value = session
+
+        # Also mock query_pause so it's a no-op
+        monkeypatch.setattr(enrichment_jobs, "query_pause", lambda: None)
+
+        enrichment_jobs.build_campaign_nodes(fake_client)
+
+        # Find the prune query in captured calls
+        prune_calls = [
+            (query, kwargs) for query, kwargs in queries_captured if "DELETE r" in query and "PART_OF" in query
+        ]
+        assert prune_calls, (
+            f"expected a prune query (MATCH PART_OF + DELETE r); got queries: {[q[:80] for q, _ in queries_captured]}"
+        )
+
+        _, prune_kwargs = prune_calls[0]
+        assert "run_start_at" in prune_kwargs, (
+            f"prune query must receive run_start_at kwarg; got {list(prune_kwargs.keys())}"
+        )
+        run_start_at = prune_kwargs["run_start_at"]
+        assert isinstance(run_start_at, str)
+        # ISO-8601 UTC format
+        assert "+00:00" in run_start_at or run_start_at.endswith("Z"), (
+            f"run_start_at must be ISO with UTC offset; got {run_start_at!r}"
+        )

--- a/tests/test_pr_m3d_campaign_determinism.py
+++ b/tests/test_pr_m3d_campaign_determinism.py
@@ -153,19 +153,89 @@ class TestPartOfEdgesDeterministic:
 
     def test_step3b_prune_query_exists(self, source: str) -> None:
         """Step 3b MUST delete PART_OF edges whose ``r.updated_at``
-        predates ``$run_start_at`` (or is NULL for pre-fix edges)."""
+        predates ``$run_start_at`` (or is NULL for pre-fix edges).
+
+        Regression pin (Bugbot commit 27965ebf): ``$run_start_at`` is a
+        Python ISO string but ``r.updated_at`` is a Neo4j DateTime (set
+        via ``datetime()`` in Step 3a). Comparing DateTime to String in
+        Cypher returns NULL — so the parameter MUST be wrapped as
+        ``datetime($run_start_at)`` to coerce it to a temporal. Without
+        the wrap, only the ``IS NULL`` branch fires → post-fix stale
+        edges NEVER pruned → bug reappears in silent form."""
         start = source.find("def build_campaign_nodes")
         end = source.find("\ndef ", start + 1)
         body = source[start:end]
         assert "prune_indicators = " in body, "Step 3b prune query must be defined"
         pi_idx = body.find("prune_indicators = ")
         prune_block = body[pi_idx : pi_idx + 1000]
-        # WHERE clause with the freshness marker check
-        assert "r.updated_at IS NULL OR r.updated_at < $run_start_at" in prune_block, (
-            "prune must gate on r.updated_at < $run_start_at (with NULL-tolerant branch for pre-fix edges)"
+        # WHERE clause with the freshness marker check — DateTime-typed
+        # parameter via ``datetime($run_start_at)``, not bare string
+        assert "r.updated_at IS NULL OR r.updated_at < datetime($run_start_at)" in prune_block, (
+            "prune must gate on ``r.updated_at < datetime($run_start_at)`` so the parameter "
+            "is coerced to DateTime (matches ``r.updated_at`` set via ``datetime()`` in Step 3a). "
+            "Without the datetime() wrap, DateTime < String returns NULL → only the IS NULL "
+            "branch fires → post-fix stale edges are never pruned."
         )
         # DELETE keyword
         assert "DELETE r" in prune_block
+
+    def test_step3b_does_not_use_bare_string_run_start_at(self, source: str) -> None:
+        """Negative pin for Bugbot finding (commit 27965ebf). The
+        bare form ``r.updated_at < $run_start_at`` (no ``datetime()``
+        wrap) compares DateTime to String and silently always returns
+        NULL, leaving every post-fix stale edge in place. This test
+        fails loudly if the regression returns."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        pi_idx = body.find("prune_indicators = ")
+        prune_block = body[pi_idx : pi_idx + 1000]
+        # Heuristic: the bare form must not appear as an active
+        # expression in the Cypher.  We check for the exact substring
+        # ``< $run_start_at`` without a preceding ``datetime(``.
+        # The only allowed instance is inside ``datetime($run_start_at)``.
+        for line in prune_block.splitlines():
+            stripped = line.strip()
+            # Skip comment lines (# or //) and non-active text
+            if stripped.startswith("#") or stripped.startswith("//"):
+                continue
+            if "< $run_start_at" in stripped:
+                raise AssertionError(
+                    f"Regression: bare ``< $run_start_at`` without ``datetime()`` wrap "
+                    f"found in active Cypher line: {stripped!r}. "
+                    f"This compares DateTime to String → always NULL → prune silently fails. "
+                    f"Use ``< datetime($run_start_at)`` instead."
+                )
+
+    def test_step4_uses_optional_match_to_catch_zombie_campaigns(self, source: str) -> None:
+        """Regression pin (Bugbot commit 27965ebf, finding 2): after
+        Step 3b prunes stale edges, a campaign whose indicators have
+        ALL gone inactive ends up with ZERO ``PART_OF`` edges (Step 3a
+        only (re)creates edges for active indicators).
+
+        The old Step 4 used ``MATCH (c:Campaign)<-[:PART_OF]-(i:Indicator)``
+        which would find zero rows for such campaigns → they stayed
+        ``active = true`` as zombies forever.
+
+        Step 4 MUST use ``OPTIONAL MATCH`` with an explicit
+        ``c.active = true`` gate so campaigns with zero linked active
+        indicators still get deactivated."""
+        start = source.find("def build_campaign_nodes")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert "cleanup_query = " in body, "Step 4 cleanup query must exist"
+        cq_idx = body.find("cleanup_query = ")
+        cleanup_block = body[cq_idx : cq_idx + 1000]
+        assert "OPTIONAL MATCH" in cleanup_block, (
+            "Step 4 must use OPTIONAL MATCH — inner MATCH misses campaigns with "
+            "zero PART_OF edges post-prune (all-retired → zombie campaigns)"
+        )
+        # Must filter on active campaigns to avoid re-setting already-inactive
+        assert "c.active IS NULL OR c.active = true" in cleanup_block, (
+            "Step 4 must scope to currently-active campaigns (c.active = true OR NULL) "
+            "to avoid re-setting already-retired campaigns"
+        )
+        assert "SET c.active = false" in cleanup_block
 
     def test_function_captures_run_start_at(self, source: str) -> None:
         """The Python function MUST capture ``run_start_at`` before


### PR DESCRIPTION
## Summary

Closes **two CRITICAL** audit findings that share a root cause: non-deterministic `collect(DISTINCT i)[0..100]` in `build_campaign_nodes`.

| Finding | Severity | Impact |
|---|---|---|
| §8-RI-S3-Camp | CRITICAL | PART_OF edges accumulate monotonically — after 730 daily runs, every indicator wired to campaign, defeating the 100-cap |
| §5-MD-C2 | CRITICAL | `c.zone` flaps between different subsets of the full zone set across runs — dashboards filtering `WHERE 'healthcare' IN c.zone` see campaigns flicker in/out |

## The bug

**§8-RI-S3-Camp** — Step 3's `collect(i)[0..100]` returned the first 100 indicators in Neo4j's internal (non-deterministic) iteration order. Combined with MERGE's no-delete semantic, edges accumulated:
- Run N → attach {i1..i100}
- Run N+1 → attach {i17..i116} (iteration order shifted)
- Old 16 keep their edges **forever**

After 730 runs on a ThreatActor with 10k active indicators, every single one has PART_OF — 100× the documented bound.

**§5-MD-C2** — Same root cause. Step 1 computed `c.zone` from `collect(DISTINCT i)[0..100]`, reducing over a non-deterministic 100-sample. `c.zone` flipped run-to-run → consumer dashboards flickered.

## The fix (three parts)

1. **Step 1**: compute `all_zones` from the FULL active-indicator set (no `[0..100]` slice). Deterministic + semantically correct — a Campaign's zones shouldn't depend on sample size. O(N) reduce is trivial even for 10k-indicator campaigns.
2. **Step 3a**: add `ORDER BY i.first_imported_at DESC, i.value ASC` before `collect(i)[0..100]`. Stable top-100 across runs. Stamp `r.updated_at = datetime()` unconditionally as freshness marker.
3. **Step 3b (NEW)**: delete PART_OF edges whose `r.updated_at IS NULL OR r.updated_at < $run_start_at`. Pre-fix edges (NULL) and displaced-from-top-100 residue both cleaned. `$run_start_at` captured in Python via `datetime.now(timezone.utc).isoformat()` before any sessions open — any edge stamped by Step 3a is guaranteed `>= run_start_at`.

**Net:** PART_OF edges for each Campaign always equal the current top-100 of active indicators. Reproducible, bounded, matches the `"sample: up to 100 per campaign"` contract.

## Tests

`tests/test_pr_m3d_campaign_determinism.py` — 8 tests across 4 classes:

- **TestCampaignZoneComputedFromFullSet** (2): Step 1 uses `reduce(z=[], ind IN all_indicators | ...)`; old `indicator_sample[0..100]` slice is gone from active Cypher
- **TestPartOfEdgesDeterministic** (5): `ORDER BY` precedes `collect(i)[0..100]`; `r.updated_at = datetime()` stamped; prune query exists with correct `WHERE r.updated_at IS NULL OR r.updated_at < $run_start_at` + `DELETE r`; `run_start_at` captured via `datetime.now(timezone.utc).isoformat()` and passed to prune; `results["links_pruned"]` reported
- **TestPruneQueryReceivesRunStartAt** (1): behavioral test with mocked Neo4j driver asserts the prune query's kwargs include `run_start_at` in ISO-8601 UTC format

Full suite: **1064 passed, 3 skipped, 3 xfailed** in 203s.

## Test plan
- [x] `pytest tests/test_pr_m3d_campaign_determinism.py -v` — 8/8 pass
- [x] `pytest tests/` — 1064/1064 pass
- [x] `ruff format --check src/ dags/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean

## Related

Part of the Tier-A audit sweep (PR-M #78). Sibling PRs:
- PR-M3a+b #79 — indicator canonicalization + decay idempotency
- PR-M3c (next) — Query #9 source_id accumulation

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Neo4j enrichment logic and introduces relationship deletion (`PART_OF` pruning), which could remove or mis-sample campaign links if ordering/timestamp assumptions are wrong, but scope is limited to derived Campaign relationships/properties.
> 
> **Overview**
> Fixes non-determinism in `build_campaign_nodes` that caused Campaign `zone` to flap and `Indicator`→`Campaign` `PART_OF` edges to grow unbounded across runs.
> 
> `c.zone` is now computed from the full active indicator set (not a 100-sample), and `PART_OF` indicator sampling is made deterministic via `ORDER BY i.first_imported_at DESC, i.value ASC` plus a new prune step that deletes stale `PART_OF` edges using a Python-captured `run_start_at` and per-edge `r.updated_at` timestamps.
> 
> Adds targeted tests (`test_pr_m3d_campaign_determinism.py`) that source-pin the Cypher changes and behaviorally assert the prune query is called with `run_start_at`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 27965ebf81a1c675691a09b76a1b07bf50deaa63. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->