### PR TITLE
fix(audit): PR-N6 — zone classification Tier-A hotfix bundle (4 findings)

### DIFF
--- a/src/collectors/misp_collector.py
+++ b/src/collectors/misp_collector.py
@@ -126,14 +126,36 @@ class MISPCollector:
 
     @staticmethod
     def _extract_zones_from_tags(tags_list):
-        """Return all zone names found in a list of MISP tag dicts/strings."""
+        """Return all zone names found in a list of MISP tag dicts/strings.
+
+        PR-N6 hotfix #1 (audit 09, Bug Hunter H2 / Cross-Checker F1):
+        filter candidates through ``VALID_ZONES`` before returning.
+        Pre-fix any MISP tag matching ``zone:<anything>`` — including
+        typos like ``zone:healthcares`` or adversarial values like
+        ``zone:<attacker-controlled>`` from a federated MISP peer —
+        was accepted verbatim and propagated into the Neo4j
+        ``n.zone`` property. No downstream filter saves it: the
+        ``VALID_ZONES`` gate lives only inside ``detect_zones_from_text``.
+
+        PR-N6 hotfix #5 (audit 09, Cross-Checker F4): also accept the
+        ``sector:`` prefix for parity with ``run_misp_to_neo4j.
+        extract_zones_from_tags`` (line ~1176). Pre-fix this reader
+        accepted only ``zone:``, so any MISP feed emitting
+        ``sector:finance`` tags was silently ignored here but picked
+        up by the other reader — causing Neo4j/STIX divergence on
+        the same attribute.
+        """
+        from config import VALID_ZONES
+
         zones = []
         for tag in tags_list:
             tag_name = tag.get("name", "") if isinstance(tag, dict) else str(tag)
-            if tag_name.startswith("zone:"):
-                zone_name = tag_name.replace("zone:", "").lower().strip()
-                if zone_name:
-                    zones.append(zone_name)
+            for prefix in ("zone:", "sector:"):
+                if tag_name.startswith(prefix):
+                    zone_name = tag_name[len(prefix) :].strip().lower()
+                    if zone_name and zone_name in VALID_ZONES:
+                        zones.append(zone_name)
+                    break
         return zones
 
     def _get_item_zones(self, item_tags, fallback_event_json: str = ""):

