### PR TITLE
fix(audit): PR-M3c — §8-RI-S3-Q9 co-occurrence source_ids accumulation

### DIFF
--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -206,7 +206,22 @@ def build_relationships():
         # 3a. Indicator → Vulnerability (EXPLOITS) — exact CVE match (indexed)
         logger.info("[LINK] 3a/12 Indicator → Vulnerability (exact CVE match)...")
         _q3a_outer = "MATCH (i:Indicator) WHERE i.cve_id IS NOT NULL AND i.cve_id <> '' RETURN i"
-        _q3a_inner = 'WITH $i AS i MATCH (v:Vulnerability {cve_id: i.cve_id}) MERGE (i)-[r:EXPLOITS]->(v) ON CREATE SET r.confidence_score = 1.0, r.match_type = "cve_tag", r.source_id = "cve_tag_match", r.created_at = datetime() SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, i.uuid), r.trg_uuid = coalesce(r.trg_uuid, v.uuid)'
+        # PR-M3c §8-RI-S3-Q9: accumulate ``r.source_ids`` (set-valued) in
+        # addition to writing scalar ``r.source_id`` (last-writer-wins, kept
+        # for legacy readers and observability). Multiple merge passes (e.g.
+        # Q4 co-occurrence and Q9 malware-family-match) share the same
+        # INDICATES edge endpoints — scalar overwrite hides prior provenance
+        # from the calibrator filter. Accumulating via ``apoc.coll.toSet``
+        # preserves every source tag that has ever applied to the edge; the
+        # calibrator can then match on ANY() over the array.
+        _q3a_inner = (
+            "WITH $i AS i MATCH (v:Vulnerability {cve_id: i.cve_id}) MERGE (i)-[r:EXPLOITS]->(v) "
+            'ON CREATE SET r.confidence_score = 1.0, r.match_type = "cve_tag", '
+            '   r.source_id = "cve_tag_match", r.created_at = datetime() '
+            "SET r.updated_at = datetime(), "
+            '    r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["cve_tag_match"]), '
+            "    r.src_uuid = coalesce(r.src_uuid, i.uuid), r.trg_uuid = coalesce(r.trg_uuid, v.uuid)"
+        )
         # PR #34 round 20: count Indicator orphans (cve_id set but no
         # matching Vulnerability) — directly the skip count, no comparison.
         _q3a_skip = (
@@ -229,7 +244,16 @@ def build_relationships():
         # 3b. Indicator → CVE (EXPLOITS) — exact CVE match (indexed)
         logger.info("[LINK] 3b/12 Indicator → CVE (exact CVE match)...")
         _q3b_outer = "MATCH (i:Indicator) WHERE i.cve_id IS NOT NULL AND i.cve_id <> '' RETURN i"
-        _q3b_inner = 'WITH $i AS i MATCH (c:CVE {cve_id: i.cve_id}) MERGE (i)-[r:EXPLOITS]->(c) ON CREATE SET r.confidence_score = 1.0, r.match_type = "cve_tag", r.source_id = "cve_tag_match", r.created_at = datetime() SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, i.uuid), r.trg_uuid = coalesce(r.trg_uuid, c.uuid)'
+        # PR-M3c: see Q3a above for rationale — same accumulate-source_ids
+        # pattern applied uniformly to every site that sets ``r.source_id``.
+        _q3b_inner = (
+            "WITH $i AS i MATCH (c:CVE {cve_id: i.cve_id}) MERGE (i)-[r:EXPLOITS]->(c) "
+            'ON CREATE SET r.confidence_score = 1.0, r.match_type = "cve_tag", '
+            '   r.source_id = "cve_tag_match", r.created_at = datetime() '
+            "SET r.updated_at = datetime(), "
+            '    r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["cve_tag_match"]), '
+            "    r.src_uuid = coalesce(r.src_uuid, i.uuid), r.trg_uuid = coalesce(r.trg_uuid, c.uuid)"
+        )
         _q3b_skip = (
             "MATCH (i:Indicator) WHERE i.cve_id IS NOT NULL AND i.cve_id <> '' "
             "AND NOT EXISTS { MATCH (c:CVE {cve_id: i.cve_id}) } "
@@ -273,7 +297,17 @@ def build_relationships():
             # in CLOUD_SYNC.md filters edges by ``r.updated_at >= ...`` to
             # extract the recent-changes window. Without it, INDICATES
             # co-occurrence edges would be silently excluded from cloud sync.
+            #
+            # PR-M3c §8-RI-S3-Q9 (HIGH): accumulate ``"misp_cooccurrence"`` in
+            # ``r.source_ids`` so Q9's later MERGE on the SAME edge (the bug —
+            # Q9 used to overwrite ``r.source_id = "malware_family_match"``,
+            # hiding the co-occurrence provenance from the calibrator filter
+            # on ``source_id IN ["misp_cooccurrence", "misp_correlation"]`` →
+            # edge silently exempted from calibration → confidence stays at
+            # 0.5/0.8 even for 96k-indicator bulk dumps) cannot erase the
+            # co-occurrence tag. ``apoc.coll.toSet`` dedupes repeated runs.
             "SET r.updated_at = datetime(), "
+            '    r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["misp_cooccurrence"]), '
             "    r.src_uuid = coalesce(r.src_uuid, i.uuid), "
             "    r.trg_uuid = coalesce(r.trg_uuid, m.uuid)"
         )
@@ -437,7 +471,41 @@ def build_relationships():
         # or family) — direct skip count, no comparison.
         logger.info("[LINK] 9/12 Indicator → Malware (malware_family match)...")
         _q9_outer = "MATCH (i:Indicator) WHERE i.malware_family IS NOT NULL AND i.malware_family <> '' RETURN i"
-        _q9_inner = 'WITH $i AS i MATCH (m:Malware) WHERE toLower(m.name) = toLower(i.malware_family) OR toLower(i.malware_family) IN [x IN coalesce(m.aliases, []) | toLower(x)] OR toLower(m.family) = toLower(i.malware_family) MERGE (i)-[r:INDICATES]->(m) ON CREATE SET r.created_at = datetime() SET r.confidence_score = CASE WHEN r.confidence_score IS NULL OR 0.8 > r.confidence_score THEN 0.8 ELSE r.confidence_score END, r.match_type = "malware_family", r.source_id = "malware_family_match", r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, i.uuid), r.trg_uuid = coalesce(r.trg_uuid, m.uuid)'
+        # PR-M3c §8-RI-S3-Q9 (HIGH): this is the overwrite site. The SAME
+        # INDICATES edge may already exist from Q4 (co-occurrence) with
+        # ``r.source_id = "misp_cooccurrence"``. Before this fix, Q9's MERGE
+        # matched that edge and clobbered ``r.source_id`` with
+        # ``"malware_family_match"``, so the calibrator's filter
+        # (``source_id IN ["misp_cooccurrence", "misp_correlation"]``)
+        # missed the edge and its confidence stayed at 0.8 even when the
+        # underlying MISP event was a 96k-indicator bulk dump that should
+        # have demoted it to 0.30. Estimated 30-50% of INDICATES edges on
+        # a 730-day baseline were inflated this way.
+        #
+        # Fix: accumulate ``"malware_family_match"`` into ``r.source_ids``
+        # via ``apoc.coll.toSet`` — both sources now coexist on the edge.
+        # The scalar ``r.source_id`` write is kept (last-writer-wins, for
+        # legacy readers) but the calibrator filter is updated in
+        # enrichment_jobs.py to match against the ``r.source_ids`` array
+        # so co-occurrence provenance is always seen.
+        _q9_inner = (
+            "WITH $i AS i MATCH (m:Malware) "
+            "WHERE toLower(m.name) = toLower(i.malware_family) "
+            "   OR toLower(i.malware_family) IN [x IN coalesce(m.aliases, []) | toLower(x)] "
+            "   OR toLower(m.family) = toLower(i.malware_family) "
+            "MERGE (i)-[r:INDICATES]->(m) "
+            "ON CREATE SET r.created_at = datetime() "
+            "SET r.confidence_score = CASE "
+            "       WHEN r.confidence_score IS NULL OR 0.8 > r.confidence_score THEN 0.8 "
+            "       ELSE r.confidence_score "
+            "    END, "
+            '    r.match_type = "malware_family", '
+            '    r.source_id = "malware_family_match", '
+            '    r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["malware_family_match"]), '
+            "    r.updated_at = datetime(), "
+            "    r.src_uuid = coalesce(r.src_uuid, i.uuid), "
+            "    r.trg_uuid = coalesce(r.trg_uuid, m.uuid)"
+        )
         _q9_skip = (
             "MATCH (i:Indicator) WHERE i.malware_family IS NOT NULL AND i.malware_family <> '' "
             "AND NOT EXISTS { "

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -429,9 +429,22 @@ def calibrate_cooccurrence_confidence(neo4j_client) -> Dict:
       ≤ 500 → 0.35  (large feed)
       > 500 → 0.30  (bulk dump — weak signal)
 
-    Only edges with source_id IN ('misp_cooccurrence', 'misp_correlation')
-    are modified. Explicit matches (malware_family_match, cve_tag_match,
-    mitre_explicit) and manually curated edges are untouched.
+    Only edges with ``'misp_cooccurrence'`` or ``'misp_correlation'`` in
+    ``r.source_ids`` (set-valued, populated by every source-tagged MERGE
+    in ``build_relationships.py``) are modified.  For edges that predate
+    PR-M3c and only have the scalar ``r.source_id``, that legacy field
+    is also consulted (fallback path).  Explicit-only matches
+    (``cve_tag_match``, ``mitre_explicit``) and manually curated edges
+    are untouched.
+
+    PR-M3c §8-RI-S3-Q9: this filter used to be ``r.source_id IN [...]``
+    (scalar) but Q9 (malware_family match) in build_relationships.py
+    OVERWROTE ``r.source_id`` on edges that ALSO came from Q4 co-occurrence,
+    hiding the co-occurrence tag and silently exempting ~30-50% of
+    INDICATES edges on a 730d baseline from calibration.  The
+    ``r.source_ids`` set accumulates every source tag that has ever
+    applied to the edge, so co-occurrence provenance cannot be erased
+    by a later MERGE.
     """
     if not neo4j_client.driver:
         logger.error("calibrate_cooccurrence_confidence: no Neo4j connection")
@@ -494,12 +507,26 @@ def calibrate_cooccurrence_confidence(neo4j_client) -> Dict:
 
                     # Match indicators that have this event id in misp_event_ids[].
                     # PR #33 round 10: dropped legacy scalar misp_event_id leg.
+                    # PR-M3c §8-RI-S3-Q9: match on ``r.source_ids`` (set-
+                    # valued accumulator, populated by every source-tagged
+                    # MERGE in build_relationships.py as of this PR) OR fall
+                    # back to scalar ``r.source_id`` for legacy edges that
+                    # predate PR-M3c and have no array yet. Before this fix,
+                    # Q9's MERGE overwrote ``r.source_id = "malware_family_match"``
+                    # on edges that ALSO came from Q4 co-occurrence, and the
+                    # scalar filter silently exempted them from size-based
+                    # calibration → confidence frozen at 0.8 instead of the
+                    # bulk-dump tier's 0.30. Matching on ANY() over the
+                    # accumulated array restores the co-occurrence tag's
+                    # visibility.
                     update_cypher = """
                     UNWIND $eids AS eid
                     MATCH (i:Indicator)
                     WHERE i.misp_event_ids IS NOT NULL AND eid IN i.misp_event_ids
                     MATCH (i)-[r:INDICATES|EXPLOITS]->(target)
-                    WHERE r.source_id IN ["misp_cooccurrence", "misp_correlation"]
+                    WHERE (r.source_ids IS NOT NULL
+                           AND any(s IN r.source_ids WHERE s IN ["misp_cooccurrence", "misp_correlation"]))
+                       OR r.source_id IN ["misp_cooccurrence", "misp_correlation"]
                     SET r.confidence_score = $conf,
                         r.calibrated_at = datetime()
                     RETURN count(r) AS updated
@@ -537,11 +564,17 @@ def calibrate_cooccurrence_confidence(neo4j_client) -> Dict:
                     # cannot safely be used as bound entities in the inner. Pattern:
                     # outer returns ``id(r) AS rid`` (primitive long), inner re-MATCHes
                     # ``MATCH ()-[r]->() WHERE id(r) = $rid`` to bind a fresh handle.
+                    # PR-M3c: same array-or-scalar filter as the small path
+                    # (see ``update_cypher`` above).  Must be expressed inside
+                    # the apoc.periodic.iterate OUTER matcher; a single line
+                    # with both branches concatenated with OR.
                     large_batch_query = (
                         "CALL apoc.periodic.iterate("
                         "  'MATCH (i:Indicator) WHERE i.misp_event_ids IS NOT NULL AND $eid IN i.misp_event_ids "
                         "  MATCH (i)-[r:INDICATES|EXPLOITS]->(target) "
-                        '  WHERE r.source_id IN ["misp_cooccurrence", "misp_correlation"] '
+                        "  WHERE (r.source_ids IS NOT NULL "
+                        '         AND any(s IN r.source_ids WHERE s IN ["misp_cooccurrence", "misp_correlation"])) '
+                        '     OR r.source_id IN ["misp_cooccurrence", "misp_correlation"] '
                         "  RETURN id(r) AS rid', "
                         "  'MATCH ()-[r]->() WHERE id(r) = $rid "
                         "  SET r.confidence_score = $conf, r.calibrated_at = datetime()', "

--- a/tests/test_pr_m3c_cooccurrence_source_ids.py
+++ b/tests/test_pr_m3c_cooccurrence_source_ids.py
@@ -1,0 +1,237 @@
+"""
+PR-M3c — §8-RI-S3-Q9: Co-occurrence ``r.source_ids`` accumulation.
+
+## The bug
+
+``src/build_relationships.py`` Q4 (Indicator→Malware co-occurrence)
+stamps ``r.source_id = "misp_cooccurrence"`` on the INDICATES edge.
+Q9 (malware_family match) later MERGEs the SAME edge and OVERWRITES
+``r.source_id = "malware_family_match"`` — the last-writer-wins scalar
+hides the co-occurrence provenance.  The calibrator
+(``calibrate_cooccurrence_confidence``) filters on
+``r.source_id IN ["misp_cooccurrence", "misp_correlation"]`` and
+silently MISSES these edges, leaving them at 0.8 confidence instead of
+the bulk-dump tier's 0.30-0.50.  Estimated 30-50% of INDICATES edges
+on a 730-day baseline are affected.
+
+## The fix
+
+1. Every MERGE site that sets ``r.source_id = "<X>"`` ALSO sets
+   ``r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["<X>"])``
+   so every tag that has ever applied to the edge is preserved.
+2. Calibrator filter becomes
+   ``(r.source_ids IS NOT NULL AND any(s IN r.source_ids WHERE s IN [...]))
+   OR r.source_id IN [...]`` — array match for post-fix edges; scalar
+   fallback for pre-fix/legacy edges.
+3. Scalar ``r.source_id`` writes kept for backwards compat with any
+   legacy reader.
+
+## Test strategy
+
+Source-pin the fix sites (Q3a/Q3b/Q4/Q9 + calibrator small-event path +
+calibrator apoc.periodic.iterate large-event path) so any future
+regression that reintroduces the scalar-only filter or drops the
+``r.source_ids`` accumulation fails loudly.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# build_relationships.py — every source_id write site accumulates source_ids
+# ===========================================================================
+
+
+class TestBuildRelationshipsAccumulatesSourceIds:
+    """Every MERGE site that sets ``r.source_id = "<X>"`` MUST also set
+    ``r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["<X>"])``
+    so the SAME edge MERGEd by a later query (the bug: Q9 overwriting Q4's
+    scalar) cannot erase earlier provenance."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "build_relationships.py").read_text()
+
+    def test_q3a_exploits_vuln_accumulates_cve_tag_match(self, source: str) -> None:
+        """Q3a Indicator→Vulnerability EXPLOITS must accumulate
+        ``"cve_tag_match"`` into ``r.source_ids``."""
+        assert "_q3a_inner" in source
+        q3a_idx = source.find("_q3a_inner")
+        block = source[q3a_idx : q3a_idx + 1500]
+        assert 'r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["cve_tag_match"])' in block, (
+            "Q3a must accumulate cve_tag_match into r.source_ids (set-valued provenance)"
+        )
+
+    def test_q3b_exploits_cve_accumulates_cve_tag_match(self, source: str) -> None:
+        """Q3b Indicator→CVE EXPLOITS must accumulate
+        ``"cve_tag_match"`` into ``r.source_ids``."""
+        assert "_q3b_inner" in source
+        q3b_idx = source.find("_q3b_inner")
+        block = source[q3b_idx : q3b_idx + 1500]
+        assert 'r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["cve_tag_match"])' in block, (
+            "Q3b must accumulate cve_tag_match into r.source_ids (set-valued provenance)"
+        )
+
+    def test_q4_cooccurrence_accumulates_misp_cooccurrence(self, source: str) -> None:
+        """Q4 (the PRE-OVERWRITE site) must accumulate
+        ``"misp_cooccurrence"`` into ``r.source_ids`` so Q9's later MERGE
+        on the same edge cannot erase the co-occurrence tag."""
+        assert "_q4_inner" in source
+        q4_idx = source.find("_q4_inner")
+        block = source[q4_idx : q4_idx + 2500]
+        assert 'r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["misp_cooccurrence"])' in block, (
+            "Q4 MUST accumulate misp_cooccurrence into r.source_ids — without "
+            "this, Q9's later MERGE on the same edge hides the co-occurrence "
+            "tag from the calibrator filter and ~30-50% of INDICATES edges "
+            "on a 730d baseline stay at inflated 0.8 confidence."
+        )
+
+    def test_q9_malware_family_accumulates_malware_family_match(self, source: str) -> None:
+        """Q9 (the OVERWRITE site — the bug origin) must accumulate
+        ``"malware_family_match"`` into ``r.source_ids`` rather than
+        ONLY writing the scalar ``r.source_id``."""
+        assert "_q9_inner" in source
+        q9_idx = source.find("_q9_inner")
+        block = source[q9_idx : q9_idx + 2500]
+        assert 'r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["malware_family_match"])' in block, (
+            "Q9 MUST accumulate malware_family_match into r.source_ids. "
+            "The scalar r.source_id write is kept (last-writer-wins legacy), "
+            "but the set-valued r.source_ids is what the calibrator now uses."
+        )
+
+    def test_q4_and_q9_both_set_scalar_source_id_too(self, source: str) -> None:
+        """Backwards compat: scalar ``r.source_id`` writes MUST remain on
+        both Q4 and Q9 so legacy readers (and the calibrator's fallback
+        branch) still work for edges stamped before the array rollout."""
+        assert "_q4_inner" in source and "_q9_inner" in source
+        q4_idx = source.find("_q4_inner")
+        q4_block = source[q4_idx : q4_idx + 2500]
+        assert 'r.source_id = "misp_cooccurrence"' in q4_block, (
+            "Q4 MUST still set scalar r.source_id (legacy/fallback compat)"
+        )
+        q9_idx = source.find("_q9_inner")
+        q9_block = source[q9_idx : q9_idx + 2500]
+        assert 'r.source_id = "malware_family_match"' in q9_block, (
+            "Q9 MUST still set scalar r.source_id (legacy/fallback compat)"
+        )
+
+
+# ===========================================================================
+# enrichment_jobs.py — calibrator filter matches on source_ids with fallback
+# ===========================================================================
+
+
+class TestCalibratorFiltersOnSourceIdsArray:
+    """The calibrator (``calibrate_cooccurrence_confidence``) MUST filter
+    on ``r.source_ids`` (array) with a fallback to ``r.source_id`` (scalar,
+    legacy edges) — NOT on the scalar alone."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def test_small_event_path_uses_source_ids_array(self, source: str) -> None:
+        """The small-event ``update_cypher`` inside the tier loop must
+        filter on ``any(s IN r.source_ids WHERE s IN [...])`` (with the
+        NULL-safe guard) and fall back to the scalar for legacy edges."""
+        start = source.find("def calibrate_cooccurrence_confidence")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert "update_cypher = " in body
+        uc_idx = body.find("update_cypher = ")
+        # Triple-quoted block <1500 chars
+        block = body[uc_idx : uc_idx + 1500]
+        # Must have the array match (with NULL guard) for post-fix edges
+        assert "r.source_ids IS NOT NULL" in block, (
+            "calibrator small-event path must guard r.source_ids IS NOT NULL before any()"
+        )
+        assert 'any(s IN r.source_ids WHERE s IN ["misp_cooccurrence", "misp_correlation"])' in block, (
+            "calibrator small-event path must match on any(s IN r.source_ids WHERE s IN [...])"
+        )
+        # Must have scalar fallback for legacy edges
+        assert 'r.source_id IN ["misp_cooccurrence", "misp_correlation"]' in block, (
+            "calibrator must retain scalar r.source_id branch as a fallback for legacy edges"
+        )
+
+    def test_large_event_path_uses_source_ids_array(self, source: str) -> None:
+        """The ``apoc.periodic.iterate`` batch for large (>1000-indicator)
+        events must apply the same array-or-scalar filter inside the
+        OUTER matcher."""
+        start = source.find("def calibrate_cooccurrence_confidence")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        assert "large_batch_query = " in body, "large-event apoc.periodic.iterate query must exist"
+        lbq_idx = body.find("large_batch_query = ")
+        # Python-string-concat block <1500 chars
+        block = body[lbq_idx : lbq_idx + 1500]
+        # Array-match branch
+        assert "r.source_ids IS NOT NULL" in block, (
+            "calibrator large-event path must guard r.source_ids IS NOT NULL before any()"
+        )
+        assert 'any(s IN r.source_ids WHERE s IN ["misp_cooccurrence", "misp_correlation"])' in block, (
+            "calibrator large-event path must match on any(s IN r.source_ids WHERE s IN [...])"
+        )
+        # Scalar fallback
+        assert 'r.source_id IN ["misp_cooccurrence", "misp_correlation"]' in block, (
+            "calibrator large-event path must retain scalar r.source_id branch (legacy fallback)"
+        )
+
+
+# ===========================================================================
+# Negative pin — the pre-fix form (scalar-only filter) must not reappear
+# ===========================================================================
+
+
+class TestCalibratorScalarOnlyFilterIsGone:
+    """Regression pin: a calibrator filter of ``WHERE r.source_id IN [...]``
+    ALONE (no array branch, no OR) is the pre-fix form that silently
+    exempts Q9-overwritten edges from calibration.  This test catches a
+    future refactor that accidentally drops the array check."""
+
+    def test_no_active_scalar_only_filter_line(self) -> None:
+        """Scan the calibrator's source for any active (non-comment)
+        line that matches ``WHERE r.source_id IN [...]`` WITHOUT an
+        accompanying ``r.source_ids`` array match on the same line or
+        the surrounding boolean expression.  If found, the pre-fix
+        scalar-only filter has regressed."""
+        source = (SRC / "enrichment_jobs.py").read_text()
+        start = source.find("def calibrate_cooccurrence_confidence")
+        end = source.find("\ndef ", start + 1)
+        body = source[start:end]
+        # Heuristic: look for ``WHERE r.source_id IN`` (capital WHERE,
+        # active Cypher) that does NOT appear next to ``source_ids``
+        # in a small window.  Active cypher lines are NOT inside Python
+        # ``#`` comments.
+        for i, line in enumerate(body.splitlines()):
+            stripped = line.lstrip()
+            # Skip Python comment lines
+            if stripped.startswith("#"):
+                continue
+            # The pre-fix scalar-only form would be a standalone
+            # ``WHERE r.source_id IN [...]`` with NO array branch.
+            # After PR-M3c, every such line is preceded/followed by a
+            # ``r.source_ids`` match in the same boolean expression.
+            if "WHERE r.source_id IN" in line and "source_ids" not in line:
+                # Check the preceding line for an OR-continuation that
+                # contains ``source_ids`` (spans two lines in the
+                # update_cypher block).
+                prev = body.splitlines()[i - 1] if i > 0 else ""
+                if "source_ids" not in prev:
+                    raise AssertionError(
+                        f"Regression: scalar-only ``WHERE r.source_id IN [...]`` filter at "
+                        f"line {i + 1}: {line.strip()!r}. "
+                        f"This is the pre-fix form — it silently exempts Q9-overwritten "
+                        f"edges from calibration. The array branch "
+                        f"(``r.source_ids IS NOT NULL AND any(s IN r.source_ids ...)``) "
+                        f"must accompany it."
+                    )


### PR DESCRIPTION
## Summary

Closes **§8-RI-S3-Q9 (HIGH)** from the flow-audit sweep (PR-M #78). Affects an estimated **30-50% of INDICATES edges** on a 730-day baseline.

## The bug

`build_relationships.py` Q4 (Indicator→Malware MISP co-occurrence) stamps `r.source_id = "misp_cooccurrence"` on the INDICATES edge. Q9 (malware-family-match) later MERGEs the **SAME edge** and overwrites `r.source_id = "malware_family_match"` — the scalar write is last-writer-wins, so the co-occurrence tag silently disappears.

`calibrate_cooccurrence_confidence` (enrichment_jobs.py) then filters on:
```cypher
WHERE r.source_id IN ["misp_cooccurrence", "misp_correlation"]
```
…and MISSES every Q9-overwritten edge. The edge's confidence stays at 0.8 even when the underlying MISP event was a 96k-indicator bulk dump that should have been demoted to 0.30.

## The fix (4 Cypher edits + docstring)

**1. `build_relationships.py` — every MERGE site accumulates `r.source_ids`**

| Query | Relationship | Source tag |
|---|---|---|
| Q3a | Indicator→Vuln EXPLOITS | `"cve_tag_match"` |
| Q3b | Indicator→CVE EXPLOITS  | `"cve_tag_match"` |
| Q4  | Indicator→Malware INDICATES (co-occurrence) | `"misp_cooccurrence"` |
| Q9  | Indicator→Malware INDICATES (malware-family) | `"malware_family_match"` |

Pattern applied uniformly:
```cypher
SET r.source_ids = apoc.coll.toSet(coalesce(r.source_ids, []) + ["<X>"])
```

Scalar `r.source_id` writes are **kept** for backwards compat with any legacy reader.

**2. `enrichment_jobs.py` — calibrator filter on the array + scalar fallback**

Both the small-event `update_cypher` AND the `apoc.periodic.iterate` large-event (>1000 indicators) matcher now use:
```cypher
WHERE (r.source_ids IS NOT NULL
       AND any(s IN r.source_ids WHERE s IN ["misp_cooccurrence", "misp_correlation"]))
   OR r.source_id IN ["misp_cooccurrence", "misp_correlation"]
```
- Array branch: handles post-fix edges (source_ids preserved across merges).
- Scalar fallback: handles pre-fix/legacy edges that only have `r.source_id` — no migration required.

## Tests

`tests/test_pr_m3c_cooccurrence_source_ids.py` — 8 tests across 3 classes:

- **TestBuildRelationshipsAccumulatesSourceIds** (5): every Q# site accumulates its source tag into `r.source_ids`; Q4 + Q9 both still write the legacy scalar `r.source_id`.
- **TestCalibratorFiltersOnSourceIdsArray** (2): both small-event and large-event paths filter on `any(s IN r.source_ids WHERE s IN [...])` with NULL guard + scalar fallback.
- **TestCalibratorScalarOnlyFilterIsGone** (1): **negative pin** — fails loudly if a future refactor regresses to the pre-fix scalar-only `WHERE r.source_id IN [...]`.

Full suite: **1077 passed, 3 skipped, 3 xfailed** in 204s.

## Test plan
- [x] `pytest tests/test_pr_m3c_cooccurrence_source_ids.py -v` — 8/8 pass
- [x] `pytest tests/` — 1077/1077 pass
- [x] `ruff format --check src/ dags/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean

## Related

Part of the Tier-A audit sweep (PR-M #78). Sibling PRs:
- PR-M3a+b #79 — indicator canonicalization + decay idempotency (MERGED)
- PR-M3d #80 — Campaign PART_OF determinism + c.zone stability (in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Neo4j relationship-writing and calibration queries to rely on a new `r.source_ids` array (with legacy fallback), which can affect large numbers of `INDICATES/EXPLOITS` confidences if the Cypher logic is wrong; adds tests to reduce regression risk.
> 
> **Overview**
> Fixes a provenance overwrite bug where later `MERGE`s could clobber relationship `r.source_id`, causing co-occurrence edges to be skipped by confidence calibration.
> 
> Relationship creation queries now **accumulate set-valued provenance** into `r.source_ids` (via `apoc.coll.toSet(...)`) for key `EXPLOITS` and `INDICATES` edges while keeping the legacy scalar `r.source_id`. The co-occurrence calibrator in `enrichment_jobs.py` is updated to filter on `r.source_ids` (with scalar fallback for pre-existing edges) so co-occurrence-derived edges are consistently calibrated.
> 
> Adds a focused regression test suite (`tests/test_pr_m3c_cooccurrence_source_ids.py`) that pins the new `source_ids` writes and ensures the calibrator no longer uses a scalar-only `source_id` filter.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8895462944ab7a815573ff4f5e46392758ff908e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->