### PR TITLE
fix(audit): PR-N2 — UUID namespace parity guard (Neo4j↔STIX cross-system traceability)

### DIFF
--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -84,6 +84,12 @@ from typing import Any, Dict, Tuple
 # ║ ``stix_exporter._deterministic_id("indicator", "...")`` produce the same ║
 # ║ UUID for the same logical entity (cross-system traceability).             ║
 # ║                                                                            ║
+# ║ PR-N2 §9-B1: ``stix_exporter`` enforces parity at module-load time via   ║
+# ║ a ``RuntimeError`` raise — if you edit either literal without the other, ║
+# ║ importing ``stix_exporter`` will fail loudly with the divergent UUIDs.   ║
+# ║ See the comment block immediately above ``EDGEGUARD_STIX_NAMESPACE`` in  ║
+# ║ src/stix_exporter.py for the rationale + the migration playbook.         ║
+# ║                                                                            ║
 # ║ If you genuinely need to migrate to a new namespace (e.g. for tenant      ║
 # ║ isolation), do it via a coordinated migration:                             ║
 # ║   1. Add a new constant ``EDGEGUARD_NODE_UUID_NAMESPACE_V2``               ║

--- a/src/stix_exporter.py
+++ b/src/stix_exporter.py
@@ -159,7 +159,45 @@ def _stix_ts(s: Optional[str]) -> Optional[str]:
 # Fixed namespace so UUIDv5 is stable across processes/machines. This
 # value is arbitrary but MUST NOT change — doing so would break ID
 # stability for ResilMesh consumers that cache by STIX ID.
+#
+# CROSS-MODULE INVARIANT (PR-N2 §9-B1): this MUST equal
+# ``node_identity.EDGEGUARD_NODE_UUID_NAMESPACE``. The deliberate
+# duplication exists so each module reads correctly in isolation —
+# the reuse is what makes ``compute_node_uuid("Indicator", {...})``
+# (Neo4j ``n.uuid``) and ``_deterministic_id("indicator", "...")``
+# (STIX SDO id UUID portion) produce the same value for the same
+# logical entity, enabling cross-system traceability between Neo4j
+# and STIX bundles consumed by ResilMesh.
+#
+# The runtime guard immediately below raises at module-load time if
+# the two literals ever drift — the audit (Devil's Advocate F2)
+# correctly noted that the comments say "MUST match" but nothing was
+# actually enforcing it. Pre-PR-N2, a routine refactor that edited
+# one literal without the other would have silently broken every
+# Neo4j↔STIX cross-reference; subsequent migration to repair would
+# require re-stamping every node + re-exporting every bundle.
 EDGEGUARD_STIX_NAMESPACE = uuid.UUID("5f2e1f9a-6a1b-5e0f-9b25-ed9ea2d574cb")
+
+# PR-N2 §9-B1: enforce parity at import time. ``assert`` is avoided
+# because Python's ``-O`` flag strips assertions; we use an explicit
+# ``raise`` instead so the check fires in production too.
+from node_identity import EDGEGUARD_NODE_UUID_NAMESPACE as _EDGEGUARD_NODE_UUID_NAMESPACE_FOR_PARITY_CHECK  # noqa: E402
+
+if EDGEGUARD_STIX_NAMESPACE != _EDGEGUARD_NODE_UUID_NAMESPACE_FOR_PARITY_CHECK:
+    raise RuntimeError(
+        "FATAL: UUID namespace drift detected between "
+        "stix_exporter.EDGEGUARD_STIX_NAMESPACE "
+        f"({EDGEGUARD_STIX_NAMESPACE}) and "
+        "node_identity.EDGEGUARD_NODE_UUID_NAMESPACE "
+        f"({_EDGEGUARD_NODE_UUID_NAMESPACE_FOR_PARITY_CHECK}). "
+        "These MUST be identical so Neo4j n.uuid and STIX SDO id UUIDs "
+        "match for the same logical entity (cross-system traceability). "
+        "If you genuinely need to migrate the namespace, follow the "
+        "coordinated migration in node_identity.py's FROZEN block — "
+        "do NOT just edit one of the literals."
+    )
+
+del _EDGEGUARD_NODE_UUID_NAMESPACE_FOR_PARITY_CHECK
 
 
 def _deterministic_id(obj_type: str, natural_key: str) -> str:

--- a/tests/test_pr_n2_uuid_namespace_parity.py
+++ b/tests/test_pr_n2_uuid_namespace_parity.py
@@ -1,0 +1,240 @@
+"""
+PR-N2 — UUID namespace parity between ``node_identity`` and ``stix_exporter``.
+
+Surfaced by Devil's Advocate F2 in the comprehensive 7-agent audit
+(see ``docs/flow_audits/09_comprehensive_audit.md`` Tier B).
+
+## The risk PR-N2 closes
+
+``src/node_identity.py`` and ``src/stix_exporter.py`` BOTH declare
+the same UUID literal ``5f2e1f9a-6a1b-5e0f-9b25-ed9ea2d574cb`` as the
+deterministic-uuid namespace. The duplication is intentional (each
+module reads correctly in isolation), but pre-PR-N2 NOTHING enforced
+that the two literals stayed identical. A routine refactor that
+edited one without the other would have silently broken every
+Neo4j↔STIX cross-reference:
+
+  * ``compute_node_uuid("Indicator", {...})`` produces ``n.uuid``
+    using ``EDGEGUARD_NODE_UUID_NAMESPACE``
+  * ``_deterministic_id("indicator", "...")`` produces the STIX SDO
+    id UUID portion using ``EDGEGUARD_STIX_NAMESPACE``
+
+When these two namespaces match (the design invariant), a ResilMesh
+consumer reading STIX bundle ``indicator--abc-123-...`` can map back
+to Neo4j ``n.uuid = "abc-123-..."`` for the same logical entity. When
+they diverge, every cross-reference is broken and recovery requires a
+graph-wide migration: re-stamp every node + re-export every bundle.
+
+## What PR-N2 enforces
+
+1. **Runtime guard at module-load time** in ``stix_exporter.py``:
+   importing the module raises ``RuntimeError`` if the two literals
+   differ. Uses an explicit ``raise`` rather than ``assert`` so the
+   check fires even with Python's ``-O`` flag enabled.
+
+2. **End-to-end parity check** in this test: compute the UUID of a
+   sample logical entity using BOTH paths and assert they're
+   byte-equal.
+
+3. **Drift simulation**: monkeypatch one of the literals and verify
+   the runtime guard would have fired (re-importing the module
+   raises).
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+
+# ===========================================================================
+# Direct equality of the two namespace constants
+# ===========================================================================
+
+
+class TestUuidNamespaceConstantsAreEqual:
+    """The two ``UUID(...)`` literals declared in ``node_identity.py``
+    and ``stix_exporter.py`` must be byte-equal at the value level."""
+
+    def test_constants_are_equal(self):
+        from node_identity import EDGEGUARD_NODE_UUID_NAMESPACE
+        from stix_exporter import EDGEGUARD_STIX_NAMESPACE
+
+        assert EDGEGUARD_STIX_NAMESPACE == EDGEGUARD_NODE_UUID_NAMESPACE, (
+            f"UUID namespace drift detected: "
+            f"node_identity={EDGEGUARD_NODE_UUID_NAMESPACE} vs "
+            f"stix_exporter={EDGEGUARD_STIX_NAMESPACE}. "
+            "These MUST be identical for cross-system Neo4j↔STIX traceability."
+        )
+
+    def test_constants_have_documented_value(self):
+        """The frozen value documented in node_identity.py's FROZEN block."""
+        from node_identity import EDGEGUARD_NODE_UUID_NAMESPACE
+
+        assert str(EDGEGUARD_NODE_UUID_NAMESPACE) == "5f2e1f9a-6a1b-5e0f-9b25-ed9ea2d574cb", (
+            "EDGEGUARD_NODE_UUID_NAMESPACE has changed value — this is a "
+            "FROZEN constant per node_identity.py. Changing it invalidates "
+            "every node uuid + every STIX SDO id ever produced. If you "
+            "genuinely need migration, follow the playbook in node_identity.py's "
+            "FROZEN block."
+        )
+
+
+# ===========================================================================
+# End-to-end parity: same logical entity → same UUID via both paths
+# ===========================================================================
+
+
+class TestNeo4jStixUuidParityE2E:
+    """Compute the UUID of a sample Indicator via the Neo4j-side
+    ``compute_node_uuid`` AND the STIX-side ``_deterministic_id``,
+    and assert the UUID portion matches.
+
+    This is the actual cross-system traceability invariant — without
+    it, a ResilMesh consumer reading a STIX bundle cannot map back
+    to the originating Neo4j node by uuid."""
+
+    def test_indicator_uuid_parity(self):
+        from node_identity import compute_node_uuid
+        from stix_exporter import _deterministic_id
+
+        # Sample logical Indicator: ipv4 address
+        ind_type = "ipv4"
+        value = "203.0.113.5"
+
+        # Neo4j-side: compute_node_uuid uses the canonical natural-key map
+        node_uuid_str = compute_node_uuid("Indicator", {"indicator_type": ind_type, "value": value})
+
+        # STIX-side: _deterministic_id needs the joined natural_key
+        # (mimicking the exporter's own call site at stix_exporter.py
+        # ``_indicator_sdo`` which does
+        # ``f"{canonicalize_field_value(ind_type)}|{canonicalize_field_value(value)}"``)
+        from node_identity import canonicalize_field_value
+
+        stix_id = _deterministic_id(
+            "indicator",
+            f"{canonicalize_field_value(ind_type)}|{canonicalize_field_value(value)}",
+        )
+        # STIX ID format: "indicator--<uuid>"
+        assert stix_id.startswith("indicator--")
+        stix_uuid_str = stix_id.split("--", 1)[1]
+
+        assert stix_uuid_str == node_uuid_str, (
+            f"Cross-system UUID parity broken: Neo4j n.uuid={node_uuid_str!r} "
+            f"vs STIX SDO id UUID portion={stix_uuid_str!r}. ResilMesh consumers "
+            "reading the STIX bundle cannot cross-reference back to Neo4j."
+        )
+
+    def test_cve_uuid_parity(self):
+        """Same parity check for a Vulnerability (different label, exercises
+        a different natural-key path)."""
+        from node_identity import canonicalize_field_value, compute_node_uuid
+        from stix_exporter import _deterministic_id
+
+        cve_id = "CVE-2013-0156"
+        node_uuid_str = compute_node_uuid("Vulnerability", {"cve_id": cve_id})
+        stix_id = _deterministic_id("vulnerability", canonicalize_field_value(cve_id))
+        stix_uuid_str = stix_id.split("--", 1)[1]
+        assert stix_uuid_str == node_uuid_str, (
+            f"CVE cross-system UUID parity broken: node={node_uuid_str!r} vs STIX={stix_uuid_str!r}"
+        )
+
+
+# ===========================================================================
+# Runtime guard fires on simulated drift
+# ===========================================================================
+
+
+class TestRuntimeGuardFiresOnDrift:
+    """The import-time guard in ``stix_exporter.py`` must raise
+    ``RuntimeError`` if someone edits one of the two literals without
+    the other.
+
+    We simulate drift by monkeypatching ``node_identity``'s constant
+    BEFORE re-importing ``stix_exporter`` from a fresh module state.
+    """
+
+    def test_guard_raises_on_drift(self, monkeypatch):
+        # We need to manipulate the module cache: remove stix_exporter
+        # from sys.modules, monkeypatch node_identity's constant, then
+        # re-import stix_exporter and confirm it raises.
+        import node_identity
+
+        # Cache the real value so we can restore later
+        real_value = node_identity.EDGEGUARD_NODE_UUID_NAMESPACE
+
+        # Drift simulation: replace node_identity's constant with a
+        # different UUID
+        drifted_uuid = uuid.UUID("00000000-0000-0000-0000-000000000001")
+        monkeypatch.setattr(node_identity, "EDGEGUARD_NODE_UUID_NAMESPACE", drifted_uuid)
+
+        # Drop stix_exporter from sys.modules so the next import
+        # re-executes the module body (and the parity guard).
+        # Save a reference so we can restore the cached module after.
+        saved_stix_exporter = sys.modules.pop("stix_exporter", None)
+        try:
+            with pytest.raises(RuntimeError) as exc_info:
+                importlib.import_module("stix_exporter")
+            # Verify the error message names both constants and both
+            # divergent values
+            err = str(exc_info.value)
+            assert "namespace drift" in err.lower() or "FATAL" in err
+            assert "stix_exporter" in err
+            assert "node_identity" in err
+            assert "5f2e1f9a-6a1b-5e0f-9b25-ed9ea2d574cb" in err
+            assert "00000000-0000-0000-0000-000000000001" in err
+        finally:
+            # Restore the real cached module + real value so other
+            # tests don't see the drifted state
+            sys.modules.pop("stix_exporter", None)
+            if saved_stix_exporter is not None:
+                sys.modules["stix_exporter"] = saved_stix_exporter
+            node_identity.EDGEGUARD_NODE_UUID_NAMESPACE = real_value
+            # Force a fresh import of stix_exporter so subsequent
+            # tests in this run get a module bound to the real value
+            importlib.import_module("stix_exporter")
+
+
+# ===========================================================================
+# Source-pin: the guard pattern is present in stix_exporter.py
+# ===========================================================================
+
+
+class TestSourceContainsRuntimeGuard:
+    """Ensure the runtime guard pattern stays in ``stix_exporter.py``
+    — a future cleanup that removed the guard while keeping the
+    constants would silently re-introduce the drift risk."""
+
+    def test_stix_exporter_has_parity_check(self):
+        src = (SRC / "stix_exporter.py").read_text()
+        # The import alias used by the guard
+        assert (
+            "from node_identity import EDGEGUARD_NODE_UUID_NAMESPACE as _EDGEGUARD_NODE_UUID_NAMESPACE_FOR_PARITY_CHECK"
+            in src
+        ), "Parity-check import must be present"
+        # The explicit raise (not assert)
+        assert "raise RuntimeError(" in src
+        # Some discriminating message text
+        assert "UUID namespace drift" in src
+
+    def test_guard_uses_raise_not_assert(self):
+        """``assert`` is stripped by Python's ``-O`` flag — must use
+        explicit ``raise``."""
+        src = (SRC / "stix_exporter.py").read_text()
+        # Find the parity check region
+        assert "PR-N2" in src
+        # Find the guard block
+        idx = src.find("EDGEGUARD_STIX_NAMESPACE != _EDGEGUARD_NODE_UUID_NAMESPACE_FOR_PARITY_CHECK")
+        assert idx != -1, "Parity check expression missing"
+        # Within ~600 chars of the check, find ``raise`` (not ``assert``)
+        block = src[idx : idx + 600]
+        assert "raise RuntimeError" in block, "guard must use explicit raise, not assert"