--- a/src/collectors/otx_collector.py
+++ b/src/collectors/otx_collector.py
@@ -52,6 +52,7 @@ from config import (
     OTX_INCREMENTAL_LOOKBACK_DAYS,
     OTX_INCREMENTAL_MAX_PAGES,
     OTX_INCREMENTAL_OVERLAP_SEC,
+    OTX_INDUSTRY_ZONE_ALIASES,
     SECTOR_TIME_RANGES,
     SOURCE_TAGS,
     SSL_VERIFY,
@@ -376,24 +377,19 @@ class OTXCollector:
 
                 # OTX-native industry_sectors override: if OTX itself classified
                 # the pulse into industries, use that as authoritative sector data.
+                #
+                # PR-N6 hotfix #4 (audit 09, Maintainer #1): the inline
+                # industry map moved to ``config.OTX_INDUSTRY_ZONE_ALIASES``
+                # so it lives side-by-side with ``VALID_ZONES`` /
+                # ``SECTOR_KEYWORDS``. Previously this was a hidden
+                # second source of truth containing vocabulary absent
+                # from ``SECTOR_KEYWORDS`` ("pharmaceutical", "utilities",
+                # "oil", "gas", "insurance") — so vocabulary refinements
+                # in ``config.py`` silently diverged from OTX ingestion.
                 otx_industries = pulse.get("industries", [])
                 if otx_industries:
-                    _industry_map = {
-                        "healthcare": "healthcare",
-                        "health": "healthcare",
-                        "medical": "healthcare",
-                        "pharmaceutical": "healthcare",
-                        "energy": "energy",
-                        "utilities": "energy",
-                        "oil": "energy",
-                        "gas": "energy",
-                        "finance": "finance",
-                        "banking": "finance",
-                        "financial": "finance",
-                        "insurance": "finance",
-                    }
                     for ind_name in otx_industries:
-                        mapped = _industry_map.get(str(ind_name).lower().strip())
+                        mapped = OTX_INDUSTRY_ZONE_ALIASES.get(str(ind_name).lower().strip())
                         if mapped and mapped not in sectors:
                             sectors.append(mapped)
                     # Remove "global" if we now have specific sectors

--- a/src/config.py
+++ b/src/config.py
@@ -1,4 +1,5 @@
 # EdgeGuard Prototype Configuration
+import math
 import os
 import re
 from datetime import datetime, timedelta, timezone
@@ -49,6 +50,39 @@ def _env_float(name: str, default: float) -> float:
         return float(raw.strip())
     except (ValueError, TypeError):
         return default
+
+
+def _bounded_env_float(name: str, default: float, *, lo: float, hi: float) -> float:
+    """PR-N6 hotfix #2 (audit 09, Bug Hunter H1): bounded + finite env
+    float. The previous idiom ``max(0.1, _env_float(name, default))``
+    had a latent bug: ``max(0.1, float('inf'))`` returns ``inf``,
+    and NaN propagates silently through subsequent comparisons because
+    ``nan < anything`` is always False. Downstream a zone-detection
+    threshold of ``inf`` causes every weighted-score comparison to
+    fail → every item routes to ``["global"]``, silently disabling
+    the entire classification layer.
+
+    This helper rejects NaN and ±inf explicitly via ``math.isfinite``
+    (same approach as ``_bounded_float_env`` in PR-N4 round 5 for
+    MISP backoff settings — see commit d9be313), and also clamps
+    out-of-range values to the default with a WARN. ``lo``/``hi``
+    form a hard safety envelope around the expected useful range.
+    """
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        val = float(raw.strip())
+    except (ValueError, TypeError):
+        return default
+    # NaN and ±inf must be rejected BEFORE the bounds check — NaN
+    # compares False against everything, so a naive ``val < lo or val > hi``
+    # guard passes NaN through. isfinite() rejects all three in one call.
+    if not math.isfinite(val):
+        return default
+    if val < lo or val > hi:
+        return default
+    return val
 
 
 # Neo4j Connection
@@ -110,12 +144,19 @@ def get_sector_cutoff_date(sector: str = "global") -> str:
 # Minimum weighted score for a sector to count in ``detect_zones_from_text`` (per field).
 # At default ``body`` weight 1.5, a single keyword match scores 1.5 — so 2.0 wrongly required
 # two matches for typical CVE/feed sentences.
-# Must be > 0; zero would match everything into every sector.
-ZONE_DETECT_THRESHOLD = max(0.1, _env_float("EDGEGUARD_ZONE_DETECT_THRESHOLD", 1.5))
+#
+# PR-N6 hotfix #2 (audit 09, Bug Hunter H1): use ``_bounded_env_float``
+# to reject NaN, ±inf, and out-of-range values with a fallback to the
+# default. Pre-fix ``max(0.1, _env_float(..., 1.5))`` let ``inf`` slip
+# through (max(0.1, inf) == inf) → every weighted score fell below
+# threshold → every item routed to ``["global"]``, silently disabling
+# the entire zone-classification layer. Bounds: [0.1, 100.0] covers
+# "effectively disabled at 100" down to "everything matches at 0.1".
+ZONE_DETECT_THRESHOLD = _bounded_env_float("EDGEGUARD_ZONE_DETECT_THRESHOLD", 1.5, lo=0.1, hi=100.0)
 
 # Minimum combined score in ``detect_zones_from_item`` after multi-field accumulation.
-# Must be > 0; zero would match everything into every sector.
-ZONE_ITEM_COMBINED_THRESHOLD = max(0.1, _env_float("EDGEGUARD_ZONE_ITEM_THRESHOLD", 1.5))
+# Same PR-N6 bounds rationale as ``ZONE_DETECT_THRESHOLD``.
+ZONE_ITEM_COMBINED_THRESHOLD = _bounded_env_float("EDGEGUARD_ZONE_ITEM_THRESHOLD", 1.5, lo=0.1, hi=100.0)
 
 
 def detect_zones_from_text(text: str, default_zone: str = "global", context: str = "body") -> list:
@@ -266,6 +307,19 @@ def detect_zones_from_item(item: dict) -> list:
 
     # Only return sectors within 50% of max score (prevents weak matches)
     matched = [s for s, score in combined_scores.items() if score >= max_score * 0.5 and score >= threshold]
+
+    # PR-N6 hotfix #1 (audit 09, Bug Hunter H3 / Cross-Checker F1):
+    # filter through VALID_ZONES before returning. ``detect_zones_from_text``
+    # already does this at line 208, but this function historically
+    # did NOT — relying on the implicit invariant
+    # ``set(SECTOR_KEYWORDS.keys()) <= VALID_ZONES``. Two unrelated
+    # constants maintained separately is a latent drift risk: the
+    # moment someone adds a key to ``SECTOR_KEYWORDS`` without
+    # updating ``VALID_ZONES``, this function would emit a zone string
+    # that breaks every downstream consumer (Neo4j ``n.zone`` queries,
+    # STIX label matching, GraphQL enum validation). Explicit filter
+    # makes the invariant load-bearing.
+    matched = [z for z in matched if z in VALID_ZONES]
 
     return matched if matched else ["global"]
 
@@ -703,6 +757,60 @@ DEFAULT_SECTOR = "global"
 
 # Valid zone values — used to filter out unexpected strings before they reach Neo4j.
 VALID_ZONES: frozenset = frozenset({"global", "healthcare", "energy", "finance"})
+
+# PR-N6 hotfix #4 (audit 09, Maintainer #1): canonical map from
+# OTX's ``pulse.industries`` raw labels to EdgeGuard zones.
+# Previously this dict lived inline inside ``otx_collector.py`` as a
+# local ``_industry_map`` variable, which made it invisible to
+# ``SECTOR_KEYWORDS`` maintainers — the OTX path contained
+# "pharmaceutical", "utilities", "oil", "gas", "insurance" that
+# were NOT in ``SECTOR_KEYWORDS``, so vocabulary refinements to
+# the latter silently diverged from OTX's mapping. Centralizing
+# here means (a) the two lists are visible side-by-side for
+# maintainers, and (b) the OTX mapping is assert-testable against
+# ``VALID_ZONES`` at module load (below).
+OTX_INDUSTRY_ZONE_ALIASES: Dict[str, str] = {
+    # Healthcare aliases
+    "healthcare": "healthcare",
+    "health": "healthcare",
+    "medical": "healthcare",
+    "pharmaceutical": "healthcare",
+    # Energy aliases
+    "energy": "energy",
+    "utilities": "energy",
+    "oil": "energy",
+    "gas": "energy",
+    # Finance aliases
+    "finance": "finance",
+    "banking": "finance",
+    "financial": "finance",
+    "insurance": "finance",
+}
+
+# Module-load invariant: every OTX mapping target must be a canonical
+# EdgeGuard zone. Adding a new target like "transport" without first
+# adding it to VALID_ZONES would silently produce out-of-whitelist
+# zones on OTX-sourced items.
+assert set(OTX_INDUSTRY_ZONE_ALIASES.values()) <= VALID_ZONES, (
+    "OTX_INDUSTRY_ZONE_ALIASES targets must be subset of VALID_ZONES; "
+    f"invalid targets: {set(OTX_INDUSTRY_ZONE_ALIASES.values()) - VALID_ZONES}"
+)
+
+# PR-N6 hotfix #1 (audit 09 / Maintainer #1): module-load assertion
+# making the previously-implicit invariant ``SECTOR_KEYWORDS.keys()
+# ⊆ VALID_ZONES`` load-bearing. Pre-fix the two constants were
+# maintained as separate sources of truth — adding a new key to
+# ``SECTOR_KEYWORDS`` without updating ``VALID_ZONES`` would make
+# ``detect_zones_from_text`` emit zone strings that silently get
+# filtered out by the VALID_ZONES gate at line 208, producing items
+# that ``["global"]`` when they should have been classified. The
+# assertion fires at import time so the error is impossible to miss
+# during development or CI startup.
+assert set(SECTOR_KEYWORDS.keys()) <= VALID_ZONES, (
+    f"SECTOR_KEYWORDS zones {set(SECTOR_KEYWORDS.keys())} must be a "
+    f"subset of VALID_ZONES {set(VALID_ZONES)}. Add the missing key(s) "
+    f"to VALID_ZONES or remove them from SECTOR_KEYWORDS."
+)
 
 # Pre-compiled word-boundary patterns for SECTOR_KEYWORDS.
 # Built once at module load time to avoid re-compiling on every call.

--- a/src/config.py
+++ b/src/config.py
@@ -1,9 +1,17 @@
 # EdgeGuard Prototype Configuration
+import logging
 import math
 import os
 import re
 from datetime import datetime, timedelta, timezone
 from typing import Dict, MutableMapping, Optional, Protocol
+
+# Module-level logger for config-time diagnostics (env parsing warnings,
+# bad-credentials path, etc.). Previously this module only used ad-hoc
+# ``logging.getLogger(__name__)`` inline calls; PR-N6 R1 Bugbot added
+# the proper WARNING output path for ``_bounded_env_float`` rejections,
+# which needed a module-scope handle.
+logger = logging.getLogger(__name__)
 
 # Deployment environment
 # ----------------------
@@ -67,6 +75,16 @@ def _bounded_env_float(name: str, default: float, *, lo: float, hi: float) -> fl
     MISP backoff settings — see commit d9be313), and also clamps
     out-of-range values to the default with a WARN. ``lo``/``hi``
     form a hard safety envelope around the expected useful range.
