### PR TITLE
fix(audit): PR-M1 — collector baseline-limit hardening (§7 H3/H6/H7/H8 + docs)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,20 @@ Staged defense-in-depth for untrusted MISP inputs. Full design + threat model in
 - ✅ **Tier 2 — Observability for the disabled state (PR-I, #71).** Defense-disabled state is now always visible: startup WARNING log fires in **all** envs (previously prod/staging only, which silently accepted the default `EDGEGUARD_ENV=dev`) + Prometheus gauge `edgeguard_misp_tag_impersonation_defense_disabled` exposes the state to alert rules. See [`docs/PROMETHEUS_SETUP.md`](docs/PROMETHEUS_SETUP.md) for the suggested alert rule.
 - 📋 **Tier 3 — Fail-closed boot refusal (planned, post-Tier 2).** After operators have had a deployment cycle to configure the allowlists, `EDGEGUARD_ENV ∈ {prod, staging}` will flip to boot-refusal: the process refuses to start unless an allowlist is configured OR `EDGEGUARD_ALLOW_UNTRUSTED_MISP=1` is set explicitly. Closes the "forgot to configure" footgun at deploy time.
 
+#### 📊 Collector baseline limits — current & planned
+
+Each collector's 730-day baseline is bounded by the upstream API's
+documented quotas, not by artificial EdgeGuard caps. The full current
+state plus planned follow-ups is tracked in
+[**docs/COLLECTORS.md § Baseline collection limits**](docs/COLLECTORS.md#baseline-collection-limits--current--planned).
+Highlights:
+
+- **NVD** — full 120-day-window iteration, no artificial cap (PR-M1 adds a defensive guard that ignores incremental-style `limit` envs in baseline mode).
+- **OTX** — `max_pages = 200` × `50/page` ≈ 10k pulses (produces ~100k graph nodes + relationships on a 730d run). Raising the ceiling is a planned env knob for paid-tier operators.
+- **VirusTotal** — baseline default raised from 20 to 100 (PR-M1); still comfortably inside the free-tier 500 req/day quota. VT is **enrichment-only** on the free tier; true bulk/historical depth requires the Premium API (future option).
+- **ThreatFox** — API hard-caps `days` at 7 (abuse.ch doc); PR-M1 clamps + logs a pointer to the [ThreatFox JSON/CSV bulk export](https://threatfox.abuse.ch/export/). **Planned:** a dedicated bulk-import collector for >7d historical depth.
+- **Energy & Healthcare sector feeds** — currently placeholders; PR-M1 makes them return `skipped=True` with `skip_reason_class="placeholder"` so they surface on the skip dashboard instead of silent zero-count. **Planned:** ENTSO-E / HC3 / FDA / national CERT integrations.
+
 #### 📋 Queued audit follow-ups (post-PR-I)
 
 Driven by the 2026-04-20 comprehensive multi-agent audit. Four merged PRs (F9 #69, G1 #70, I #71, plus earlier F-series) closed 7 P0 findings; three queued items remain:

--- a/docs/COLLECTORS.md
+++ b/docs/COLLECTORS.md
@@ -758,6 +758,37 @@ SOURCE_TAG_MAPPING = {
 
 ---
 
+## Baseline collection limits — current & planned
+
+This table captures **what each collector actually pulls on a 730-day
+baseline today**, the **upstream API constraint** driving that choice,
+and any **planned follow-up work**. Operators running long baselines
+should expect the numbers in the "Current ceiling" column as the hard
+upper bound for a single baseline run.
+
+| Collector | Current ceiling | Upstream API constraint | Notes & planned follow-ups |
+|-----------|-----------------|-------------------------|----------------------------|
+| **NVD** | Full windowed collection (no artificial run-level cap on baseline) | `resultsPerPage <= 2000`; `pubStartDate..pubEndDate` must span `<= 120` days per request | Already iterates 120-day windows via `iter_nvd_published_windows`. PR-M1 adds a defensive WARNING + ignore if an incremental-style `limit` env is present in baseline (prevents ~99% silent truncation) |
+| **OTX** | `max_pages = 200` × `50/page` ≈ 10k pulses (~7 min runtime, 2 s between pages) | No publicly documented pulse cap; effective throttle ≈ 30 req/min on the free tier | Current settings produce **~100k nodes + relationships** on a 730-day run. Raising `max_pages` is a future knob (likely an env var) for operators with a paid tier and very active subscriptions |
+| **CISA KEV** | Full KEV snapshot per run | Public JSON, no auth, no rate limit | No change planned |
+| **MITRE ATT&CK** | Full STIX 2.1 bundle per run | Public GitHub raw file, no rate limit | No change planned |
+| **MISP (local)** | Full MISP server content matching the filter | Bounded by local MISP; no external quota | No change planned |
+| **AbuseIPDB** | As per `ABUSEIPDB_*` limits | Public API daily checks quota (1k free) | No change planned |
+| **VirusTotal** | `limit = 100` (baseline default, raised from 20 in PR-M1) | Free tier: **4 req/min**, **500 req/day** | At `limit=100` a baseline run consumes ~100-105 API calls (~26 min wall-clock at 4/min); comfortably inside the 500/day quota with headroom for incremental runs. **VT is enrichment-only on the free tier** — genuine bulk or historical depth requires the Premium API (no 4 req/min cap; per-step daily quotas). A Premium path is a future option, not planned |
+| **Finance (Feodo / SSLBL)** | Full feed | Public CSV/text feeds, no rate limit | No change planned |
+| **Global (URLhaus / CyberCure / ThreatFox)** | **ThreatFox: last 7 days via API** (clamped in PR-M1); URLhaus/CyberCure full feeds | **abuse.ch ThreatFox:** `get_iocs` `days` param `Min 1, Max 7` per [abuse.ch docs](https://threatfox.abuse.ch/api/); historical >7d is the documented **JSON/CSV bulk export** (`https://threatfox.abuse.ch/export/`), NOT this endpoint | **Planned:** bulk-import collector that ingests the ThreatFox JSON/CSV export for true historical depth beyond 7 days |
+| **Energy (sector)** | Placeholder (returns `skipped=True`, `skip_reason_class="placeholder"`) | — | **Planned:** ENTSO-E, EU-CERT, E-ISAC, national CERT integrations. Surfaces on the skip dashboard as a placeholder (not silent zero-count) since PR-M1 |
+| **Healthcare (sector)** | Placeholder (returns `skipped=True`, `skip_reason_class="placeholder"`) | — | **Planned:** HC3, FDA, H-ISAC, national healthcare CERT integrations. Same skip-dashboard behaviour as Energy |
+
+### Planned improvements (future PRs)
+
+- **ThreatFox bulk-import collector** for historical IOCs >7 days (reads the abuse.ch JSON/CSV export, pushes to MISP with a dedicated `Source(source_id="threatfox_bulk")`)
+- **Energy + Healthcare sector collectors** — implementations for the placeholder slots; ENTSO-E + HC3 are the likeliest near-term integrations
+- **VT Premium API path** for operators with licensed service steps (unlocks bulk Intelligence search beyond the 500/day free-tier cap)
+- **OTX max-pages env knob** (`EDGEGUARD_OTX_BASELINE_MAX_PAGES`) for paid-tier operators with very active pulse subscriptions
+
+---
+
 ## Testing Collectors
 
 Each collector can be tested individually:

--- a/src/collectors/energy_feed_collector.py
+++ b/src/collectors/energy_feed_collector.py
@@ -54,6 +54,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 # Import MISP writer
+from collectors.collector_utils import make_skipped_optional_source
 from collectors.misp_writer import MISPWriter
 from config import resolve_collection_limit
 
@@ -97,19 +98,35 @@ class EnergyPlaceholderCollector:
         self.last_collection_time = None
         self.collection_stats = {"total_attempts": 0, "successful_collections": 0, "last_error": None}
 
-    def collect(self, limit=None, push_to_misp=True) -> List[Dict[str, Any]]:
+    def collect(self, limit=None, push_to_misp=True, baseline=False, baseline_days=365):
         """
         Placeholder collection method.
-        Returns empty list until actual feeds are implemented.
+
+        PR-M1 §7-H7: returns a ``make_skipped_optional_source`` status
+        (``skipped=True``, ``skip_reason_class="placeholder"``) instead of
+        silent ``count=0`` so the collector surfaces on the skip dashboard
+        with a clear "not_implemented" reason rather than looking like a
+        failed/empty real run.  Operators scanning Airflow or Grafana
+        panels can now distinguish "placeholder, safe to ignore" from
+        "real collector that returned zero items (investigate)".
 
         Args:
-            limit: Maximum number of items to collect
-            push_to_misp: Whether to push to MISP (no-op for placeholder)
+            limit:         Maximum number of items to collect (ignored —
+                           placeholder returns nothing).
+            push_to_misp:  Ignored for the placeholder path.
+            baseline:      Parity with other collectors — the DAG signature-
+                           inspect uses this to route; accepting it avoids
+                           falling into the ``limit=X`` else branch.
+            baseline_days: Parity parameter (ignored).
 
         Returns:
-            Empty list (placeholder)
+            ``make_skipped_optional_source`` status dict when pushing to
+            MISP (the standard pipeline path), else an empty list for
+            manual/test harnesses that expect the old return shape.
         """
-        limit = resolve_collection_limit(limit, "energy", baseline=False)
+        # ``limit`` is accepted for API parity but unused — the placeholder
+        # never collects anything regardless of baseline vs. incremental.
+        resolve_collection_limit(limit, "energy", baseline=baseline)
         self.collection_stats["total_attempts"] += 1
 
         logger.info("⚡ Energy collector: Placeholder - no active feeds configured")
@@ -127,23 +144,21 @@ class EnergyPlaceholderCollector:
         # # 2. Fetch ENISA publications
         # enisa_results = self._fetch_enisa_energy_reports(limit=limit//2)
         # results.extend(enisa_results)
-        #
-        # # 3. Push to MISP if requested
-        # if push_to_misp and results:
-        #     success, failed = self.misp_writer.push_indicators(results, self.source_name)
-        #     logger.info(f"[PUSH] Energy: Pushed {success} to MISP ({failed} failed)")
-
-        results = []  # Placeholder - no data yet
-
-        if push_to_misp and results:
-            # This won't execute for empty results but maintains the pattern
-            success, failed = self.misp_writer.push_indicators(results, self.source_name)
-            logger.info(f"[PUSH] Energy collector: Pushed {success} to MISP ({failed} failed)")
-        elif push_to_misp:
-            logger.info("⚡ Energy collector: Placeholder - no active feeds to push")
 
         self.last_collection_time = datetime.now(timezone.utc).isoformat()
-        return results
+
+        if push_to_misp:
+            return make_skipped_optional_source(
+                self.source_name,
+                skip_reason=(
+                    "Energy sector feed is a placeholder — no active feeds are wired yet. "
+                    "See src/collectors/energy_feed_collector.py docstring for planned sources "
+                    "(ENTSO-E, EU-CERT, E-ISAC, national CERTs). "
+                    "Public energy/ICS advisories are already collected via cisa_collector."
+                ),
+                skip_reason_class="placeholder",
+            )
+        return []
 
     def health_check(self) -> Dict[str, Any]:
         """

--- a/src/collectors/global_feed_collector.py
+++ b/src/collectors/global_feed_collector.py
@@ -132,9 +132,36 @@ class ThreatFoxCollector:
         """
         limit = resolve_collection_limit(limit, "threatfox", baseline=baseline)
 
-        # Use more days in baseline mode
+        # PR-M1 §7-H8: respect the abuse.ch ThreatFox API hard cap.
+        # Documented at https://threatfox.abuse.ch/api/ — the ``days``
+        # parameter for ``get_iocs`` is ``Min: 1, Max: 7``.  For any
+        # historical depth >7 days the documented path is the bulk JSON/
+        # CSV export (https://threatfox.abuse.ch/export/), NOT this
+        # endpoint.
+        #
+        # Previous behaviour: ``days = baseline_days`` (typically 365 or
+        # 730) was sent verbatim; the API either silently clamped or
+        # returned ``query_status`` != ``ok`` for out-of-range values,
+        # making baseline runs non-obviously short on data.
+        #
+        # New behaviour:
+        #   * clamp ``days`` to [1, 7] unconditionally (the API ceiling)
+        #   * if a baseline with >7d was requested, emit an INFO log
+        #     pointing the operator at the documented bulk-export path
+        #   * a bulk-import collector for the ThreatFox JSON/CSV export
+        #     is planned (see docs/COLLECTORS.md "Planned improvements")
         if baseline:
             days = baseline_days
+        days_requested = days
+        days = max(1, min(7, int(days)))
+        if baseline and days_requested > 7:
+            logger.info(
+                "ThreatFox: baseline_days=%d clamped to days=%d (abuse.ch API max). "
+                "For historical IOCs >7 days use the ThreatFox bulk export: "
+                "https://threatfox.abuse.ch/export/ (a bulk-import collector is planned).",
+                days_requested,
+                days,
+            )
 
         results = []
 

--- a/src/collectors/healthcare_feed_collector.py
+++ b/src/collectors/healthcare_feed_collector.py
@@ -63,6 +63,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List
 
 # Import MISP writer
+from collectors.collector_utils import make_skipped_optional_source
 from collectors.misp_writer import MISPWriter
 from config import detect_zones_from_text, resolve_collection_limit
 
@@ -116,19 +117,35 @@ class HealthcarePlaceholderCollector:
         self.last_collection_time = None
         self.collection_stats = {"total_attempts": 0, "successful_collections": 0, "last_error": None}
 
-    def collect(self, limit=None, push_to_misp=True) -> List[Dict[str, Any]]:
+    def collect(self, limit=None, push_to_misp=True, baseline=False, baseline_days=365):
         """
         Placeholder collection method.
-        Returns empty list until actual feeds are implemented.
+
+        PR-M1 §7-H7: returns a ``make_skipped_optional_source`` status
+        (``skipped=True``, ``skip_reason_class="placeholder"``) instead of
+        silent ``count=0`` so the collector surfaces on the skip dashboard
+        with a clear "not_implemented" reason rather than looking like a
+        failed/empty real run.  Operators scanning Airflow or Grafana
+        panels can now distinguish "placeholder, safe to ignore" from
+        "real collector that returned zero items (investigate)".
 
         Args:
-            limit: Maximum number of items to collect
-            push_to_misp: Whether to push to MISP (no-op for placeholder)
+            limit:         Maximum number of items to collect (ignored —
+                           placeholder returns nothing).
+            push_to_misp:  Ignored for the placeholder path.
+            baseline:      Parity with other collectors — the DAG signature-
+                           inspect uses this to route; accepting it avoids
+                           falling into the ``limit=X`` else branch.
+            baseline_days: Parity parameter (ignored).
 
         Returns:
-            Empty list (placeholder)
+            ``make_skipped_optional_source`` status dict when pushing to
+            MISP (the standard pipeline path), else an empty list for
+            manual/test harnesses that expect the old return shape.
         """
-        limit = resolve_collection_limit(limit, "healthcare", baseline=False)
+        # ``limit`` is accepted for API parity but unused — the placeholder
+        # never collects anything regardless of baseline vs. incremental.
+        resolve_collection_limit(limit, "healthcare", baseline=baseline)
         self.collection_stats["total_attempts"] += 1
 
         logger.info("🏥 Healthcare collector: Placeholder - no active feeds configured")
@@ -150,23 +167,21 @@ class HealthcarePlaceholderCollector:
         # # 3. Fetch CISA healthcare alerts
         # cisa_results = self._fetch_cisa_healthcare_alerts(limit=limit//3)
         # results.extend(cisa_results)
-        #
-        # # 4. Push to MISP if requested
-        # if push_to_misp and results:
-        #     success, failed = self.misp_writer.push_indicators(results, self.source_name)
-        #     logger.info(f"[PUSH] Healthcare: Pushed {success} to MISP ({failed} failed)")
-
-        results = []  # Placeholder - no data yet
-
-        if push_to_misp and results:
-            # This won't execute for empty results but maintains the pattern
-            success, failed = self.misp_writer.push_indicators(results, self.source_name)
-            logger.info(f"[PUSH] Healthcare collector: Pushed {success} to MISP ({failed} failed)")
-        elif push_to_misp:
-            logger.info("🏥 Healthcare collector: Placeholder - no active feeds to push")
 
         self.last_collection_time = datetime.now(timezone.utc).isoformat()
-        return results
+
+        if push_to_misp:
+            return make_skipped_optional_source(
+                self.source_name,
+                skip_reason=(
+                    "Healthcare sector feed is a placeholder — no active feeds are wired yet. "
+                    "See src/collectors/healthcare_feed_collector.py docstring for planned "
+                    "sources (HC3, FDA, H-ISAC, national healthcare CERTs). "
+                    "Public healthcare advisories are already collected via cisa_collector."
+                ),
+                skip_reason_class="placeholder",
+            )
+        return []
 
     def health_check(self) -> Dict[str, Any]:
         """

--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -615,7 +615,36 @@ class NVDCollector:
                         extra={"nvd_window_idx": wi + 1, "nvd_start_index": 0},
                     )
 
-                vulnerabilities = all_cves if limit is None else all_cves[:limit]
+                # PR-M1 §7-H3: defensive guard against a run-level ``limit``
+                # leaking from an incremental-style config into the baseline
+                # path. The NVD baseline iterates 120-day windows across
+                # ``baseline_days`` (default 365, often 730 in production),
+                # accumulating potentially millions of CVEs in ``all_cves``.
+                # The previous line ``all_cves if limit is None else all_cves[:limit]``
+                # would silently truncate the entire accumulation to a
+                # small number if an operator had set (e.g.)
+                # ``EDGEGUARD_BASELINE_COLLECTION_LIMIT=200`` — we've seen
+                # this copy-pasted from incremental configs. In baseline
+                # mode the run-level ``limit`` is the wrong ceiling; the
+                # correct per-baseline cap is a separate concept.
+                #
+                # New behaviour: in baseline we IGNORE ``limit`` and return
+                # the full windowed collection, emitting a WARNING if a
+                # non-None ``limit`` was supplied so the operator can see
+                # that their env value had no effect and remove it.
+                if limit is not None:
+                    logger.warning(
+                        "NVD baseline: ignoring run-level limit=%d — it would truncate "
+                        "the full %d-day windowed collection of %d CVEs. In baseline mode "
+                        "this run-level cap is almost always a copy-paste from an "
+                        "incremental config. If you genuinely need a baseline ceiling, "
+                        "raise an issue and we'll add EDGEGUARD_NVD_BASELINE_MAX as a "
+                        "dedicated knob.",
+                        limit,
+                        baseline_days,
+                        len(all_cves),
+                    )
+                vulnerabilities = all_cves
                 if not vulnerabilities:
                     logger.warning(
                         "NVD baseline returned 0 CVEs for %s-day window — verify API key and connectivity",
@@ -644,7 +673,12 @@ class NVDCollector:
             processed = []
             skipped_old = 0
 
-            to_process = vulnerabilities if limit is None else vulnerabilities[:limit]
+            # PR-M1 §7-H3: same defensive stance as the accumulation-side
+            # guard above — in baseline mode the run-level ``limit`` is
+            # ignored so the windowed collection reaches the processing
+            # loop in full. In incremental mode the limit acts as normal
+            # (it was applied upstream by ``_fetch_cves`` as well).
+            to_process = vulnerabilities if (baseline or limit is None) else vulnerabilities[:limit]
             for vuln in to_process:
                 cve_data = vuln.get("cve", {})
                 cve_id = cve_data.get("id", "")

--- a/src/collectors/vt_collector.py
+++ b/src/collectors/vt_collector.py
@@ -583,9 +583,30 @@ class VTCollector:
             List of processed items or status dict
         """
         limit = resolve_collection_limit(limit, "virustotal", baseline=baseline)
-        # VT is heavily rate-limited; uncapped runs use a modest per-run ceiling.
+        # PR-M1 §7-H6: bumped from 20 to 100 (still well inside the free-tier
+        # daily cap).
+        #
+        # VirusTotal public API quota (documented at
+        # https://docs.virustotal.com/reference/public-vs-premium-api):
+        #   * 4 requests / minute
+        #   * 500 requests / day
+        #
+        # At ``limit=100`` the collector makes ~50 file lookups + ~50 URL
+        # lookups + a couple of search/fallback calls ≈ 100-105 API calls.
+        # That is:
+        #   * ~26 min wall-clock at 4 req/min (acceptable for a baseline run)
+        #   * well under the 500/day daily quota with headroom for
+        #     incremental runs throughout the rest of the day
+        #
+        # The previous default of 20 dated from the initial proof-of-concept
+        # wiring where we deliberately kept the ceiling tiny.  Bumping to
+        # 100 gives a useful enrichment sample while staying safely
+        # ``free-tier-compatible``.  For genuine bulk / historical depth
+        # the Premium API (no 4 req/min cap, per-step daily quotas) is
+        # required — documented in docs/COLLECTORS.md under "VT is
+        # enrichment-only on the free tier".
         if limit is None:
-            limit = 20
+            limit = 100
 
         # Optional source: no key → DAG succeeds with skipped + skip metrics (see run_collector_with_metrics)
         # Re-check at collect() time (handles post-init assignment + placeholders)
@@ -609,9 +630,16 @@ class VTCollector:
         try:
             processed = []
 
-            # Fetch recent files (consumes 1 API call)
-            # Due to rate limits, we fetch small batches
-            files_limit = min(limit // 2, 10)  # Half for files, max 10
+            # PR-M1 §7-H6: the inner per-batch caps were hard-coded at 10
+            # which silently bound ``limit`` to 20 (10 files + 10 URLs)
+            # regardless of the caller's ask.  Raised to 50 so the new
+            # default of ``limit=100`` actually flows through to the
+            # fetchers; the per-minute rate limit (4 req/min) and the
+            # daily quota (500/day) are the real ceilings and are
+            # comfortably respected even at 50+50.
+            # ~(50 files + 50 URLs) × 1 call each ≈ 100 API calls per
+            # baseline run; 500/day quota keeps 4 headroom runs/day.
+            files_limit = min(limit // 2, 50)  # Half for files, capped at 50
             if files_limit > 0:
                 try:
                     files = self._fetch_recent_files(files_limit)
@@ -628,7 +656,7 @@ class VTCollector:
                 processed = self._fetch_known_malware(limit)
 
             # Fetch recent URLs (consumes 1 API call)
-            urls_limit = min(limit - len(processed), 10)  # Remaining for URLs, max 10
+            urls_limit = min(limit - len(processed), 50)  # Remaining for URLs, capped at 50
             if urls_limit > 0:
                 try:
                     urls = self._fetch_recent_urls(urls_limit)

--- a/tests/test_pr_m1_collector_limits_hardening.py
+++ b/tests/test_pr_m1_collector_limits_hardening.py
@@ -1,0 +1,313 @@
+"""
+PR-M1 — Collector baseline-limit hardening.
+
+Closes the subset of §7 audit findings that are pure wins (no trade-off
+against upstream API quotas):
+
+- §7-H3 (NVD): run-level ``limit`` silently truncates the windowed
+  baseline collection by up to 99% when an operator leaks an
+  incremental-style ``EDGEGUARD_BASELINE_COLLECTION_LIMIT`` into the
+  baseline path. Guard: in baseline the limit is IGNORED with a
+  WARNING pointing the operator at the leak.
+
+- §7-H6 (VirusTotal): default substitute raised from 20 to 100. VT
+  free tier is 4 req/min × 500 req/day; at ``limit=100`` the
+  collector consumes ~100-105 API calls (~26 min wall-clock, well
+  under the daily quota). Inner per-batch caps raised from 10 → 50
+  so the new default actually flows through to the fetchers.
+
+- §7-H7 (Energy / Healthcare placeholders): return
+  ``make_skipped_optional_source(..., skip_reason_class="placeholder")``
+  instead of silent ``count=0`` so the sector feeds surface on the
+  skip dashboard with a clear reason.
+
+- §7-H8 (ThreatFox): baseline_days was sent verbatim even though the
+  abuse.ch ``get_iocs`` ``days`` parameter hard-caps at 7 (per docs,
+  "Min: 1, Max: 7"). Baseline now clamps ``days`` to 7 and logs a
+  pointer to the documented bulk JSON/CSV export for historical >7d.
+
+OTX H1 is deliberately NOT addressed here — the current ``max_pages
+= 200`` produces ~100k graph nodes/relationships in production, is
+within the free-tier throttle, and raising it is a planned env-knob
+follow-up for paid-tier operators (see docs/COLLECTORS.md).
+
+## Test strategy
+
+Source-pin each behaviour change so a future refactor that
+regresses to the pre-fix form fails loudly. Runtime behaviour is
+covered at unit level where it can be cheaply mocked (placeholders,
+ThreatFox clamp).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# §7-H3 — NVD: defensive guard against incremental-limit leak
+# ===========================================================================
+
+
+class TestNvdBaselineIgnoresRunLevelLimit:
+    """In baseline mode the NVD collector MUST ignore a non-None
+    ``limit`` (it would truncate the full windowed collection) and
+    emit a WARNING so the operator can see the leak."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "collectors" / "nvd_collector.py").read_text()
+
+    def test_baseline_path_does_not_truncate_all_cves_by_limit(self, source: str) -> None:
+        """The old ``vulnerabilities = all_cves if limit is None else
+        all_cves[:limit]`` silently truncated a 730-day windowed
+        collection to e.g. 200 CVEs when an operator set
+        ``EDGEGUARD_BASELINE_COLLECTION_LIMIT=200`` (copy-pasted from
+        their incremental config). The fix unconditionally returns
+        the full ``all_cves`` in baseline."""
+        # Negative pin: the buggy form with ``[:limit]`` must not
+        # reappear on the accumulation boundary.
+        assert "vulnerabilities = all_cves if limit is None else all_cves[:limit]" not in source, (
+            "Regression: the pre-PR-M1 form silently truncated baseline CVEs to the "
+            "run-level limit. Baseline must ignore limit entirely and return all_cves."
+        )
+        # Positive pin: the new unconditional form is present.
+        assert "vulnerabilities = all_cves\n" in source, (
+            "Baseline must assign ``vulnerabilities = all_cves`` (no slice) so the "
+            "full windowed collection reaches the processing loop."
+        )
+
+    def test_baseline_to_process_respects_baseline_branch(self, source: str) -> None:
+        """The ``to_process = vulnerabilities if limit is None else
+        vulnerabilities[:limit]`` slice on the processing side has the
+        same leak surface. In baseline the slice MUST be bypassed."""
+        assert "to_process = vulnerabilities if (baseline or limit is None) else vulnerabilities[:limit]" in source, (
+            "to_process gate must include the baseline branch so the run-level "
+            "limit does not truncate the processing loop either"
+        )
+
+    def test_baseline_emits_warning_when_limit_is_set(self, source: str) -> None:
+        """Observability: operators must see a WARNING explaining that
+        their ``limit`` env has been ignored."""
+        assert "NVD baseline: ignoring run-level limit=%d" in source, (
+            "WARNING log must name the exact limit value and explain that baseline ignored it"
+        )
+
+
+# ===========================================================================
+# §7-H6 — VirusTotal: default bumped from 20 to 100
+# ===========================================================================
+
+
+class TestVirusTotalDefaultLimit:
+    """The ``vt_collector`` baseline default when ``limit is None``
+    MUST be 100 (raised from 20) and the inner per-batch caps raised
+    from 10 to 50 so the new default actually flows through."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "collectors" / "vt_collector.py").read_text()
+
+    def test_default_limit_is_100_not_20(self, source: str) -> None:
+        """The ``if limit is None: limit = <N>`` default must be 100."""
+        start = source.find("def collect(")
+        assert start != -1
+        end = source.find("\n    def ", start + 1)
+        body = source[start:end]
+        # Positive pin: new default
+        assert "limit = 100" in body, "VT baseline default must be bumped to 100"
+        # Negative pin: old default must be gone from the active substitution
+        # (the comment mentioning the old value is allowed).
+        for line in body.splitlines():
+            stripped = line.lstrip()
+            if stripped.startswith("#"):
+                continue
+            if stripped == "limit = 20":
+                raise AssertionError(
+                    f"Regression: pre-PR-M1 VT default ``limit = 20`` found in "
+                    f"active (non-comment) code: {line.strip()!r}"
+                )
+
+    def test_inner_file_batch_cap_raised_to_50(self, source: str) -> None:
+        """The files-per-run cap of 10 must be raised to 50 so
+        ``limit=100`` is not silently bounded by the inner batch cap."""
+        assert "files_limit = min(limit // 2, 50)" in source, (
+            "VT inner files cap must be 50 so limit=100 flows through (was 10)"
+        )
+
+    def test_inner_url_batch_cap_raised_to_50(self, source: str) -> None:
+        """Same for URLs."""
+        assert "urls_limit = min(limit - len(processed), 50)" in source, (
+            "VT inner URLs cap must be 50 so limit=100 flows through (was 10)"
+        )
+
+
+# ===========================================================================
+# §7-H7 — Energy / Healthcare placeholders return skipped status
+# ===========================================================================
+
+
+class TestPlaceholderCollectorsReturnSkippedStatus:
+    """Placeholder sector feeds (``energy_feed_collector``,
+    ``healthcare_feed_collector``) MUST return
+    ``make_skipped_optional_source`` with
+    ``skip_reason_class="placeholder"`` when ``push_to_misp=True``, so
+    they appear on the Airflow/Grafana skip dashboard with a clear
+    reason instead of silent ``count=0``."""
+
+    def _mk_collector(self, module_name: str, class_name: str):
+        # Lazy import — collectors pull in optional deps (MISP, requests)
+        # that may be heavy; we only need the class for a placeholder
+        # collect() call.
+        import importlib
+
+        mod = importlib.import_module(f"collectors.{module_name}")
+        cls = getattr(mod, class_name)
+        # Inject a MagicMock MISPWriter so we don't need real MISP
+        return cls(misp_writer=MagicMock())
+
+    def test_energy_placeholder_returns_skipped_status(self) -> None:
+        collector = self._mk_collector("energy_feed_collector", "EnergyCollector")
+        result = collector.collect(push_to_misp=True)
+        assert isinstance(result, dict), "placeholder collect() must return a status dict, not a list"
+        assert result.get("success") is True, "placeholder is not a failure — success must be True"
+        assert result.get("skipped") is True, "placeholder must be marked skipped"
+        assert result.get("skip_reason_class") == "placeholder", (
+            f"placeholder must use skip_reason_class='placeholder', got {result.get('skip_reason_class')!r}"
+        )
+        assert result.get("count") == 0
+        # The reason text should point operators at the implementation plan
+        assert "placeholder" in (result.get("skip_reason") or "").lower()
+
+    def test_healthcare_placeholder_returns_skipped_status(self) -> None:
+        collector = self._mk_collector("healthcare_feed_collector", "HealthcareCollector")
+        result = collector.collect(push_to_misp=True)
+        assert isinstance(result, dict)
+        assert result.get("success") is True
+        assert result.get("skipped") is True
+        assert result.get("skip_reason_class") == "placeholder"
+        assert result.get("count") == 0
+        assert "placeholder" in (result.get("skip_reason") or "").lower()
+
+    def test_placeholders_accept_baseline_kwargs(self) -> None:
+        """DAG signature-inspection routes based on kwargs; the
+        placeholders MUST accept ``baseline`` and ``baseline_days``
+        (previously they raised ``TypeError`` and fell into the else
+        branch, silently returning ``count=0``)."""
+        energy = self._mk_collector("energy_feed_collector", "EnergyCollector")
+        healthcare = self._mk_collector("healthcare_feed_collector", "HealthcareCollector")
+        # Should not raise
+        energy.collect(push_to_misp=True, baseline=True, baseline_days=730)
+        healthcare.collect(push_to_misp=True, baseline=True, baseline_days=730)
+
+
+# ===========================================================================
+# §7-H8 — ThreatFox: clamp days to [1, 7] (abuse.ch API hard cap)
+# ===========================================================================
+
+
+class TestThreatFoxDaysClampedToApiMax:
+    """The ThreatFox ``get_iocs`` endpoint hard-caps ``days`` at 7
+    (abuse.ch docs: "Min: 1, Max: 7"). Baseline MUST clamp the
+    request and log a pointer to the bulk export."""
+
+    @pytest.fixture(scope="class")
+    def source(self) -> str:
+        return (SRC / "collectors" / "global_feed_collector.py").read_text()
+
+    def test_threatfox_clamp_present(self, source: str) -> None:
+        """The fix applies ``days = max(1, min(7, int(days)))`` so
+        out-of-range values (730, negative, 0) are all bounded."""
+        assert "days = max(1, min(7, int(days)))" in source, (
+            "ThreatFox baseline must clamp days to [1, 7] — the API hard cap"
+        )
+
+    def test_threatfox_clamp_logs_bulk_export_pointer(self, source: str) -> None:
+        """When baseline_days > 7 the collector must log an INFO
+        pointing operators at the bulk export as the documented
+        alternative."""
+        assert "https://threatfox.abuse.ch/export/" in source, "clamp log must point at the documented bulk-export URL"
+        assert "clamped to days=" in source, "clamp log must say ``clamped to days=`` so operators see the behaviour"
+
+    def test_threatfox_clamp_actually_runs_in_baseline(self, monkeypatch) -> None:
+        """Behavioural check: drive ``collect(baseline=True,
+        baseline_days=730)`` with a mocked ``_fetch_iocs`` and assert
+        the ``days`` argument observed by the fetcher is 7, not 730."""
+        import collectors.global_feed_collector as gfc
+
+        collector = gfc.ThreatFoxCollector.__new__(gfc.ThreatFoxCollector)
+        collector.source_name = "threatfox"
+        collector.api_key = "fake-but-non-placeholder-key"
+        collector.misp_writer = MagicMock()
+        collector.misp_writer.push_indicators.return_value = (0, 0)
+
+        # Avoid circuit-breaker / rate-limiter side effects
+        monkeypatch.setattr(gfc.THREATFOX_CIRCUIT_BREAKER, "can_execute", lambda: True)
+        monkeypatch.setattr(gfc.THREATFOX_CIRCUIT_BREAKER, "record_success", lambda: None)
+        monkeypatch.setattr(gfc.THREATFOX_RATE_LIMITER, "wait_if_needed", lambda: None)
+        # The optional-key check must pass so we don't short-circuit
+        monkeypatch.setattr(gfc, "optional_api_key_effective", lambda *a, **k: True)
+
+        observed_days: list = []
+
+        def fake_fetch(days: int):
+            observed_days.append(days)
+            # Return an empty but well-formed response so collect() exits cleanly
+            return {"query_status": "ok", "data": []}
+
+        collector._fetch_iocs = fake_fetch  # type: ignore[method-assign]
+
+        collector.collect(push_to_misp=True, baseline=True, baseline_days=730)
+
+        assert observed_days, "collect() should have invoked _fetch_iocs at least once"
+        assert all(d == 7 for d in observed_days), (
+            f"ThreatFox baseline must clamp days to 7 (API cap); got {observed_days}"
+        )
+
+    def test_threatfox_clamp_log_fires_when_requested_exceeds_7(
+        self, monkeypatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The INFO log with the bulk-export pointer fires ONLY when
+        the operator actually requested >7 days — an incremental call
+        with ``days=3`` should not log the clamp notice."""
+        import collectors.global_feed_collector as gfc
+
+        collector = gfc.ThreatFoxCollector.__new__(gfc.ThreatFoxCollector)
+        collector.source_name = "threatfox"
+        collector.api_key = "fake"
+        collector.misp_writer = MagicMock()
+        collector.misp_writer.push_indicators.return_value = (0, 0)
+        monkeypatch.setattr(gfc.THREATFOX_CIRCUIT_BREAKER, "can_execute", lambda: True)
+        monkeypatch.setattr(gfc.THREATFOX_CIRCUIT_BREAKER, "record_success", lambda: None)
+        monkeypatch.setattr(gfc.THREATFOX_RATE_LIMITER, "wait_if_needed", lambda: None)
+        monkeypatch.setattr(gfc, "optional_api_key_effective", lambda *a, **k: True)
+
+        def fake_fetch(days: int):
+            return {"query_status": "ok", "data": []}
+
+        collector._fetch_iocs = fake_fetch  # type: ignore[method-assign]
+
+        # Case 1: baseline with days > 7 → clamp log fires
+        with caplog.at_level(logging.INFO, logger=gfc.logger.name):
+            collector.collect(push_to_misp=True, baseline=True, baseline_days=365)
+        assert any("clamped to days=7" in rec.message for rec in caplog.records), (
+            "baseline_days=365 should emit the clamp log"
+        )
+        caplog.clear()
+
+        # Case 2: incremental with days=3 → no clamp log
+        with caplog.at_level(logging.INFO, logger=gfc.logger.name):
+            collector.collect(push_to_misp=True, baseline=False, days=3)
+        assert not any("clamped to days=" in rec.message for rec in caplog.records), (
+            "incremental days=3 is inside the cap — no clamp log should fire"
+        )


### PR DESCRIPTION
## Summary

Closes the **subset of §7 audit findings that are pure wins** for the 730-day baseline — fixes that don't fight any upstream API quota. The OTX limit (H1) is left as-is since it produces ~100k graph nodes/relationships in production today.

| ID | Severity | What changes |
|---|---|---|
| §7-H3 | HIGH | NVD baseline: ignore run-level `limit` (was silently truncating to ~99% data loss when operator copy-pasted incremental config) + WARNING |
| §7-H6 | HIGH | VirusTotal default: 20 → 100 (still inside free-tier 500/day quota); inner per-batch caps 10 → 50 |
| §7-H7 | HIGH | Energy + Healthcare placeholders return `skipped=True, skip_reason_class="placeholder"` (no more silent zero-count) |
| §7-H8 | HIGH | ThreatFox: clamp `days` to `[1, 7]` (abuse.ch API hard cap) + INFO pointer to bulk export |

## Provider-doc grounding (the audit was originally too aggressive)

| Provider | Documented public-tier ceiling | Current code's choice | Verdict |
|---|---|---|---|
| **VT** | 4 req/min, 500 req/day (free tier) | Was `limit=20`; now **100**; ~100-105 API calls/run ≈ 26 min wall-clock; comfortably <500/day | ✅ Safe bump |
| **ThreatFox** | `days` Min 1, Max 7 (per docs); historical >7d via JSON/CSV bulk export | Sent `days=730` verbatim → API clamped/errored silently | ✅ Honor cap, document export path |
| **NVD** | 2000 results/page; 120-day window per request; no documented daily cap | Already iterates 120-day windows correctly | ✅ Just guard the config-leak |
| **OTX** | No documented public-tier cap; ~30 req/min | `max_pages=200` × 50/page ≈ 10k pulses (~7 min runtime) | ✅ Producing ~100k nodes+rels in production — leave alone, planned env-knob for paid tiers |

## What's NOT in this PR

- **OTX max_pages bump** — current settings already deliver ~100k graph objects on a 730d run; raising is a planned follow-up env knob (`EDGEGUARD_OTX_BASELINE_MAX_PAGES`) for paid-tier operators only
- **VT Premium API path** — out of scope; future option only
- **ThreatFox bulk-import collector** — out of scope; planned separate collector for >7d historical (reads abuse.ch JSON/CSV export)
- **Sector feed implementations** — placeholder behaviour fixed here; ENTSO-E/HC3/etc. integrations are separate work

## Tests

`tests/test_pr_m1_collector_limits_hardening.py` — 13 tests across 4 classes:

- **TestNvdBaselineIgnoresRunLevelLimit** (3) — negative pin on the old truncating form; positive pins on the new full-collection flow + WARNING log
- **TestVirusTotalDefaultLimit** (3) — `limit=100` substitution + inner files/URLs caps at 50
- **TestPlaceholderCollectorsReturnSkippedStatus** (3) — Energy + Healthcare return `skipped=True` with `skip_reason_class="placeholder"`, both accept baseline kwargs
- **TestThreatFoxDaysClampedToApiMax** (4) — clamp expression + log + **behavioural test** with mocked `_fetch_iocs` confirming `days=7` observed when `baseline_days=730`, and INFO log fires only when >7d was requested

Full suite: **1082 passed, 3 skipped, 3 xfailed** in 204s.

## Docs

- `docs/COLLECTORS.md` — new "Baseline collection limits — current & planned" section: per-collector table of current ceilings, upstream API constraints, and planned follow-ups
- `README.md` — new "Collector baseline limits — current & planned" sub-section under 🚧 In Progress, linking to the above

## Test plan
- [x] `pytest tests/test_pr_m1_collector_limits_hardening.py -v` — 13/13 pass
- [x] `pytest tests/` — 1082/1082 pass
- [x] `ruff format --check src/ dags/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean

## Related

Part of the Tier-A audit sweep (PR-M #78). Sibling PRs:
- PR-M3a+b #79 — indicator canonicalization + decay idempotency (MERGED)
- PR-M3c #81 — co-occurrence source_ids accumulation (in review)
- PR-M3d #80 — Campaign PART_OF determinism + c.zone stability (in review)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes baseline collection behavior and default volumes for multiple external collectors, which can affect runtime, API usage, and downstream data size; safeguards and tests reduce regression risk.
> 
> **Overview**
> Improves **730-day baseline reliability** by preventing accidental truncation and aligning collector requests with upstream API constraints.
> 
> NVD baseline now **ignores run-level `limit`** (with a WARNING) to avoid silently cutting the windowed baseline dataset, VirusTotal baseline defaults increase **20→100** and lift inner per-batch caps so the requested limit is actually honored, and ThreatFox baseline **clamps `days` to the API max (7)** with an INFO pointer to the bulk-export path.
> 
> Energy/Healthcare placeholder collectors now return a **standard `skipped=True` status** (and accept `baseline` kwargs) so they show up explicitly on skip dashboards instead of looking like successful zero-data runs. Docs add a new **baseline limits** section/table, and a new test suite pins these behaviors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a96ef87ddd28bfff5a348848707c9a8ec789c56. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->