### PR TITLE
fix(audit): PR-N5 — producer hardening bundle (B4 + B5 + C5 + C7)

### DIFF
--- a/src/baseline_checkpoint.py
+++ b/src/baseline_checkpoint.py
@@ -179,6 +179,42 @@ def _checkpoint_lock_path() -> Path:
     return CHECKPOINT_FILE.with_suffix(".lock")
 
 
+def _atomic_acquire_lock_fd(lock_path: Path) -> int:
+    """Atomically create-or-open the advisory lock file and return its fd.
+
+    PR-N5 B5 (Bug Hunter F10, audit 09): the prior pattern was:
+
+        lock_path.touch(exist_ok=True)   # step 1: ensure file exists
+        with open(lock_path, "r") as lf: # step 2: open for flock
+            fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+
+    Between steps 1 and 2, an aggressive cleanup process (systemd-tmpfiles,
+    tmpwatch, a ``find /tmp -mtime +N -delete`` cron, or a disk-pressure
+    GC) can unlink the file. ``open("r")`` on the vanished file then
+    raises ``FileNotFoundError``, aborting the checkpoint update — and
+    on retry the same race recurs. Worse, if two concurrent writers
+    both get past the ``touch`` but one gets the file unlinked and the
+    other opens the newly-recreated file, they're flocking DIFFERENT
+    inodes and the "exclusive" lock isn't exclusive at all.
+
+    ``os.open(path, O_CREAT | O_RDWR, 0o644)`` is atomic: the kernel
+    create-or-open step happens under the filesystem's inode lock.
+    Since we're only using the fd for ``fcntl.flock`` (advisory), we
+    don't need to write anything to it; 0-byte lock file is fine.
+
+    The caller is responsible for ``os.close(fd)`` — that releases the
+    flock atomically.  Normal pattern:
+
+        fd = _atomic_acquire_lock_fd(lock_path)
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            ...critical section...
+        finally:
+            os.close(fd)  # also releases the flock
+    """
+    return os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+
+
 def update_source_checkpoint(
     source: str,
     page: int = None,
@@ -196,9 +232,11 @@ def update_source_checkpoint(
     ``nvd_window_idx``, ``nvd_start_index``).
     """
     lock_path = _checkpoint_lock_path()
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r") as lf:
-        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+    # PR-N5 B5: atomic create-or-open (see _atomic_acquire_lock_fd
+    # docstring).  ``os.close(fd)`` in the finally releases the flock.
+    fd = _atomic_acquire_lock_fd(lock_path)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
         checkpoints = load_checkpoint()
 
         if source not in checkpoints:
@@ -233,6 +271,8 @@ def update_source_checkpoint(
 
         entry["updated_at"] = datetime.now(timezone.utc).isoformat()
         save_checkpoint(checkpoints)
+    finally:
+        os.close(fd)
 
 
 def get_source_incremental(source: str) -> dict:
@@ -251,9 +291,11 @@ def update_source_incremental(source: str, **kwargs) -> None:
     Uses the same advisory file lock as update_source_checkpoint.
     """
     lock_path = _checkpoint_lock_path()
-    lock_path.touch(exist_ok=True)
-    with open(lock_path, "r") as lf:
-        fcntl.flock(lf.fileno(), fcntl.LOCK_EX)
+    # PR-N5 B5: atomic create-or-open (see _atomic_acquire_lock_fd
+    # docstring).  ``os.close(fd)`` in the finally releases the flock.
+    fd = _atomic_acquire_lock_fd(lock_path)
+    try:
+        fcntl.flock(fd, fcntl.LOCK_EX)
         checkpoints = load_checkpoint()
         if source not in checkpoints:
             checkpoints[source] = {
@@ -267,6 +309,8 @@ def update_source_incremental(source: str, **kwargs) -> None:
         inc.update({k: v for k, v in kwargs.items() if v is not None})
         entry["updated_at"] = datetime.now(timezone.utc).isoformat()
         save_checkpoint(checkpoints)
+    finally:
+        os.close(fd)
 
 
 def clear_checkpoint(source: str = None, *, include_incremental: bool = False) -> None:

--- a/src/collectors/misp_collector.py
+++ b/src/collectors/misp_collector.py
@@ -277,7 +277,13 @@ class MISPCollector:
                     # If this attribute carries a CVE, emit a structured vulnerability node
                     # in addition to (or instead of) a generic indicator.
                     attr_type = attr.get("type", "")
-                    attr_value = attr.get("value", "")
+                    # PR-N5 B4 (Bug Hunter F3, audit 09): defensive
+                    # str-coerce. A buggy MISP relay returning
+                    # ``value: 12345`` (int, not str) would crash the
+                    # next line's ``.lower()`` with AttributeError
+                    # mid-batch, killing the whole event's processing.
+                    # Also handles None silently (``"" or ""`` is "").
+                    attr_value = str(attr.get("value", "") or "")
                     if attr_type == "vulnerability" or "cve" in attr_value.lower():
                         cve_val = self.extract_cve(attr_value)
                         if cve_val:

--- a/src/collectors/misp_collector.py
+++ b/src/collectors/misp_collector.py
@@ -282,8 +282,16 @@ class MISPCollector:
                     # ``value: 12345`` (int, not str) would crash the
                     # next line's ``.lower()`` with AttributeError
                     # mid-batch, killing the whole event's processing.
-                    # Also handles None silently (``"" or ""`` is "").
-                    attr_value = str(attr.get("value", "") or "")
+                    #
+                    # PR-N5 R1 Bugbot LOW (2026-04-21): earlier form
+                    # ``str(attr.get("value", "") or "")`` had a latent
+                    # falsy-int bug — ``0 or ""`` evaluates to ``""``
+                    # because ``0`` is falsy, so an integer zero value
+                    # silently became an empty string instead of ``"0"``.
+                    # Explicit ``is not None`` check handles zero / False
+                    # correctly; only None falls to the empty-string path.
+                    _raw_value = attr.get("value")
+                    attr_value = str(_raw_value) if _raw_value is not None else ""
                     if attr_type == "vulnerability" or "cve" in attr_value.lower():
                         cve_val = self.extract_cve(attr_value)
                         if cve_val:

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -38,6 +38,8 @@ from config import (
 # PR-N4: Prometheus metrics for permanent-failure counter + adaptive-
 # backoff trigger. Optional import so MISPWriter can run in environments
 # without prometheus_client installed (CI, dev shells, dry-run).
+#
+# PR-N5 C7: honest-NULL violation counter joins the same optional bundle.
 try:
     from metrics_server import (
         MISP_PUSH_BACKOFF_TRIGGERED as _MISP_BACKOFF_TRIGGERED,
@@ -46,17 +48,114 @@ try:
         MISP_PUSH_PERMANENT_FAILURES as _MISP_PUSH_PERMANENT_FAILURES,
     )
 
+    try:
+        from metrics_server import (
+            MISP_HONEST_NULL_VIOLATIONS as _MISP_HONEST_NULL_VIOLATIONS,
+        )
+    except ImportError:
+        # Older metrics_server without the PR-N5 counter — set to None so
+        # the guard below degrades gracefully without breaking the PR-N4
+        # metrics that ARE available.
+        _MISP_HONEST_NULL_VIOLATIONS = None  # type: ignore[assignment]
+
     _METRICS_AVAILABLE = True
 except ImportError:
     _METRICS_AVAILABLE = False
     _MISP_PUSH_PERMANENT_FAILURES = None  # type: ignore[assignment]
     _MISP_BACKOFF_TRIGGERED = None  # type: ignore[assignment]
+    _MISP_HONEST_NULL_VIOLATIONS = None  # type: ignore[assignment]
 
 # Suppress InsecureRequestWarning only when SSL verification is explicitly disabled.
 if not SSL_VERIFY:
     urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 logger = logging.getLogger(__name__)
+
+
+def _validate_honest_null(item: Dict[str, Any], source_hint: Optional[str] = None) -> None:
+    """PR-N5 C7 (Devil's Advocate F5, audit 09) — defensive runtime
+    guard for the PR-M2 honest-NULL invariant.
+
+    **Invariant under guard:** when a source does NOT report
+    ``first_seen`` / ``last_seen``, EdgeGuard stores NULL rather than
+    manufacturing a wall-clock substitute. Manufacturing substitutes
+    would turn ``n.source_reported_first_at`` into a lie — downstream
+    consumers couldn't distinguish "source said so" from "EdgeGuard
+    guessed".
+
+    **What this guard catches:** a future collector (or a future bug
+    in an existing one) that starts coercing a missing source timestamp
+    to ``datetime.now(timezone.utc).isoformat()``. Pre-guard that
+    corruption was invisible in the MISPWriter layer — nodes and edges
+    would just carry a fresh-looking ``source_reported_first_at``
+    indistinguishable from a real claim.
+
+    **Heuristic:** ``first_seen`` / ``last_seen`` values within
+    **±5 minutes of wall-clock NOW** are flagged. Real source claims
+    virtually never land in that window (even an NVD CVE published
+    "today" was published hours-to-days ago by the time we ingest it).
+    False positives are possible (e.g. a MISP attribute created right
+    now and immediately federated to us) but they're rare enough that
+    a WARN is the right disposition, not an exception.
+
+    **Action on violation:** logs a WARNING with structured context +
+    emits the ``edgeguard_misp_honest_null_violation_total`` Prometheus
+    counter so operators can alert on it. Does NOT raise — the point
+    is detection, not breaking a live push.
+    """
+    from datetime import datetime, timezone
+
+    from source_truthful_timestamps import coerce_iso
+
+    # ±5-minute window is a heuristic tuned for "this looks wall-clock NOW-ish".
+    # Real source claims are essentially never this fresh.
+    _suspicious_window_sec = 300.0
+    _now_epoch = datetime.now(timezone.utc).timestamp()
+
+    for field in ("first_seen", "last_seen"):
+        raw = item.get(field)
+        if raw is None or raw == "":
+            continue  # honest NULL — the desired case
+        iso = coerce_iso(raw)
+        if not iso:
+            continue  # unparseable, let the existing pathway log
+        try:
+            val_epoch = datetime.fromisoformat(iso.replace("Z", "+00:00")).timestamp()
+        except (ValueError, TypeError):
+            continue
+        delta = abs(val_epoch - _now_epoch)
+        if delta <= _suspicious_window_sec:
+            # Looks wall-clock NOW-ish.
+            source = source_hint or item.get("tag") or item.get("source") or "unknown"
+            if isinstance(source, list):
+                source = source[0] if source else "unknown"
+            logger.warning(
+                "[honest-NULL] Item %s=%r within ±%.0fs of wall-clock NOW "
+                "(delta=%.0fs, source=%s, item_type=%s, value=%r). "
+                "This is suspicious — real source claims are rarely that fresh. "
+                "Possible causes: (1) collector manufacturing a NOW() substitute "
+                "(violates PR-M2 honest-NULL invariant); (2) genuine MISP "
+                "attribute federated immediately after creation (rare). "
+                "If (1), check the collector's %s extraction path.",
+                field,
+                iso,
+                _suspicious_window_sec,
+                delta,
+                source,
+                item.get("type") or item.get("indicator_type") or "?",
+                item.get("value") or item.get("cve_id") or item.get("name") or "?",
+                field,
+            )
+            try:
+                if _METRICS_AVAILABLE:
+                    _MISP_HONEST_NULL_VIOLATIONS.labels(source=str(source), field=field).inc()
+            except Exception as _metric_err:
+                # Same non-silent pattern as the other metric guards.
+                logger.debug(
+                    "honest-NULL violation metric increment failed: %s",
+                    _metric_err,
+                    exc_info=True,
+                )
 
 
 def _apply_source_truthful_timestamps(attribute: Dict[str, Any], item: Dict[str, Any]) -> None:
@@ -101,6 +200,14 @@ def _apply_source_truthful_timestamps(attribute: Dict[str, Any], item: Dict[str,
     # source_truthful_timestamps module lives at src/ root; this
     # collector module is under src/collectors/).
     from source_truthful_timestamps import coerce_iso
+
+    # PR-N5 C7 (audit 09): runtime honest-NULL invariant check.
+    # Detects collectors that manufacture wall-clock-NOW substitutes
+    # instead of passing NULL through when the source is silent. See
+    # ``_validate_honest_null`` docstring for heuristic + rationale.
+    # Runs BEFORE the coerce_iso calls below so the raw item state
+    # is observed (the coerce helper could normalize differently).
+    _validate_honest_null(item)
 
     first_seen = coerce_iso(item.get("first_seen"))
     # last_modified (NVD / STIX) is accepted as an alias for last_seen.

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -112,7 +112,18 @@ def _validate_honest_null(item: Dict[str, Any], source_hint: Optional[str] = Non
     _suspicious_window_sec = 300.0
     _now_epoch = datetime.now(timezone.utc).timestamp()
 
-    for field in ("first_seen", "last_seen"):
+    # PR-N5 R2 Bugbot MED (2026-04-21): include ``last_modified`` in
+    # the field list. The downstream chokepoint
+    # ``_apply_source_truthful_timestamps`` reads ``last_modified`` as
+    # an alias for ``last_seen`` (NVD/STIX collectors emit it under
+    # this name) — so a collector that manufactures
+    # ``item["last_modified"] = NOW`` but leaves ``last_seen`` unset
+    # would propagate the wall-clock substitute into the MISP attribute
+    # as ``last_seen`` while bypassing the honest-NULL guard entirely.
+    # Adding ``"last_modified"`` to this loop closes the gap; the WARN
+    # message already templates ``%s=...`` so the violation reports
+    # the field as ``last_modified``, preserving the audit trail.
+    for field in ("first_seen", "last_seen", "last_modified"):
         raw = item.get(field)
         if raw is None or raw == "":
             continue  # honest NULL — the desired case

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -147,7 +147,19 @@ def _validate_honest_null(item: Dict[str, Any], source_hint: Optional[str] = Non
                 field,
             )
             try:
-                if _METRICS_AVAILABLE:
+                # PR-N5 R1 Bugbot LOW (2026-04-21): check the COUNTER
+                # itself for None, not just ``_METRICS_AVAILABLE``. When
+                # the outer ``metrics_server`` import succeeds (PR-N4
+                # counters are present) but the nested PR-N5 counter
+                # import fails (older metrics_server without the new
+                # counter — backward-compat path), ``_METRICS_AVAILABLE``
+                # stays ``True`` while ``_MISP_HONEST_NULL_VIOLATIONS``
+                # stays ``None``. ``None.labels(...)`` raises
+                # AttributeError — the try/except below catches it, but
+                # the DEBUG log fires on EVERY violation (noisy + lies
+                # about the true failure mode). Explicit None check
+                # avoids the exception path entirely in that case.
+                if _MISP_HONEST_NULL_VIOLATIONS is not None:
                     _MISP_HONEST_NULL_VIOLATIONS.labels(source=str(source), field=field).inc()
             except Exception as _metric_err:
                 # Same non-silent pattern as the other metric guards.

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -294,9 +294,26 @@ def build_campaign_nodes(neo4j_client) -> Dict:
                  min(coalesce(i_source_first, i.first_imported_at)) AS first_seen,
                  max(coalesce(i_source_last,  i.last_updated))      AS last_seen
             WHERE size(malware_list) > 0 AND indicator_total > 0
+            // PR-N5 C5 (Devil's Advocate F3, audit 09): deterministic
+            // zone ordering. ``apoc.coll.toSet()`` dedupes but preserves
+            // the INSERTION order of its input, which here comes from
+            // ``reduce()`` iterating ``all_indicators`` in the order
+            // ``collect(DISTINCT i)`` returned them — a Neo4j-internal
+            // iteration order that's non-deterministic across runs.
+            // Net: ``c.zone`` on the same logical campaign would come
+            // out ``["healthcare","energy"]`` one run and
+            // ``["energy","healthcare"]`` the next — same set, different
+            // list. Downstream diff tooling (Neo4j MERGE detect-change,
+            // STIX/GraphQL serialization) would flag the node as "updated"
+            // on every enrichment run even when nothing semantically changed,
+            // and dashboards/queries doing ``c.zone[0]`` would see the
+            // "primary" zone flicker. Wrapping in ``apoc.coll.sort()``
+            // pins the list to a stable alphabetical order.
             WITH a, malware_list, indicator_total, first_seen, last_seen,
-                 apoc.coll.toSet(
-                     reduce(z=[], ind IN all_indicators | z + coalesce(ind.zone, []))
+                 apoc.coll.sort(
+                     apoc.coll.toSet(
+                         reduce(z=[], ind IN all_indicators | z + coalesce(ind.zone, []))
+                     )
                  ) AS all_zones
             MERGE (c:Campaign {{name: a.name + ' Campaign'}})
             ON CREATE SET c.created_at = datetime(),

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -178,6 +178,24 @@ MISP_PUSH_BACKOFF_TRIGGERED = Counter(
     ["source"],
 )
 
+# PR-N5 C7: honest-NULL invariant violation counter. Fires when
+# MISPWriter's runtime validator spots an incoming item whose
+# ``first_seen`` / ``last_seen`` is suspiciously close to wall-clock
+# NOW (default ±5 min heuristic in ``_validate_honest_null``) —
+# a strong signal that a collector is manufacturing NOW() substitutes
+# instead of honoring the PR-M2 honest-NULL contract. Source-only
+# label keeps cardinality bounded (same reasoning as PR-N4 round 2:
+# ``event_id`` would explode time-series count).
+MISP_HONEST_NULL_VIOLATIONS = Counter(
+    "edgeguard_misp_honest_null_violation_total",
+    "Count of MISPWriter items flagged as violating the honest-NULL "
+    "invariant (first_seen / last_seen within ±5 min of wall-clock NOW, "
+    "a strong proxy for 'collector manufactured a NOW substitute instead "
+    "of passing NULL through'). Non-zero rate on a source indicates the "
+    "collector needs auditing.",
+    ["source", "field"],
+)
+
 MISP_HEALTH = Gauge("edgeguard_misp_health", "MISP health status (1=healthy, 0=unhealthy)", ["check_type"])
 
 # Neo4j metrics

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1411,9 +1411,15 @@ class MISPToNeo4jSync:
         # and is used as the ``value`` field on STIX SCOs (ipv4-addr /
         # domain-name / url / file). An int-typed MISP value would
         # crash ``re.match`` with TypeError and produce schema-invalid
-        # STIX bundles. ``str(... or "")`` handles both None and
-        # non-string types in one idiom.
-        value = str(attr.get("value", "") or "")
+        # STIX bundles.
+        #
+        # PR-N5 R1 Bugbot LOW (2026-04-21): earlier form
+        # ``str(attr.get("value", "") or "")`` had a latent falsy-int
+        # bug — ``0 or ""`` evaluates to ``""``, so integer zero values
+        # silently became empty strings. Explicit ``is not None`` check
+        # handles ``0`` / ``False`` correctly.
+        _raw_value = attr.get("value")
+        value = str(_raw_value) if _raw_value is not None else ""
         attr_uuid = attr.get("uuid", str(uuid.uuid4()))
 
         # PR-M2 §4-F3: build the timestamp envelope cleanly, separating

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1406,7 +1406,14 @@ class MISPToNeo4jSync:
         from datetime import datetime, timezone
 
         attr_type = attr.get("type", "")
-        value = attr.get("value", "")
+        # PR-N5 B4 (Bug Hunter F3, audit 09): defensive str-coerce.
+        # Downstream this ``value`` hits ``re.match()`` (line ~1595)
+        # and is used as the ``value`` field on STIX SCOs (ipv4-addr /
+        # domain-name / url / file). An int-typed MISP value would
+        # crash ``re.match`` with TypeError and produce schema-invalid
+        # STIX bundles. ``str(... or "")`` handles both None and
+        # non-string types in one idiom.
+        value = str(attr.get("value", "") or "")
         attr_uuid = attr.get("uuid", str(uuid.uuid4()))
 
         # PR-M2 §4-F3: build the timestamp envelope cleanly, separating

--- a/tests/test_pr_n5_producer_hardening.py
+++ b/tests/test_pr_n5_producer_hardening.py
@@ -1,0 +1,380 @@
+"""
+PR-N5 — Producer hardening bundle.
+
+Addresses four Tier-B / Tier-C findings from the 7-agent comprehensive
+audit (``docs/flow_audits/09_comprehensive_audit.md``):
+
+  B4 [MED]  ``attr.get("value", "").lower()`` crashes on int-typed MISP
+            value (Bug Hunter F3). One bad upstream attribute kills an
+            entire batch mid-flight.  Fix: defensive ``str(... or "")``
+            coerce at the two parse-entry points
+            (misp_collector.py:280, run_misp_to_neo4j.py:1409).
+
+  B5 [MED]  Checkpoint lock race: ``touch() + open("r")`` is non-atomic
+            (Bug Hunter F10). An aggressive cleanup between the two
+            syscalls can unlink the lock file, defeating the mutex and
+            corrupting checkpoint state under concurrent writers. Fix:
+            ``os.open(path, O_CREAT | O_RDWR)`` single atomic syscall.
+
+  C5 [MED]  Campaign zone reduce iterates ``collect(DISTINCT i)``
+            without ORDER BY (Devil's Advocate F3). ``apoc.coll.toSet``
+            preserves insertion order, so ``c.zone`` flickers between
+            different permutations of the same zone set across enrichment
+            runs — triggering spurious MERGE-detects-change on every
+            run. Fix: wrap in ``apoc.coll.sort()`` for deterministic
+            alphabetical order.
+
+  C7 [MED]  No collector-level runtime guard for the PR-M2 honest-NULL
+            invariant (Devil's Advocate F5). A future collector that
+            manufactures ``datetime.now()`` substitutes instead of
+            passing NULL through would corrupt downstream consumers
+            silently.  Fix: ``_validate_honest_null`` helper in MISPWriter
+            that flags ``first_seen`` / ``last_seen`` values within
+            ±5 min of wall-clock NOW and emits both a WARN and the
+            ``edgeguard_misp_honest_null_violation_total`` Prometheus
+            counter.
+
+## Test strategy
+
+Source pins for each fix + behavioural tests where feasible without a
+live MISP / Neo4j backend. B5's atomic lock is exercised against a real
+tempdir; the other three are source-pin + unit-level behavioural.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n5")
+
+
+# ===========================================================================
+# B4 — str-coerce attr value
+# ===========================================================================
+
+
+class TestB4StrCoerceAttrValue:
+    """Pin the defensive ``str(attr.get("value", "") or "")`` pattern
+    at the two parse-entry points. Pre-fix, an int-typed MISP value
+    would crash ``.lower()`` / ``re.match`` mid-batch."""
+
+    def test_misp_collector_str_coerces(self):
+        src = (SRC / "collectors" / "misp_collector.py").read_text()
+        assert 'attr_value = str(attr.get("value", "") or "")' in src, (
+            "misp_collector.py:280 must str-coerce attr.value to survive "
+            "upstream int/None values without crashing .lower() downstream"
+        )
+
+    def test_run_misp_to_neo4j_str_coerces(self):
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        assert 'value = str(attr.get("value", "") or "")' in src, (
+            "run_misp_to_neo4j.py (STIX build path) must str-coerce attr.value "
+            "so re.match() and STIX SCO value fields don't crash on int input"
+        )
+
+    def test_b4_behaviour_int_value_does_not_crash_lower(self):
+        """Direct behavioural check: given ``attr = {"value": 12345}``,
+        the coerce pattern must produce a string that survives
+        ``.lower()`` — NOT raise AttributeError."""
+        attr = {"value": 12345}
+        # The exact pattern shipped in the fix
+        attr_value = str(attr.get("value", "") or "")
+        # Must not raise
+        result = attr_value.lower()
+        assert result == "12345", f"expected '12345', got {result!r}"
+
+    def test_b4_behaviour_none_value_coerces_to_empty(self):
+        """``None`` in Python's ``or`` chain falls to ``""`` — lower()
+        works on empty string, no crash."""
+        attr = {"value": None}
+        attr_value = str(attr.get("value", "") or "")
+        assert attr_value == ""
+        assert attr_value.lower() == ""  # no crash
+
+    def test_b4_behaviour_missing_value_coerces_to_empty(self):
+        """No ``value`` key at all — default ``""`` kicks in."""
+        attr = {}
+        attr_value = str(attr.get("value", "") or "")
+        assert attr_value == ""
+
+
+# ===========================================================================
+# B5 — atomic checkpoint lock
+# ===========================================================================
+
+
+class TestB5AtomicCheckpointLock:
+    """Pin the atomic-acquire helper + removal of the prior
+    ``touch() + open("r")`` pattern."""
+
+    def _read(self) -> str:
+        return (SRC / "baseline_checkpoint.py").read_text()
+
+    def test_atomic_helper_exists(self):
+        src = self._read()
+        assert "def _atomic_acquire_lock_fd(" in src, (
+            "B5 fix: _atomic_acquire_lock_fd helper must exist as the single chokepoint for atomic lock acquisition"
+        )
+        # Must use O_CREAT | O_RDWR (single-syscall create-or-open)
+        assert "os.O_CREAT | os.O_RDWR" in src, "B5: helper must use O_CREAT | O_RDWR"
+
+    def test_no_racy_touch_then_open_pattern(self):
+        """The prior pattern ``lock_path.touch(exist_ok=True)`` followed
+        by ``open(lock_path, "r")`` must not appear in **executable**
+        code.
+
+        Parse the module with ``ast`` and walk call nodes rather than
+        string-matching, so the breadcrumb mention in
+        ``_atomic_acquire_lock_fd``'s docstring (which intentionally
+        quotes the old broken pattern to explain why we're not using it)
+        doesn't false-match."""
+        import ast
+
+        src = self._read()
+        tree = ast.parse(src)
+
+        # Walk every Attribute access; flag any `<x>.touch(exist_ok=True)`
+        # that's an actual function call, not a string.
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute):
+                if node.func.attr == "touch":
+                    # Confirm the kwarg is exist_ok=True to match the specific pattern
+                    for kw in node.keywords or []:
+                        if kw.arg == "exist_ok" and isinstance(kw.value, ast.Constant) and kw.value.value is True:
+                            raise AssertionError(
+                                f"B5 regression at line {node.lineno}: found "
+                                f"executable `.touch(exist_ok=True)` call — the "
+                                f"non-atomic pattern must be fully removed from "
+                                f"active code; use _atomic_acquire_lock_fd"
+                            )
+
+    def test_update_source_checkpoint_uses_atomic_helper(self):
+        src = self._read()
+        # Both public APIs that take the lock must route through the
+        # atomic helper, not re-invent the touch+open sequence.
+        assert "update_source_checkpoint" in src
+        assert "update_source_incremental" in src
+        # Two call sites minimum (both updaters)
+        assert src.count("_atomic_acquire_lock_fd(lock_path)") >= 2, (
+            "B5: both update_source_checkpoint and update_source_incremental must use the atomic helper"
+        )
+
+    def test_b5_behaviour_lock_acquires_when_file_missing(self, tmp_path):
+        """Real-filesystem check: the helper must create-and-open in a
+        single atomic step, even when the path doesn't exist."""
+        import fcntl
+
+        # Import the helper directly
+        from baseline_checkpoint import _atomic_acquire_lock_fd
+
+        lock_path = tmp_path / "foo.lock"
+        assert not lock_path.exists(), "precondition: lock file must not exist"
+
+        fd = _atomic_acquire_lock_fd(lock_path)
+        try:
+            assert lock_path.exists(), "helper must create the file"
+            # flock should work on the returned fd
+            fcntl.flock(fd, fcntl.LOCK_EX)
+            # Release & close
+            fcntl.flock(fd, fcntl.LOCK_UN)
+        finally:
+            os.close(fd)
+
+    def test_b5_behaviour_lock_reacquires_after_external_unlink(self, tmp_path):
+        """The pre-fix bug was: between touch() and open("r"), an
+        external unlink could vanish the file. Our atomic helper must
+        handle that gracefully on subsequent acquisition (create again).
+        This test simulates tmpwatch / systemd-tmpfiles removing the
+        file between acquisitions."""
+        from baseline_checkpoint import _atomic_acquire_lock_fd
+
+        lock_path = tmp_path / "foo2.lock"
+
+        # Acquire once, close
+        fd = _atomic_acquire_lock_fd(lock_path)
+        os.close(fd)
+        assert lock_path.exists()
+
+        # External agent unlinks the file
+        lock_path.unlink()
+        assert not lock_path.exists()
+
+        # Re-acquire — must not raise; the O_CREAT re-creates it
+        fd2 = _atomic_acquire_lock_fd(lock_path)
+        try:
+            assert lock_path.exists()
+        finally:
+            os.close(fd2)
+
+
+# ===========================================================================
+# C5 — Campaign zone deterministic ordering
+# ===========================================================================
+
+
+class TestC5CampaignZoneOrdering:
+    """Pin ``apoc.coll.sort()`` wrap on the Campaign zone reduce so
+    ``c.zone`` doesn't flicker across enrichment runs."""
+
+    def _read(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def test_all_zones_wrapped_in_sort(self):
+        src = self._read()
+        assert "apoc.coll.sort(" in src, "C5 fix: must use apoc.coll.sort for deterministic zone ordering"
+        # The sort must wrap the toSet+reduce combo, not appear somewhere
+        # unrelated. Look for the specific ordering.
+        idx = src.find("AS all_zones")
+        assert idx != -1
+        # Scan backwards 600 chars for the sort wrapping the toSet
+        window = src[max(0, idx - 600) : idx + 50]
+        assert "apoc.coll.sort(" in window and "apoc.coll.toSet(" in window, (
+            "C5 regression: the all_zones reduce must be wrapped "
+            "apoc.coll.sort(apoc.coll.toSet(reduce(...))) for deterministic order"
+        )
+        # Order: sort should be OUTSIDE toSet (sorts the dedupe'd result)
+        sort_idx = window.find("apoc.coll.sort(")
+        toset_idx = window.find("apoc.coll.toSet(")
+        assert sort_idx < toset_idx, "sort must wrap toSet (sort(toSet(...)))"
+
+
+# ===========================================================================
+# C7 — honest-NULL validator
+# ===========================================================================
+
+
+class TestC7HonestNullValidator:
+    """Pin the validator helper + its integration into the timestamp
+    chokepoint + the Prometheus metric."""
+
+    def _src(self) -> str:
+        return (SRC / "collectors" / "misp_writer.py").read_text()
+
+    def _metrics(self) -> str:
+        return (SRC / "metrics_server.py").read_text()
+
+    def test_validator_helper_defined(self):
+        src = self._src()
+        assert "def _validate_honest_null(" in src, "C7: _validate_honest_null helper must be defined in misp_writer.py"
+
+    def test_validator_called_from_timestamp_chokepoint(self):
+        """The single chokepoint ``_apply_source_truthful_timestamps`` must
+        call ``_validate_honest_null`` so EVERY collector's items flow
+        through the guard."""
+        src = self._src()
+        apply_idx = src.find("def _apply_source_truthful_timestamps(")
+        assert apply_idx != -1
+        next_def_idx = src.find("\ndef ", apply_idx + 1)
+        block = src[apply_idx : next_def_idx if next_def_idx != -1 else apply_idx + 3000]
+        assert "_validate_honest_null(item)" in block, (
+            "C7 regression: _apply_source_truthful_timestamps must call "
+            "_validate_honest_null(item) so every collector's timestamps "
+            "flow through the guard"
+        )
+
+    def test_validator_emits_warn_not_exception(self):
+        """Implementation guard: the validator must NOT raise — the
+        point is detection, not breaking a live push."""
+        src = self._src()
+        helper_idx = src.find("def _validate_honest_null(")
+        assert helper_idx != -1
+        next_def_idx = src.find("\ndef ", helper_idx + 1)
+        body = src[helper_idx : next_def_idx if next_def_idx != -1 else helper_idx + 3500]
+        assert "logger.warning(" in body, "C7: validator must logger.warning"
+        # No `raise` statements in the validator body (allowed only for
+        # re-raise after our own handling — here we must never raise)
+        active = "\n".join(line for line in body.splitlines() if not line.lstrip().startswith("#"))
+        assert "\n            raise" not in active and "\n        raise" not in active, (
+            "C7: validator must NOT raise; detection only, don't break pushes"
+        )
+
+    def test_honest_null_counter_declared_in_metrics_server(self):
+        m = self._metrics()
+        assert "MISP_HONEST_NULL_VIOLATIONS = Counter(" in m
+        assert '"edgeguard_misp_honest_null_violation_total"' in m
+        # Bounded labels (cardinality discipline from PR-N4 round 2)
+        assert '["source", "field"]' in m
+
+    def test_honest_null_counter_imported_optionally(self):
+        """The counter import must be inside the optional try/except so
+        MISPWriter still works on systems without prometheus_client."""
+        src = self._src()
+        assert "MISP_HONEST_NULL_VIOLATIONS as _MISP_HONEST_NULL_VIOLATIONS" in src
+        assert "_MISP_HONEST_NULL_VIOLATIONS = None" in src, (
+            "C7: optional-import graceful degradation — _MISP_HONEST_NULL_VIOLATIONS "
+            "must be None when prometheus_client isn't available"
+        )
+
+    def test_c7_behaviour_validator_warns_on_now_timestamp(self, caplog):
+        """Drive the validator with a wall-clock-NOW-ish timestamp and
+        assert the WARN fires. This is the scenario the guard exists
+        to catch: a collector silently manufacturing a NOW() substitute
+        instead of passing NULL."""
+        import logging
+        from datetime import datetime, timezone
+
+        from collectors.misp_writer import _validate_honest_null
+
+        # Build an item with first_seen = NOW (simulates manufactured substitute)
+        now_iso = datetime.now(timezone.utc).isoformat()
+        item = {
+            "type": "ipv4",
+            "indicator_type": "ipv4",
+            "value": "198.51.100.77",
+            "tag": "otx",
+            "first_seen": now_iso,
+        }
+        with caplog.at_level(logging.WARNING):
+            _validate_honest_null(item)
+
+        assert any("honest-NULL" in rec.message for rec in caplog.records), (
+            f"C7 behaviour: validator must WARN on a NOW-adjacent first_seen. "
+            f"Got logs: {[r.message for r in caplog.records]}"
+        )
+
+    def test_c7_behaviour_validator_quiet_on_old_timestamp(self, caplog):
+        """The validator must NOT warn on a legitimate historical claim
+        (e.g. a CVE published in 2021 whose ``first_seen`` reflects the
+        real source timestamp). False-positive rate must stay low or
+        operators will learn to ignore the warning."""
+        import logging
+
+        from collectors.misp_writer import _validate_honest_null
+
+        # An old CVE — source-truthful first_seen from 2021
+        item = {
+            "type": "vulnerability",
+            "cve_id": "CVE-2021-44228",
+            "value": "CVE-2021-44228",
+            "tag": "nvd",
+            "first_seen": "2021-12-09T00:00:00Z",
+        }
+        with caplog.at_level(logging.WARNING):
+            _validate_honest_null(item)
+
+        assert not any("honest-NULL" in rec.message for rec in caplog.records), (
+            f"C7 false-positive: validator must stay quiet on legitimate "
+            f"historical claims. Got logs: {[r.message for r in caplog.records]}"
+        )
+
+    def test_c7_behaviour_validator_quiet_on_null(self, caplog):
+        """The HAPPY path: ``first_seen`` is None / absent (collector
+        correctly passed NULL through). Validator must be silent."""
+        import logging
+
+        from collectors.misp_writer import _validate_honest_null
+
+        item = {"type": "domain", "value": "example.test", "tag": "otx"}  # no first_seen
+        with caplog.at_level(logging.WARNING):
+            _validate_honest_null(item)
+
+        assert not any("honest-NULL" in rec.message for rec in caplog.records), (
+            "C7: validator must be silent when first_seen is absent (honest-NULL case)"
+        )

--- a/tests/test_pr_n5_producer_hardening.py
+++ b/tests/test_pr_n5_producer_hardening.py
@@ -65,44 +65,144 @@ class TestB4StrCoerceAttrValue:
     at the two parse-entry points. Pre-fix, an int-typed MISP value
     would crash ``.lower()`` / ``re.match`` mid-batch."""
 
+    # NOTE: the shipped coerce idiom was revised in response to Bugbot
+    # R1 LOW (2026-04-21 "Falsy integer values silently coerced to empty
+    # string"). The first form ``str(attr.get("value", "") or "")`` had
+    # a latent bug: ``0 or ""`` evaluates to ``""`` because 0 is falsy,
+    # so an integer zero silently became empty string. The corrected
+    # form uses explicit ``is not None`` — see
+    # ``test_b4_bugbot_r1_zero_preserved`` below for the regression pin.
+
+    _EXPECTED_COERCE_SNIPPET = (
+        '_raw_value = attr.get("value")\n'
+        '                    attr_value = str(_raw_value) if _raw_value is not None else ""'
+    )
+
+    @staticmethod
+    def _file_has_buggy_or_idiom(src: str) -> bool:
+        """AST-walk: return True iff any executable ``str(attr.get("value",
+        "") or "")`` expression exists in ``src``. Walks the AST rather
+        than string-matching so that the breadcrumb comment in the fix
+        commit — which intentionally quotes the old buggy idiom to
+        explain what was broken — doesn't false-match.
+        """
+        import ast
+
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            # Looking for ``str(<BoolOp or=[<attr.get(...)>, Constant("")]>``
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "str"
+                and len(node.args) == 1
+                and isinstance(node.args[0], ast.BoolOp)
+                and isinstance(node.args[0].op, ast.Or)
+            ):
+                # Check left operand is an attr.get("value", ...) call
+                or_expr = node.args[0]
+                if len(or_expr.values) != 2:
+                    continue
+                lhs, rhs = or_expr.values
+                if not (isinstance(lhs, ast.Call) and isinstance(lhs.func, ast.Attribute) and lhs.func.attr == "get"):
+                    continue
+                if not lhs.args or not (isinstance(lhs.args[0], ast.Constant) and lhs.args[0].value == "value"):
+                    continue
+                if not (isinstance(rhs, ast.Constant) and rhs.value == ""):
+                    continue
+                return True
+        return False
+
     def test_misp_collector_str_coerces(self):
         src = (SRC / "collectors" / "misp_collector.py").read_text()
-        assert 'attr_value = str(attr.get("value", "") or "")' in src, (
-            "misp_collector.py:280 must str-coerce attr.value to survive "
-            "upstream int/None values without crashing .lower() downstream"
+        # Current form: explicit ``is not None`` guard (Bugbot R1 fix)
+        assert '_raw_value = attr.get("value")' in src, (
+            "misp_collector.py must extract value via an intermediate variable"
+        )
+        assert 'attr_value = str(_raw_value) if _raw_value is not None else ""' in src, (
+            "misp_collector.py must use explicit is-not-None coerce so integer "
+            "zero / False don't collapse to empty string (Bugbot PR-N5 R1)"
+        )
+        # Regression pin: the old buggy idiom must NOT appear as executable code
+        assert not self._file_has_buggy_or_idiom(src), (
+            "Bugbot PR-N5 R1 regression: the `str(attr.get('value','') or '')` "
+            "idiom silently drops falsy values (0, False) — must stay out of "
+            "executable code"
         )
 
     def test_run_misp_to_neo4j_str_coerces(self):
         src = (SRC / "run_misp_to_neo4j.py").read_text()
-        assert 'value = str(attr.get("value", "") or "")' in src, (
-            "run_misp_to_neo4j.py (STIX build path) must str-coerce attr.value "
-            "so re.match() and STIX SCO value fields don't crash on int input"
+        assert '_raw_value = attr.get("value")' in src, (
+            "run_misp_to_neo4j.py (STIX build path) must extract value via an intermediate variable"
         )
+        assert 'value = str(_raw_value) if _raw_value is not None else ""' in src, (
+            "run_misp_to_neo4j.py must use explicit is-not-None coerce so "
+            "integer zero / False don't collapse to empty string"
+        )
+        assert not self._file_has_buggy_or_idiom(src), "Bugbot PR-N5 R1 regression pin"
 
     def test_b4_behaviour_int_value_does_not_crash_lower(self):
         """Direct behavioural check: given ``attr = {"value": 12345}``,
         the coerce pattern must produce a string that survives
         ``.lower()`` — NOT raise AttributeError."""
         attr = {"value": 12345}
-        # The exact pattern shipped in the fix
-        attr_value = str(attr.get("value", "") or "")
+        # The exact pattern shipped in the Bugbot-R1 fix
+        _raw = attr.get("value")
+        attr_value = str(_raw) if _raw is not None else ""
         # Must not raise
         result = attr_value.lower()
         assert result == "12345", f"expected '12345', got {result!r}"
 
     def test_b4_behaviour_none_value_coerces_to_empty(self):
-        """``None`` in Python's ``or`` chain falls to ``""`` — lower()
+        """``None`` must fall to the empty-string branch; lower() then
         works on empty string, no crash."""
         attr = {"value": None}
-        attr_value = str(attr.get("value", "") or "")
+        _raw = attr.get("value")
+        attr_value = str(_raw) if _raw is not None else ""
         assert attr_value == ""
         assert attr_value.lower() == ""  # no crash
 
     def test_b4_behaviour_missing_value_coerces_to_empty(self):
-        """No ``value`` key at all — default ``""`` kicks in."""
+        """No ``value`` key at all — ``.get()`` returns None, same branch."""
         attr = {}
-        attr_value = str(attr.get("value", "") or "")
+        _raw = attr.get("value")
+        attr_value = str(_raw) if _raw is not None else ""
         assert attr_value == ""
+
+    # --- Bugbot PR-N5 R1 regression pins (falsy-int preservation) ---
+
+    def test_b4_bugbot_r1_zero_int_preserved(self):
+        """Bugbot PR-N5 R1 LOW: integer ``0`` must be preserved as
+        the string ``"0"``, not collapsed to ``""`` by the ``or ""``
+        idiom the original fix used."""
+        attr = {"value": 0}
+        _raw = attr.get("value")
+        attr_value = str(_raw) if _raw is not None else ""
+        assert attr_value == "0", (
+            f"Bugbot PR-N5 R1 regression: integer 0 must coerce to '0', "
+            f"got {attr_value!r}. The old `or ''` idiom dropped it."
+        )
+        # Downstream .lower() still works
+        assert attr_value.lower() == "0"
+
+    def test_b4_bugbot_r1_empty_string_still_empty(self):
+        """Bugbot PR-N5 R1: an empty-string input must remain empty.
+        (Contrast with the zero case — empty string IS the honest empty
+        value; only None should collapse to ``""``.)"""
+        attr = {"value": ""}
+        _raw = attr.get("value")
+        attr_value = str(_raw) if _raw is not None else ""
+        assert attr_value == ""
+
+    def test_b4_bugbot_r1_false_bool_preserved(self):
+        """Bugbot PR-N5 R1 analogue: Python ``False`` is falsy like 0.
+        If a buggy relay ever sent ``value: false`` (MISP doesn't
+        usually, but JSON permits it), the old idiom would drop it.
+        New idiom preserves it as the string ``"False"``."""
+        attr = {"value": False}
+        _raw = attr.get("value")
+        attr_value = str(_raw) if _raw is not None else ""
+        assert attr_value == "False"
 
 
 # ===========================================================================
@@ -311,6 +411,52 @@ class TestC7HonestNullValidator:
             "C7: optional-import graceful degradation — _MISP_HONEST_NULL_VIOLATIONS "
             "must be None when prometheus_client isn't available"
         )
+
+    def test_honest_null_counter_guarded_by_is_not_none(self):
+        """Bugbot PR-N5 R1 LOW: the guard around the counter increment
+        must check ``_MISP_HONEST_NULL_VIOLATIONS is not None``, NOT
+        just ``_METRICS_AVAILABLE``. The outer import can succeed (PR-N4
+        counters present) while the nested PR-N5 counter import fails
+        on older metrics_server deploys — in that case
+        ``_METRICS_AVAILABLE=True`` but ``_MISP_HONEST_NULL_VIOLATIONS
+        is None``. Without this guard, every violation detection calls
+        ``None.labels(...)`` and the try/except catches AttributeError
+        → noisy DEBUG log on every event."""
+        src = self._src()
+        # Find the increment block and verify the guard shape
+        inc_idx = src.find("_MISP_HONEST_NULL_VIOLATIONS.labels(")
+        assert inc_idx != -1, "counter increment must exist"
+        # Scan backwards for the guard line
+        preceding = src[max(0, inc_idx - 300) : inc_idx]
+        assert "_MISP_HONEST_NULL_VIOLATIONS is not None" in preceding, (
+            "Bugbot PR-N5 R1 regression: the honest-NULL counter increment "
+            "must be guarded by `is not None` check on the counter itself, "
+            "not just `_METRICS_AVAILABLE`. See comment in misp_writer.py "
+            "at the increment site for rationale."
+        )
+
+    def test_honest_null_guard_does_not_rely_on_metrics_available_only(self):
+        """Stronger guard: scan the increment block and verify the
+        naive pattern (``if _METRICS_AVAILABLE:`` directly followed by
+        the .labels call) is NOT present."""
+        src = self._src()
+        inc_idx = src.find("_MISP_HONEST_NULL_VIOLATIONS.labels(")
+        assert inc_idx != -1
+        preceding = src[max(0, inc_idx - 200) : inc_idx]
+        # The naive pattern would be `if _METRICS_AVAILABLE:` immediately
+        # before the .labels() call with no None check. Sentinel strings
+        # that would be present in the buggy form but absent in the fix.
+        lines_before = preceding.strip().splitlines()
+        # Last non-empty line before the .labels call
+        for line in reversed(lines_before):
+            stripped = line.strip()
+            if stripped and not stripped.startswith("#"):
+                # Must mention None, not just _METRICS_AVAILABLE
+                assert "is not None" in stripped or "_MISP_HONEST_NULL_VIOLATIONS" in stripped, (
+                    f"Bugbot PR-N5 R1: the line directly guarding the counter "
+                    f"increment must reference the counter's None-ness, got: {stripped!r}"
+                )
+                break
 
     def test_c7_behaviour_validator_warns_on_now_timestamp(self, caplog):
         """Drive the validator with a wall-clock-NOW-ish timestamp and

--- a/tests/test_pr_n5_producer_hardening.py
+++ b/tests/test_pr_n5_producer_hardening.py
@@ -510,6 +510,55 @@ class TestC7HonestNullValidator:
             f"historical claims. Got logs: {[r.message for r in caplog.records]}"
         )
 
+    def test_c7_behaviour_validator_catches_last_modified_alias(self, caplog):
+        """Bugbot PR-N5 R2 MED (2026-04-21): the validator MUST also
+        scan ``last_modified`` because the downstream chokepoint
+        ``_apply_source_truthful_timestamps`` accepts it as an alias
+        for ``last_seen``. Pre-fix a collector setting
+        ``item["last_modified"] = NOW`` (without ``last_seen``) would
+        bypass the validator entirely, yet still propagate a wall-clock
+        substitute into the MISP attribute as ``last_seen``."""
+        import logging
+        from datetime import datetime, timezone
+
+        from collectors.misp_writer import _validate_honest_null
+
+        now_iso = datetime.now(timezone.utc).isoformat()
+        # Critical: only `last_modified` is set (the alias path), not `last_seen`
+        item = {
+            "type": "vulnerability",
+            "cve_id": "CVE-2026-9999",
+            "tag": "nvd",
+            "last_modified": now_iso,
+        }
+        with caplog.at_level(logging.WARNING):
+            _validate_honest_null(item)
+
+        # Must catch via the last_modified branch
+        relevant = [r.message for r in caplog.records if "honest-NULL" in r.message]
+        assert relevant, (
+            f"R2 regression: validator must catch wall-clock-NOW values in "
+            f"`last_modified` (alias for last_seen). Got logs: "
+            f"{[r.message for r in caplog.records]}"
+        )
+        # The WARN should mention the field name `last_modified` so operators
+        # can audit which collector path produced the violation.
+        assert any("last_modified" in m for m in relevant), (
+            f"R2 regression: WARN must reference `last_modified` field name; got: {relevant}"
+        )
+
+    def test_c7_validator_field_list_source_pin(self):
+        """Source pin: the validator's field tuple must include all three
+        timestamp aliases that ``_apply_source_truthful_timestamps``
+        reads (``first_seen``, ``last_seen``, ``last_modified``).
+        Pre-Bugbot R2, only the first two were checked → silent gap."""
+        src = self._src()
+        # The exact tuple shipped in the R2 fix
+        assert '("first_seen", "last_seen", "last_modified")' in src, (
+            "Bugbot PR-N5 R2 regression: _validate_honest_null must scan all "
+            "three timestamp fields that the chokepoint reads, not just two"
+        )
+
     def test_c7_behaviour_validator_quiet_on_null(self, caplog):
         """The HAPPY path: ``first_seen`` is None / absent (collector
         correctly passed NULL through). Validator must be silent."""


### PR DESCRIPTION
## Summary

Four Tier-B / Tier-C findings from the 7-agent comprehensive audit (`docs/flow_audits/09_comprehensive_audit.md`), bundled because each is small (~10-50 LOC), independent, and low-risk:

- **B4** [MED] `attr.get("value","").lower()` crashes on int-typed MISP value → defensive `str(...)` coerce at 2 parse-entry points
- **B5** [MED] Non-atomic checkpoint lock (`touch()+open("r")` race) → new `_atomic_acquire_lock_fd` helper using `O_CREAT|O_RDWR`
- **C5** [MED] Campaign `c.zone` flickers across runs due to non-deterministic collect ordering → wrap in `apoc.coll.sort()`
- **C7** [MED] No runtime guard for the PR-M2 honest-NULL invariant → new `_validate_honest_null` helper + Prometheus counter

## Why it matters for the 730-day baseline

- **B4**: one buggy upstream attribute would kill a whole event's processing. Over 730 daily runs, probability of at least one int-typed value is high.
- **B5**: baseline checkpoint is the single most critical state for resumability — a race here corrupts the progress manifest and forces a re-run.
- **C5**: spurious MERGE-detects-change on Campaign nodes every enrichment run wastes DB cycles and triggers misleading "updated_at" jitter.
- **C7**: defense-in-depth against a regression of the PR-M2 invariant. Today's collectors all honor it; tomorrow's might not, and we'd never know.

## Test plan

- [x] `tests/test_pr_n5_producer_hardening.py` — 19 new regression tests (source pins + behavioural). Highlights:
  - AST-based check that `.touch(exist_ok=True)` is gone from executable code in `baseline_checkpoint.py`
  - Real-filesystem check that `_atomic_acquire_lock_fd` acquires + re-acquires after external unlink
  - Behavioural check that honest-NULL validator fires WARN on NOW-ish timestamp + stays quiet on old + missing
  - Cardinality check: new `MISP_HONEST_NULL_VIOLATIONS` counter uses bounded `["source", "field"]` labels (lesson from PR-N4 R2)
- [x] `ruff format --check src/ tests/` ✓
- [x] `ruff check src/ tests/` ✓
- [x] `mypy src/` ✓
- [x] `pytest tests/` → 1227 passed, 3 skipped, 3 xfailed (was 1208 + 19 new)

## Scope discipline

This is the "low-risk, high-value" quartet from PR-N0. Does NOT include:
- B6 (Neo4j MERGE ineffective-batch counters) — separate PR
- B2/B3 (enrichment exception handling + Campaign txn boundary) — separate PR
- B8 (neo4j_client.py unit-test backfill) — separate PR

Keeps the diff small and the review story clean per the pr-bot-review protocol learning from PR-N4 (5 rounds of bot-fix cycle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches checkpoint locking and timestamp handling paths that are central to baseline resumability and data provenance; while changes are small and well-tested, failures could impact progress tracking or emitted metadata.
> 
> **Overview**
> Improves producer robustness against bad upstream data and concurrency races by (1) coercing MISP `attr.value` to a string at the main parse entry points to avoid batch crashes on non-string values, and (2) making checkpoint advisory locking truly atomic via `os.open(O_CREAT|O_RDWR)` to prevent lock-file unlink races.
> 
> Adds a runtime *honest-NULL* validator in `misp_writer` that warns (and optionally increments a new Prometheus `MISP_HONEST_NULL_VIOLATIONS` counter) when `first_seen`/`last_seen`/`last_modified` look like wall-clock “now” substitutes, and stabilizes Campaign `zone` output by sorting the deduped zone list to avoid non-deterministic ordering churn. A new `tests/test_pr_n5_producer_hardening.py` suite pins these regressions (including filesystem-level lock behavior).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c1659971e84be0eb8d3cc038499d22d0f5d8a703. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->