+
+    PR-N6 R1 Bugbot MED (2026-04-21): all three rejection paths now
+    emit a ``logger.warning`` — matching the behaviour of the twin
+    ``_bounded_float_env`` helper in ``misp_writer.py``. Pre-fix the
+    docstring CLAIMED WARN-on-rejection but the implementation was
+    silent, so an operator setting ``EDGEGUARD_ZONE_DETECT_THRESHOLD=inf``
+    would silently fall back to the default with no log signal. For a
+    security-critical classification threshold, silent config
+    rejection is the worst outcome — the operator thinks their
+    override is in effect while the code uses the default.
     """
     raw = os.getenv(name)
     if not raw:
@@ -74,13 +92,28 @@ def _bounded_env_float(name: str, default: float, *, lo: float, hi: float) -> fl
     try:
         val = float(raw.strip())
     except (ValueError, TypeError):
+        logger.warning("%s=%r is not a valid float; using default %.3f", name, raw, default)
         return default
     # NaN and ±inf must be rejected BEFORE the bounds check — NaN
     # compares False against everything, so a naive ``val < lo or val > hi``
     # guard passes NaN through. isfinite() rejects all three in one call.
     if not math.isfinite(val):
+        logger.warning(
+            "%s=%r resolved to non-finite value (NaN/±inf); using default %.3f",
+            name,
+            raw,
+            default,
+        )
         return default
     if val < lo or val > hi:
+        logger.warning(
+            "%s=%.3f is out of valid range [%.3f, %.3f]; using default %.3f",
+            name,
+            val,
+            lo,
+            hi,
+            default,
+        )
         return default
     return val
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1496,15 +1496,41 @@ class MISPToNeo4jSync:
         # Start with zones from event name
         all_zones = set(event_zones) if event_zones else set()
 
-        # Extract zones from attribute tags for STIX labels
+        # Extract zones from attribute tags for STIX labels.
+        #
+        # PR-N6 hotfix #1 (audit 09, Cross-Checker F1): filter
+        # candidates through ``VALID_ZONES`` before accepting them
+        # as zones / STIX labels. Pre-fix this manual-STIX fallback
+        # path read ``zone:<anything>`` verbatim — including
+        # adversarial tags a malicious MISP peer could inject —
+        # and emitted them straight into STIX ``labels`` +
+        # ``x_edgeguard_zones``. The convert_to_stix21 path above
+        # (line ~1218) already went through ``extract_zones_from_tags``
+        # which DOES whitelist, so only this attribute-level fallback
+        # loop was affected, causing asymmetric behaviour between
+        # the pyMISP and manual-fallback conversion paths.
+        #
+        # PR-N6 hotfix #5 (audit 09, Cross-Checker F4): also accept
+        # the ``sector:`` prefix for parity with
+        # ``extract_zones_from_tags`` above. Pre-fix only ``zone:``
+        # was accepted here, so any MISP feed emitting
+        # ``sector:finance`` was silently dropped by the STIX
+        # exporter while being picked up by the Neo4j-merge path —
+        # same attribute ends up with ``n.zone=["finance"]`` but
+        # ``x_edgeguard_zones=[]``.
+        from config import VALID_ZONES
+
         labels = []
         attr_tags = normalize_misp_tag_list(attr.get("Tag", []))
         for tag in attr_tags:
             tag_name = tag.get("name", "") if isinstance(tag, dict) else str(tag)
-            if tag_name.startswith("zone:"):
-                zone_name = tag_name.replace("zone:", "").lower().strip()
-                all_zones.add(zone_name)
-                labels.append(f"zone:{zone_name}")
+            for prefix in ("zone:", "sector:"):
+                if tag_name.startswith(prefix):
+                    zone_name = tag_name[len(prefix) :].strip().lower()
+                    if zone_name and zone_name in VALID_ZONES:
+                        all_zones.add(zone_name)
+                        labels.append(f"zone:{zone_name}")
+                    break
 
         # If no zones found in attribute tags, use event zones
         if not labels and event_zones:

--- a/src/stix_exporter.py
+++ b/src/stix_exporter.py
@@ -1332,17 +1332,44 @@ def _extract_zones(props: Dict[str, Any]) -> List[str]:
     ``["healthcare", "global"]``) per ``neo4j_client.py`` merge
     semantics. Fall back to ``zones`` (plural) if present, and accept a
     scalar string for defensive tolerance. Empty/null → ``[]``.
+
+    PR-N6 hotfix #1 (audit 09, Cross-Checker F2): defense-in-depth
+    VALID_ZONES filter. Every writer today validates zones against
+    the whitelist before storing on Neo4j, so in principle this
+    filter is redundant. But ``_extract_zones`` is the last stop
+    before zones flow out to ResilMesh via STIX — if ANY writer ever
+    slips an unvalidated zone through (a future bug, an out-of-band
+    Cypher write, a direct Bolt query from an ops script), this
+    prevents the corruption from propagating to downstream
+    consumers. Also logs a WARNING so the operator notices.
     """