### PR DESCRIPTION
## Summary

Closes **Devil's Advocate F2** from the comprehensive 7-agent audit (`docs/flow_audits/09_comprehensive_audit.md` Tier B).

## The risk PR-N2 closes

`src/node_identity.py` and `src/stix_exporter.py` both declare the same UUID literal `5f2e1f9a-6a1b-5e0f-9b25-ed9ea2d574cb` as the deterministic-uuid namespace. The duplication is intentional (each module reads correctly in isolation), but **pre-PR-N2 nothing enforced** that the two literals stayed identical.

A routine refactor that edited one without the other would silently break every Neo4j↔STIX cross-reference:

| Path | Uses |
|---|---|
| `compute_node_uuid("Indicator", {...})` → `n.uuid` | `EDGEGUARD_NODE_UUID_NAMESPACE` (node_identity.py) |
| `_deterministic_id("indicator", "...")` → STIX SDO id UUID | `EDGEGUARD_STIX_NAMESPACE` (stix_exporter.py) |

When matched (the design invariant), a ResilMesh consumer reading STIX bundle `indicator--abc-123-...` can map back to Neo4j `n.uuid = "abc-123-..."` for the same logical entity. When drifted, **recovery requires a graph-wide migration**: re-stamp every node + re-export every bundle.

