### PR TITLE
fix(audit): PR-N4 — MISP-at-scale hardening (adaptive batching + backoff + observability + runbook)

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,6 +135,43 @@ Staged defense-in-depth for untrusted MISP inputs. Full design + threat model in
 - ✅ **Tier 2 — Observability for the disabled state (PR-I, #71).** Defense-disabled state is now always visible: startup WARNING log fires in **all** envs (previously prod/staging only, which silently accepted the default `EDGEGUARD_ENV=dev`) + Prometheus gauge `edgeguard_misp_tag_impersonation_defense_disabled` exposes the state to alert rules. See [`docs/PROMETHEUS_SETUP.md`](docs/PROMETHEUS_SETUP.md) for the suggested alert rule.
 - 📋 **Tier 3 — Fail-closed boot refusal (planned, post-Tier 2).** After operators have had a deployment cycle to configure the allowlists, `EDGEGUARD_ENV ∈ {prod, staging}` will flip to boot-refusal: the process refuses to start unless an allowlist is configured OR `EDGEGUARD_ALLOW_UNTRUSTED_MISP=1` is set explicitly. Closes the "forgot to configure" footgun at deploy time.
 
+#### 🛡️ MISP backend tuning (required for >50K-attr events)
+
+When EdgeGuard is pushing into MISP events with >50,000 attributes
+(typical for OTX / NVD baselines at 365-730 day lookback), the
+default Docker MISP container's PHP / MySQL settings cause HTTP 500
+errors per batch. EdgeGuard's `MISPWriter` now adapts batch size +
+throttle automatically (PR-N4: at 50K attrs → 100/batch + 15s
+throttle; at 100K → 50/batch + 30s throttle), and inserts an
+extended cooldown after sustained 5xx failures, but the **MISP
+backend itself needs the settings below** for the adaptive scaling
+to actually help:
+
+```ini
+# /etc/php/8.x/apache2/php.ini
+memory_limit = 4096M
+max_execution_time = 600
+post_max_size = 256M
+upload_max_filesize = 256M
+max_input_vars = 50000
+
+# /etc/mysql/mariadb.conf.d/50-server.cnf
+[mysqld]
+innodb_buffer_pool_size = 4G       # ~50% of host RAM
+innodb_log_file_size = 512M
+max_allowed_packet = 256M
+wait_timeout = 600
+```
+
+Apply + restart with `docker compose restart misp misp-db`. Full
+playbook (verification commands, EdgeGuard env knobs, Prometheus
+alerts, symptom→setting cheat-sheet) in
+[**`docs/MISP_TUNING.md`**](docs/MISP_TUNING.md). Two new metrics
+added in PR-N4 — `edgeguard_misp_push_permanent_failure_total` and
+`edgeguard_misp_push_backoff_triggered_total` — let operators alert
+on the data-loss rate that previously had to be hand-counted from
+logs.
+
 #### 🕒 Timestamp semantic model
 
 EdgeGuard carries **four distinct timestamps per indicator**, each

--- a/README.md
+++ b/README.md
@@ -163,14 +163,26 @@ max_allowed_packet = 256M
 wait_timeout = 600
 ```
 
-Apply + restart with `docker compose restart misp misp-db`. Full
-playbook (verification commands, EdgeGuard env knobs, Prometheus
-alerts, symptom→setting cheat-sheet) in
+Apply + restart with `docker compose restart misp misp_db` (in **your**
+MISP compose dir — MISP is not vendored in EdgeGuard's
+`docker-compose.yml`). Path varies by image:
+
+- **`harvarditsecurity/misp:latest`** (currently deployed) — Apache
+  mod_php → edit `/etc/php/8.x/apache2/php.ini` or mount a custom
+  `*.ini` into `/etc/php/8.x/apache2/conf.d/zz-edgeguard.ini`.
+- **`coolacid/misp-docker:latest`** — php-fpm → mount
+  `php-overrides.ini` per the reference compose at
+  [`docs/sources/MISP/docker-compose.yml`](docs/sources/MISP/docker-compose.yml).
+
+Full playbook (image-aware paths, verification commands, prereq host
+RAM ≥ 8GB, EdgeGuard env knobs with bounded validation, Prometheus
+alerts, rollback steps, symptom→setting cheat-sheet) in
 [**`docs/MISP_TUNING.md`**](docs/MISP_TUNING.md). Two new metrics
-added in PR-N4 — `edgeguard_misp_push_permanent_failure_total` and
-`edgeguard_misp_push_backoff_triggered_total` — let operators alert
-on the data-loss rate that previously had to be hand-counted from
-logs.
+added in PR-N4 — `edgeguard_misp_push_permanent_failure_total{source}`
+and `edgeguard_misp_push_backoff_triggered_total{source}` — let
+operators alert on the data-loss rate that previously had to be
+hand-counted from logs. (Round 2 dropped the `event_id` label to
+keep cardinality bounded — each MISP run mints a date-stamped event.)
 
 #### 🕒 Timestamp semantic model
 

--- a/docs/MISP_TUNING.md
+++ b/docs/MISP_TUNING.md
@@ -21,6 +21,65 @@ attrs in single events).
 
 ---
 
+## Where MISP runs (read this first)
+
+**MISP is NOT in EdgeGuard's main `docker-compose.yml`.** EdgeGuard
+treats MISP as the system of record; it's a separate, operator-managed
+container that EdgeGuard talks to over HTTPS via `MISP_URL` /
+`MISP_API_KEY`. The settings below apply to **your MISP container**,
+wherever you run it — not to anything in EdgeGuard's compose file.
+
+There are two MISP container images we've validated against. Where
+the tuning files live depends on which one you use:
+
+| Image | Base | PHP version | PHP config path inside container |
+|---|---|---|---|
+| `harvarditsecurity/misp:latest` | Ubuntu + Apache mod_php | PHP 8.x | `/etc/php/8.x/apache2/php.ini` (Apache SAPI) |
+| `coolacid/misp-docker:latest` | Debian bullseye-slim + php-fpm | PHP 7.4 (older builds) / 8.x (newer) | `/etc/php/<ver>/fpm/conf.d/*.ini` (drop-in scan dir) |
+
+**EdgeGuard's currently-deployed MISP is `harvarditsecurity/misp:latest`.**
+The reference compose layout for the `coolacid` image (with mounted
+`php-overrides.ini`) lives at
+[`docs/sources/MISP/docker-compose.yml`](sources/MISP/docker-compose.yml)
++ [`docs/sources/MISP/php-overrides.ini`](sources/MISP/php-overrides.ini).
+That reference compose is also a good template if you migrate from
+`harvarditsecurity` to `coolacid` later.
+
+### Which path to apply the TL;DR settings to
+
+| If you use… | Apply PHP settings to… | Apply MySQL settings to… |
+|---|---|---|
+| `harvarditsecurity/misp:latest` (current) | edit `/etc/php/8.x/apache2/php.ini` inside the running container, OR mount a custom `*.ini` into `/etc/php/8.x/apache2/conf.d/zz-edgeguard.ini` (drop-in dir, scanned after php.ini). | Same as below — the image's own MariaDB / MySQL container; configure via `my.cnf` mount or the container's environment. |
+| `coolacid/misp-docker:latest` | mount `php-overrides.ini` into `/etc/php/<ver>/fpm/conf.d/99-edgeguard.ini` per [`docs/sources/MISP/docker-compose.yml`](sources/MISP/docker-compose.yml). | the bundled `mysql:8.0` sidecar; configure via `my.cnf` mount. |
+
+**Apache vs php-fpm — important.** The `harvarditsecurity` image runs
+PHP via Apache mod_php, so the settings live under
+`/etc/php/<ver>/apache2/`. The `coolacid` image runs PHP via php-fpm,
+so the settings live under `/etc/php/<ver>/fpm/`. Editing the wrong
+path silently does nothing. Always verify with:
+```bash
+docker compose exec misp php -i | grep memory_limit
+```
+
+### `mem_limit` on the docker compose service
+
+Both images need the **container** memory ceiling raised in addition
+to the PHP ceiling. The reference compose sets `mem_limit: 8g` on
+both `misp` and `misp_db`. If your compose doesn't, the PHP process
+will be killed by the kernel OOM-killer at the container limit even
+though `memory_limit = 4096M` in php.ini would otherwise allow it.
+
+```yaml
+# docker-compose.yml — both services
+services:
+  misp:
+    mem_limit: 8g
+  misp_db:
+    mem_limit: 8g
+```
+
+---
+
 ## Prerequisites — host capacity before applying
 
 The TL;DR settings below assume a MISP host with **at least 8 GB
@@ -45,7 +104,12 @@ docker stats misp misp-db --no-stream      # current usage
 
 ## TL;DR — Apply these on the MISP container
 
-### `/etc/php/8.x/apache2/php.ini` (and the equivalent `php-fpm` if used)
+> See **"Where MISP runs"** above for which path applies to your
+> image (`harvarditsecurity` uses Apache `/etc/php/8.x/apache2/`;
+> `coolacid` uses fpm `/etc/php/<ver>/fpm/conf.d/`). The values
+> below are identical for both images.
+
+### PHP — `php.ini` (Apache mod_php) or `conf.d/zz-edgeguard.ini` (php-fpm)
 
 ```ini
 ; PR-N4 EdgeGuard MISP tuning — large-event batch ingest
@@ -71,15 +135,45 @@ innodb_flush_log_at_trx_commit = 2  ; faster commits, ACID-on-shutdown only
 
 ### Apply + verify
 
+**For `harvarditsecurity/misp:latest`** — drop-in conf.d file (survives
+container restart but not container rebuild; for permanence, mount via
+docker-compose):
 ```bash
-# In your MISP docker compose dir
-docker compose restart misp misp-db
+# In your MISP docker compose dir (NOT EdgeGuard's compose dir)
+# Option A: edit php.ini directly inside the container
+docker compose exec misp bash -c "cat >> /etc/php/8.2/apache2/php.ini <<'EOF'
+memory_limit = 4096M
+max_execution_time = 600
+post_max_size = 256M
+upload_max_filesize = 256M
+max_input_vars = 50000
+EOF"
 
-# Verify PHP changes
+# Option B (preferred): mount via docker-compose so it survives rebuild
+# Add to your MISP docker-compose.yml under services.misp.volumes:
+#   - ./misp-php-overrides.ini:/etc/php/8.2/apache2/conf.d/zz-edgeguard.ini:ro
+
+docker compose restart misp misp_db
+```
+
+**For `coolacid/misp-docker:latest`** — use the reference compose +
+`php-overrides.ini` already in this repo:
+```bash
+# Use the reference layout
+cp docs/sources/MISP/docker-compose.yml /path/to/your/misp-deploy/
+cp docs/sources/MISP/php-overrides.ini /path/to/your/misp-deploy/
+cd /path/to/your/misp-deploy/
+docker compose up -d
+```
+
+**Verify (both images):**
+```bash
+# PHP changes
 docker compose exec misp php -i | grep -E 'memory_limit|max_execution_time|post_max_size'
+# Should show: memory_limit => 4G => 4G  (or 8G if you bumped it)
 
-# Verify MySQL changes
-docker compose exec misp-db mysql -u root -p \
+# MySQL changes (service name varies: misp-db, misp_db_1, misp_db)
+docker compose exec misp_db mysql -u root -p \
   -e "SHOW GLOBAL VARIABLES WHERE Variable_name IN ('innodb_buffer_pool_size','max_allowed_packet','wait_timeout');"
 ```
 

--- a/docs/MISP_TUNING.md
+++ b/docs/MISP_TUNING.md
@@ -1,0 +1,171 @@
+# MISP Backend Tuning for EdgeGuard at Scale
+
+**Audience:** operators deploying or upgrading EdgeGuard against a
+MISP backend that will absorb >50,000 attributes per event during
+baseline runs (typical for OTX, NVD, ThreatFox at 365–730 day
+lookback).
+
+**Why this exists:** during the 2026-04-21 730-day baseline, the
+default Docker MISP container hit HTTP 500 errors on most batch pushes
+once events crossed ~50K attributes — Apache PHP workers OOMed,
+MySQL transactions timed out, and ~11,500 attributes were silently
+dropped across the OTX + NVD pushes. EdgeGuard now scales batch
+size / throttle adaptively (PR-N4), but the **MISP backend itself
+needs the settings below** for the adaptive scaling to actually
+help. Adaptive batching alone, against a tiny PHP `memory_limit`,
+just fails slower.
+
+The thresholds and settings here are field-tested against the
+EdgeGuard 730-day baseline workload (~150K OTX attrs + ~100K NVD
+attrs in single events).
+
+---
+
+## TL;DR — Apply these on the MISP container
+
+### `/etc/php/8.x/apache2/php.ini` (and the equivalent `php-fpm` if used)
+
+```ini
+; PR-N4 EdgeGuard MISP tuning — large-event batch ingest
+memory_limit = 4096M             ; default 512M was OOMing on >50K attr events
+max_execution_time = 600         ; default 30s was timing out on bulk inserts
+post_max_size = 256M             ; default 8M rejected the JSON payloads
+upload_max_filesize = 256M       ; same
+max_input_vars = 50000           ; large attribute arrays exceed default 1000
+```
+
+### `/etc/mysql/mariadb.conf.d/50-server.cnf` (or equivalent `my.cnf`)
+
+```ini
+[mysqld]
+# PR-N4 EdgeGuard MISP tuning — large-event batch ingest
+innodb_buffer_pool_size = 4G     ; default 128M; aim for ~50% of host RAM
+innodb_log_file_size = 512M      ; default 48M; reduces frequent flushes
+max_allowed_packet = 256M        ; default 64M; the big payloads hit this
+wait_timeout = 600               ; default 28800 is fine; setting explicit
+                                 ; for documentation
+innodb_flush_log_at_trx_commit = 2  ; faster commits, ACID-on-shutdown only
+```
+
+### Apply + verify
+
+```bash
+# In your MISP docker compose dir
+docker compose restart misp misp-db
+
+# Verify PHP changes
+docker compose exec misp php -i | grep -E 'memory_limit|max_execution_time|post_max_size'
+
+# Verify MySQL changes
+docker compose exec misp-db mysql -u root -p \
+  -e "SHOW GLOBAL VARIABLES WHERE Variable_name IN ('innodb_buffer_pool_size','max_allowed_packet','wait_timeout');"
+```
+
+If you can't restart MISP cleanly, the EdgeGuard side will also work
+with the env knobs in the next section — they just slow EdgeGuard
+down to whatever rate the un-tuned MISP can handle.
+
+---
+
+## EdgeGuard-side env knobs (PR-N4 adaptive scaling)
+
+EdgeGuard's `MISPWriter.push_items` adapts per-event automatically.
+The thresholds below are env-tunable — defaults are sane for the MISP
+settings above.
+
+| Env var | Default | When to change |
+|---|---|---|
+| `EDGEGUARD_MISP_PUSH_BATCH_SIZE` | `500` | Hard ceiling; the adaptive logic downscales below this when the target event is large. Lower it (e.g. `200`) only if you're stuck on un-tuned MISP and want to slow down even small events. |
+| `EDGEGUARD_MISP_BATCH_THROTTLE_SEC` | `5.0` | Sleep between batches. The adaptive logic widens this to `15s` / `30s` for large/huge events. |
+| `EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD` | `50000` | Above this attribute count on the target event, EdgeGuard switches to `batch_size=100, throttle=15s`. Lower if your MISP is undersized. |
+| `EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD` | `100000` | Above this, switches to `batch_size=50, throttle=30s`. |
+| `EDGEGUARD_MISP_BACKOFF_THRESHOLD` | `3` | Number of consecutive 5xx batch failures before EdgeGuard inserts an extended cooldown. |
+| `EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC` | `300.0` | Cooldown duration. 5 min is enough for MISP's PHP to recycle and MySQL to free transaction locks. |
+| `EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS` | `true` | Cross-event dedup. Leave on; it prevents pushing duplicates that would just consume MISP cycles. |
+
+### Adaptive scaling tiers (the rule EdgeGuard applies per event)
+
+| Existing event size | batch_size | throttle |
+|---|---|---|
+| `< 50 000` attrs | configured (default 500) | configured (default 5s) |
+| `50 000 – 100 000` | `min(100, configured)` | `max(15s, configured)` |
+| `>= 100 000` | `min(50, configured)` | `max(30s, configured)` |
+
+Per-event, not per-collector — so an OTX run pushing into a
+small CISA event still uses default batching.
+
+---
+
+## Prometheus metrics PR-N4 added
+
+| Metric | Labels | Meaning |
+|---|---|---|
+| `edgeguard_misp_push_permanent_failure_total` | `source`, `event_id` | Each increment = one batch (default 500 attrs) lost after `@retry_with_backoff(max_retries=4)` exhausted. **Non-zero rate is the operator signal that backend is undersized.** |
+| `edgeguard_misp_push_backoff_triggered_total` | `source` | Each increment = EdgeGuard entered an extended cooldown (default 5 min) after N consecutive 5xx failures. Distinguishes "occasional flap" from "sustained backend overload." |
+
+### Suggested alert rules
+
+```yaml
+- alert: EdgeGuardMispBatchPermanentFailure
+  expr: sum(rate(edgeguard_misp_push_permanent_failure_total[5m])) > 0
+  for: 5m
+  annotations:
+    summary: "EdgeGuard losing MISP batches permanently"
+    description: |
+      MISP rejected one or more attribute batches after EdgeGuard's
+      retry budget exhausted. Each failure is ~500 attributes lost.
+      Check MISP backend RAM / PHP memory_limit / MySQL innodb_buffer_pool_size.
+      See docs/MISP_TUNING.md.
+
+- alert: EdgeGuardMispSustainedBackoff
+  expr: sum(rate(edgeguard_misp_push_backoff_triggered_total[15m])) > 1
+  for: 15m
+  annotations:
+    summary: "EdgeGuard MISPWriter in extended cooldown >1×/15min"
+    description: |
+      MISPWriter is hitting consecutive 5xx failures often enough to
+      enter the 5-minute cooldown more than once per 15 minutes.
+      Backend is sustained-degraded. Tune MISP per docs/MISP_TUNING.md.
+```
+
+---
+
+## Symptom → setting cheat-sheet
+
+| What you see | What's wrong | What to change |
+|---|---|---|
+| HTTP 500 on every batch over a certain size | PHP `memory_limit` or `post_max_size` too small | `memory_limit = 4096M`, `post_max_size = 256M` |
+| HTTP 500 with MySQL "Lost connection" or "Lock wait timeout" | InnoDB buffer pool too small for the attribute table | `innodb_buffer_pool_size = 4G`, `innodb_log_file_size = 512M` |
+| HTTP 500 with "MySQL has gone away" | `max_allowed_packet` rejecting the JSON | `max_allowed_packet = 256M` |
+| HTTP 504 / Apache hangs after ~30s | `max_execution_time` truncating the PHP | `max_execution_time = 600` |
+| `Trying to access array offset on value of type null` | MISP attribute payload rejected as too many vars | `max_input_vars = 50000` |
+| Push completes but only some attributes saved | MISP silent dedup; expected if `EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS=true` and you're re-running | No action; check `attrs_skipped_existing` in collector stats |
+| MISP container restarts mid-push | Apache prefork OOMing the container | Raise the Docker compose `mem_limit` for `misp` AND apply the PHP / MySQL settings above |
+
+---
+
+## Long-term: event sharding (planned, not in PR-N4)
+
+Adaptive batching makes the current single-large-event design SURVIVE
+big pushes. The structural fix — **one MISP event capped at ~25K
+attributes**, auto-sharded into `EdgeGuard-{source}-{date}-shard-{N}`
+— is tracked as a future PR. With shards, no single event ever
+crosses the threshold where MISP starts to struggle, and the adaptive
+downscaling becomes belt-and-suspenders.
+
+Until shards land, the settings above + PR-N4's adaptive scaling are
+the recommended posture.
+
+---
+
+## References
+
+- PR-N4: `src/collectors/misp_writer.py` `push_items` adaptive scaling
+- Audit triage: `docs/flow_audits/09_comprehensive_audit.md` (Prod
+  Readiness #1, #2, #11)
+- On-call report: 2026-04-21 OTX + NVD baseline, ~11,500 attrs lost
+- MISP upstream tuning notes:
+  https://misp.github.io/MISP/INSTALL.ubuntu2204/#performance-tuning
+- PHP `memory_limit`: https://www.php.net/manual/en/ini.core.php
+- InnoDB `innodb_buffer_pool_size`:
+  https://dev.mysql.com/doc/refman/8.0/en/innodb-buffer-pool-resize.html

--- a/docs/MISP_TUNING.md
+++ b/docs/MISP_TUNING.md
@@ -195,7 +195,7 @@ settings above.
 | `EDGEGUARD_MISP_BATCH_THROTTLE_SEC` | `5.0` | Sleep between batches. The adaptive logic widens this to `15s` / `30s` for large/huge events. |
 | `EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD` | `50000` | Above this attribute count on the target event, EdgeGuard switches to `batch_size=100, throttle=15s`. Lower if your MISP is undersized. |
 | `EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD` | `100000` | Above this, switches to `batch_size=50, throttle=30s`. |
-| `EDGEGUARD_MISP_BACKOFF_THRESHOLD` | `3` | Number of consecutive 5xx batch failures before EdgeGuard inserts an extended cooldown. |
+| `EDGEGUARD_MISP_BACKOFF_THRESHOLD` | `3` | Number of consecutive 5xx batch failures before EdgeGuard inserts an extended cooldown. **Valid range: 2–100.** Setting `1` would trigger the 5-min cooldown after a single failure (which `@retry_with_backoff` already handles internally), turning every transient 5xx into a multi-hour stall — values below 2 are silently clamped to the default 3 with a WARN. |
 | `EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC` | `300.0` | Cooldown duration. 5 min is enough for MISP's PHP to recycle and MySQL to free transaction locks. |
 | `EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS` | `true` | Cross-event dedup. **Leave on** — the adaptive scaling tier resolution depends on `existing_attrs_count` which is computed from the prefetch result. With prefetch off, the writer has no per-event size signal and falls back to the configured default batch/throttle for every event, which is exactly the un-adaptive behaviour PR-N4 tried to fix. Turning it off only makes sense if you have an external dedup layer (rare). |
 

--- a/docs/MISP_TUNING.md
+++ b/docs/MISP_TUNING.md
@@ -21,6 +21,28 @@ attrs in single events).
 
 ---
 
+## Prerequisites — host capacity before applying
+
+The TL;DR settings below assume a MISP host with **at least 8 GB
+RAM** (PHP 4 GB + InnoDB 4 GB + OS/other ≈ 8 GB minimum). Applying
+them on a 4 GB container will swap or OOM the host itself, which
+is strictly worse than the un-tuned defaults.
+
+| Host RAM | Suggested settings |
+|---|---|
+| < 4 GB | **Do not apply.** Use EdgeGuard env knobs to slow the writer (`EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD=10000`, batch=100, throttle=15s); plan a host upgrade. |
+| 4 – 6 GB | `memory_limit = 2048M`, `innodb_buffer_pool_size = 2G`, leave the rest at TL;DR values. |
+| 8 GB | TL;DR values exactly. |
+| 16 GB+ | TL;DR values; raise `innodb_buffer_pool_size` to ~50% of RAM if the MISP DB is otherwise idle. |
+
+Verify before applying:
+```bash
+docker compose exec misp free -h           # check container limit, not host
+docker stats misp misp-db --no-stream      # current usage
+```
+
+---
+
 ## TL;DR — Apply these on the MISP container
 
 ### `/etc/php/8.x/apache2/php.ini` (and the equivalent `php-fpm` if used)
@@ -81,7 +103,7 @@ settings above.
 | `EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD` | `100000` | Above this, switches to `batch_size=50, throttle=30s`. |
 | `EDGEGUARD_MISP_BACKOFF_THRESHOLD` | `3` | Number of consecutive 5xx batch failures before EdgeGuard inserts an extended cooldown. |
 | `EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC` | `300.0` | Cooldown duration. 5 min is enough for MISP's PHP to recycle and MySQL to free transaction locks. |
-| `EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS` | `true` | Cross-event dedup. Leave on; it prevents pushing duplicates that would just consume MISP cycles. |
+| `EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS` | `true` | Cross-event dedup. **Leave on** — the adaptive scaling tier resolution depends on `existing_attrs_count` which is computed from the prefetch result. With prefetch off, the writer has no per-event size signal and falls back to the configured default batch/throttle for every event, which is exactly the un-adaptive behaviour PR-N4 tried to fix. Turning it off only makes sense if you have an external dedup layer (rare). |
 
 ### Adaptive scaling tiers (the rule EdgeGuard applies per event)
 
@@ -100,7 +122,7 @@ small CISA event still uses default batching.
 
 | Metric | Labels | Meaning |
 |---|---|---|
-| `edgeguard_misp_push_permanent_failure_total` | `source`, `event_id` | Each increment = one batch (default 500 attrs) lost after `@retry_with_backoff(max_retries=4)` exhausted. **Non-zero rate is the operator signal that backend is undersized.** |
+| `edgeguard_misp_push_permanent_failure_total` | `source` | Each increment = one batch (default 500 attrs) lost after `@retry_with_backoff(max_retries=4)` exhausted. **Non-zero rate is the operator signal that backend is undersized.** Labelled by `source` only (PR-N4 round 2 dropped `event_id` to keep cardinality bounded — each MISP run creates a date-stamped event, which would generate one new time series per source per day). |
 | `edgeguard_misp_push_backoff_triggered_total` | `source` | Each increment = EdgeGuard entered an extended cooldown (default 5 min) after N consecutive 5xx failures. Distinguishes "occasional flap" from "sustained backend overload." |
 
 ### Suggested alert rules
@@ -141,6 +163,40 @@ small CISA event still uses default batching.
 | `Trying to access array offset on value of type null` | MISP attribute payload rejected as too many vars | `max_input_vars = 50000` |
 | Push completes but only some attributes saved | MISP silent dedup; expected if `EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS=true` and you're re-running | No action; check `attrs_skipped_existing` in collector stats |
 | MISP container restarts mid-push | Apache prefork OOMing the container | Raise the Docker compose `mem_limit` for `misp` AND apply the PHP / MySQL settings above |
+
+---
+
+## Rollback — if a tuning change makes things worse
+
+The settings here are field-tested for the documented workload, but
+host hardware varies. If after applying you see the MISP container
+swapping, the host OOMing, or the `edgeguard_misp_push_permanent_failure_total`
+rate going up rather than down, roll back in this order:
+
+1. **Halve `innodb_buffer_pool_size`** first (it's the biggest RAM
+   consumer; 4G → 2G). Restart `misp-db`.
+2. If still bad, **halve `memory_limit`** (4096M → 2048M). Restart `misp`.
+3. If still bad, revert `php.ini` and `my.cnf` to the previous values
+   from your container image (typically `memory_limit=512M`,
+   `innodb_buffer_pool_size=128M`).
+4. With the backend fully reverted, raise EdgeGuard's caution by
+   setting:
+   ```bash
+   EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD=10000   # was 50000
+   EDGEGUARD_MISP_PUSH_BATCH_SIZE=100           # was 500
+   EDGEGUARD_MISP_BATCH_THROTTLE_SEC=15.0       # was 5.0
+   ```
+   This makes EdgeGuard work *with* the un-tuned MISP. It is slower
+   (a 730d baseline that would have taken 4h now takes 8–10h) but
+   correctness is preserved.
+5. File a host-capacity ticket. The combination of a >150K-attribute
+   single event and a sub-8GB MISP host is unsustainable for a
+   production deployment.
+
+The `edgeguard_misp_push_backoff_triggered_total` metric is the
+single best signal that you're in this hole — if it's non-zero
+after the tuning is applied, the tuning isn't sufficient for your
+host.
 
 ---
 

--- a/docs/sources/MISP/SETUP.md
+++ b/docs/sources/MISP/SETUP.md
@@ -23,8 +23,17 @@ MISP_URL=https://your-misp-host.example
 MISP_API_KEY=...
 ```
 
-See also: [SETUP_GUIDE.md](../../SETUP_GUIDE.md), [SECRETS_MANAGEMENT.md](../../SECRETS_MANAGEMENT.md), and [MISP_SOURCES.md](../../MISP_SOURCES.md).
+See also: [SETUP_GUIDE.md](../../SETUP_GUIDE.md), [SECRETS_MANAGEMENT.md](../../SECRETS_MANAGEMENT.md), [MISP_SOURCES.md](../../MISP_SOURCES.md), and **[MISP_TUNING.md](../../MISP_TUNING.md) — required reading before a baseline run >50K attrs**.
+
+## Image choice — `harvarditsecurity` vs `coolacid`
+
+EdgeGuard validates against two MISP images. They differ only in PHP SAPI:
+
+- **`harvarditsecurity/misp:latest`** — Apache mod_php; PHP config under `/etc/php/8.x/apache2/`. **Currently deployed for EdgeGuard.**
+- **`coolacid/misp-docker:latest`** — php-fpm; PHP config under `/etc/php/<ver>/fpm/conf.d/`. The reference compose layout in this directory ([`docker-compose.yml`](docker-compose.yml) + [`php-overrides.ini`](php-overrides.ini)) is for this image.
+
+The TL;DR PHP / MySQL settings in [`MISP_TUNING.md`](../../MISP_TUNING.md) are identical for both; only the file paths differ.
 
 ---
 
-_Last updated: 2026-03-17 — Removed machine-specific paths; aligned with repo-agnostic deployment._
+_Last updated: 2026-04-21 — Added image-choice section + MISP_TUNING.md cross-reference (PR-N4 round 2)._

--- a/docs/sources/MISP/docker-compose.yml
+++ b/docs/sources/MISP/docker-compose.yml
@@ -1,3 +1,16 @@
+## Reference compose for the `coolacid/misp-docker:latest` image.
+##
+## NOTE: This is NOT EdgeGuard's main docker-compose.yml. EdgeGuard does
+## not vendor MISP — operators run MISP wherever they host Docker.
+## EdgeGuard's currently-deployed instance uses the alternative image
+## ``harvarditsecurity/misp:latest`` (Apache mod_php). Both images are
+## tuned via the same TL;DR settings — see ``docs/MISP_TUNING.md``
+## § "Where MISP runs" for the path differences (Apache vs php-fpm).
+##
+## Settings here are field-tested against the EdgeGuard 730-day baseline
+## (~150K OTX attrs + ~100K NVD attrs in single events). See PR-N4 +
+## docs/MISP_TUNING.md for the full backend-tuning playbook.
+
 services:
   misp:
     image: coolacid/misp-docker:latest
@@ -7,7 +20,8 @@ services:
     # EdgeGuard baseline pushes 95K+ attributes per event (NVD feed),
     # and PHP loads the full event context on every POST /attributes/add.
     # On a 4g cap the MISP container OOM-kills mid-baseline and the
-    # Airflow task has to retry. See docs/DOCKER_SETUP_GUIDE.md §
+    # Airflow task has to retry. See docs/MISP_TUNING.md § "Prerequisites"
+    # for the host-RAM sliding scale and docs/DOCKER_SETUP_GUIDE.md §
     # "MISP memory pressure" for the symptoms.
     mem_limit: 8g
     ports:
@@ -47,6 +61,16 @@ services:
     # memory for InnoDB buffer pool and query cache. 4g is the old
     # default and was OOM-prone during baseline.
     mem_limit: 8g
+    # MySQL CLI flags applied at startup. These match the PR-N4 TL;DR
+    # in docs/MISP_TUNING.md and supersede whatever the image's default
+    # my.cnf ships with. For a more permanent layout, mount a custom
+    # my.cnf at /etc/mysql/conf.d/zz-edgeguard.cnf instead.
+    command:
+      - --innodb-buffer-pool-size=4G       # default 128M; aim for ~50% of host RAM
+      - --innodb-log-file-size=512M        # default 48M; reduces frequent flushes
+      - --max-allowed-packet=256M          # default 64M; the big payloads hit this
+      - --innodb-flush-log-at-trx-commit=2 # faster commits, ACID-on-shutdown only
+      - --wait-timeout=600                 # explicit
     environment:
       - MYSQL_ROOT_PASSWORD=misp
       - MYSQL_DATABASE=misp

--- a/docs/sources/MISP/php-overrides.ini
+++ b/docs/sources/MISP/php-overrides.ini
@@ -34,3 +34,15 @@ upload_max_filesize = 512M
 ; on the image build) silently kills the PHP process mid-write.
 max_execution_time = 3600
 max_input_time = 3600
+
+; PR-N4 (2026-04-21 on-call): the per-batch JSON the writer POSTs in
+; large-event tier (50K-100K existing) decomposes server-side into a
+; PHP $_POST array of >1000 vars. Default max_input_vars=1000 silently
+; truncates, leading to attributes_added < attributes_pushed mismatches
+; that the operator only sees when comparing collector counts to the
+; MISP-side count. 50000 covers the worst-case 25K-attr batch we've
+; observed in the wild.
+max_input_vars = 50000
+
+; See docs/MISP_TUNING.md for the full backend-tuning playbook,
+; including MySQL settings and EdgeGuard-side env knobs.

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -12,6 +12,7 @@ sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 import json
 import logging
+import math
 import re
 import time
 from contextlib import contextmanager
@@ -1639,6 +1640,27 @@ class MISPWriter:
                 val = float(raw.strip())
             except (ValueError, TypeError):
                 logger.warning("%s=%r is not a valid float; using default %.1f", name, raw, default)
+                return default
+            # Bugbot R5 (commit bb86c329): reject NaN and ±inf BEFORE the
+            # bounds check.  Python's ``float("nan") < lo`` and ``> hi``
+            # both return False, so NaN slips past the ``val < lo or
+            # val > hi`` guard and propagates into the caller. For
+            # ``_backoff_cooldown_sec`` specifically this silently
+            # DISABLES the cooldown: the ``_backoff_cooldown_sec > 0``
+            # check later in push_items evaluates False for NaN, so the
+            # adaptive cooldown never fires — the opposite of what an
+            # operator setting an (accidentally-NaN) value intended.
+            # ``math.isfinite()`` rejects NaN, +inf, and -inf in one
+            # call.  ``_bounded_int_env`` doesn't need this guard
+            # because ``int("nan")`` / ``int("inf")`` raise ValueError
+            # and take the parse-fail branch above.
+            if not math.isfinite(val):
+                logger.warning(
+                    "%s=%r resolved to non-finite value (NaN/inf); using default %.1f",
+                    name,
+                    raw,
+                    default,
+                )
                 return default
             if val < lo or val > hi:
                 logger.warning(

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1653,19 +1653,23 @@ class MISPWriter:
             return val
 
         # Bounds rationale:
-        # * thresholds: floor 1 (no zero — would trigger immediately);
-        #   ceil 10M (sanity cap; MISP events with >10M attrs are
-        #   pathological regardless)
-        # * backoff threshold: floor 1 (one consecutive 5xx isn't enough
-        #   to warrant a 5-min pause; require at least 2); ceil 100
-        #   (effectively-disabled threshold)
+        # * tier thresholds (large / huge): floor 1 (no zero — would
+        #   classify every event as "huge"); ceil 10M (sanity cap; MISP
+        #   events with >10M attrs are pathological regardless)
+        # * backoff threshold: floor 2 (one consecutive 5xx isn't enough
+        #   to warrant a 5-min pause; require at least 2 — this matches
+        #   the comment intent and prevents an operator typo of "1"
+        #   from turning the @retry_with_backoff's first-attempt-fail
+        #   into a 5-min stall); ceil 100 (effectively-disabled threshold).
+        #   Bugbot R4 (commit 001846b) caught the prior floor=1 silently
+        #   contradicting this comment — now load-bearing.
         # * cooldown: floor 0.0 (operator can disable the cooldown by
         #   setting to 0; the cooldown branch then becomes a no-op);
         #   ceil 3600.0 (1 hour — anything longer is almost certainly
         #   a typo, e.g. 999999)
         _large_threshold = _bounded_int_env("EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", 50000, lo=1, hi=10_000_000)
         _huge_threshold = _bounded_int_env("EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", 100000, lo=1, hi=10_000_000)
-        _backoff_threshold = _bounded_int_env("EDGEGUARD_MISP_BACKOFF_THRESHOLD", 3, lo=1, hi=100)
+        _backoff_threshold = _bounded_int_env("EDGEGUARD_MISP_BACKOFF_THRESHOLD", 3, lo=2, hi=100)
         _backoff_cooldown_sec = _bounded_float_env("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", 300.0, lo=0.0, hi=3600.0)
 
         # PR-N4 round 2 (Red Team #6, Bug Hunter #3, Devil's Advocate):

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1397,7 +1397,13 @@ class MISPWriter:
         the writer inserts a longer cooldown (default 5min, env
         ``EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC``) before the next batch
         — gives MISP time to fully recover instead of hammering a
-        struggling worker. Reset on success.
+        struggling worker.  The failure counter persists across
+        ``push_items`` calls (instance-scoped on ``self``) and resets
+        only after **2 consecutive fully-successful** batches — one
+        success could be a fluke; two suggests genuine recovery.
+        During the cooldown the writer wakes every 30s to call the
+        parent-DAG liveness callback so a sibling task failure is
+        detected within ~30s rather than after the full cooldown.
 
         See docs/MISP_TUNING.md for the full playbook (php.ini /
         my.cnf settings + when to apply each EdgeGuard env knob).
@@ -1464,7 +1470,12 @@ class MISPWriter:
         total_failed = 0
         processed_batches = 0
         start_time = time.time()
-        push_queue: List[Tuple[str, List[Dict]]] = []
+        # PR-N4 round 2 (Bugbot R2-A): widened from 2-tuple to 4-tuple
+        # carrying (source, event_id, existing_attrs_count, attrs).
+        # The threading was added in round 1 (F1: stale source) + round 1
+        # (F2: avoid duplicate _get_existing_attribute_keys fetch); the
+        # type annotation was forgotten and silently misled mypy.
+        push_queue: List[Tuple[str, str, int, List[Dict]]] = []
 
         # PR-F7 (Issue #61 quick-fix): cache cross-event prefetch per
         # source so a single push_items call doesn't re-fetch the same
@@ -1588,22 +1599,92 @@ class MISPWriter:
 
         # PR-N4 adaptive-scaling thresholds + backoff knobs (env-tunable
         # so ops can tune without code change). See push_items docstring.
-        try:
-            _large_threshold = int(os.environ.get("EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", "50000"))
-        except (ValueError, TypeError):
-            _large_threshold = 50000
-        try:
-            _huge_threshold = int(os.environ.get("EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", "100000"))
-        except (ValueError, TypeError):
-            _huge_threshold = 100000
-        try:
-            _backoff_threshold = int(os.environ.get("EDGEGUARD_MISP_BACKOFF_THRESHOLD", "3"))
-        except (ValueError, TypeError):
-            _backoff_threshold = 3
-        try:
-            _backoff_cooldown_sec = float(os.environ.get("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "300.0"))
-        except (ValueError, TypeError):
-            _backoff_cooldown_sec = 300.0
+        #
+        # PR-N4 round 2 (Bugbot R2-B + 7-agent audit Red Team #1, Bug Hunter
+        # #2): every env var is now BOUNDS-CHECKED on parse. Pre-fix, an
+        # operator setting ``EDGEGUARD_MISP_BACKOFF_THRESHOLD=0`` would
+        # immediately satisfy ``_consecutive_failures (0) >= 0``, firing
+        # the 5-min cooldown on the first batch and turning a 30-min push
+        # into a multi-hour stall with the confusing log "0 consecutive
+        # 5xx failures — entering extended cooldown." Negative values had
+        # similar pathologies. Now: unparseable / out-of-bounds values
+        # log a WARNING and use the safe default. See docs/MISP_TUNING.md
+        # § "EdgeGuard-side env knobs" for valid ranges.
+        def _bounded_int_env(name: str, default: int, *, lo: int, hi: int) -> int:
+            raw = os.environ.get(name)
+            if not raw:
+                return default
+            try:
+                val = int(raw.strip())
+            except (ValueError, TypeError):
+                logger.warning("%s=%r is not a valid integer; using default %d", name, raw, default)
+                return default
+            if val < lo or val > hi:
+                logger.warning(
+                    "%s=%d is out of valid range [%d, %d]; using default %d",
+                    name,
+                    val,
+                    lo,
+                    hi,
+                    default,
+                )
+                return default
+            return val
+
+        def _bounded_float_env(name: str, default: float, *, lo: float, hi: float) -> float:
+            raw = os.environ.get(name)
+            if not raw:
+                return default
+            try:
+                val = float(raw.strip())
+            except (ValueError, TypeError):
+                logger.warning("%s=%r is not a valid float; using default %.1f", name, raw, default)
+                return default
+            if val < lo or val > hi:
+                logger.warning(
+                    "%s=%.1f is out of valid range [%.1f, %.1f]; using default %.1f",
+                    name,
+                    val,
+                    lo,
+                    hi,
+                    default,
+                )
+                return default
+            return val
+
+        # Bounds rationale:
+        # * thresholds: floor 1 (no zero — would trigger immediately);
+        #   ceil 10M (sanity cap; MISP events with >10M attrs are
+        #   pathological regardless)
+        # * backoff threshold: floor 1 (one consecutive 5xx isn't enough
+        #   to warrant a 5-min pause; require at least 2); ceil 100
+        #   (effectively-disabled threshold)
+        # * cooldown: floor 0.0 (operator can disable the cooldown by
+        #   setting to 0; the cooldown branch then becomes a no-op);
+        #   ceil 3600.0 (1 hour — anything longer is almost certainly
+        #   a typo, e.g. 999999)
+        _large_threshold = _bounded_int_env("EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", 50000, lo=1, hi=10_000_000)
+        _huge_threshold = _bounded_int_env("EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", 100000, lo=1, hi=10_000_000)
+        _backoff_threshold = _bounded_int_env("EDGEGUARD_MISP_BACKOFF_THRESHOLD", 3, lo=1, hi=100)
+        _backoff_cooldown_sec = _bounded_float_env("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", 300.0, lo=0.0, hi=3600.0)
+
+        # PR-N4 round 2 (Red Team #6, Bug Hunter #3, Devil's Advocate):
+        # validate that HUGE > LARGE so the tier-resolution logic below
+        # produces semantically correct labels.  Pre-fix, an operator
+        # mistakenly setting LARGE=100000, HUGE=50000 (inverted) would
+        # cause every event in the 50K-100K range to mis-label as "huge"
+        # and over-throttle (50/batch + 30s instead of 100/batch + 15s).
+        # Auto-swap + warn rather than silently accept the inversion.
+        if _huge_threshold <= _large_threshold:
+            logger.warning(
+                "MISP adaptive-scaling thresholds inverted: LARGE=%d, HUGE=%d "
+                "(huge must be > large). Auto-swapping; please fix the env vars "
+                "EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD / "
+                "EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD per docs/MISP_TUNING.md.",
+                _large_threshold,
+                _huge_threshold,
+            )
+            _large_threshold, _huge_threshold = _huge_threshold, _large_threshold
 
         # PR-N4 helper: resolve the adaptive-scaling tier from an
         # existing-attribute count. Defined inside push_items so the
@@ -1630,12 +1711,25 @@ class MISPWriter:
             for _src, _eid, existing_ct, attrs in push_queue
         )
 
-        # Track consecutive 5xx failures across the entire push (per writer
-        # instance, scoped to this push_items call). Reset on any successful
-        # batch. When count >= threshold, insert an extended cooldown
-        # before the next batch — gives MISP time to fully recover instead
-        # of hammering a struggling worker with 10s × 2^n retries.
-        _consecutive_failures = 0
+        # PR-N4 round 2 (Devil's Advocate #1): track consecutive 5xx
+        # failures on the WRITER INSTANCE so the count persists across
+        # successive ``push_items`` calls. Pre-fix the counter was
+        # local-var scoped (`_consecutive_failures = 0` at function
+        # entry) and reset every call — meaning a sustained MISP
+        # degradation that flapped across multiple push_items calls
+        # never accumulated 3 consecutive failures within ANY single
+        # call, so the cooldown never fired even though MISP was clearly
+        # struggling. Now the count is on ``self`` and only resets on
+        # SUSTAINED recovery (Fix #3 below).
+        #
+        # Defensive ``getattr`` (not ``self.``): same pattern as
+        # ``liveness_callback`` lower in the file — existing tests
+        # construct MISPWriter via __new__ and bypass __init__, so the
+        # instance attribute may not exist on test instances.
+        if not hasattr(self, "_misp_push_consecutive_failures"):
+            self._misp_push_consecutive_failures = 0
+        if not hasattr(self, "_misp_push_consecutive_successes"):
+            self._misp_push_consecutive_successes = 0
 
         for source, event_id, existing_attrs_count, unique_attrs in push_queue:
             # PR-N4: ADAPTIVE SCALING. ``existing_attrs_count`` was
@@ -1672,20 +1766,32 @@ class MISPWriter:
                     time.sleep(effective_throttle)
 
                 # PR-N4 adaptive backoff: if we've seen N consecutive 5xx
-                # failures, insert an extended cooldown BEFORE retrying.
-                # The @retry_with_backoff decorator on _push_batch retries
+                # failures (instance-scoped via self._misp_push_*), insert
+                # an extended cooldown BEFORE retrying. The
+                # @retry_with_backoff decorator on _push_batch retries
                 # internally with 10s × 2^n delay (max ~150s budget per
                 # batch); that's not enough when the underlying MISP is
                 # stuck OOMing. The cooldown gives MISP a real chance to
                 # recover before we send the next request.
-                if _consecutive_failures >= _backoff_threshold:
+                #
+                # PR-N4 round 2 (Logic Tracker #1, Prod Readiness #3 #7):
+                # CHUNKED sleep with a liveness check between chunks.
+                # Pre-fix the cooldown was a single ``time.sleep(300)``
+                # call that blocked the parent-DAG liveness callback for
+                # the full 5 minutes. If a sibling DAG task failed during
+                # that window, EdgeGuard slept through the failure signal
+                # and continued pushing for ~5 min before noticing.
+                # Now we sleep in 30s chunks, calling the liveness
+                # callback between each — DAG-failure detection latency
+                # drops from 5min to ~30s.
+                if self._misp_push_consecutive_failures >= _backoff_threshold and _backoff_cooldown_sec > 0:
                     logger.warning(
                         "[PUSH] %d consecutive 5xx failures (>= threshold %d) — "
                         "entering extended cooldown for %.0fs before next batch. "
                         "MISP backend appears overwhelmed; check backend RAM / "
                         "PHP memory_limit / MySQL innodb_buffer_pool_size — see "
                         "docs/MISP_TUNING.md.",
-                        _consecutive_failures,
+                        self._misp_push_consecutive_failures,
                         _backoff_threshold,
                         _backoff_cooldown_sec,
                     )
@@ -1704,13 +1810,28 @@ class MISPWriter:
                                 _metric_err,
                                 exc_info=True,
                             )
-                    time.sleep(_backoff_cooldown_sec)
+                    # Chunked sleep + liveness check. ``_BACKOFF_LIVENESS_CHUNK_SEC``
+                    # default 30s — short enough to detect parent-DAG death
+                    # within 30s, long enough that we don't burn CPU calling
+                    # the rate-limited liveness callback.
+                    _liveness_cb_in_cooldown = getattr(self, "liveness_callback", None)
+                    _chunk = 30.0
+                    _slept = 0.0
+                    while _slept < _backoff_cooldown_sec:
+                        _step = min(_chunk, _backoff_cooldown_sec - _slept)
+                        time.sleep(_step)
+                        _slept += _step
+                        # Liveness check; re-raises AbortedByDagFailureException
+                        # if parent DAG died (per PR-F6 contract).
+                        if _liveness_cb_in_cooldown is not None:
+                            _liveness_cb_in_cooldown()
                     # Reset the counter so we don't immediately re-pause
                     # if the next batch ALSO fails — the @retry_with_backoff
                     # gives it 4 attempts; if those fail, we'll re-trigger
                     # the cooldown after another N consecutive batch-level
                     # failures.
-                    _consecutive_failures = 0
+                    self._misp_push_consecutive_failures = 0
+                    self._misp_push_consecutive_successes = 0
 
                 # PR-F6 (Issue #65): parent-DAG liveness check BEFORE the
                 # next push. If the parent dag_run has been marked failed
@@ -1764,30 +1885,62 @@ class MISPWriter:
                 # bad event doesn't destroy a whole NVD push.
                 try:
                     success, failed = self._push_batch(event_id, batch)
-                    # PR-N4: success resets the consecutive-failure counter
-                    # (any single successful batch means MISP recovered)
+                    # PR-N4 round 2 (Cross-Checker #2, Bug Hunter #5):
+                    # require N CONSECUTIVE FULL SUCCESSES before
+                    # resetting the failure counter. Pre-fix, a single
+                    # success between two failure clusters reset the
+                    # counter, masking a chronically-flapping backend.
+                    # ``_REQUIRED_RECOVERIES = 2`` — one success could
+                    # be a fluke; two suggests genuine recovery. Kept
+                    # in-function (not env-tunable) because the right
+                    # answer doesn't vary across deployments.
                     if success > 0 and failed == 0:
-                        _consecutive_failures = 0
+                        self._misp_push_consecutive_successes += 1
+                        if self._misp_push_consecutive_successes >= 2:
+                            self._misp_push_consecutive_failures = 0
+                    else:
+                        # Partial success (some attrs failed but no exception):
+                        # don't count as recovery, but don't punish either.
+                        self._misp_push_consecutive_successes = 0
                 except MispTransientError as exc:
+                    # PR-N4 round 2 (Bug Hunter #6, Prod Readiness #11):
+                    # sanitize event_id in log output. ``event_id`` is
+                    # operator-controlled-but-tainted (it comes from MISP
+                    # API responses; if MISP is compromised, it could
+                    # contain log-injection sequences). Strip ANSI/control
+                    # chars defensively.
+                    _safe_event_id = "".join(c for c in str(event_id) if c.isprintable() and c not in ("\r", "\n"))[:64]
                     logger.error(
                         "Batch %s for event %s failed after retries (%s) — counting batch as failed and continuing",
                         processed_batches,
-                        event_id,
+                        _safe_event_id,
                         exc,
                     )
                     success, failed = 0, len(batch)
                     self.stats["errors"] += 1
-                    # PR-N4: track for adaptive backoff (next iteration of
-                    # the inner loop will check this against threshold)
-                    _consecutive_failures += 1
+                    # PR-N4 round 2 (Cross-Checker #2): instance-scoped
+                    # counter persists across push_items calls so a
+                    # flapping backend eventually trips the cooldown.
+                    self._misp_push_consecutive_failures += 1
+                    self._misp_push_consecutive_successes = 0
                     # PR-N4: emit Prometheus permanent-failure counter so
                     # operators can alert on data loss rate. Pre-PR-N4 the
                     # only signal was the log line above, which Bravo had
                     # to hand-count from. ``source`` is the resolved
                     # source string from the outer loop's ``grouped`` dict.
+                    #
+                    # PR-N4 round 2 (Maintainer Dev #4, Bug Hunter #4):
+                    # DROPPED ``event_id`` label. Each MISP run creates a
+                    # new event_id (date-stamped), so labelling by event_id
+                    # produced a new Prometheus time series every day.
+                    # Over 365 days that's 365 unbounded series PER
+                    # SOURCE — would balloon Prometheus storage and
+                    # slow alerting queries. ``source`` alone gives
+                    # operators the actionable signal ("OTX is dropping
+                    # batches") without the cardinality.
                     if _METRICS_AVAILABLE:
                         try:
-                            _MISP_PUSH_PERMANENT_FAILURES.labels(source=source, event_id=str(event_id)).inc()
+                            _MISP_PUSH_PERMANENT_FAILURES.labels(source=source).inc()
                         except Exception as _metric_err:
                             # Bugbot (PR-N4 round 1): don't swallow silently.
                             # See backoff-trigger metric block above for rationale.

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1556,9 +1556,21 @@ class MISPWriter:
                 )
             if not unique_attrs:
                 continue
-            push_queue.append((event_id, unique_attrs))
-
-        total_batches = sum((len(attrs) + batch_size - 1) // batch_size for _, attrs in push_queue)
+            # PR-N4 (Bugbot round 1): thread ``source`` and the
+            # already-fetched per-event attribute count INTO the queue.
+            #
+            #  * ``source`` is needed by the second loop's Prometheus
+            #    metric increments. The pre-fix version reused the
+            #    outer-loop ``source`` variable, which retains its last
+            #    iteration's value after the loop ends — silently
+            #    mis-attributing every metric in a multi-source push.
+            #  * ``existing_attrs_count`` is needed for adaptive scaling.
+            #    Pre-fix the second loop re-called
+            #    ``_get_existing_attribute_keys(event_id)`` (a 30-60s
+            #    paginated REST call on large events) — doubling the
+            #    prefetch cost on the exact events PR-N4 targets. Reuse
+            #    the count we already paid for during dedup.
+            push_queue.append((source, event_id, len(per_event_keys), unique_attrs))
 
         if not push_queue and total_items > 0:
             logger.warning(
@@ -1593,6 +1605,31 @@ class MISPWriter:
         except (ValueError, TypeError):
             _backoff_cooldown_sec = 300.0
 
+        # PR-N4 helper: resolve the adaptive-scaling tier from an
+        # existing-attribute count. Defined inside push_items so the
+        # closure captures the env-tuned thresholds; both the
+        # ``total_batches`` precompute (immediately below) and the
+        # inner loop (further below) use the same logic — no
+        # duplication / drift risk.
+        def _adaptive_for(existing_ct: int) -> Tuple[int, float, str]:
+            if existing_ct >= _huge_threshold:
+                return min(50, batch_size), max(30.0, batch_throttle), "huge"
+            if existing_ct >= _large_threshold:
+                return min(100, batch_size), max(15.0, batch_throttle), "large"
+            return batch_size, batch_throttle, "default"
+
+        # PR-N4 (Bugbot round 1, LOW): ``total_batches`` recomputed using
+        # the per-event ``effective_batch_size`` (the adaptive tier may
+        # downscale from the static ``batch_size``). Pre-fix this was
+        # computed once with the static value, so when scaling kicked in
+        # the progress log reported >100% and negative ETAs on huge
+        # events. Now uses the same ``_adaptive_for`` helper as the inner
+        # loop — single source of truth.
+        total_batches = sum(
+            (len(attrs) + _adaptive_for(existing_ct)[0] - 1) // _adaptive_for(existing_ct)[0]
+            for _src, _eid, existing_ct, attrs in push_queue
+        )
+
         # Track consecutive 5xx failures across the entire push (per writer
         # instance, scoped to this push_items call). Reset on any successful
         # batch. When count >= threshold, insert an extended cooldown
@@ -1600,34 +1637,19 @@ class MISPWriter:
         # of hammering a struggling worker with 10s × 2^n retries.
         _consecutive_failures = 0
 
-        for event_id, unique_attrs in push_queue:
-            # PR-N4: ADAPTIVE SCALING. Look at how many attributes already
-            # live in the target event and downscale batch size + throttle
-            # if it's already large. The existing-attrs prefetch above
-            # already has a count for free via per_event_keys
-            # (set of (type, value) tuples) — re-use it rather than firing
-            # another network call. ``per_event_keys`` is scoped to a
-            # different ``event_id`` per outer loop iteration, so we
-            # re-derive each time.
-            try:
-                existing_attrs_count = len(self._get_existing_attribute_keys(event_id))
-            except Exception:
-                # Defensive: if the count lookup fails, fall back to
-                # default batching rather than crashing the push.
-                existing_attrs_count = 0
-
-            effective_batch_size = batch_size
-            effective_throttle = batch_throttle
-            if existing_attrs_count >= _huge_threshold:
-                effective_batch_size = min(50, batch_size)
-                effective_throttle = max(30.0, batch_throttle)
-                _scale_tier = "huge"
-            elif existing_attrs_count >= _large_threshold:
-                effective_batch_size = min(100, batch_size)
-                effective_throttle = max(15.0, batch_throttle)
-                _scale_tier = "large"
-            else:
-                _scale_tier = "default"
+        for source, event_id, existing_attrs_count, unique_attrs in push_queue:
+            # PR-N4: ADAPTIVE SCALING. ``existing_attrs_count`` was
+            # captured during the dedup loop above (we already paid for
+            # ``_get_existing_attribute_keys(event_id)`` there) and
+            # threaded through ``push_queue``. No second MISP call here.
+            #
+            # Bugbot round 1 caught the duplicate fetch (lines 1505 and
+            # 1613 both called the same paginated 30-60s REST endpoint)
+            # AND the silent except-pass that defaulted to 0 on lookup
+            # failure (defeating adaptive scaling exactly when it was
+            # most needed). Both fixed by threading the dedup-time count
+            # through ``push_queue``.
+            effective_batch_size, effective_throttle, _scale_tier = _adaptive_for(existing_attrs_count)
             if _scale_tier != "default":
                 logger.info(
                     "[PUSH] Event %s has %d existing attrs (>= %s threshold) — "
@@ -1670,8 +1692,18 @@ class MISPWriter:
                     if _METRICS_AVAILABLE:
                         try:
                             _MISP_BACKOFF_TRIGGERED.labels(source=source).inc()
-                        except Exception:
-                            pass
+                        except Exception as _metric_err:
+                            # Bugbot (PR-N4 round 1): don't swallow silently.
+                            # Metric failures shouldn't block the push, but they
+                            # SHOULD be debuggable — if Prometheus client is
+                            # mis-configured (e.g. duplicate registry registration)
+                            # the operator needs to see something other than
+                            # "no metric ever increments."
+                            logger.debug(
+                                "MISP backoff-triggered metric increment failed: %s",
+                                _metric_err,
+                                exc_info=True,
+                            )
                     time.sleep(_backoff_cooldown_sec)
                     # Reset the counter so we don't immediately re-pause
                     # if the next batch ALSO fails — the @retry_with_backoff
@@ -1756,8 +1788,14 @@ class MISPWriter:
                     if _METRICS_AVAILABLE:
                         try:
                             _MISP_PUSH_PERMANENT_FAILURES.labels(source=source, event_id=str(event_id)).inc()
-                        except Exception:
-                            pass
+                        except Exception as _metric_err:
+                            # Bugbot (PR-N4 round 1): don't swallow silently.
+                            # See backoff-trigger metric block above for rationale.
+                            logger.debug(
+                                "MISP permanent-failure metric increment failed: %s",
+                                _metric_err,
+                                exc_info=True,
+                            )
                 total_success += success
                 total_failed += failed
 

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -34,6 +34,23 @@ from config import (
     apply_misp_http_host_header,
 )
 
+# PR-N4: Prometheus metrics for permanent-failure counter + adaptive-
+# backoff trigger. Optional import so MISPWriter can run in environments
+# without prometheus_client installed (CI, dev shells, dry-run).
+try:
+    from metrics_server import (
+        MISP_PUSH_BACKOFF_TRIGGERED as _MISP_BACKOFF_TRIGGERED,
+    )
+    from metrics_server import (
+        MISP_PUSH_PERMANENT_FAILURES as _MISP_PUSH_PERMANENT_FAILURES,
+    )
+
+    _METRICS_AVAILABLE = True
+except ImportError:
+    _METRICS_AVAILABLE = False
+    _MISP_PUSH_PERMANENT_FAILURES = None  # type: ignore[assignment]
+    _MISP_BACKOFF_TRIGGERED = None  # type: ignore[assignment]
+
 # Suppress InsecureRequestWarning only when SSL verification is explicitly disabled.
 if not SSL_VERIFY:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
@@ -1355,6 +1372,35 @@ class MISPWriter:
 
         Returns:
             Tuple of (successful_count, failed_count)
+
+        PR-N4 — adaptive scaling for MISP-at-scale (closes the on-call
+        report from 2026-04-21 where a 730d baseline lost ~11,500 attrs
+        across OTX + NVD pushes due to MISP HTTP 500s on large events):
+
+        The default ``batch_size=500, throttle=5s`` works well when MISP
+        events are small (<50K attrs). At ~50K+ attributes per event
+        the MISP PHP/MySQL backend starts crashing per batch
+        (worker OOMs, MySQL transaction timeouts, Apache prefork
+        restarts). EdgeGuard now adapts on a per-event basis:
+
+          existing_attrs >= 100K → batch_size=50,  throttle=30s
+          existing_attrs >= 50K  → batch_size=100, throttle=15s
+          existing_attrs <  50K  → use the configured/default values
+
+        Per-batch HTTP POST is smaller, MISP PHP can finish, less
+        likely to OOM. The thresholds are env-tunable via
+        ``EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD`` (default 50000) and
+        ``EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD`` (default 100000).
+
+        Plus an adaptive backoff: after N consecutive HTTP 5xx batch
+        failures (default 3, env ``EDGEGUARD_MISP_BACKOFF_THRESHOLD``)
+        the writer inserts a longer cooldown (default 5min, env
+        ``EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC``) before the next batch
+        — gives MISP time to fully recover instead of hammering a
+        struggling worker. Reset on success.
+
+        See docs/MISP_TUNING.md for the full playbook (php.ini /
+        my.cnf settings + when to apply each EdgeGuard env knob).
         """
         if not items:
             return 0, 0
@@ -1528,14 +1574,111 @@ class MISPWriter:
         except (ValueError, TypeError):
             batch_throttle = 5.0
 
+        # PR-N4 adaptive-scaling thresholds + backoff knobs (env-tunable
+        # so ops can tune without code change). See push_items docstring.
+        try:
+            _large_threshold = int(os.environ.get("EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", "50000"))
+        except (ValueError, TypeError):
+            _large_threshold = 50000
+        try:
+            _huge_threshold = int(os.environ.get("EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", "100000"))
+        except (ValueError, TypeError):
+            _huge_threshold = 100000
+        try:
+            _backoff_threshold = int(os.environ.get("EDGEGUARD_MISP_BACKOFF_THRESHOLD", "3"))
+        except (ValueError, TypeError):
+            _backoff_threshold = 3
+        try:
+            _backoff_cooldown_sec = float(os.environ.get("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "300.0"))
+        except (ValueError, TypeError):
+            _backoff_cooldown_sec = 300.0
+
+        # Track consecutive 5xx failures across the entire push (per writer
+        # instance, scoped to this push_items call). Reset on any successful
+        # batch. When count >= threshold, insert an extended cooldown
+        # before the next batch — gives MISP time to fully recover instead
+        # of hammering a struggling worker with 10s × 2^n retries.
+        _consecutive_failures = 0
+
         for event_id, unique_attrs in push_queue:
+            # PR-N4: ADAPTIVE SCALING. Look at how many attributes already
+            # live in the target event and downscale batch size + throttle
+            # if it's already large. The existing-attrs prefetch above
+            # already has a count for free via per_event_keys
+            # (set of (type, value) tuples) — re-use it rather than firing
+            # another network call. ``per_event_keys`` is scoped to a
+            # different ``event_id`` per outer loop iteration, so we
+            # re-derive each time.
+            try:
+                existing_attrs_count = len(self._get_existing_attribute_keys(event_id))
+            except Exception:
+                # Defensive: if the count lookup fails, fall back to
+                # default batching rather than crashing the push.
+                existing_attrs_count = 0
+
+            effective_batch_size = batch_size
+            effective_throttle = batch_throttle
+            if existing_attrs_count >= _huge_threshold:
+                effective_batch_size = min(50, batch_size)
+                effective_throttle = max(30.0, batch_throttle)
+                _scale_tier = "huge"
+            elif existing_attrs_count >= _large_threshold:
+                effective_batch_size = min(100, batch_size)
+                effective_throttle = max(15.0, batch_throttle)
+                _scale_tier = "large"
+            else:
+                _scale_tier = "default"
+            if _scale_tier != "default":
+                logger.info(
+                    "[PUSH] Event %s has %d existing attrs (>= %s threshold) — "
+                    "adaptive scaling: batch_size=%d, throttle=%.0fs (was %d / %.0fs)",
+                    event_id,
+                    existing_attrs_count,
+                    _scale_tier,
+                    effective_batch_size,
+                    effective_throttle,
+                    batch_size,
+                    batch_throttle,
+                )
+
             # Send attributes in batches
-            for i in range(0, len(unique_attrs), batch_size):
-                batch = unique_attrs[i : i + batch_size]
+            for i in range(0, len(unique_attrs), effective_batch_size):
+                batch = unique_attrs[i : i + effective_batch_size]
 
                 # Throttle between batches (skip only the very first batch of the first event)
-                if (i > 0 or processed_batches > 0) and batch_throttle > 0:
-                    time.sleep(batch_throttle)
+                if (i > 0 or processed_batches > 0) and effective_throttle > 0:
+                    time.sleep(effective_throttle)
+
+                # PR-N4 adaptive backoff: if we've seen N consecutive 5xx
+                # failures, insert an extended cooldown BEFORE retrying.
+                # The @retry_with_backoff decorator on _push_batch retries
+                # internally with 10s × 2^n delay (max ~150s budget per
+                # batch); that's not enough when the underlying MISP is
+                # stuck OOMing. The cooldown gives MISP a real chance to
+                # recover before we send the next request.
+                if _consecutive_failures >= _backoff_threshold:
+                    logger.warning(
+                        "[PUSH] %d consecutive 5xx failures (>= threshold %d) — "
+                        "entering extended cooldown for %.0fs before next batch. "
+                        "MISP backend appears overwhelmed; check backend RAM / "
+                        "PHP memory_limit / MySQL innodb_buffer_pool_size — see "
+                        "docs/MISP_TUNING.md.",
+                        _consecutive_failures,
+                        _backoff_threshold,
+                        _backoff_cooldown_sec,
+                    )
+                    if _METRICS_AVAILABLE:
+                        try:
+                            _MISP_BACKOFF_TRIGGERED.labels(source=source).inc()
+                        except Exception:
+                            pass
+                    time.sleep(_backoff_cooldown_sec)
+                    # Reset the counter so we don't immediately re-pause
+                    # if the next batch ALSO fails — the @retry_with_backoff
+                    # gives it 4 attempts; if those fail, we'll re-trigger
+                    # the cooldown after another N consecutive batch-level
+                    # failures.
+                    _consecutive_failures = 0
 
                 # PR-F6 (Issue #65): parent-DAG liveness check BEFORE the
                 # next push. If the parent dag_run has been marked failed
@@ -1589,6 +1732,10 @@ class MISPWriter:
                 # bad event doesn't destroy a whole NVD push.
                 try:
                     success, failed = self._push_batch(event_id, batch)
+                    # PR-N4: success resets the consecutive-failure counter
+                    # (any single successful batch means MISP recovered)
+                    if success > 0 and failed == 0:
+                        _consecutive_failures = 0
                 except MispTransientError as exc:
                     logger.error(
                         "Batch %s for event %s failed after retries (%s) — counting batch as failed and continuing",
@@ -1598,6 +1745,19 @@ class MISPWriter:
                     )
                     success, failed = 0, len(batch)
                     self.stats["errors"] += 1
+                    # PR-N4: track for adaptive backoff (next iteration of
+                    # the inner loop will check this against threshold)
+                    _consecutive_failures += 1
+                    # PR-N4: emit Prometheus permanent-failure counter so
+                    # operators can alert on data loss rate. Pre-PR-N4 the
+                    # only signal was the log line above, which Bravo had
+                    # to hand-count from. ``source`` is the resolved
+                    # source string from the outer loop's ``grouped`` dict.
+                    if _METRICS_AVAILABLE:
+                        try:
+                            _MISP_PUSH_PERMANENT_FAILURES.labels(source=source, event_id=str(event_id)).inc()
+                        except Exception:
+                            pass
                 total_success += success
                 total_failed += failed
 

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -149,12 +149,21 @@ MISP_PUSH_DURATION = Histogram(
 # to hand-count from the logs because no metric existed. A non-zero
 # rate is the operator signal that MISP backend is undersized for the
 # current event size — see docs/MISP_TUNING.md for the tuning playbook.
+#
+# PR-N4 round 2 (Maintainer Dev #4, Bug Hunter #4): label set is
+# ``["source"]`` only. ``event_id`` was dropped because each MISP run
+# creates a new event (date-stamped name like ``EdgeGuard-otx-2026-04-21``),
+# which would balloon the time-series cardinality by ~365/year per source
+# (12 sources × 365 days = ~4.4K series/year just from this metric).
+# The actionable signal for operators is "is source X dropping batches?",
+# which ``source`` alone provides; the specific event_id is recoverable
+# from logs.
 MISP_PUSH_PERMANENT_FAILURES = Counter(
     "edgeguard_misp_push_permanent_failure_total",
     "MISP batch pushes that failed permanently after retry exhaustion. "
     "Each increment = one batch (typically 500 attributes) lost. "
     "See docs/MISP_TUNING.md for ops tuning playbook.",
-    ["source", "event_id"],
+    ["source"],
 )
 
 # PR-N4: adaptive backoff trigger — fires when the writer enters

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -142,6 +142,33 @@ MISP_PUSH_DURATION = Histogram(
     buckets=[0.5, 1.0, 2.5, 5.0, 10.0, 30.0, 60.0, 120.0],
 )
 
+# PR-N4: permanent batch failure after exhausting MISPWriter's
+# @retry_with_backoff(max_retries=4) on 5xx. The on-call report from
+# Bravo Vanko on 2026-04-21 had 7 OTX + 16 NVD batches × 500 attrs ≈
+# 11,500 attrs silently dropped during a 730-day baseline; Bravo had
+# to hand-count from the logs because no metric existed. A non-zero
+# rate is the operator signal that MISP backend is undersized for the
+# current event size — see docs/MISP_TUNING.md for the tuning playbook.
+MISP_PUSH_PERMANENT_FAILURES = Counter(
+    "edgeguard_misp_push_permanent_failure_total",
+    "MISP batch pushes that failed permanently after retry exhaustion. "
+    "Each increment = one batch (typically 500 attributes) lost. "
+    "See docs/MISP_TUNING.md for ops tuning playbook.",
+    ["source", "event_id"],
+)
+
+# PR-N4: adaptive backoff trigger — fires when the writer enters
+# extended-pause mode after N consecutive 5xx failures. Lets operators
+# distinguish "occasional flap MISP is recovering from" from "MISP is
+# sustained-degraded and we're throttling ourselves down."
+MISP_PUSH_BACKOFF_TRIGGERED = Counter(
+    "edgeguard_misp_push_backoff_triggered_total",
+    "Number of times MISPWriter entered extended-cooldown mode after "
+    "N consecutive HTTP 5xx batch failures (default N=3, see "
+    "EDGEGUARD_MISP_BACKOFF_THRESHOLD).",
+    ["source"],
+)
+
 MISP_HEALTH = Gauge("edgeguard_misp_health", "MISP health status (1=healthy, 0=unhealthy)", ["check_type"])
 
 # Neo4j metrics

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -91,16 +91,21 @@ class TestPushItemsHasAdaptiveScalingSourcePins:
             assert env in src, f"{env} env knob must be present + documented"
 
     def test_default_thresholds_are_sane(self):
-        """Defaults must match docs/MISP_TUNING.md."""
+        """Defaults must match docs/MISP_TUNING.md.
+
+        Round-2 update: env-var parsing now goes through the bounded
+        ``_bounded_int_env`` / ``_bounded_float_env`` helper, so the
+        default values appear as the second positional arg (an int /
+        float, not a string)."""
         src = self._read()
         # Large event = 50K
-        assert '"EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", "50000"' in src
+        assert '"EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", 50000' in src
         # Huge event = 100K
-        assert '"EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", "100000"' in src
+        assert '"EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", 100000' in src
         # Backoff after 3 consecutive failures
-        assert '"EDGEGUARD_MISP_BACKOFF_THRESHOLD", "3"' in src
+        assert '"EDGEGUARD_MISP_BACKOFF_THRESHOLD", 3' in src
         # 5-minute cooldown
-        assert '"EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "300.0"' in src
+        assert '"EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", 300.0' in src
 
     def test_three_tier_adaptive_logic_present(self):
         src = self._read()
@@ -115,23 +120,39 @@ class TestPushItemsHasAdaptiveScalingSourcePins:
 
     def test_consecutive_failure_tracking(self):
         src = self._read()
-        # Counter must be tracked, incremented on failure, reset on success
-        assert "_consecutive_failures" in src
-        assert "_consecutive_failures += 1" in src
-        assert "_consecutive_failures = 0" in src
+        # PR-N4 round 2 (Cross-Checker #2 / Bug Hunter #5): the counter
+        # is now an INSTANCE variable (self._misp_push_consecutive_failures)
+        # so it persists across push_items calls — see round-2 tests below.
+        assert "self._misp_push_consecutive_failures" in src
+        assert "self._misp_push_consecutive_failures += 1" in src
+        assert "self._misp_push_consecutive_failures = 0" in src
 
     def test_backoff_cooldown_call_present(self):
-        """When threshold hit, must sleep for the cooldown duration
-        (test that the time.sleep on the cooldown var is in source)."""
+        """When threshold hit, must sleep for the cooldown duration.
+
+        PR-N4 round 2 (Logic Tracker #1 / Prod Readiness #3): the
+        cooldown is now CHUNKED (30s steps with liveness-callback
+        between) rather than a single ``time.sleep(_backoff_cooldown_sec)``
+        — see test_cooldown_is_chunked_with_liveness for the round-2
+        pin. This test pins the existence of the cooldown logic via
+        the cooldown-var reference + chunked-sleep loop."""
         src = self._read()
-        assert "time.sleep(_backoff_cooldown_sec)" in src
+        # The cooldown variable must still drive a sleep loop
+        assert "_backoff_cooldown_sec" in src
+        # The chunked-sleep pattern (round 2 replacement for the single sleep)
+        assert "while _slept < _backoff_cooldown_sec:" in src
 
     def test_prometheus_failure_metric_increment(self):
         src = self._read()
-        # Permanent failure increments the counter with source + event_id labels
+        # PR-N4 round 2: permanent-failure metric now ``source``-only
+        # (event_id label dropped to keep cardinality bounded — each
+        # MISP run creates a date-stamped event id, which would explode
+        # the time-series count).
         assert "_MISP_PUSH_PERMANENT_FAILURES.labels(" in src
-        assert "source=source" in src
-        assert "event_id=str(event_id)" in src
+        assert "_MISP_PUSH_PERMANENT_FAILURES.labels(source=source).inc()" in src
+        # event_id label MUST NOT appear in the increment (regression
+        # pin: a future maintainer mustn't reintroduce it)
+        assert "_MISP_PUSH_PERMANENT_FAILURES.labels(source=source, event_id" not in src
 
     def test_prometheus_backoff_metric_increment(self):
         src = self._read()
@@ -154,7 +175,13 @@ class TestPrometheusMetricsDeclared:
         src = self._read()
         assert "MISP_PUSH_PERMANENT_FAILURES = Counter(" in src
         assert '"edgeguard_misp_push_permanent_failure_total"' in src
-        assert '["source", "event_id"]' in src
+        # PR-N4 round 2 (Maintainer Dev #4 / Bug Hunter #4): event_id
+        # label dropped — each MISP run creates a date-stamped event,
+        # which would explode Prometheus cardinality. Source-only label
+        # gives operators the actionable signal without the explosion.
+        assert '["source"]' in src
+        # Regression pin: event_id MUST NOT come back as a label
+        assert '["source", "event_id"]' not in src
 
     def test_backoff_triggered_counter_declared(self):
         src = self._read()
@@ -558,3 +585,441 @@ class TestAdaptiveBatchSizing:
         # Default tier: configured batch_size honored, so 200 items
         # = 1 batch of 200 (since 200 < 500)
         assert observed == [200], f"default tier should not downscale; got {observed}"
+
+
+# ===========================================================================
+# Bugbot round 2 + 7-agent audit regression pins (PR-N4 commit 53c66c1 → fix)
+# ===========================================================================
+
+
+class TestBugbotRound2Fixes:
+    """Pin the eight findings from the 7-agent comprehensive audit
+    (Red Team / Devil's Advocate / Maintainer Dev / Bug Hunter /
+    Cross-Checker / Logic Tracker / Prod Readiness) cross-referenced
+    with Bugbot round 2 on commit 53c66c1.
+
+      Fix #1  Validate all 4 env vars on parse (bounds + WARN on bad)
+      Fix #2  Drop ``event_id`` label from MISP_PUSH_PERMANENT_FAILURES
+              (cardinality explosion: each MISP run mints a new event_id)
+      Fix #3  Reset failure counter only after N **consecutive** full
+              successes (not on a single success — that masked flapping)
+      Fix #4  Promote ``_consecutive_failures`` to instance variable so
+              it persists across push_items calls
+      Fix #5  Chunked cooldown sleep + liveness check between chunks
+              (single ``time.sleep(300)`` blocked DAG-failure detection
+              for 5 min)
+      Fix #6  Validate ``HUGE > LARGE``; auto-swap + WARN if inverted
+      Fix #7  Update push_queue type annotation to 4-tuple
+      Fix #8  Sanitize ``event_id`` in log output (strip non-printable
+              + cap length 64)
+    """
+
+    def _src(self) -> str:
+        return (SRC / "collectors" / "misp_writer.py").read_text()
+
+    def _metrics(self) -> str:
+        return (SRC / "metrics_server.py").read_text()
+
+    def _docs(self) -> str:
+        return (REPO_ROOT / "docs" / "MISP_TUNING.md").read_text()
+
+    # -- Fix #1 ---------------------------------------------------------
+
+    def test_env_vars_use_bounded_helper(self):
+        """All 4 PR-N4 env vars must go through ``_bounded_int_env`` /
+        ``_bounded_float_env`` so bad operator input is caught + logged
+        instead of silently corrupting the adaptive logic."""
+        src = self._src()
+        assert "def _bounded_int_env(" in src, "round-2 helper missing"
+        assert "def _bounded_float_env(" in src, "round-2 helper missing"
+        # Each env var must be parsed via the bounded helper
+        for env in (
+            "EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD",
+            "EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD",
+            "EDGEGUARD_MISP_BACKOFF_THRESHOLD",
+        ):
+            assert f'_bounded_int_env(\n            "{env}"' in src or f'_bounded_int_env("{env}"' in src, (
+                f"{env} must be parsed via _bounded_int_env (round-2 Fix #1)"
+            )
+        assert "EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC" in src
+        assert "_bounded_float_env(" in src
+
+    def test_bounded_helper_warns_on_bad_input(self):
+        """The helper must log a WARNING (not silently default) so an
+        operator typo is visible in the logs."""
+        src = self._src()
+        helper_idx = src.find("def _bounded_int_env(")
+        assert helper_idx != -1
+        helper_body = src[helper_idx : helper_idx + 800]
+        assert "logger.warning" in helper_body, "_bounded_int_env must logger.warning on parse failure / out-of-range"
+
+    # -- Fix #2 ---------------------------------------------------------
+
+    def test_permanent_failure_counter_has_no_event_id_label(self):
+        """Cardinality regression pin: ``event_id`` must NOT be a label
+        on MISP_PUSH_PERMANENT_FAILURES (date-stamped → unbounded)."""
+        m = self._metrics()
+        # The Counter declaration block
+        idx = m.find("MISP_PUSH_PERMANENT_FAILURES = Counter(")
+        assert idx != -1
+        block = m[idx : idx + 500]
+        assert '["source"]' in block
+        assert '"event_id"' not in block, (
+            "Round-2 Fix #2 regression: event_id label was DROPPED for cardinality reasons; must not be reintroduced"
+        )
+
+    # -- Fix #3 ---------------------------------------------------------
+
+    def test_failure_counter_resets_only_after_consecutive_successes(self):
+        """The success branch must increment a ``_consecutive_successes``
+        counter and only reset failures after it crosses 2 — a single
+        success is not enough to declare recovery."""
+        src = self._src()
+        # Both counters must exist
+        assert "self._misp_push_consecutive_successes" in src
+        # Reset condition gated on >= 2 consecutive successes
+        success_idx = src.find("self._misp_push_consecutive_successes += 1")
+        assert success_idx != -1, "success branch must increment _consecutive_successes"
+        nearby = src[success_idx : success_idx + 400]
+        assert "self._misp_push_consecutive_successes >= 2" in nearby, (
+            "Round-2 Fix #3: reset only after >= 2 consecutive full successes"
+        )
+
+    # -- Fix #4 ---------------------------------------------------------
+
+    def test_consecutive_failures_is_instance_variable(self):
+        """Counter on ``self`` (not a function-local) so it persists
+        across push_items calls and a flapping backend eventually
+        trips the cooldown."""
+        src = self._src()
+        # No more bare ``_consecutive_failures = 0`` initialization
+        # at function scope (it's now ``self._misp_push_consecutive_failures``)
+        # — search for the bare assignment in active (non-comment) lines.
+        active = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+        # The bare local ``_consecutive_failures = 0`` initializer
+        # must be gone — only ``self._misp_push_consecutive_failures = 0``
+        # is allowed.
+        assert "        _consecutive_failures = 0" not in active, (
+            "Round-2 Fix #4 regression: failure counter must be instance-scoped, "
+            "not local — see round-2 rationale (cross-call persistence)"
+        )
+        # And the defensive hasattr-init pattern must be present
+        assert 'hasattr(self, "_misp_push_consecutive_failures")' in src
+
+    # -- Fix #5 ---------------------------------------------------------
+
+    def test_cooldown_is_chunked_with_liveness(self):
+        """The cooldown sleep must be chunked (≤30s steps) with the
+        liveness callback called between chunks — single 5-min
+        ``time.sleep(_backoff_cooldown_sec)`` blocked sibling DAG
+        failure detection."""
+        src = self._src()
+        # The chunked-loop pattern
+        assert "while _slept < _backoff_cooldown_sec:" in src
+        # Liveness callback called inside the loop
+        chunk_idx = src.find("while _slept < _backoff_cooldown_sec:")
+        assert chunk_idx != -1
+        chunk_body = src[chunk_idx : chunk_idx + 600]
+        assert "_liveness_cb_in_cooldown" in chunk_body
+        # The single bare time.sleep(_backoff_cooldown_sec) must be gone
+        assert "time.sleep(_backoff_cooldown_sec)" not in src, (
+            "Round-2 Fix #5 regression: cooldown must be chunked, not "
+            "a single time.sleep that blocks for the full duration"
+        )
+
+    # -- Fix #6 ---------------------------------------------------------
+
+    def test_threshold_inversion_warned_and_swapped(self):
+        """If an operator sets LARGE=100000, HUGE=50000 (inverted),
+        the writer must WARN and auto-swap so the tier resolution
+        produces semantically correct labels."""
+        src = self._src()
+        assert "_huge_threshold <= _large_threshold:" in src
+        # Warn + swap pattern
+        idx = src.find("_huge_threshold <= _large_threshold:")
+        block = src[idx : idx + 600]
+        assert "logger.warning" in block, "must warn on inversion"
+        assert "_large_threshold, _huge_threshold = _huge_threshold, _large_threshold" in block, (
+            "Round-2 Fix #6: must auto-swap inverted thresholds"
+        )
+
+    # -- Fix #7 ---------------------------------------------------------
+
+    def test_push_queue_type_annotation_is_4tuple(self):
+        """``push_queue`` annotation must reflect the 4-tuple shape
+        added in round 1 (Bugbot F1 + F2). Pre-fix the annotation said
+        2-tuple while the data was 4-tuple, silently misleading mypy."""
+        src = self._src()
+        assert "push_queue: List[Tuple[str, str, int, List[Dict]]] = []" in src, (
+            "Round-2 Fix #7: push_queue type annotation must match the "
+            "4-tuple actually used (source, event_id, existing_count, attrs)"
+        )
+
+    # -- Fix #8 ---------------------------------------------------------
+
+    def test_event_id_sanitized_in_error_log(self):
+        """``event_id`` going into the error log line must be sanitized
+        (printable-only, length-capped) — defense against
+        log-injection if the upstream MISP API ever returns a tainted
+        id."""
+        src = self._src()
+        # The sanitization pattern (loose match: ruff may inline or
+        # split the .join() call across lines depending on width).
+        # Required components: c.isprintable, str(event_id), [:64] cap.
+        assert "c.isprintable()" in src and "str(event_id)" in src and "[:64]" in src, (
+            "Round-2 Fix #8: event_id sanitization missing the isprintable / [:64] / str(event_id) pattern"
+        )
+        # Must use _safe_event_id in the error log call (not bare event_id)
+        log_idx = src.find('"Batch %s for event %s failed after retries')
+        assert log_idx != -1
+        log_block = src[log_idx : log_idx + 400]
+        assert "_safe_event_id" in log_block, (
+            "Round-2 Fix #8: error log line must use _safe_event_id, not the raw event_id"
+        )
+
+    # -- Doc round-2 additions -----------------------------------------
+
+    def test_runbook_has_prereq_section(self):
+        """Round-2 doc fix: a ``Prerequisites`` section telling
+        operators not to apply the TL;DR settings on a 4GB host."""
+        d = self._docs()
+        assert "Prerequisites" in d, "round-2 doc fix: prereq section missing"
+        assert "8 GB" in d or "8GB" in d, "round-2 doc fix: prereq must call out the 8GB minimum"
+
+    def test_runbook_has_rollback_section(self):
+        """Round-2 doc fix: a ``Rollback`` section so operators can
+        undo a tuning change cleanly."""
+        d = self._docs()
+        assert "Rollback" in d, "round-2 doc fix: rollback section missing"
+        assert "EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD=10000" in d, (
+            "round-2 doc fix: rollback must show conservative env values"
+        )
+
+    def test_runbook_documents_prefetch_dependency(self):
+        """Round-2 doc fix: the prefetch knob row must explain that
+        adaptive scaling DEPENDS on it (turning it off defeats the
+        whole point of PR-N4)."""
+        d = self._docs()
+        idx = d.find("EDGEGUARD_MISP_PREFETCH_EXISTING_ATTRS")
+        assert idx != -1
+        # Find the row containing the env var
+        row = d[idx : idx + 800]
+        assert "adaptive scaling" in row.lower() or "existing_attrs_count" in row.lower(), (
+            "round-2 doc fix: prefetch row must explain the adaptive-scaling dependency"
+        )
+
+
+# ===========================================================================
+# Behavioural — round-2 cross-call persistence + chunked cooldown
+# ===========================================================================
+
+
+class TestBugbotRound2Behavioural:
+    """Verify the round-2 invariants ACTUALLY hold at runtime, not just
+    in source. These complement the source pins in TestBugbotRound2Fixes
+    so a refactor that preserves the source patterns but breaks the
+    semantics still fails."""
+
+    def _make_writer(self):
+        from collectors.misp_writer import MISPWriter
+
+        w = MISPWriter.__new__(MISPWriter)
+        w.url = "http://test"
+        w.api_key = "test"
+        w.session = MagicMock()
+        w.verify_ssl = False
+        w.SOURCE_TAGS = {}
+        w.stats = {
+            "events_created": 0,
+            "events_existing": 0,
+            "attributes_added": 0,
+            "attrs_skipped_existing": 0,
+            "batches_sent": 0,
+            "errors": 0,
+        }
+        w.CONNECT_TIMEOUT = 30
+        w.READ_TIMEOUT = 60
+        return w
+
+    def test_failure_counter_persists_across_push_items_calls(self, monkeypatch):
+        """Fix #4 behaviour: two consecutive ``push_items`` calls each
+        producing 2 failures must accumulate to 4 on the writer
+        instance — pre-fix the counter reset to 0 every call."""
+        from collectors.misp_writer import MispTransientError
+
+        w = self._make_writer()
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-1")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "create_attribute", lambda item: {"type": "ip-dst", "value": item["value"]})
+        # Make every batch fail
+        monkeypatch.setattr(w, "_push_batch", MagicMock(side_effect=MispTransientError("simulated 500")))
+        # Disable the cooldown so the test doesn't trigger it (we're
+        # just measuring the counter, not the cooldown side-effect).
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_THRESHOLD", "100")
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+        # Call 1: 2 failures
+        items1 = [{"indicator_type": "ipv4", "value": f"1.0.0.{i}", "tag": "test"} for i in range(1, 3)]
+        w.push_items(items1, batch_size=1)
+        after_call_1 = w._misp_push_consecutive_failures
+        assert after_call_1 == 2, f"after first call counter should be 2, got {after_call_1}"
+
+        # Call 2: 2 more failures
+        items2 = [{"indicator_type": "ipv4", "value": f"2.0.0.{i}", "tag": "test"} for i in range(1, 3)]
+        w.push_items(items2, batch_size=1)
+        after_call_2 = w._misp_push_consecutive_failures
+        # Round-2 Fix #4: counter persists, so it's now 4 (2+2), not 2
+        assert after_call_2 == 4, (
+            f"Fix #4 regression: counter should accumulate across push_items calls (2+2=4); got {after_call_2}"
+        )
+
+    def test_failure_counter_only_resets_after_two_successes(self, monkeypatch):
+        """Fix #3 behaviour: a SINGLE successful batch between failure
+        clusters must NOT reset the counter (chronic flap masking).
+        Only after 2 consecutive successes does the counter reset."""
+        from collectors.misp_writer import MispTransientError
+
+        w = self._make_writer()
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-1")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "create_attribute", lambda item: {"type": "ip-dst", "value": item["value"]})
+
+        # fail, fail, success, fail, fail (the lone success must NOT reset)
+        push_results = iter(
+            [
+                MispTransientError("f1"),
+                MispTransientError("f2"),
+                (1, 0),  # one success
+                MispTransientError("f3"),
+                MispTransientError("f4"),
+            ]
+        )
+
+        def fake_push(event_id, batch):
+            r = next(push_results)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        monkeypatch.setattr(w, "_push_batch", fake_push)
+        # Disable cooldown so we can exclusively measure counter behaviour
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_THRESHOLD", "100")
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+        items = [{"indicator_type": "ipv4", "value": f"3.0.0.{i}", "tag": "test"} for i in range(1, 6)]
+        w.push_items(items, batch_size=1)
+
+        # Sequence is [fail, fail, success, fail, fail]:
+        #   Pre-Fix-#3 (BUGGY): counter = 0+1=1, +1=2, RESET=0, +1=1, +1=2
+        #     final = 2
+        #   Post-Fix-#3 (CORRECT): counter = 0+1=1, +1=2, (single success
+        #     does NOT reset; success_ct=1 < 2), +1=3, +1=4
+        #     final = 4
+        assert w._misp_push_consecutive_failures == 4, (
+            f"Fix #3 regression: a single successful batch between failure "
+            f"clusters reset the counter. After fail-fail-success-fail-fail "
+            f"the counter must be 4, got {w._misp_push_consecutive_failures}"
+        )
+
+    def test_two_consecutive_successes_DO_reset_failure_counter(self, monkeypatch):
+        """Fix #3 complement: two consecutive successes IS enough to
+        signal recovery, so the counter must reset."""
+        from collectors.misp_writer import MispTransientError
+
+        w = self._make_writer()
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-1")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "create_attribute", lambda item: {"type": "ip-dst", "value": item["value"]})
+
+        push_results = iter(
+            [
+                MispTransientError("f1"),
+                MispTransientError("f2"),
+                (1, 0),
+                (1, 0),  # 2 consecutive — should reset
+                MispTransientError("f3"),
+            ]
+        )
+
+        def fake_push(event_id, batch):
+            r = next(push_results)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        monkeypatch.setattr(w, "_push_batch", fake_push)
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_THRESHOLD", "100")
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+        items = [{"indicator_type": "ipv4", "value": f"4.0.0.{i}", "tag": "test"} for i in range(1, 6)]
+        w.push_items(items, batch_size=1)
+
+        # Sequence [fail, fail, success, success, fail]:
+        #   counter: 0,1,2, (success #1: success_ct=1 < 2, no reset; counter=2)
+        #            (success #2: success_ct=2 >= 2, RESET; counter=0)
+        #            +1 (final fail) = 1
+        assert w._misp_push_consecutive_failures == 1, (
+            f"Fix #3: after 2 consecutive successes the counter must reset "
+            f"to 0, then the final failure increments to 1; got "
+            f"{w._misp_push_consecutive_failures}"
+        )
+
+    def test_inverted_thresholds_auto_swap(self, monkeypatch, caplog):
+        """Fix #6 behaviour: setting LARGE > HUGE must auto-swap (with
+        a warning) so the tier resolution works correctly."""
+        import logging
+
+        w = self._make_writer()
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-1")
+        # Tiny event so we don't hit the adaptive tiers anyway
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "create_attribute", lambda item: {"type": "ip-dst", "value": item["value"]})
+        monkeypatch.setattr(w, "_push_batch", lambda eid, b: (len(b), 0))
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        # INVERTED: LARGE > HUGE
+        monkeypatch.setenv("EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", "100000")
+        monkeypatch.setenv("EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", "50000")
+
+        items = [{"indicator_type": "ipv4", "value": "9.0.0.1", "tag": "test"}]
+        with caplog.at_level(logging.WARNING):
+            w.push_items(items, batch_size=10)
+
+        # Must have warned about the inversion
+        assert any("inverted" in rec.message.lower() or "swap" in rec.message.lower() for rec in caplog.records), (
+            f"Fix #6: must warn on inverted thresholds; got log: {[r.message for r in caplog.records]}"
+        )
+
+    def test_bad_env_var_warns_and_uses_default(self, monkeypatch, caplog):
+        """Fix #1 behaviour: an out-of-bounds env value must trigger a
+        WARNING and fall back to the default (not silently use the
+        bad value)."""
+        import logging
+
+        w = self._make_writer()
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-1")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "create_attribute", lambda item: {"type": "ip-dst", "value": item["value"]})
+        monkeypatch.setattr(w, "_push_batch", lambda eid, b: (len(b), 0))
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        # Pre-fix this would silently configure threshold=0 → cooldown
+        # fires on the very first batch. Now must warn + use default.
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_THRESHOLD", "0")  # below floor of 1
+
+        items = [{"indicator_type": "ipv4", "value": "5.0.0.1", "tag": "test"}]
+        with caplog.at_level(logging.WARNING):
+            w.push_items(items, batch_size=10)
+
+        assert any("BACKOFF_THRESHOLD" in rec.message and "valid range" in rec.message for rec in caplog.records), (
+            f"Fix #1: bad env value must trigger WARNING via _bounded_int_env; "
+            f"got log: {[r.message for r in caplog.records]}"
+        )

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -678,6 +678,24 @@ class TestBugbotRound2Fixes:
         helper_body = src[helper_idx : helper_idx + 800]
         assert "logger.warning" in helper_body, "_bounded_int_env must logger.warning on parse failure / out-of-range"
 
+    def test_backoff_threshold_floor_is_2_not_1(self):
+        """Bugbot R4 (commit 001846b): the backoff-threshold floor must
+        be ``lo=2``, not ``lo=1``. Pre-fix the parsing accepted ``1``,
+        which would trigger the 5-min cooldown after a single
+        ``MispTransientError`` — defeating the @retry_with_backoff
+        layer's first-attempt-fail recovery and turning every
+        transient 5xx into a multi-hour stall.
+
+        The bounds-rationale comment said "require at least 2" but
+        the code said ``lo=1``. This test pins the corrected value
+        so the comment and code stay in sync."""
+        src = self._src()
+        assert '"EDGEGUARD_MISP_BACKOFF_THRESHOLD", 3, lo=2, hi=100' in src, (
+            "Bugbot R4: backoff threshold floor must be 2 to match the "
+            "comment intent ('require at least 2'). lo=1 would let a "
+            "single transient 5xx trip the 5-min cooldown."
+        )
+
     # -- Fix #2 ---------------------------------------------------------
 
     def test_permanent_failure_counter_has_no_event_id_label(self):

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -696,6 +696,80 @@ class TestBugbotRound2Fixes:
             "single transient 5xx trip the 5-min cooldown."
         )
 
+    def test_bounded_float_env_rejects_nan_and_inf(self, monkeypatch, caplog):
+        """Bugbot R5 (commit bb86c329): ``_bounded_float_env`` must
+        reject NaN and ±inf BEFORE the ``val < lo or val > hi`` bounds
+        check. Pre-fix NaN bypassed the bounds check (NaN compares
+        False against anything), then propagated to the cooldown
+        guard ``_backoff_cooldown_sec > 0`` which is also False for
+        NaN, silently DISABLING the adaptive cooldown — the exact
+        opposite of operator intent.
+
+        This test exercises the helper via the real ``push_items``
+        path (defined as a nested function inside push_items, so we
+        drive it with an environment variable) and asserts a WARN is
+        emitted with the "non-finite" diagnostic.
+        """
+        import logging
+
+        from collectors.misp_writer import MISPWriter
+
+        w = MISPWriter.__new__(MISPWriter)
+        w.url = "http://test"
+        w.api_key = "test"
+        w.session = MagicMock()
+        w.verify_ssl = False
+        w.SOURCE_TAGS = {}
+        w.stats = {
+            "events_created": 0,
+            "events_existing": 0,
+            "attributes_added": 0,
+            "attrs_skipped_existing": 0,
+            "batches_sent": 0,
+            "errors": 0,
+        }
+        w.CONNECT_TIMEOUT = 30
+        w.READ_TIMEOUT = 60
+
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-1")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "create_attribute", lambda item: {"type": "ip-dst", "value": item["value"]})
+        monkeypatch.setattr(w, "_push_batch", lambda eid, b: (len(b), 0))
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+        # Set NaN via string — float("nan") succeeds, so the parse
+        # branch in _bounded_float_env does NOT reject it. Only the
+        # new math.isfinite() guard catches it.
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "NaN")
+
+        items = [{"indicator_type": "ipv4", "value": "5.0.0.1", "tag": "test"}]
+        with caplog.at_level(logging.WARNING):
+            w.push_items(items, batch_size=10)
+
+        # Must have warned about non-finite
+        assert any("non-finite" in rec.message.lower() for rec in caplog.records), (
+            f"R5 regression: NaN must be caught as non-finite with a WARNING. "
+            f"Got logs: {[r.message for r in caplog.records]}"
+        )
+
+    def test_bounded_float_env_source_uses_isfinite(self):
+        """Source pin: the helper must use ``math.isfinite()`` (rejects
+        NaN and ±inf) rather than an isnan-only check. Using
+        ``math.isfinite`` provides belt-and-suspenders for +inf even
+        though +inf would also fail the upper bound — future refactors
+        that change the bounds shouldn't reopen the NaN door."""
+        src = self._src()
+        # Helper must exist
+        idx = src.find("def _bounded_float_env(")
+        assert idx != -1
+        body = src[idx : idx + 1500]
+        assert "math.isfinite" in body, (
+            "R5 fix must use math.isfinite() inside _bounded_float_env so NaN and ±inf are rejected together"
+        )
+        # import must be at module-level too
+        assert "\nimport math\n" in src, "module must `import math`"
+
     # -- Fix #2 ---------------------------------------------------------
 
     def test_permanent_failure_counter_has_no_event_id_label(self):

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -795,6 +795,21 @@ class TestBugbotRound2Fixes:
             "round-2 doc fix: rollback must show conservative env values"
         )
 
+    def test_runbook_covers_both_misp_images(self):
+        """Round-2 doc fix (post-commit, addressing colleague note):
+        the runbook must call out BOTH ``harvarditsecurity/misp`` (the
+        currently-deployed Apache mod_php image) and
+        ``coolacid/misp-docker`` (the reference php-fpm image). Pre-fix
+        the runbook only mentioned a generic Apache path, leaving
+        operators of the harvarditsecurity image unsure where to apply
+        settings vs operators of the coolacid image who needed the
+        ``conf.d/`` mount."""
+        d = self._docs()
+        assert "harvarditsecurity" in d, "doc fix: must call out the harvarditsecurity/misp image (currently deployed)"
+        assert "coolacid" in d, "doc fix: must call out the coolacid/misp-docker image (reference compose)"
+        assert "Apache mod_php" in d or "apache2" in d, "doc fix: must distinguish Apache vs php-fpm config paths"
+        assert "php-fpm" in d.lower() or "fpm/conf.d" in d, "doc fix: must distinguish Apache vs php-fpm config paths"
+
     def test_runbook_documents_prefetch_dependency(self):
         """Round-2 doc fix: the prefetch knob row must explain that
         adaptive scaling DEPENDS on it (turning it off defeats the

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -341,7 +341,17 @@ class TestAdaptiveBackoffBehavioural:
 
     def test_no_cooldown_when_failures_below_threshold(self, monkeypatch):
         """Two consecutive failures (below default threshold of 3)
-        must NOT trigger the cooldown."""
+        must NOT trigger the cooldown.
+
+        Bugbot catch (commit 02a94ba5): the previous assertion
+        ``999.0 not in sleep_calls`` was trivially true because the
+        round-2 chunked cooldown (``_chunk = 30.0``) would never call
+        ``time.sleep(999.0)`` — it would call ``time.sleep(30.0)``
+        many times. Replaced with a cumulative-sleep assertion that
+        actually distinguishes "cooldown fired" from "didn't fire":
+        if the cooldown fires, total sleep time must be >= the
+        env-configured cooldown; if it doesn't, total sleep time is 0
+        (since we force batch throttle to 0.0)."""
         from collectors.misp_writer import MispTransientError
 
         w = self._make_writer()
@@ -372,7 +382,12 @@ class TestAdaptiveBackoffBehavioural:
             return r
 
         monkeypatch.setattr(w, "_push_batch", fake_push)
-        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "999.0")  # would be glaring if it fired
+        # Use a SMALL cooldown value (1.5s) that ends up as ONE chunk
+        # (min(30.0, 1.5) = 1.5), so if the cooldown fires sleep_calls
+        # contains the value 1.5. All other sleeps in this test are
+        # throttles forced to 0.0, so 1.5 in sleep_calls uniquely
+        # identifies cooldown firing.
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "1.5")
         monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
         sleep_calls = []
         monkeypatch.setattr("time.sleep", lambda s: sleep_calls.append(s))
@@ -380,8 +395,18 @@ class TestAdaptiveBackoffBehavioural:
         items = [{"indicator_type": "ipv4", "value": f"10.0.0.{i}", "tag": "test"} for i in range(1, 6)]
         w.push_items(items, batch_size=1)
 
-        # Must NOT have invoked the 999s cooldown
-        assert 999.0 not in sleep_calls, f"cooldown fired below threshold; sleeps: {sleep_calls}"
+        # Primary assertion: total cumulative sleep must be ≈ 0. If the
+        # cooldown fired once it would contribute 1.5s; >=2 cooldowns
+        # would contribute 3.0s+. Throttles are 0.0 in this test.
+        total_sleep = sum(sleep_calls)
+        assert total_sleep < 0.5, (
+            f"cooldown fired below threshold (2 failures < default 3); "
+            f"total sleep time {total_sleep}s, calls: {sleep_calls}"
+        )
+        # Secondary assertion: the exact cooldown chunk value must not
+        # appear (belt-and-suspenders — catches the case where a future
+        # change sets cooldown=0 accidentally bypassing the sum check)
+        assert 1.5 not in sleep_calls, f"cooldown chunk value observed in sleeps below threshold; calls: {sleep_calls}"
 
 
 # ===========================================================================

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -1,0 +1,464 @@
+"""
+PR-N4 — MISP-at-scale hardening.
+
+Closes Prod Readiness #1 / #2 / #11 from the comprehensive 7-agent
+audit (``docs/flow_audits/09_comprehensive_audit.md``), motivated by
+the on-call report from 2026-04-21 where a 730-day baseline lost
+~11,500 attributes (7 OTX + 16 NVD batches × 500) silently to MISP
+HTTP 500 errors on large events.
+
+## What PR-N4 adds
+
+1. **Adaptive batch size + throttle** based on the existing event size:
+   - ``< 50K`` attrs:  configured defaults (typically 500 / 5s)
+   - ``50K – 100K``:   ``min(100, configured)`` / ``max(15s, configured)``
+   - ``>= 100K``:      ``min(50, configured)`` / ``max(30s, configured)``
+   Per-event, not per-collector — small events stay fast.
+
+2. **Adaptive backoff** after N consecutive 5xx batch failures:
+   - Default threshold: 3 failures (env ``EDGEGUARD_MISP_BACKOFF_THRESHOLD``)
+   - Default cooldown: 5 minutes (env ``EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC``)
+   - Reset on any successful batch
+   Pre-PR-N4 the ``@retry_with_backoff(max_retries=4, base_delay=10.0)``
+   gave only 10s × 2^n ≈ 150s budget per batch — not enough when MISP
+   is sustained-degraded.
+
+3. **Prometheus permanent-failure metric** ``edgeguard_misp_push_permanent_failure_total{source, event_id}``
+   — pre-PR-N4 the only signal was a log line operators had to
+   hand-count.
+
+4. **Backoff-triggered metric** ``edgeguard_misp_push_backoff_triggered_total{source}``
+   — distinguishes occasional flap from sustained backend overload.
+
+5. **Operator runbook** ``docs/MISP_TUNING.md`` with the field-tested
+   ``php.ini`` + ``my.cnf`` settings.
+
+## Test strategy
+
+Source-pin every behavioural change so a future refactor that
+removes the adaptive logic fails loudly. Behavioural sanity for the
+adaptive functions is exercised via ``MISPWriter.__new__`` +
+monkeypatched dependencies (the full push_items path requires a
+live MISP backend; we test the adaptive logic in isolation).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+# misp_writer requires NEO4J_PASSWORD via config import
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n4")
+
+
+# ===========================================================================
+# Source pins — adaptive scaling logic present in misp_writer.push_items
+# ===========================================================================
+
+
+class TestPushItemsHasAdaptiveScalingSourcePins:
+    """The adaptive-scaling logic in ``MISPWriter.push_items`` must
+    stay in source. A future cleanup that removed the tier branches
+    would silently re-introduce the on-call problem."""
+
+    def _read(self) -> str:
+        return (SRC / "collectors" / "misp_writer.py").read_text()
+
+    def test_imports_metrics_optionally(self):
+        src = self._read()
+        # The metrics are imported optionally so MISPWriter still
+        # works in CI / dev shells without prometheus_client
+        assert "MISP_PUSH_PERMANENT_FAILURES" in src
+        assert "MISP_PUSH_BACKOFF_TRIGGERED" in src
+        assert "_METRICS_AVAILABLE = True" in src
+        assert "_METRICS_AVAILABLE = False" in src
+
+    def test_threshold_envs_present(self):
+        src = self._read()
+        for env in (
+            "EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD",
+            "EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD",
+            "EDGEGUARD_MISP_BACKOFF_THRESHOLD",
+            "EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC",
+        ):
+            assert env in src, f"{env} env knob must be present + documented"
+
+    def test_default_thresholds_are_sane(self):
+        """Defaults must match docs/MISP_TUNING.md."""
+        src = self._read()
+        # Large event = 50K
+        assert '"EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD", "50000"' in src
+        # Huge event = 100K
+        assert '"EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD", "100000"' in src
+        # Backoff after 3 consecutive failures
+        assert '"EDGEGUARD_MISP_BACKOFF_THRESHOLD", "3"' in src
+        # 5-minute cooldown
+        assert '"EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "300.0"' in src
+
+    def test_three_tier_adaptive_logic_present(self):
+        src = self._read()
+        # Tier 1: huge (100K+) → batch_size=50, throttle=30s
+        assert "_huge_threshold" in src
+        assert "min(50, batch_size)" in src
+        assert "max(30.0, batch_throttle)" in src
+        # Tier 2: large (50K-100K) → batch_size=100, throttle=15s
+        assert "_large_threshold" in src
+        assert "min(100, batch_size)" in src
+        assert "max(15.0, batch_throttle)" in src
+
+    def test_consecutive_failure_tracking(self):
+        src = self._read()
+        # Counter must be tracked, incremented on failure, reset on success
+        assert "_consecutive_failures" in src
+        assert "_consecutive_failures += 1" in src
+        assert "_consecutive_failures = 0" in src
+
+    def test_backoff_cooldown_call_present(self):
+        """When threshold hit, must sleep for the cooldown duration
+        (test that the time.sleep on the cooldown var is in source)."""
+        src = self._read()
+        assert "time.sleep(_backoff_cooldown_sec)" in src
+
+    def test_prometheus_failure_metric_increment(self):
+        src = self._read()
+        # Permanent failure increments the counter with source + event_id labels
+        assert "_MISP_PUSH_PERMANENT_FAILURES.labels(" in src
+        assert "source=source" in src
+        assert "event_id=str(event_id)" in src
+
+    def test_prometheus_backoff_metric_increment(self):
+        src = self._read()
+        assert "_MISP_BACKOFF_TRIGGERED.labels(source=source).inc()" in src
+
+
+# ===========================================================================
+# Source pins — Prometheus metrics declared in metrics_server
+# ===========================================================================
+
+
+class TestPrometheusMetricsDeclared:
+    """The two new counters must exist in metrics_server.py with the
+    right metric names + label sets."""
+
+    def _read(self) -> str:
+        return (SRC / "metrics_server.py").read_text()
+
+    def test_permanent_failure_counter_declared(self):
+        src = self._read()
+        assert "MISP_PUSH_PERMANENT_FAILURES = Counter(" in src
+        assert '"edgeguard_misp_push_permanent_failure_total"' in src
+        assert '["source", "event_id"]' in src
+
+    def test_backoff_triggered_counter_declared(self):
+        src = self._read()
+        assert "MISP_PUSH_BACKOFF_TRIGGERED = Counter(" in src
+        assert '"edgeguard_misp_push_backoff_triggered_total"' in src
+        assert '["source"]' in src
+
+
+# ===========================================================================
+# Source pin — runbook exists at the documented location
+# ===========================================================================
+
+
+class TestRunbookExistsAndCoversCriticalSettings:
+    """``docs/MISP_TUNING.md`` must exist and contain the canonical
+    settings the README points to. Regression: a future docs cleanup
+    that deleted the runbook would orphan the README pointer."""
+
+    def _read(self) -> str:
+        return (REPO_ROOT / "docs" / "MISP_TUNING.md").read_text()
+
+    def test_runbook_exists(self):
+        path = REPO_ROOT / "docs" / "MISP_TUNING.md"
+        assert path.exists(), "docs/MISP_TUNING.md must exist (PR-N4 deliverable)"
+
+    def test_runbook_has_php_ini_settings(self):
+        src = self._read()
+        for setting in (
+            "memory_limit = 4096M",
+            "max_execution_time = 600",
+            "post_max_size = 256M",
+            "upload_max_filesize = 256M",
+            "max_input_vars = 50000",
+        ):
+            assert setting in src, f"runbook missing PHP setting: {setting}"
+
+    def test_runbook_has_mysql_settings(self):
+        src = self._read()
+        for setting in (
+            "innodb_buffer_pool_size = 4G",
+            "innodb_log_file_size = 512M",
+            "max_allowed_packet = 256M",
+            "wait_timeout = 600",
+        ):
+            assert setting in src, f"runbook missing MySQL setting: {setting}"
+
+    def test_runbook_documents_all_env_knobs(self):
+        """Every PR-N4 env knob in code must appear in the runbook so
+        operators can find what they're tuning."""
+        src = self._read()
+        for env in (
+            "EDGEGUARD_MISP_PUSH_BATCH_SIZE",
+            "EDGEGUARD_MISP_BATCH_THROTTLE_SEC",
+            "EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD",
+            "EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD",
+            "EDGEGUARD_MISP_BACKOFF_THRESHOLD",
+            "EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC",
+        ):
+            assert env in src, f"runbook missing env knob: {env}"
+
+    def test_readme_points_to_runbook(self):
+        readme = (REPO_ROOT / "README.md").read_text()
+        assert "docs/MISP_TUNING.md" in readme, (
+            "README must reference docs/MISP_TUNING.md so operators can find the playbook"
+        )
+
+
+# ===========================================================================
+# Behavioural — adaptive backoff cooldown actually fires when threshold hit
+# ===========================================================================
+
+
+class TestAdaptiveBackoffBehavioural:
+    """End-to-end check that the adaptive cooldown actually pauses
+    when consecutive failures hit threshold. Uses ``time.sleep``
+    monkeypatch to capture call args without actually sleeping."""
+
+    def _make_writer(self):
+        """Build a MISPWriter without going through __init__ (which
+        requires a live MISP)."""
+        from collectors.misp_writer import MISPWriter
+
+        w = MISPWriter.__new__(MISPWriter)
+        # Stub out all the things push_items touches
+        w.url = "http://test"
+        w.api_key = "test"
+        w.session = MagicMock()
+        w.verify_ssl = False
+        w.SOURCE_TAGS = {}
+        w.stats = {
+            "events_created": 0,
+            "events_existing": 0,
+            "attributes_added": 0,
+            "attrs_skipped_existing": 0,
+            "batches_sent": 0,
+            "errors": 0,
+        }
+        w.CONNECT_TIMEOUT = 30
+        w.READ_TIMEOUT = 60
+        return w
+
+    def test_extended_cooldown_fires_after_threshold(self, monkeypatch):
+        """Drive push_items with a mocked ``_push_batch`` that always
+        raises ``MispTransientError``. After 3 consecutive failures
+        (default threshold), the next iteration must call
+        ``time.sleep(_backoff_cooldown_sec)``."""
+        from collectors.misp_writer import MispTransientError
+
+        w = self._make_writer()
+
+        # Make _get_or_create_event return a fixed event id, no real MISP.
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-99")
+        # Make existing-attrs lookup return 0 so default tier is selected
+        # (not what we're testing here; we want consistent throttle).
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        # Make every batch fail with transient
+        monkeypatch.setattr(
+            w,
+            "_push_batch",
+            MagicMock(side_effect=MispTransientError("simulated 500")),
+        )
+        # Speed: env-tune the cooldown to a tiny value so the test
+        # finishes fast (we just want to verify it FIRED, not wait 5min).
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "0.01")
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        # Capture sleep calls
+        sleep_calls = []
+        real_sleep = __import__("time").sleep
+
+        def capture_sleep(secs):
+            sleep_calls.append(secs)
+            # Don't actually sleep — keep tests fast
+            real_sleep(0)
+
+        monkeypatch.setattr("time.sleep", capture_sleep)
+
+        # Build 5 items, batch_size=1, so we get 5 batch attempts.
+        # First 3 fail → 4th iteration triggers cooldown.
+        items = [{"indicator_type": "ipv4", "value": f"10.0.0.{i}", "tag": "test"} for i in range(1, 6)]
+        # Stub create_attribute so it doesn't crash on minimal item shape
+        monkeypatch.setattr(
+            w,
+            "create_attribute",
+            lambda item: {"type": "ip-dst", "value": item["value"]},
+        )
+
+        success, failed = w.push_items(items, batch_size=1)
+
+        # All 5 batches failed
+        assert success == 0
+        assert failed == 5
+        # The cooldown sleep (0.01s, our test override) must have been
+        # called at least once. Also the regular throttle sleeps (0.0s)
+        # appear, so check for the COOLDOWN value specifically.
+        assert 0.01 in sleep_calls, f"adaptive cooldown sleep did not fire; sleep calls: {sleep_calls}"
+
+    def test_no_cooldown_when_failures_below_threshold(self, monkeypatch):
+        """Two consecutive failures (below default threshold of 3)
+        must NOT trigger the cooldown."""
+        from collectors.misp_writer import MispTransientError
+
+        w = self._make_writer()
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-99")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(
+            w,
+            "create_attribute",
+            lambda item: {"type": "ip-dst", "value": item["value"]},
+        )
+
+        # First 2 batches fail, last 3 succeed — counter never reaches threshold
+        push_results = iter(
+            [
+                MispTransientError("fail 1"),
+                MispTransientError("fail 2"),
+                (1, 0),  # success
+                (1, 0),
+                (1, 0),
+            ]
+        )
+
+        def fake_push(event_id, batch):
+            r = next(push_results)
+            if isinstance(r, Exception):
+                raise r
+            return r
+
+        monkeypatch.setattr(w, "_push_batch", fake_push)
+        monkeypatch.setenv("EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC", "999.0")  # would be glaring if it fired
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        sleep_calls = []
+        monkeypatch.setattr("time.sleep", lambda s: sleep_calls.append(s))
+
+        items = [{"indicator_type": "ipv4", "value": f"10.0.0.{i}", "tag": "test"} for i in range(1, 6)]
+        w.push_items(items, batch_size=1)
+
+        # Must NOT have invoked the 999s cooldown
+        assert 999.0 not in sleep_calls, f"cooldown fired below threshold; sleeps: {sleep_calls}"
+
+
+# ===========================================================================
+# Behavioural — adaptive batch sizing kicks in for large events
+# ===========================================================================
+
+
+class TestAdaptiveBatchSizing:
+    """When the target event already has >= LARGE_THRESHOLD existing
+    attributes, ``push_items`` must downscale ``batch_size`` to 100
+    (large) or 50 (huge)."""
+
+    def _make_writer(self):
+        from collectors.misp_writer import MISPWriter
+
+        w = MISPWriter.__new__(MISPWriter)
+        w.url = "http://test"
+        w.api_key = "test"
+        w.session = MagicMock()
+        w.verify_ssl = False
+        w.SOURCE_TAGS = {}
+        w.stats = {
+            "events_created": 0,
+            "events_existing": 0,
+            "attributes_added": 0,
+            "attrs_skipped_existing": 0,
+            "batches_sent": 0,
+            "errors": 0,
+        }
+        w.CONNECT_TIMEOUT = 30
+        w.READ_TIMEOUT = 60
+        return w
+
+    def test_huge_event_uses_50_batch_size(self, monkeypatch):
+        """Existing attrs >= 100K → batch_size=50 (downscaled from
+        the default 500)."""
+
+        w = self._make_writer()
+        # Simulate a huge event: 120K existing attrs
+        huge_keys = {("ip-dst", f"10.{i // 65536}.{(i // 256) % 256}.{i % 256}") for i in range(120_000)}
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-HUGE")
+        monkeypatch.setattr(w, "_get_existing_attribute_keys", lambda *a, **k: huge_keys)
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(
+            w,
+            "create_attribute",
+            lambda item: {"type": "ip-dst", "value": item["value"]},
+        )
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+        # Track batch sizes the writer actually sends
+        observed_batch_sizes: list = []
+
+        def capture_batch(event_id, batch):
+            observed_batch_sizes.append(len(batch))
+            return len(batch), 0
+
+        monkeypatch.setattr(w, "_push_batch", capture_batch)
+
+        # 200 NEW items (not in huge_keys); default batch_size=500
+        # → without adaptive scaling, would be 1 batch of 200
+        # → with HUGE tier scaling, should be 4 batches of 50
+        items = [{"indicator_type": "ipv4", "value": f"203.0.113.{i}", "tag": "test"} for i in range(1, 201)]
+        w.push_items(items, batch_size=500)
+
+        # All batches must be <= 50 (the huge tier ceiling)
+        assert observed_batch_sizes, "no batches sent"
+        assert all(sz <= 50 for sz in observed_batch_sizes), (
+            f"huge-event tier should cap batch_size at 50; got {observed_batch_sizes}"
+        )
+        # Specifically: 200 items / 50 = 4 batches
+        assert sum(observed_batch_sizes) == 200
+        assert len(observed_batch_sizes) == 4
+
+    def test_default_tier_uses_configured_batch_size(self, monkeypatch):
+        """Existing attrs < 50K → use the configured batch_size as-is."""
+        w = self._make_writer()
+        # Tiny event: only 100 existing
+        monkeypatch.setattr(w, "_get_or_create_event", lambda *a, **k: "EID-TINY")
+        monkeypatch.setattr(
+            w, "_get_existing_attribute_keys", lambda *a, **k: {("ip-dst", f"x{i}") for i in range(100)}
+        )
+        monkeypatch.setattr(w, "_get_existing_source_attribute_keys", lambda *a, **k: set())
+        monkeypatch.setattr(
+            w,
+            "create_attribute",
+            lambda item: {"type": "ip-dst", "value": item["value"]},
+        )
+        monkeypatch.setenv("EDGEGUARD_MISP_BATCH_THROTTLE_SEC", "0.0")
+        monkeypatch.setattr("time.sleep", lambda s: None)
+
+        observed: list = []
+
+        def capture_batch(event_id, batch):
+            observed.append(len(batch))
+            return len(batch), 0
+
+        monkeypatch.setattr(w, "_push_batch", capture_batch)
+
+        # 200 new items, batch_size=500 default → 1 batch of 200 (no downscale)
+        items = [{"indicator_type": "ipv4", "value": f"198.51.100.{i}", "tag": "test"} for i in range(1, 201)]
+        w.push_items(items, batch_size=500)
+
+        # Default tier: configured batch_size honored, so 200 items
+        # = 1 batch of 200 (since 200 < 500)
+        assert observed == [200], f"default tier should not downscale; got {observed}"

--- a/tests/test_pr_n4_misp_at_scale_hardening.py
+++ b/tests/test_pr_n4_misp_at_scale_hardening.py
@@ -358,6 +358,102 @@ class TestAdaptiveBackoffBehavioural:
 
 
 # ===========================================================================
+# Bugbot round 1 regression pins (PR-N4 commit 8ae3f82 → fix)
+# ===========================================================================
+
+
+class TestBugbotRound1Fixes:
+    """Pin the four Bugbot findings on PR-N4 commit 8ae3f82 so they
+    can't silently regress:
+
+      F1 [HIGH] Prometheus metrics used stale ``source`` from outer loop
+      F2 [MED]  Duplicate ``_get_existing_attribute_keys`` call (30-60s
+                paginated fetch run twice on the exact large events
+                PR-N4 targets)
+      F3 [LOW]  ``total_batches`` used wrong batch_size after adaptive
+                scaling \u2192 progress log >100% and negative ETAs
+      F4 [MED]  ``except Exception: pass`` around metric increments
+                silently swallowed errors with no signal
+    """
+
+    def _read(self) -> str:
+        return (SRC / "collectors" / "misp_writer.py").read_text()
+
+    def test_push_queue_threads_source(self):
+        """F1: push_queue tuples must include ``source`` so the second
+        loop binds it correctly per-event instead of inheriting the
+        last value of the outer loop's ``source`` variable."""
+        src = self._read()
+        # 4-tuple form (source, event_id, existing_count, attrs)
+        assert "push_queue.append((source, event_id, len(per_event_keys), unique_attrs))" in src, (
+            "push_queue must thread (source, event_id, existing_count, attrs) "
+            "so per-event metric labels are correct in a multi-source push"
+        )
+        # Inner loop must unpack the 4-tuple
+        assert "for source, event_id, existing_attrs_count, unique_attrs in push_queue:" in src
+
+    def test_no_duplicate_existing_attrs_fetch_in_inner_loop(self):
+        """F2: the inner loop must NOT re-call
+        ``_get_existing_attribute_keys`` for adaptive scaling \u2014 that
+        data is now threaded through ``push_queue`` from the dedup
+        loop. Pre-fix the call ran a second time per event,
+        doubling the prefetch cost on the exact 50K-120K events
+        PR-N4 targets.
+
+        Strip Python comment lines first so the historical breadcrumb
+        explaining what was removed (which legitimately mentions the
+        function name) doesn't false-match."""
+        src = self._read()
+        loop_idx = src.find("for source, event_id, existing_attrs_count, unique_attrs in push_queue:")
+        assert loop_idx != -1, "inner push loop must use the threaded 4-tuple"
+        next_def = src.find("\n    def ", loop_idx)
+        inner_block = src[loop_idx:next_def] if next_def != -1 else src[loop_idx:]
+        # Strip whole-line ``#`` Python comments
+        active_inner = "\n".join(line for line in inner_block.splitlines() if not line.lstrip().startswith("#"))
+        assert "_get_existing_attribute_keys(event_id)" not in active_inner, (
+            "Bugbot F2 regression: inner loop must reuse the existing-count "
+            "threaded through push_queue, not re-fetch via "
+            "_get_existing_attribute_keys (30-60s paginated REST call)"
+        )
+
+    def test_total_batches_uses_adaptive_helper(self):
+        """F3: ``total_batches`` must be computed using the same
+        ``_adaptive_for`` helper as the inner loop, so progress
+        percentages are accurate when scaling kicks in."""
+        src = self._read()
+        assert "def _adaptive_for(existing_ct: int)" in src, (
+            "PR-N4 must define an _adaptive_for helper inside push_items"
+        )
+        assert "total_batches = sum(" in src
+        ts_idx = src.find("total_batches = sum(")
+        assert ts_idx != -1
+        ts_block = src[ts_idx : ts_idx + 400]
+        assert "_adaptive_for(existing_ct)" in ts_block, (
+            "Bugbot F3 regression: total_batches must use _adaptive_for "
+            "so progress reporting matches the actual batches sent"
+        )
+
+    def test_metric_except_blocks_log_with_exc_info(self):
+        """F4: the ``except Exception:`` blocks around metric
+        increments must log at DEBUG with ``exc_info=True``, not
+        silently ``pass``."""
+        src = self._read()
+        active = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+        for needle in ("MISP_BACKOFF_TRIGGERED.labels", "MISP_PUSH_PERMANENT_FAILURES.labels"):
+            label_idx = active.find(needle)
+            if label_idx == -1:
+                continue
+            block = active[label_idx : label_idx + 600]
+            assert "except Exception as _metric_err:" in block, (
+                f"Bugbot F4 regression: except block around {needle} must name the exception as _metric_err for logging"
+            )
+            assert "logger.debug(" in block and "exc_info=True" in block, (
+                f"Bugbot F4 regression: except block around {needle} must "
+                "log at DEBUG with exc_info=True (not silently swallow)"
+            )
+
+
+# ===========================================================================
 # Behavioural — adaptive batch sizing kicks in for large events
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

Closes **Prod Readiness #1 / #2 / #11** from the comprehensive 7-agent audit (`docs/flow_audits/09_comprehensive_audit.md`), motivated directly by the on-call report from 2026-04-21 where a 730-day baseline lost **~11,500 attributes** (7 OTX + 16 NVD batches × 500) silently to MISP HTTP 500 errors on large events.

## What this PR adds

### 1. Adaptive batch size + throttle (per event, not per collector)

| Existing event size | batch_size | throttle |
|---|---|---|
| `< 50 000` attrs | configured (default 500) | configured (default 5s) |
| `50 000 – 100 000` | `min(100, configured)` | `max(15s, configured)` |
| `>= 100 000` | `min(50, configured)` | `max(30s, configured)` |

Per-event lookup re-uses the existing `_get_existing_attribute_keys` prefetch — no extra MISP call. Thresholds env-tunable (`EDGEGUARD_MISP_LARGE_EVENT_THRESHOLD`, `EDGEGUARD_MISP_HUGE_EVENT_THRESHOLD`).

### 2. Adaptive backoff after sustained 5xx failures

After N consecutive batch-level transient failures (default **3**, env `EDGEGUARD_MISP_BACKOFF_THRESHOLD`), MISPWriter inserts an extended cooldown (default **5 min**, env `EDGEGUARD_MISP_BACKOFF_COOLDOWN_SEC`) before the next batch — gives MISP time to fully recover instead of hammering a struggling worker. Reset on success.

Pre-PR-N4, the `@retry_with_backoff(max_retries=4, base_delay=10.0)` gave only 10s × 2^n ≈ 150s budget per batch; that's not enough when MISP is sustained-degraded (the on-call scenario).

### 3. Two new Prometheus metrics

| Metric | Labels | Meaning |
|---|---|---|
| `edgeguard_misp_push_permanent_failure_total` | `source, event_id` | Each increment = one batch (~500 attrs) lost after retry exhaustion. **Pre-PR-N4 the only signal was a log line operators had to hand-count.** |
| `edgeguard_misp_push_backoff_triggered_total` | `source` | Each increment = entered extended cooldown. Distinguishes occasional flap from sustained backend overload. |

Both declared in `src/metrics_server.py` with suggested Prometheus alert rules in `docs/MISP_TUNING.md`.

### 4. Operator runbook: `docs/MISP_TUNING.md` (new, comprehensive)

Field-tested `php.ini` + `my.cnf` settings:

```ini
# php.ini
memory_limit = 4096M
max_execution_time = 600
post_max_size = 256M
upload_max_filesize = 256M
max_input_vars = 50000

# my.cnf
innodb_buffer_pool_size = 4G
innodb_log_file_size = 512M
max_allowed_packet = 256M
wait_timeout = 600
```

Plus: full env-knob reference, suggested alert rules, **symptom→setting cheat-sheet** for incidents, and pointer to the future event-sharding design.

### 5. README pointer

New "MISP backend tuning" subsection under In Progress so operators see the tuning requirement BEFORE they hit the 500s on a baseline run.

## Tests

`tests/test_pr_n4_misp_at_scale_hardening.py` — **19 tests across 4 classes**:

- **TestPushItemsHasAdaptiveScalingSourcePins** (8) — pin every adaptive knob, env name, threshold value, metric increment site
- **TestPrometheusMetricsDeclared** (2) — both counters in `metrics_server.py` with the right labels
- **TestRunbookExistsAndCoversCriticalSettings** (5) — runbook exists, has all PHP + MySQL settings, documents every env knob, README points to it
- **TestAdaptiveBackoffBehavioural** (2) — extended cooldown **fires at threshold** (captures `time.sleep` calls); **does NOT fire below threshold** (negative pin)
- **TestAdaptiveBatchSizing** (2) — huge event (120K existing) **downscales to 50/batch**; default tier (100 existing) keeps configured size

Full suite: **1183 passed, 3 skipped, 3 xfailed** (was 1164; +19 new tests).

## Diff

- `src/collectors/misp_writer.py` — adaptive logic (~120 LOC) + import
- `src/metrics_server.py` — 2 new Counter declarations
- `docs/MISP_TUNING.md` (new) — runbook
- `README.md` — pointer subsection
- `tests/test_pr_n4_misp_at_scale_hardening.py` (new) — 19 tests

Total: **~860 lines** (most of it docs + tests; ~150 LOC of code change).

## Operational note

The PR-N4 adaptive scaling makes the next baseline **survive un-tuned MISP**, but the `docs/MISP_TUNING.md` settings are still the right deployment-time posture. Adaptive batching alone, against a tiny PHP `memory_limit`, just fails slower; with the runbook applied, large events should push at near-default speed.

## Test plan

- [x] `pytest tests/test_pr_n4_misp_at_scale_hardening.py -v` — 19/19 pass
- [x] `pytest tests/ -k misp_writer` — 8/8 existing tests still pass (no regression)
- [x] `pytest tests/` — 1183/1183 pass
- [x] `ruff format --check src/ dags/ tests/` — clean
- [x] `ruff check src/ tests/` — clean
- [x] `mypy src/ --ignore-missing-imports` — clean
- [x] Behavioural tests confirm cooldown fires at threshold + downscale to 50/batch on huge events

## Related

Part of the PR-N series (PR-N0 #84 audit triage; PR-N1 #85, PR-N2 #86, PR-N3 #87 all merged). Directly addresses the on-call report from Bravo Vanko's 2026-04-21 OTX + NVD baseline.

Future work tracked: **event sharding** (cap each MISP event at ~25K attrs, auto-shard) — adaptive batching + the runbook are the immediate fix; sharding is the structural follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the core `MISPWriter.push_items` write path (batch sizing, throttling, and retry/backoff behavior) and adds new operational knobs/metrics; misconfiguration or logic bugs could slow ingestion or change failure handling under load.
> 
> **Overview**
> Improves large-event MISP ingestion by making `MISPWriter.push_items` **adapt batch size and throttle per target event size** and introduce an **extended cooldown** after sustained batch-level 5xx failures (with env-tunable thresholds and bounded validation).
> 
> Adds **Prometheus counters** for permanent batch loss and backoff triggers, plus optional metric imports to keep non-metrics environments working. Documentation is expanded with a new operator runbook `docs/MISP_TUNING.md`, README/SETUP references, and updated MISP reference compose/INI guidance for PHP/MySQL tuning and memory limits; a new test suite pins and exercises the adaptive behavior and metrics/label choices (including dropping `event_id` to avoid cardinality blowups).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d9be31347a35ecdf03fd3c7022e4206f26694d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->