+    from config import VALID_ZONES
+
     raw = props.get("zone")
     if raw is None:
         raw = props.get("zones")
     if raw is None:
         return []
     if isinstance(raw, str):
-        return [raw] if raw else []
-    if isinstance(raw, (list, tuple)):
-        return [str(z) for z in raw if z]
-    return []
+        candidates = [raw] if raw else []
+    elif isinstance(raw, (list, tuple)):
+        candidates = [str(z) for z in raw if z]
+    else:
+        return []
+
+    valid = [z for z in candidates if z in VALID_ZONES]
+    # Log a single WARN per call if ANY candidate was dropped — a
+    # non-zero rate is the signal that upstream write-path validation
+    # has regressed somewhere.
+    if len(valid) != len(candidates):
+        dropped = [z for z in candidates if z not in VALID_ZONES]
+        logger.warning(
+            "[stix-export] Dropped %d non-canonical zone(s) %r from Neo4j node "
+            "while exporting to STIX — check upstream write-path validation.",
+            len(dropped),
+            dropped,
+        )
+    return valid
 
 
 def _bundle_provenance() -> Dict[str, Any]:

--- a/tests/test_pr_n6_zone_classification_hotfix.py
+++ b/tests/test_pr_n6_zone_classification_hotfix.py
@@ -1,0 +1,370 @@
+"""
+PR-N6 — Zone classification Tier-A hotfix bundle.
+
+Four findings from the 5-agent zone-classification audit (run 2026-04-21,
+synthesis at the end of PR #89's cycle). All four are strongest-signal
+cross-agent-corroborated findings:
+
+  #1 [HIGH]  VALID_ZONES whitelist bypass at 4 call sites.
+            (Bug Hunter H2 + H3, Cross-Checker F1 + F2)
+            A MISP user / federated peer adding ``zone:malware`` or
+            ``zone:<typo>`` tags silently corrupts Neo4j + STIX output
+            — no downstream filter catches it because the only existing
+            filter lived inside ``detect_zones_from_text``.
+
+  #2 [HIGH]  ``EDGEGUARD_ZONE_*_THRESHOLD=inf`` silently disables
+            classification.  (Bug Hunter H1)
+            ``max(0.1, float('inf'))`` returns ``inf``; every weighted
+            score falls below threshold → every item routes to
+            ``["global"]``. Same class of bug as PR-N4 R5 NaN-bypass
+            in MISP backoff settings.
+
+  #4 [HIGH]  OTX ``_industry_map`` dictionary drifts from
+            ``SECTOR_KEYWORDS``.  (Maintainer #1, Cross-Checker F4)
+            A second keyword source of truth hidden inside
+            otx_collector.py, containing vocabulary absent from
+            ``config.py`` ("pharmaceutical", "utilities", "oil",
+            "gas", "insurance"). Future vocabulary refinements in
+            the canonical dict silently skipped OTX ingestion.
+
+  #5 [MED]   ``sector:`` tag prefix accepted in one reader, not others.
+            (Cross-Checker F4)
+            ``run_misp_to_neo4j.extract_zones_from_tags`` read both
+            ``zone:`` and ``sector:``. ``misp_collector._extract_zones_from_tags``
+            and the manual-STIX fallback read only ``zone:``. Any
+            feed using ``sector:`` produced divergent Neo4j vs STIX
+            output on the same attribute.
+
+## Test strategy
+
+Mix of source pins and behavioural tests. The env-override tests
+(finding #2) reload ``config`` so the new env value is read; callers
+are responsible for restoring the env after the test.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n6")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n6")
+
+
+# ===========================================================================
+# Finding #1 — VALID_ZONES whitelist closed across all 4 extraction sites
+# ===========================================================================
+
+
+class TestFinding1ValidZonesWhitelist:
+    """The ``VALID_ZONES`` whitelist must be applied consistently at
+    every zone-extraction site. Pre-fix 4 sites bypassed it."""
+
+    def test_module_load_asserts_sector_keywords_is_subset(self):
+        """Implicit invariant made explicit: ``SECTOR_KEYWORDS.keys() <=
+        VALID_ZONES``. Pre-fix a maintainer could add a key to
+        ``SECTOR_KEYWORDS`` without updating ``VALID_ZONES`` and the
+        drift would be silent (the VALID_ZONES filter in
+        detect_zones_from_text would silently drop the new key's matches).
+        Module-load assertion now makes the contract load-bearing."""
+        src = (SRC / "config.py").read_text()
+        assert "set(SECTOR_KEYWORDS.keys()) <= VALID_ZONES" in src, (
+            "module-load assertion on SECTOR_KEYWORDS ⊆ VALID_ZONES must exist"
+        )
+
+    def test_detect_zones_from_item_filters_through_valid_zones(self):
+        """Audit finding #1 site 3: ``detect_zones_from_item`` previously
+        did NOT filter through VALID_ZONES before returning — it relied
+        on the implicit invariant SECTOR_KEYWORDS ⊆ VALID_ZONES.
+        Making the filter explicit closes the drift risk."""
+        src = (SRC / "config.py").read_text()
+        fn_idx = src.find("def detect_zones_from_item(")
+        assert fn_idx != -1
+        next_fn = src.find("\ndef ", fn_idx + 1)
+        body = src[fn_idx : next_fn if next_fn != -1 else len(src)]
+        # Filter must appear within the function body
+        assert "z in VALID_ZONES" in body, "detect_zones_from_item must filter matched zones through VALID_ZONES"
+
+    def test_misp_collector_tag_reader_filters_through_valid_zones(self):
+        """Audit finding #1 site 1: ``_extract_zones_from_tags`` in
+        misp_collector.py previously accepted ``zone:<anything>``
+        verbatim. Must now filter through VALID_ZONES."""
+        src = (SRC / "collectors" / "misp_collector.py").read_text()
+        fn_idx = src.find("def _extract_zones_from_tags(")
+        assert fn_idx != -1
+        next_fn = src.find("\n    def ", fn_idx + 1)
+        body = src[fn_idx : next_fn if next_fn != -1 else len(src)]
+        assert "VALID_ZONES" in body, "misp_collector._extract_zones_from_tags must filter through VALID_ZONES"
+        # And the filter must be a membership check on the extracted zone
+        assert "in VALID_ZONES" in body, "filter must be 'zone_name in VALID_ZONES' membership check"
+
+    def test_run_misp_to_neo4j_stix_fallback_filters_through_valid_zones(self):
+        """Audit finding #1 site 2: the attribute-level manual-STIX
+        fallback in ``_attribute_to_stix21`` previously read
+        ``zone:<anything>`` verbatim and emitted STIX labels. Must
+        now filter through VALID_ZONES."""
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        # Find the attribute-tag zone loop by its distinctive
+        # ``labels.append(f"zone:{zone_name}")`` line
+        marker = 'labels.append(f"zone:{zone_name}")'
+        idx = src.find(marker)
+        assert idx != -1
+        block = src[max(0, idx - 800) : idx]
+        assert "VALID_ZONES" in block, "the manual-STIX fallback zone loop must filter through VALID_ZONES"
+
+    def test_stix_exporter_extract_zones_defense_in_depth_filter(self):
+        """Audit finding #1 site 4: ``_extract_zones`` in stix_exporter.py
+        reads zones from Neo4j and emits STIX labels/custom props.
+        Must filter through VALID_ZONES as defense-in-depth — if any
+        upstream write path ever slips an unvalidated zone through,
+        this is the last stop before ResilMesh sees it."""
+        src = (SRC / "stix_exporter.py").read_text()
+        fn_idx = src.find("def _extract_zones(")
+        assert fn_idx != -1
+        next_fn = src.find("\ndef ", fn_idx + 1)
+        body = src[fn_idx : next_fn if next_fn != -1 else len(src)]
+        assert "VALID_ZONES" in body, "stix_exporter._extract_zones must filter through VALID_ZONES"
+
+    # --- Behavioural ---
+
+    def test_behaviour_misp_collector_drops_malicious_tag(self):
+        """A MISP tag ``zone:malware`` (attacker-controlled or typo)
+        must be dropped, not emitted as a zone."""
+        from collectors.misp_collector import MISPCollector
+
+        tags = [{"name": "zone:malware"}, {"name": "zone:healthcare"}]
+        zones = MISPCollector._extract_zones_from_tags(tags)
+        assert "malware" not in zones, "malicious zone tag must be filtered"
+        assert "healthcare" in zones, "legitimate zone must pass through"
+
+    def test_behaviour_misp_collector_drops_typo_tag(self):
+        """A MISP tag ``zone:healthcares`` (typo) must be dropped."""
+        from collectors.misp_collector import MISPCollector
+
+        tags = [{"name": "zone:healthcares"}]
+        zones = MISPCollector._extract_zones_from_tags(tags)
+        assert zones == [], f"typo'd zone must not pass; got {zones}"
+
+    def test_behaviour_stix_exporter_drops_non_canonical_zone(self):
+        """A Neo4j node with ``zone: ["malware", "finance"]`` (some
+        data corruption) must emit only ``["finance"]`` to STIX —
+        plus a WARN log (checked in test_behaviour_stix_exporter_warns_on_drop)."""
+        from stix_exporter import _extract_zones
+
+        props = {"zone": ["malware", "finance"]}
+        result = _extract_zones(props)
+        assert result == ["finance"], f"expected ['finance'], got {result}"
+
+
+# ===========================================================================
+# Finding #2 — inf / NaN threshold bypass
+# ===========================================================================
+
+
+class TestFinding2InfNaNThresholdBypass:
+    """``EDGEGUARD_ZONE_*_THRESHOLD=inf`` / ``NaN`` previously slipped
+    past the ``max(0.1, float('inf')) == inf`` guard and silently
+    disabled all classification."""
+
+    def test_bounded_env_float_helper_exists(self):
+        src = (SRC / "config.py").read_text()
+        assert "def _bounded_env_float(" in src, "PR-N6 #2: bounded helper must exist"
+        assert "math.isfinite" in src, "helper must use math.isfinite"
+
+    def test_thresholds_use_bounded_helper(self):
+        src = (SRC / "config.py").read_text()
+        assert '_bounded_env_float("EDGEGUARD_ZONE_DETECT_THRESHOLD"' in src
+        assert '_bounded_env_float("EDGEGUARD_ZONE_ITEM_THRESHOLD"' in src
+        # The old buggy idiom must be fully removed
+        assert 'max(0.1, _env_float("EDGEGUARD_ZONE_DETECT_THRESHOLD"' not in src, (
+            "PR-N6 #2 regression: the old max(0.1, _env_float(...)) idiom let inf slip through — must stay removed"
+        )
+
+    def test_behaviour_inf_env_falls_back_to_default(self, monkeypatch):
+        """Setting the env var to ``inf`` must NOT propagate inf into
+        ``ZONE_DETECT_THRESHOLD`` — must fall back to 1.5 default."""
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "inf")
+        import config
+
+        importlib.reload(config)
+        assert config.ZONE_DETECT_THRESHOLD == 1.5, (
+            f"inf env must fall back to 1.5 default; got {config.ZONE_DETECT_THRESHOLD}"
+        )
+        # Reset for other tests
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_behaviour_nan_env_falls_back_to_default(self, monkeypatch):
+        """NaN must also fall back to default."""
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "NaN")
+        import config
+
+        importlib.reload(config)
+        assert config.ZONE_DETECT_THRESHOLD == 1.5, (
+            f"NaN env must fall back to 1.5 default; got {config.ZONE_DETECT_THRESHOLD}"
+        )
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_behaviour_neg_inf_env_falls_back_to_default(self, monkeypatch):
+        """-inf must fall back too (math.isfinite rejects both ±inf)."""
+        monkeypatch.setenv("EDGEGUARD_ZONE_ITEM_THRESHOLD", "-inf")
+        import config
+
+        importlib.reload(config)
+        assert config.ZONE_ITEM_COMBINED_THRESHOLD == 1.5
+        monkeypatch.delenv("EDGEGUARD_ZONE_ITEM_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_behaviour_out_of_range_env_falls_back(self, monkeypatch):
+        """Values outside [0.1, 100.0] must fall back — sanity envelope."""
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "1000.0")
+        import config
+
+        importlib.reload(config)
+        assert config.ZONE_DETECT_THRESHOLD == 1.5
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_behaviour_valid_env_takes_effect(self, monkeypatch):
+        """Positive: a valid value in range IS applied."""
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "2.5")
+        import config
+
+        importlib.reload(config)
+        assert config.ZONE_DETECT_THRESHOLD == 2.5, (
+            f"valid env value must be applied; got {config.ZONE_DETECT_THRESHOLD}"
+        )
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+
+# ===========================================================================
+# Finding #4 — OTX industry map unification
+# ===========================================================================
+
+
+class TestFinding4OtxIndustryMapUnification:
+    """The OTX ``_industry_map`` previously lived inline inside
+    ``otx_collector.py``. Moved to ``config.OTX_INDUSTRY_ZONE_ALIASES``
+    so it's visible to SECTOR_KEYWORDS maintainers."""
+
+    def test_canonical_const_exists_in_config(self):
+        src = (SRC / "config.py").read_text()
+        assert "OTX_INDUSTRY_ZONE_ALIASES" in src, (
+            "PR-N6 #4: canonical OTX_INDUSTRY_ZONE_ALIASES const must be in config.py"
+        )
+        # Must preserve all the known aliases
+        for alias in ("pharmaceutical", "utilities", "oil", "gas", "insurance"):
+            assert f'"{alias}"' in src, f"PR-N6 #4: alias {alias!r} must be preserved"
+
+    def test_otx_collector_imports_shared_const(self):
+        src = (SRC / "collectors" / "otx_collector.py").read_text()
+        assert "OTX_INDUSTRY_ZONE_ALIASES" in src, "otx_collector must import the shared const"
+        # Old inline dict must be gone
+        assert "local_industry_map = {" not in src  # historical variant
+        # The distinctive inline literal should no longer appear in executable code
+        assert "_industry_map = {" not in src, (
+            "PR-N6 #4 regression: inline _industry_map must be removed; use config.OTX_INDUSTRY_ZONE_ALIASES"
+        )
+
+    def test_module_load_asserts_otx_targets_are_valid_zones(self):
+        """Every OTX alias target must be a canonical EdgeGuard zone.
+        Pre-fix nothing caught a future ``{"transport": "transport"}``
+        entry that would silently emit out-of-whitelist zones."""
+        src = (SRC / "config.py").read_text()
+        assert "set(OTX_INDUSTRY_ZONE_ALIASES.values()) <= VALID_ZONES" in src, (
+            "module-load assertion on OTX targets ⊆ VALID_ZONES must exist"
+        )
+
+    def test_behaviour_const_has_expected_mappings(self):
+        from config import OTX_INDUSTRY_ZONE_ALIASES
+
+        # Spot-check the known aliases resolve to the right zone
+        assert OTX_INDUSTRY_ZONE_ALIASES["pharmaceutical"] == "healthcare"
+        assert OTX_INDUSTRY_ZONE_ALIASES["utilities"] == "energy"
+        assert OTX_INDUSTRY_ZONE_ALIASES["oil"] == "energy"
+        assert OTX_INDUSTRY_ZONE_ALIASES["gas"] == "energy"
+        assert OTX_INDUSTRY_ZONE_ALIASES["insurance"] == "finance"
+        assert OTX_INDUSTRY_ZONE_ALIASES["banking"] == "finance"
+
+
+# ===========================================================================
+# Finding #5 — sector: prefix parity across readers
+# ===========================================================================
+
+
+class TestFinding5SectorPrefixConsistency:
+    """All three zone-tag readers must accept BOTH ``zone:`` and
+    ``sector:`` prefixes (matching the most permissive reader,
+    ``run_misp_to_neo4j.extract_zones_from_tags``).  Pre-fix the other
+    two readers only accepted ``zone:``, causing silent divergence."""
+
+    def test_misp_collector_accepts_sector_prefix(self):
+        src = (SRC / "collectors" / "misp_collector.py").read_text()
+        fn_idx = src.find("def _extract_zones_from_tags(")
+        assert fn_idx != -1
+        next_fn = src.find("\n    def ", fn_idx + 1)
+        body = src[fn_idx : next_fn if next_fn != -1 else len(src)]
+        assert '"sector:"' in body, "misp_collector reader must accept sector: prefix"
+
+    def test_run_misp_to_neo4j_stix_fallback_accepts_sector_prefix(self):
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        marker = 'labels.append(f"zone:{zone_name}")'
+        idx = src.find(marker)
+        assert idx != -1
+        block = src[max(0, idx - 800) : idx]
+        assert '"sector:"' in block, "manual-STIX fallback must accept sector: prefix"
+
+    def test_behaviour_misp_collector_reads_sector_tag(self):
+        """Given a MISP tag ``sector:healthcare``, the reader must
+        produce ``["healthcare"]``."""
+        from collectors.misp_collector import MISPCollector
+
+        tags = [{"name": "sector:healthcare"}]
+        zones = MISPCollector._extract_zones_from_tags(tags)
+        assert "healthcare" in zones, f"sector:healthcare must be read; got {zones}"
+
+    def test_behaviour_misp_collector_sector_also_whitelist_filtered(self):
+        """``sector:malware`` (invalid) must still be filtered."""
+        from collectors.misp_collector import MISPCollector
+
+        tags = [{"name": "sector:malware"}]
+        zones = MISPCollector._extract_zones_from_tags(tags)
+        assert zones == [], "sector: prefix must still obey VALID_ZONES"
+
+
+# ===========================================================================
+# Cross-cutting: integration check on the fix bundle
+# ===========================================================================
+
+
+class TestPRN6Integration:
+    """End-to-end check that the 4 fixes work together — a tag list
+    containing a mix of legitimate, typo'd, mixed-prefix, and malicious
+    tags produces the expected output at the first-stop reader."""
+
+    def test_mixed_tag_list_full_normalization(self):
+        from collectors.misp_collector import MISPCollector
+
+        tags = [
+            {"name": "zone:healthcare"},  # legitimate
+            {"name": "sector:finance"},  # sector: prefix, legitimate
+            {"name": "zone:malware"},  # attacker-controlled, must drop
+            {"name": "zone:healthcares"},  # typo, must drop
+            {"name": "sector:retail"},  # valid prefix, out-of-whitelist, must drop
+            {"name": "tlp:white"},  # unrelated prefix, must ignore
+            {"name": "zone:ENERGY"},  # uppercase, must normalize to lowercase
+        ]
+        zones = MISPCollector._extract_zones_from_tags(tags)
+        # Order of list is insertion-order; verify set equality
+        assert set(zones) == {"healthcare", "finance", "energy"}, (
+            f"integration: expected {{healthcare, finance, energy}}, got {set(zones)}"
+        )

--- a/tests/test_pr_n6_zone_classification_hotfix.py
+++ b/tests/test_pr_n6_zone_classification_hotfix.py
@@ -245,6 +245,104 @@ class TestFinding2InfNaNThresholdBypass:
         monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
         importlib.reload(config)
 
+    # --- Bugbot PR-N6 R1 MED regression pins: WARN-on-rejection ---
+
+    def test_r1_warn_on_nan(self, monkeypatch, caplog):
+        """Bugbot PR-N6 R1 MED (2026-04-21): ``_bounded_env_float`` must
+        emit ``logger.warning`` on every rejection path. Pre-fix the
+        docstring CLAIMED WARN-on-rejection but the implementation was
+        silent — operator setting
+        ``EDGEGUARD_ZONE_DETECT_THRESHOLD=inf`` would silently fall
+        back to default with no log signal."""
+        import logging
+
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "NaN")
+        with caplog.at_level(logging.WARNING, logger="config"):
+            import config
+
+            importlib.reload(config)
+
+        assert any(
+            "non-finite" in rec.message and "EDGEGUARD_ZONE_DETECT_THRESHOLD" in rec.message for rec in caplog.records
+        ), f"R1: NaN must trigger a WARN naming the env var; got logs: {[r.message for r in caplog.records]}"
+
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_r1_warn_on_inf(self, monkeypatch, caplog):
+        """±inf must also WARN."""
+        import logging
+
+        monkeypatch.setenv("EDGEGUARD_ZONE_ITEM_THRESHOLD", "inf")
+        with caplog.at_level(logging.WARNING, logger="config"):
+            import config
+
+            importlib.reload(config)
+
+        assert any(
+            "non-finite" in rec.message and "EDGEGUARD_ZONE_ITEM_THRESHOLD" in rec.message for rec in caplog.records
+        ), f"R1: inf must trigger a WARN; got logs: {[r.message for r in caplog.records]}"
+
+        monkeypatch.delenv("EDGEGUARD_ZONE_ITEM_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_r1_warn_on_out_of_range(self, monkeypatch, caplog):
+        """Out-of-range value (above ceiling) must WARN."""
+        import logging
+
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "500.0")
+        with caplog.at_level(logging.WARNING, logger="config"):
+            import config
+
+            importlib.reload(config)
+
+        assert any("out of valid range" in rec.message for rec in caplog.records), (
+            f"R1: out-of-range must trigger a WARN; got logs: {[r.message for r in caplog.records]}"
+        )
+
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_r1_warn_on_unparseable(self, monkeypatch, caplog):
+        """Unparseable ``abc123`` must WARN on the parse-fail path."""
+        import logging
+
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "abc123")
+        with caplog.at_level(logging.WARNING, logger="config"):
+            import config
+
+            importlib.reload(config)
+
+        assert any("not a valid float" in rec.message for rec in caplog.records), (
+            f"R1: unparseable must trigger a WARN; got logs: {[r.message for r in caplog.records]}"
+        )
+
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
+    def test_r1_no_warn_on_valid(self, monkeypatch, caplog):
+        """Negative: a valid value must NOT trigger any WARN from
+        ``_bounded_env_float``."""
+        import logging
+
+        monkeypatch.setenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", "3.0")
+        with caplog.at_level(logging.WARNING, logger="config"):
+            import config
+
+            importlib.reload(config)
+
+        # Must not have any bounded_env_float rejection log
+        relevant = [
+            r.message
+            for r in caplog.records
+            if "EDGEGUARD_ZONE_DETECT_THRESHOLD" in r.message
+            and any(tag in r.message for tag in ("not a valid float", "non-finite", "out of valid range"))
+        ]
+        assert not relevant, f"R1 false-positive: valid value should not WARN; got: {relevant}"
+
+        monkeypatch.delenv("EDGEGUARD_ZONE_DETECT_THRESHOLD", raising=False)
+        importlib.reload(config)
+
 
 # ===========================================================================
 # Finding #4 — OTX industry map unification


