### PR TITLE
fix(audit): PR-N1 — Tier-A alert_id binding + full legacy USES removal

### DIFF
--- a/docs/RESILMESH_INTEROPERABILITY.md
+++ b/docs/RESILMESH_INTEROPERABILITY.md
@@ -152,21 +152,34 @@ Graph                                                  → STIX 2.1 SRO
 (Indicator)  -[:USES_TECHNIQUE]->(Technique)           → relationship { source_ref: indicator,      relationship_type: "indicates", target_ref: attack-pattern }
 ```
 
-**Backward compatibility during rollout:** `create_misp_relationships_batch` in `src/neo4j_client.py` still accepts `rel_type="USES"` when `to_type="Technique"` and routes it to the correct specialized type based on `from_type`. Partners with code that emits the legacy value will keep working.
+**Backward compatibility:** **Removed in PR-N1 (2026-04).** Earlier
+versions of `create_misp_relationships_batch` in `src/neo4j_client.py`
+accepted `rel_type="USES"` when `to_type="Technique"` and routed it to
+the specialized type based on `from_type`. That shim is gone — verified
+no caller anywhere in `src/`, `dags/`, or `tests/` emits
+`rel_type="USES"`. Any partner code still emitting the legacy value
+will be silently dropped (the row never matches any of the specialized
+buckets), so check your call sites before upgrading. Same goes for
+read paths — the alternation `[:EMPLOYS_TECHNIQUE|USES]` was removed
+from the alert-enrichment query in PR-N1.
 
-**Migration:** *Pre-release framework — no production graph exists, so no migration script is shipped.* The first baseline run already writes the specialized edge types (`EMPLOYS_TECHNIQUE` for actor/campaign, `IMPLEMENTS_TECHNIQUE` for malware/tool); a fresh baseline rerun heals any dev/test graph that still carries the legacy generic `USES` edges.
+**Migration:** *Pre-release framework — no production graph exists, so
+no migration script is shipped.* The first baseline run already writes
+the specialized edge types (`EMPLOYS_TECHNIQUE` for actor/campaign,
+`IMPLEMENTS_TECHNIQUE` for malware/tool); a fresh baseline rerun heals
+any dev/test graph that still carries the legacy generic `USES` edges.
 
 **What to update in your code:**
 
 ```cypher
-// Before (still works due to backward-compat read path, but write path is deprecated):
+// Before (no longer supported as of PR-N1):
 MATCH (a:ThreatActor)-[:USES]->(t:Technique) RETURN a, t
 
-// After (recommended — reads both attribution and capability explicitly):
+// After (specialized — reads attribution OR capability OR observation):
 MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t:Technique) RETURN a, t
 MATCH (m:Malware)-[:IMPLEMENTS_TECHNIQUE]->(t:Technique)  RETURN m, t
 