## What PR-N2 adds

1. **Runtime guard at module-load time** in `stix_exporter.py`: importing the module raises `RuntimeError` if the two literals diverge. Uses an explicit `raise` (NOT `assert`, which Python's `-O` flag strips) so the check fires in production too.

2. **End-to-end parity tests**: compute the UUID of a sample Indicator AND a sample Vulnerability via BOTH the Neo4j-side (`compute_node_uuid`) and STIX-side (`_deterministic_id`) paths, assert byte-for-byte match.

3. **Drift simulation test**: monkeypatch `node_identity`'s constant, re-import `stix_exporter` from a fresh module state, and assert the guard fires with both divergent UUIDs named in the error message — proves the guard actually works under the failure mode it's designed to catch.

4. **Source pins**: the runtime guard pattern stays in `stix_exporter.py` (catches a future cleanup that silently removes the guard).

## Tests

`tests/test_pr_n2_uuid_namespace_parity.py` — **7 tests across 4 classes**:

- **TestUuidNamespaceConstantsAreEqual** (2) — constants equal at value level + frozen value matches the documented literal in `node_identity.py`'s "FROZEN — DO NOT CHANGE" block
- **TestNeo4jStixUuidParityE2E** (2) — Indicator + Vulnerability UUID parity via both paths
- **TestRuntimeGuardFiresOnDrift** (1) — behavioural: monkeypatch + re-import asserts `RuntimeError` fires with both UUIDs named in the error
- **TestSourceContainsRuntimeGuard** (2) — pin the import-alias + `raise` pattern; pin uses `raise` not `assert`

Full suite: **1149 passed, 3 skipped, 3 xfailed** (was 1142; +7 new tests).

## Diff size

**Compact**: 2 source files modified (node_identity.py docstring update + stix_exporter.py guard insertion), 1 new test file. Zero behaviour change for any code path that currently has matching constants — the guard only activates on genuine drift.

## Test plan

- [x] `pytest tests/test_pr_n2_uuid_namespace_parity.py -v` — 7/7 pass
- [x] `pytest tests/` — 1149/1149 pass
- [x] `ruff format --check src/ dags/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] Drift simulation test confirms the runtime guard actually raises with both divergent UUIDs in the error message

## Related

Part of the PR-N series following the comprehensive 7-agent audit (PR-N0 #84, PR-N1 #85 — both merged). Tier-B finding; subsequent PRs (PR-N3 through PR-N8) cover remaining hardening per the triage doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: behavior is unchanged when the namespaces match, but deployments will now fail fast at `stix_exporter` import if a future edit introduces namespace drift (intentional hard stop).
> 
> **Overview**
> Adds an import-time runtime guard in `stix_exporter.py` that raises `RuntimeError` if `EDGEGUARD_STIX_NAMESPACE` ever diverges from `node_identity.EDGEGUARD_NODE_UUID_NAMESPACE`, preventing silent Neo4j↔STIX ID mismatches.
> 
> Introduces `tests/test_pr_n2_uuid_namespace_parity.py` to pin the frozen namespace value, assert end-to-end UUID parity for sample entities, and simulate drift via re-import to prove the guard fires; `node_identity.py` updates the frozen-namespace docs to reference this enforcement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e58b59df03e12f8b37b6b3214334a689d5e48e61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->