### PR DESCRIPTION
## Summary

Four cross-agent-corroborated findings from the 5-agent zone-classification audit (Devil's Advocate / Bug Hunter / Cross-Checker / Maintainer Dev / Test Coverage), run 2026-04-21. These are the strongest-signal, highest-confidence actionable items from the audit — everything else (taxonomy expansion, ground-truth, test backfill) is tracked for follow-up PRs.

### #1 [HIGH] — VALID_ZONES whitelist bypass at 4 call sites
Bug Hunter H2+H3, Cross-Checker F1+F2. Tags like `zone:malware` / `zone:<typo>` from MISP peers silently polluted Neo4j `n.zone` and propagated to STIX `labels` — only one of 4 readers was applying the whitelist. **Fix:** explicit `in VALID_ZONES` filter at all 4 sites + module-load assertion `set(SECTOR_KEYWORDS.keys()) <= VALID_ZONES`.

### #2 [HIGH] — `EDGEGUARD_ZONE_*_THRESHOLD=inf` silently disables classification
Bug Hunter H1. Same class of bug as PR-N4 R5: `max(0.1, float('inf'))` returns `inf`. Every zone score falls below threshold → every item routes to `["global"]`. **Fix:** new `_bounded_env_float` helper using `math.isfinite` rejection.

### #4 [HIGH] — OTX `_industry_map` drifts from `SECTOR_KEYWORDS`
Maintainer #1, Cross-Checker F4. A hidden second source of truth inside `otx_collector.py` with vocabulary absent from `config.SECTOR_KEYWORDS` ("pharmaceutical", "utilities", "oil", "gas", "insurance"). **Fix:** moved to `config.OTX_INDUSTRY_ZONE_ALIASES` + module-load assertion on targets ⊆ VALID_ZONES.

### #5 [MED] — `sector:` prefix accepted in one reader, not others
Cross-Checker F4. `run_misp_to_neo4j.extract_zones_from_tags` read both `zone:` and `sector:`; the other two readers (misp_collector + manual-STIX fallback) read only `zone:`. Resulted in same attribute having `n.zone=["finance"]` but `x_edgeguard_zones=[]`. **Fix:** unified both readers to accept both prefixes.

## Test plan

- [x] 24 new regression tests in `tests/test_pr_n6_zone_classification_hotfix.py`:
  - Finding #1 (8) — source pins at all 4 sites, module-load assertion, behavioural (malicious/typo dropped, non-canonical stripped)
  - Finding #2 (7) — helper presence + inf/NaN/-inf/out-of-range → default, valid value applies
  - Finding #4 (4) — canonical const, import, inline dict gone, module-load assertion, spot-check
  - Finding #5 (4) — source pins + behavioural (sector: read, malicious still dropped)
  - Integration (1) — mixed-tag end-to-end
- [x] `ruff format` ✓ / `ruff check` ✓ / `mypy src/` ✓
- [x] `pytest tests/` → **1258 passed**, 3 skipped, 3 xfailed (was 1232 + 24 new + 2 invariant-hardened)

## What is NOT in this PR (deferred per scope discipline)

Tracked for separate PRs:
- **#9** taxonomy expansion (transport/water/telecom/government/retail) — needs product sign-off
- **#3** ground-truth gold set + accuracy measurement — needs hand-labelling
- **#11** classification test backfill (weighted-engine coverage) — 400+ LOC of new tests
- **#6/#8/#13/#10/#15** negative-keyword rigidity, generic-keyword false positives, dead `SECTOR_TIME_RANGES`, GraphQL filter schema, `["global"]` overload

## Review cycle expectation

Previous PRs in this audit series (#85–#89) averaged 2–3 Bugbot rounds. This PR's fixes are each well-scoped and regression-tested; I'd expect 0–1 rounds. If Bugbot catches something, I'll fold in per the pr-bot-review protocol.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches multiple ingestion/export paths and adds import-time assertions, so misconfigured deployments or unexpected zone strings could now fail fast or drop data that previously flowed through. Overall changes are localized and heavily regression-tested but affect security-sensitive labeling/classification.
> 
> **Overview**
> Tightens zone handling end-to-end by **whitelisting zones against `VALID_ZONES`** anywhere zones are derived from tags or exported, and by accepting both `zone:` and `sector:` tag prefixes to prevent Neo4j vs STIX divergence.
> 
> Hardens configuration and classification by adding `_bounded_env_float` (rejects NaN/±inf/out-of-range with warnings) for zone-detection thresholds, centralizing OTX industry→zone mappings in `config.OTX_INDUSTRY_ZONE_ALIASES` with import-time invariants, and adding regression tests covering malicious/typo tags, prefix parity, and env-threshold edge cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1aac369ae038afac9b6664139c757dd69fa58f5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->