-// If you want both specialized types in one query:
+// If you want all three specialized types in one query:
 MATCH (n)-[r:EMPLOYS_TECHNIQUE|IMPLEMENTS_TECHNIQUE|USES_TECHNIQUE]->(t:Technique)
 RETURN n, type(r) AS rel, t
 ```

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -377,13 +377,26 @@ class AlertProcessor:
                     enrichment["known_malware"] = malware_list
                     metadata["malware_found"] = len(malware_list) > 0
 
-                # Query 3: Find threat actors via malware
+                # Query 3: Find threat actors via malware.
+                # PR-N1 §9-A2: dropped legacy ``|USES`` alternation. The
+                # generic ``USES`` edge type was retired in 2026-04
+                # (PR #41) — fresh-start writes only the specialized
+                # ``EMPLOYS_TECHNIQUE`` (attribution: ThreatActor →
+                # Technique). Keeping the alternation as defensive
+                # fallback was dead code that masked schema-drift
+                # regressions: if a future write path accidentally
+                # re-introduced ``USES``, this query would silently
+                # re-include it and the operator wouldn't catch it.
+                # The backward-compat read path was also removed from
+                # ``neo4j_client.create_misp_relationships_batch`` in
+                # this PR (no callers emit ``rel_type="USES"`` anywhere
+                # in the codebase).
                 actors_result = session.run(
                     """
                     MATCH (i:Indicator {value: $indicator})
                     OPTIONAL MATCH (i)-[:INDICATES]->(m:Malware)
                     OPTIONAL MATCH (m)-[:ATTRIBUTED_TO]->(a:ThreatActor)
-                    OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE|USES]->(t:Technique)
+                    OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE]->(t:Technique)
                     RETURN collect(DISTINCT a {
                         .name, .aliases, .description
                     }) as actors,
@@ -436,11 +449,34 @@ class AlertProcessor:
                 enrichment["cves"] = cves
                 metadata["cves_found"] = len(cves)
 
-                # Query 5: Find related Assets and Users from Alert
+                # Query 5: Find related Assets and Users from THIS Alert.
+                #
+                # PR-N1 §9-A1 (Tier-A production blocker, Logic Tracker
+                # found): the previous query bound ``alert_id`` as a
+                # parameter but the Cypher had NO ``WHERE`` filter
+                # using it. The variable ``a`` matched ALL ``:Alert``
+                # nodes in the graph and the query returned the
+                # cartesian product of every alert's assets + users.
+                # Every alert enrichment payload published to NATS /
+                # ResilMesh carried unrelated alerts' assets + users —
+                # healthcare-zone alerts mis-routed to finance-zone
+                # users, etc. On a graph with N alerts, every
+                # enrichment payload's ``assets`` list was N× too
+                # large (DoS-shaped if N grows).
+                #
+                # Fix: bind on ``Alert {alert_id: $alert_id}`` (matches
+                # the natural-key constraint at neo4j_client.py:794:
+                # ``CREATE CONSTRAINT alert_key IF NOT EXISTS FOR
+                # (n:Alert) REQUIRE (n.alert_id) IS UNIQUE``). Use
+                # ``OPTIONAL MATCH`` for assets / users so an alert
+                # with no associations still returns a single row with
+                # empty lists — preserving the original return shape
+                # the downstream code expects.
                 context_result = session.run(
                     """
-                    MATCH (a:Alert)-[:TARGETS]->(asset:Asset)
-                    MATCH (a:Alert)-[:INVOLVES_USER]->(u:User)
+                    MATCH (a:Alert {alert_id: $alert_id})
+                    OPTIONAL MATCH (a)-[:TARGETS]->(asset:Asset)
+                    OPTIONAL MATCH (a)-[:INVOLVES_USER]->(u:User)
                     RETURN collect(DISTINCT asset {
                         .hostname, .asset_type, .device_type, .zone
                     }) as assets,

--- a/src/collectors/mitre_collector.py
+++ b/src/collectors/mitre_collector.py
@@ -271,9 +271,12 @@ class MITRECollector:
                 self.relationships = relationships
                 logger.info(f"   → Extracted {len(relationships)} relationships (no cap)")
 
-            # Build lookup: actor_name → [technique_mitre_ids] from explicit USES relationships.
-            # Used to populate uses_techniques on ThreatActor nodes so build_relationships.py
-            # can create ThreatActor -[:USES]-> Technique without co-occurrence guesswork.
+            # Build lookup: actor_name → [technique_mitre_ids] from explicit MITRE STIX
+            # ``uses`` relationships. Used to populate uses_techniques on ThreatActor
+            # nodes so build_relationships.py can create
+            # ThreatActor -[:EMPLOYS_TECHNIQUE]-> Technique without co-occurrence
+            # guesswork. (Edge type renamed from generic ``USES`` to specialized
+            # ``EMPLOYS_TECHNIQUE`` in 2026-04 PR #41 — see docs/KNOWLEDGE_GRAPH.md.)
             _actor_uses: dict = {}
             _malware_uses: dict = {}
             _tool_uses: dict = {}
@@ -397,9 +400,12 @@ class MITRECollector:
                             "first_seen": obj.get("created"),
                             "last_seen": obj.get("modified"),
                             "confidence_score": 0.7,
-                            # Explicit technique list from MITRE ATT&CK USES relationships.
-                            # Stored as a node property so build_relationships.py can create
-                            # ThreatActor -[:USES]-> Technique without co-occurrence guesswork.
+                            # Explicit technique list from MITRE ATT&CK ``uses``
+                            # STIX relationships. Stored as a node property so
+                            # build_relationships.py can create
+                            # ThreatActor -[:EMPLOYS_TECHNIQUE]-> Technique
+                            # without co-occurrence guesswork. (Edge type renamed
+                            # from generic ``USES`` in 2026-04 PR #41.)
                             "uses_techniques": _actor_uses.get(actor_name, []),
                         }
                     )

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2757,7 +2757,10 @@ class Neo4jClient:
         if not self.driver or not relationships:
             return 0
 
-        # Split from a previously-generic "USES" bucket in the 2026-04 refactor:
+        # Specialized technique edge types (the legacy generic ``USES`` bucket
+        # was retired in 2026-04 PR #41; the backward-compat ``rt == "USES"``
+        # routing shim was removed in PR-N1 once verified that no caller
+        # emits the legacy value):
         # EMPLOYS_TECHNIQUE = attribution  (ThreatActor/Campaign → Technique)
         # IMPLEMENTS_TECHNIQUE = capability (Malware/Tool → Technique)
         # USES_TECHNIQUE already existed for Indicator → Technique (OTX attack_ids)
@@ -2817,12 +2820,15 @@ class Neo4jClient:
             # → uuid computed from "" → wrong fallback uuid that doesn't
             # match the node's n.uuid). Bugbot caught this on PR #33 round 4.
             #
-            # Backward-compat: accept legacy "USES" rel_type from callers that
-            # haven't been migrated yet, and route based on from_type. New
-            # code should emit the specialized rel_type directly.
-            if rt in ("EMPLOYS_TECHNIQUE", "IMPLEMENTS_TECHNIQUE") or (
-                rt == "USES" and rel.get("to_type") == "Technique"
-            ):
+            # PR-N1 §9-A2: removed the backward-compat ``rt == "USES"
+            # and to_type == "Technique"`` branch. Verified no caller
+            # anywhere in the codebase emits ``rel_type="USES"``
+            # (grep ``rel_type=.USES.`` returns zero hits in src/, dags/,
+            # and tests/), so the shim was dead defensive code that
+            # masked schema-drift regressions. The legacy ``USES`` edge
+            # type was retired in 2026-04 (PR #41) and fresh-start
+            # writes only the specialized rel_types below.
+            if rt in ("EMPLOYS_TECHNIQUE", "IMPLEMENTS_TECHNIQUE"):
                 # Require an explicit from_type. The previous default of
                 # "ThreatActor" silently misrouted any IMPLEMENTS_TECHNIQUE
                 # caller that forgot to set it — their row went to the

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -677,10 +677,12 @@ async def graph_explore(
                     zone_ind = "AND $zone IN coalesce(i.zone, [])"
 
                 # Malware → Indicator edges are INDICATES (dropped/observed
-                # artifact) or DROPS (file drop). The legacy filter included
-                # "USES" which was incorrect — USES here was previously
-                # (Actor/Malware)→Technique, not Malware→Indicator, so any
-                # match was unreachable. Kept the two valid types.
+                # artifact) or DROPS (file drop). The pre-2026-04 filter
+                # included a generic "USES" type which was unreachable here
+                # — USES used to mean (Actor/Malware) → Technique, not
+                # Malware → Indicator. The generic USES edge type was
+                # retired entirely in PR #41 / PR-N1; only the two valid
+                # Malware → Indicator edge types remain.
                 cypher = f"""
                     MATCH (m:Malware)-[r]->(i:Indicator)
                     WHERE type(r) IN ['INDICATES', 'DROPS'] AND m.edgeguard_managed = true

--- a/tests/test_pr_n1_alert_enrichment_and_uses_removal.py
+++ b/tests/test_pr_n1_alert_enrichment_and_uses_removal.py
@@ -1,0 +1,217 @@
+"""
+PR-N1 — Tier-A audit hotfix:
+  A1. alert_processor.py:440 Query 5 ignored ``alert_id`` parameter,
+      cross-contaminating ResilMesh enrichment payloads with assets +
+      users from every Alert in the graph.
+  A2. alert_processor.py:386 query alternation ``EMPLOYS_TECHNIQUE|USES``
+      kept the legacy ``USES`` edge type alive after the 2026-04
+      PR #41 refactor; backward-compat shim in
+      ``neo4j_client.create_misp_relationships_batch`` was dead code
+      that masked schema drift.
+
+Both surfaced by the 7-agent comprehensive audit (Logic Tracker F4
+and Cross-Checker F1, see ``docs/flow_audits/09_comprehensive_audit.md``
+Tier A).
+
+This PR removes the legacy ``USES`` edge type **fully** — not just from
+the alert-enrichment query, but also the backward-compat read shim in
+``neo4j_client.py`` and the misleading historical comments in
+``mitre_collector.py`` / ``query_api.py``.
+
+The current valid technique edge types (per
+``docs/KNOWLEDGE_GRAPH.md``) are:
+  * ``EMPLOYS_TECHNIQUE``  — ThreatActor / Campaign → Technique (attribution)
+  * ``IMPLEMENTS_TECHNIQUE`` — Malware / Tool → Technique (capability)
+  * ``USES_TECHNIQUE`` — Indicator → Technique (observation, OTX)
+
+The bare ``USES`` edge type (no suffix) was retired and must not appear
+in any active Cypher fragment, query, MERGE site, or backward-compat
+shim. ``USES_TECHNIQUE`` is fine — distinct edge type with the
+``_TECHNIQUE`` suffix.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# A1 — alert_id binding in Query 5
+# ===========================================================================
+
+
+class TestAlertEnrichmentBindsAlertId:
+    """The Cypher in ``_enrich_alert``'s Query 5 must bind on
+    ``Alert {alert_id: $alert_id}`` so the asset/user enrichment is
+    scoped to the current alert. Pre-PR-N1 the parameter was bound but
+    not used in the query → cross-contamination across all alerts."""
+
+    def _read(self) -> str:
+        return (SRC / "alert_processor.py").read_text()
+
+    def test_query_5_matches_alert_by_alert_id(self) -> None:
+        src = self._read()
+        # Positive pin: the new MATCH form is present
+        assert "MATCH (a:Alert {alert_id: $alert_id})" in src, (
+            "Query 5 in alert_processor must bind ``Alert`` on its natural "
+            "key ``alert_id`` (constraint at neo4j_client.py:794). Without "
+            "this, the query matches ALL :Alert nodes in the graph and "
+            "returns the cartesian product of every alert's assets + users."
+        )
+
+    def test_query_5_uses_optional_match_for_assets_and_users(self) -> None:
+        """An alert with no associated assets / users must still return
+        a single row with empty lists — preserving the original return
+        shape."""
+        src = self._read()
+        assert "OPTIONAL MATCH (a)-[:TARGETS]->(asset:Asset)" in src
+        assert "OPTIONAL MATCH (a)-[:INVOLVES_USER]->(u:User)" in src
+
+    def test_query_5_no_unbound_alert_match(self) -> None:
+        """Negative pin: the buggy form ``MATCH (a:Alert)-[:TARGETS]->...``
+        with no key binding must NOT reappear. Strip comment-only lines
+        before scanning so historical breadcrumbs explaining the bug
+        are allowed."""
+        src = self._read()
+        # Active code only
+        active = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+        # The bare un-bound form
+        assert "MATCH (a:Alert)-[:TARGETS]->(asset:Asset)" not in active, (
+            "Regression: the un-bound ``MATCH (a:Alert)-[:TARGETS]->...`` "
+            "form (no alert_id filter) silently cross-contaminates "
+            "enrichment payloads. PR-N1 fixed this — must not return."
+        )
+        assert "MATCH (a:Alert)-[:INVOLVES_USER]->(u:User)" not in active, (
+            "Same regression for the INVOLVES_USER half of the query."
+        )
+
+    def test_query_5_passes_alert_id_kwarg(self) -> None:
+        """The Python call site must still pass ``alert_id`` as a
+        kwarg to ``session.run``."""
+        src = self._read()
+        # Find the context_result block
+        assert "context_result = session.run(" in src
+        cr_idx = src.find("context_result = session.run(")
+        block = src[cr_idx : cr_idx + 1000]
+        assert "alert_id=alert.alert_id" in block, "context_result must pass alert_id=alert.alert_id as kwarg"
+
+
+# ===========================================================================
+# A2 — legacy USES edge type fully removed
+# ===========================================================================
+
+
+class TestLegacyUsesEdgeTypeFullyRemoved:
+    """The bare ``USES`` edge type was retired in 2026-04 (PR #41).
+    The fresh-start model writes only the specialized forms
+    ``EMPLOYS_TECHNIQUE`` / ``IMPLEMENTS_TECHNIQUE`` / ``USES_TECHNIQUE``.
+    PR-N1 removes ALL remaining traces:
+      * the alternation ``[:EMPLOYS_TECHNIQUE|USES]`` in alert_processor
+      * the ``rt == "USES" and to_type == "Technique"`` backward-compat
+        shim in neo4j_client.create_misp_relationships_batch (verified
+        no caller emits this)
+      * misleading historical comments referencing ``USES``
+    """
+
+    @staticmethod
+    def _strip_comments(src: str) -> str:
+        """Strip whole-line ``#`` Python comments so historical
+        breadcrumbs explaining what was removed don't false-match."""
+        return "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+
+    def test_alert_processor_no_uses_alternation(self) -> None:
+        src = (SRC / "alert_processor.py").read_text()
+        active = self._strip_comments(src)
+        assert "EMPLOYS_TECHNIQUE|USES" not in active, (
+            "Regression: the legacy ``EMPLOYS_TECHNIQUE|USES`` Cypher "
+            "alternation in alert_processor.py:386 was removed in PR-N1. "
+            "It was dead defensive code that masked schema drift."
+        )
+        # Positive pin: the bare specialized form
+        assert "OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE]->(t:Technique)" in src
+
+    def test_neo4j_client_no_legacy_uses_routing_shim(self) -> None:
+        src = (SRC / "neo4j_client.py").read_text()
+        active = self._strip_comments(src)
+        # The dead shim form
+        assert 'rt == "USES" and rel.get("to_type") == "Technique"' not in active, (
+            "Regression: the backward-compat ``rt == 'USES' and to_type == "
+            "'Technique'`` routing shim was removed in PR-N1. Verified no "
+            "caller anywhere emits ``rel_type='USES'``."
+        )
+
+    def test_no_bare_uses_edge_in_active_cypher_anywhere(self) -> None:
+        """Sweep all Python source under ``src/`` for any active Cypher
+        fragment that uses the bare ``[:USES]`` or ``[:USES|`` /
+        ``|USES]`` / ``|USES->`` shape. ``USES_TECHNIQUE`` is allowed
+        (it's a distinct current edge type with the ``_TECHNIQUE``
+        suffix)."""
+        # Exclude collector pyc + test files
+        py_files = [p for p in SRC.rglob("*.py") if "__pycache__" not in str(p)]
+        # Build a regex that matches the bare USES edge type but NOT
+        # USES_TECHNIQUE. Word-boundary guard ensures we don't match
+        # the longer suffix.
+        bad = re.compile(r":USES(?!_)|\|USES(?!_)|USES(?!_)\|")
+        offenders = []
+        for p in py_files:
+            text = p.read_text()
+            # Strip comment-only lines
+            active_lines = [line for line in text.splitlines() if not line.lstrip().startswith("#")]
+            active = "\n".join(active_lines)
+            for m in bad.finditer(active):
+                # Find the source line for the offender
+                line_no = active[: m.start()].count("\n") + 1
+                line = active.splitlines()[line_no - 1] if line_no <= len(active.splitlines()) else ""
+                offenders.append(f"{p.relative_to(REPO_ROOT)}:{line_no}: {line.strip()!r}")
+        assert not offenders, (
+            "Legacy bare ``USES`` edge type found in active code. "
+            "Use one of the specialized types instead "
+            "(EMPLOYS_TECHNIQUE / IMPLEMENTS_TECHNIQUE / USES_TECHNIQUE):\n" + "\n".join(f"  - {o}" for o in offenders)
+        )
+
+
+# ===========================================================================
+# Cross-check: $alert_id parameter is referenced inside the Cypher text
+# ===========================================================================
+
+
+class TestAlertEnrichmentParameterIsActuallyUsed:
+    """A subtle source-level check: verify that the ``alert_id`` kwarg
+    passed to ``session.run`` is ACTUALLY referenced as ``$alert_id``
+    inside the Cypher block immediately preceding the kwarg.
+
+    This catches the original PR-N0 audit finding: the parameter was
+    bound (``alert_id=alert.alert_id``) but the Cypher had no
+    ``$alert_id`` reference. A future regression that reverts the
+    Cypher would re-introduce the cross-contamination silently because
+    the kwarg binding looks correct.
+    """
+
+    def test_alert_id_kwarg_paired_with_dollar_alert_id_in_cypher(self) -> None:
+        src = (SRC / "alert_processor.py").read_text()
+        # Find the context_result block (Query 5)
+        cr_idx = src.find("context_result = session.run(")
+        assert cr_idx != -1, "context_result session.run call missing"
+        # The whole call expression up to its matching close-paren —
+        # use a generous slice; bounded by the next blank line.
+        call_block = src[cr_idx : cr_idx + 1500]
+        # The Cypher itself is delimited by triple quotes
+        first_quote = call_block.find('"""')
+        second_quote = call_block.find('"""', first_quote + 3)
+        cypher = call_block[first_quote + 3 : second_quote]
+        # The cypher MUST contain ``$alert_id`` since the wrapper
+        # passes ``alert_id=alert.alert_id`` as kwarg
+        assert "$alert_id" in cypher, (
+            "Cypher in Query 5 must reference ``$alert_id`` — without this, "
+            "the kwarg is silently unused and the query matches ALL Alerts "
+            "(the cross-contamination bug PR-N1 fixes)."
+        )
+        # And the kwarg call site is present
+        assert "alert_id=alert.alert_id" in call_block


### PR DESCRIPTION
## Summary

Closes the **two Tier-A findings** from the comprehensive 7-agent audit (`docs/flow_audits/09_comprehensive_audit.md`), surfaced independently by Logic Tracker (A1) and Cross-Checker (A2):

### A1 — `alert_processor.py:440` cross-contamination

The Cypher in `_enrich_alert`'s Query 5 bound `alert_id` as a kwarg but the query had **no WHERE filter** using it. The variable `a` matched ALL `:Alert` nodes in the graph and returned the cartesian product of every alert's assets + users.

**Production impact:** every alert enrichment payload published to NATS / ResilMesh carried unrelated alerts' assets + users. Healthcare-zone alerts mis-routed to finance-zone users; on a graph with N alerts, each enrichment payload's `assets` list was N× too large (DoS-shaped at scale).

**Fix:** bind on `MATCH (a:Alert {alert_id: $alert_id})` (uses the natural-key constraint `alert_key` UNIQUE at `neo4j_client.py:794`) + use `OPTIONAL MATCH` for assets / users so an alert with no associations still returns a single row with empty lists.

### A2 — Full legacy `USES` removal

The bare `USES` edge type was retired in 2026-04 (PR #41). The fresh-start model writes only the specialized forms `EMPLOYS_TECHNIQUE` (attribution) / `IMPLEMENTS_TECHNIQUE` (capability) / `USES_TECHNIQUE` (observation). PR-N1 removes ALL remaining traces:

| Site | What was removed |
|---|---|
| `alert_processor.py:386` | Cypher alternation `[:EMPLOYS_TECHNIQUE\|USES]` → bare `:EMPLOYS_TECHNIQUE` |
| `neo4j_client.py:2820-2825` | Backward-compat routing shim `rt == "USES" and to_type == "Technique"` (verified zero callers across `src/`, `dags/`, `tests/`) |
| `mitre_collector.py:276,402` | Misleading "ThreatActor -[:USES]-> Technique" comments rewritten to `[:EMPLOYS_TECHNIQUE]` |
| `query_api.py:679-683` | Comment now references PR #41 + PR-N1, frames USES as historical |
| `neo4j_client.py:2760-2763` | Header comment expanded to note shim removal |
| `docs/RESILMESH_INTEROPERABILITY.md:155-172` | Migration section updated: shim is **gone**, partners with code emitting `rel_type="USES"` will be silently dropped (not routed) |

**Why fully remove vs. defensively keep?** The shim was dead defensive code that masked schema-drift regressions. If a future write path accidentally re-introduced `USES`, the alternation would silently re-include it and the operator wouldn't catch it. Better to fail loudly + force the caller to fix.

## Tests

`tests/test_pr_n1_alert_enrichment_and_uses_removal.py` — **8 tests across 3 classes**:

- **TestAlertEnrichmentBindsAlertId** (4) — Query 5 has the new `MATCH (a:Alert {alert_id: $alert_id})`, both OPTIONAL MATCH branches, negative pin against bare un-bound MATCH, kwarg still passed
- **TestLegacyUsesEdgeTypeFullyRemoved** (3) — alert_processor + neo4j_client clean of legacy USES; **codebase-wide sweep** across all `src/**/*.py` files using regex `r":USES(?!_)|\|USES(?!_)|USES(?!_)\|"` (negative lookahead distinguishes legacy `USES` from the current valid `USES_TECHNIQUE`)
- **TestAlertEnrichmentParameterIsActuallyUsed** (1) — cross-check that the `alert_id` kwarg is actually referenced as `$alert_id` inside the Cypher text (catches the original bug shape: kwarg bound but never used)

Full suite: **1142 passed, 3 skipped, 3 xfailed** in 205s (was 1134; +8 new tests).

## Test plan

- [x] `pytest tests/test_pr_n1_alert_enrichment_and_uses_removal.py -v` — 8/8 pass
- [x] `pytest tests/` — 1142/1142 pass
- [x] `ruff format --check src/ dags/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] Verified no caller anywhere emits `rel_type="USES"`
- [x] Verified existing test `test_stix_exporter.py:407-408` (negative pins on USES alternation in STIX exporter) still passes

## Notes for upgrade

Partners running EdgeGuard need a fresh baseline rerun if their dev / test graphs ever carried legacy `:USES` edges (the `EMPLOYS_TECHNIQUE` / `IMPLEMENTS_TECHNIQUE` writers heal automatically; the alert enrichment query no longer reads `:USES` at all).

## Related

Part of the PR-N series following the comprehensive 7-agent audit (PR-N0 #84, merged). Tier-A blockers; subsequent PRs (PR-N2 through PR-N8) cover B/C tier hardening per the triage doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Fixes a Neo4j alert-enrichment query that previously matched all `:Alert` nodes (risking cross-alert data leakage and payload bloat) and removes remaining backward-compat support for the retired `USES` relationship type, which could break external callers still emitting it.
> 
> **Overview**
> Fixes alert enrichment so asset/user context is scoped to the *current* alert by matching `Alert {alert_id: $alert_id}` and using `OPTIONAL MATCH` for `TARGETS`/`INVOLVES_USER`, eliminating cross-alert contamination and cartesian-product payload growth.
> 
> Fully removes the legacy generic `USES` technique relationship: drops the `EMPLOYS_TECHNIQUE|USES` read alternation in enrichment, deletes the `rel_type="USES"` routing shim in `neo4j_client.create_misp_relationships_batch`, and updates docs/comments accordingly. Adds regression tests that pin the new `alert_id` binding and enforce that bare `:USES` never reappears in active Cypher under `src/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f28769372cb697a520ad3e80d01d2ba601484c98. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->