### PR TITLE
fix(audit): PR-N9 — merge robustness bundle (NULL/empty filter + B6 observability)

### DIFF
--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -388,8 +388,19 @@ def build_relationships():
         # whitespace-only values via ``size(trim(x)) > 0``, so the
         # inner comparison never sees a post-trim empty string at all.
         logger.info("[LINK] 2/12 Malware → ThreatActor (exact name match)...")
+        # PR-N9 (follow-up to PR-N8 R1 Bugbot): list comprehensions
+        # filter out NULL/whitespace-only alias entries before
+        # comparing. Without the filter, a single whitespace-only
+        # entry in ``a.aliases`` (e.g. ``["foo", "  ", "bar"]``)
+        # would trim to ``""`` inside the comprehension. Combined
+        # with a whitespace-only ``m.attributed_to`` (which can
+        # reach the inner via the aliases-leg of the OR outer),
+        # the check ``"" IN ["foo", "", "bar"]`` → TRUE → spurious
+        # ATTRIBUTED_TO edge to every ThreatActor with a malformed
+        # alias. Unlikely in clean data but observable on noisy
+        # threat-intel feeds. Filter restores robustness.
         _outer = "MATCH (m:Malware) WHERE (m.attributed_to IS NOT NULL AND size(trim(m.attributed_to)) > 0) OR size(coalesce(m.aliases, [])) > 0 RETURN m"
-        _inner = 'WITH $m AS m MATCH (a:ThreatActor) WHERE toLower(trim(m.attributed_to)) = toLower(trim(a.name)) OR toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) | toLower(trim(x))] OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) | toLower(trim(x))] MERGE (m)-[r:ATTRIBUTED_TO]->(a) ON CREATE SET r.confidence_score = 1.0, r.match_type = "exact", r.created_at = datetime() SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, m.uuid), r.trg_uuid = coalesce(r.trg_uuid, a.uuid)'
+        _inner = 'WITH $m AS m MATCH (a:ThreatActor) WHERE toLower(trim(m.attributed_to)) = toLower(trim(a.name)) OR toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] MERGE (m)-[r:ATTRIBUTED_TO]->(a) ON CREATE SET r.confidence_score = 1.0, r.match_type = "exact", r.created_at = datetime() SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, m.uuid), r.trg_uuid = coalesce(r.trg_uuid, a.uuid)'
         if not _safe_run_batched(client, "Malware → ThreatActor", _outer, _inner, stats, "attributed_to"):
             failures += 1
         query_pause()
@@ -756,7 +767,12 @@ def build_relationships():
         _q9_inner = (
             "WITH $i AS i MATCH (m:Malware) "
             "WHERE toLower(trim(m.name)) = toLower(trim(i.malware_family)) "
-            "   OR toLower(trim(i.malware_family)) IN [x IN coalesce(m.aliases, []) | toLower(trim(x))] "
+            # PR-N9: filter NULL/whitespace aliases (see Q2 comment for
+            # rationale). Q9's outer filter already ensures
+            # trim(i.malware_family) is non-empty so the LHS can't
+            # produce a false-match via "" = "", but defense-in-depth
+            # keeps the shape symmetric with Q2.
+            "   OR toLower(trim(i.malware_family)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] "
             "   OR toLower(trim(m.family)) = toLower(trim(i.malware_family)) "
             "MERGE (i)-[r:INDICATES]->(m) "
             "ON CREATE SET r.created_at = datetime() "
@@ -782,7 +798,9 @@ def build_relationships():
             "AND NOT EXISTS { "
             "  MATCH (m:Malware) "
             "  WHERE toLower(trim(m.name)) = toLower(trim(i.malware_family)) "
-            "     OR toLower(trim(i.malware_family)) IN [x IN coalesce(m.aliases, []) | toLower(trim(x))] "
+            # PR-N9: same NULL/whitespace filter as _q9_inner above so
+            # the orphan count matches actual match behaviour.
+            "     OR toLower(trim(i.malware_family)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] "
             "     OR toLower(trim(m.family)) = toLower(trim(i.malware_family)) "
             "} "
             "RETURN count(i) AS c"

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -321,6 +321,32 @@ NEO4J_QUERY_DURATION = Histogram(
     buckets=[0.01, 0.05, 0.1, 0.5, 1.0, 5.0],
 )
 
+# PR-N9 B6 (audit 09 Prod Readiness #2): ineffective-batch counter —
+# fires when ``merge_indicators_batch`` / ``merge_vulnerabilities_batch``
+# runs a non-empty batch that produces ZERO counter-visible writes
+# (no nodes_created, nodes_updated, properties_set, rels_created or
+# rels_updated). The typical silent-failure causes are:
+#
+#  * Source node missing (the SOURCED_FROM MATCH inside the UNWIND
+#    returns zero rows; the per-row edge MERGE never runs)
+#  * Constraint violation on the primary MERGE key (write rejected
+#    silently; caller still returns ``len(batch)`` as success_count)
+#  * Schema mismatch or broken Cypher
+#
+# Labels are bounded: ``label`` is one of the static node labels
+# (Indicator / Vulnerability / …), ``source`` is the per-source
+# identifier (otx / nvd / misp / …). No unbounded cardinality axes.
+# Alerting: ``rate(edgeguard_neo4j_merge_ineffective_batch_total[5m])
+# > 0`` for 5 min → write path is silently dropping edges.
+NEO4J_MERGE_INEFFECTIVE_BATCH = Counter(
+    "edgeguard_neo4j_merge_ineffective_batch_total",
+    "Non-empty Neo4j MERGE batches that produced ZERO counter-visible "
+    "writes (no nodes / rels / properties touched). Indicates silent-"
+    "write failure — missing prerequisite Source, constraint violation, "
+    "or schema drift. Non-zero rate is an operator-actionable signal.",
+    ["label", "source"],
+)
+
 # Pipeline metrics
 PIPELINE_DURATION = Histogram(
     "edgeguard_pipeline_duration_seconds",

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -44,9 +44,114 @@ logger = logging.getLogger(__name__)
 try:
     from metrics_server import NEO4J_QUERIES, NEO4J_QUERY_DURATION
 
+    # PR-N9 B6 (audit 09 Prod Readiness #2): ineffective-batch counter —
+    # increments when a batch of N items produces ZERO
+    # nodes_created/updated. See ``_record_batch_counters`` below.
+    try:
+        from metrics_server import (
+            NEO4J_MERGE_INEFFECTIVE_BATCH as _NEO4J_MERGE_INEFFECTIVE_BATCH,
+        )
+    except ImportError:
+        # Older metrics_server without the PR-N9 counter — keep the
+        # rest of the metrics bundle working (PR-N5 C7 established the
+        # nested-import graceful-degradation pattern).
+        _NEO4J_MERGE_INEFFECTIVE_BATCH = None  # type: ignore[assignment]
+
     _METRICS_AVAILABLE = True
 except ImportError:
     _METRICS_AVAILABLE = False
+    _NEO4J_MERGE_INEFFECTIVE_BATCH = None  # type: ignore[assignment]
+
+
+def _record_batch_counters(*, label: str, source_id: str, batch_len: int, result) -> None:
+    """PR-N9 B6 (audit 09 Prod Readiness #2, 2026-04-21): inspect Neo4j
+    result counters to detect silent-write failures.
+
+    **The bug this closes:** ``merge_indicators_batch`` and
+    ``merge_vulnerabilities_batch`` historically used ``len(batch)``
+    as the success_count regardless of what Neo4j actually wrote. If
+    the MATCH-into-SOURCED_FROM silently failed (e.g. Source node
+    missing, constraint violation, schema mismatch), the outer
+    success_count lied and operators had no signal — the batch
+    silently produced zero edges.
+
+    **What this helper does:** reads
+    ``result.consume().counters.nodes_created +
+    nodes_updated + relationships_created + properties_set``. If ALL
+    four are zero on a non-empty batch, emits:
+
+      - ERROR log with label, source, batch size, and counter values
+        (so operators see exactly which batch went silent)
+      - Increments ``edgeguard_neo4j_merge_ineffective_batch_total``
+        Prometheus counter (so Grafana can alert on a non-zero rate)
+
+    A non-empty batch producing zero writes is almost always a bug
+    (missing prerequisite nodes, broken schema, constraint violation).
+    The rare legitimate case — every item already MERGEd with
+    identical properties — still increments ``properties_set`` at
+    least via the ``r.updated_at = datetime()`` clauses every batch
+    sets, so the all-zero check is a strong signal.
+
+    **Never raises:** defensive wrapped in try/except so a counter
+    bug can't break production writes. The metric increment itself
+    is None-guarded (PR-N5 R1 pattern).
+    """
+    try:
+        counters = result.consume().counters
+        # ``counters`` exposes attributes as ints; absent attrs default
+        # to 0 via getattr.
+        nodes_created = getattr(counters, "nodes_created", 0)
+        nodes_updated = getattr(counters, "nodes_updated", 0) if hasattr(counters, "nodes_updated") else 0
+        # Neo4j 5.x uses ``properties_set``; 4.x/5.0 naming is consistent.
+        properties_set = getattr(counters, "properties_set", 0)
+        rels_created = getattr(counters, "relationships_created", 0)
+        rels_updated = (
+            getattr(counters, "relationships_updated", 0) if hasattr(counters, "relationships_updated") else 0
+        )
+
+        total_touched = nodes_created + nodes_updated + properties_set + rels_created + rels_updated
+
+        if batch_len > 0 and total_touched == 0:
+            logger.error(
+                "[MERGE-INEFFECTIVE] label=%s source=%s batch_len=%d — Neo4j counters "
+                "all zero (nodes_created=%d, nodes_updated=%d, properties_set=%d, "
+                "rels_created=%d, rels_updated=%d). The batch silently produced zero "
+                "writes. Likely cause: missing prerequisite node (e.g. Source), "
+                "constraint violation, or schema mismatch. Operator action: check the "
+                "current Source nodes via ``MATCH (s:Source {source_id: '%s'}) RETURN s`` "
+                "and re-run ``ensure_sources()`` if missing.",
+                label,
+                source_id,
+                batch_len,
+                nodes_created,
+                nodes_updated,
+                properties_set,
+                rels_created,
+                rels_updated,
+                source_id,
+            )
+            if _NEO4J_MERGE_INEFFECTIVE_BATCH is not None:
+                try:
+                    _NEO4J_MERGE_INEFFECTIVE_BATCH.labels(label=label, source=source_id).inc()
+                except Exception as _metric_err:
+                    # Same non-silent pattern as other metric guards.
+                    logger.debug(
+                        "ineffective-batch metric increment failed: %s",
+                        _metric_err,
+                        exc_info=True,
+                    )
+    except Exception as _inspect_err:
+        # Counter inspection itself failed (e.g. driver API change,
+        # result already consumed). Log at DEBUG and continue — don't
+        # let observability code break a production write.
+        logger.debug(
+            "result-counter inspection failed for label=%s source=%s: %s",
+            label,
+            source_id,
+            _inspect_err,
+            exc_info=True,
+        )
+
 
 # Configuration constants
 NEO4J_CONNECTION_TIMEOUT = 60  # seconds
@@ -2125,11 +2230,28 @@ class Neo4jClient:
                 """
 
                 with self.driver.session() as session:
-                    session.run(
+                    result = session.run(
                         query,
                         batch=batch_data,
                         source_node_uuid=source_node_uuid,
                         timeout=NEO4J_READ_TIMEOUT,
+                    )
+                    # PR-N9 B6 (audit 09 Prod Readiness #2, 2026-04-21):
+                    # inspect the result counters to detect silent-write
+                    # failures. Pre-fix we used ``len(batch)`` as the
+                    # success_count even when Neo4j rejected every row
+                    # (e.g. constraint violation, schema mismatch, wrong
+                    # label). The SOURCED_FROM inner MATCH could fail
+                    # silently if the Source node was missing (PR (S5)
+                    # documented this hazard) — the ON CREATE edge never
+                    # ran, but the outer success_count lied. This
+                    # mirrors the PR-N4 permanent-failure metric that
+                    # the MISPWriter side now emits.
+                    _record_batch_counters(
+                        label="Indicator",
+                        source_id=source_id,
+                        batch_len=len(batch),
+                        result=result,
                     )
 
                 success_count += len(batch)
@@ -2318,11 +2440,19 @@ class Neo4jClient:
                 """
 
                 with self.driver.session() as session:
-                    session.run(
+                    result = session.run(
                         query,
                         batch=batch_data,
                         source_node_uuid=source_node_uuid,
                         timeout=NEO4J_READ_TIMEOUT,
+                    )
+                    # PR-N9 B6: counter inspection (see
+                    # merge_indicators_batch for rationale).
+                    _record_batch_counters(
+                        label="Vulnerability",
+                        source_id=source_id,
+                        batch_len=len(batch_data),
+                        result=result,
                     )
 
                 success_count += len(batch_data)

--- a/tests/test_pr_n9_merge_robustness_bundle.py
+++ b/tests/test_pr_n9_merge_robustness_bundle.py
@@ -1,0 +1,367 @@
+"""
+PR-N9 — merge robustness bundle (NULL/empty filter + B6 observability).
+
+Two independent themes, both "merge logic robustness":
+
+## Fix A — NULL/empty filter in Q2/Q9 alias list comprehensions
+
+Follow-up to PR-N8's R1 Bugbot fix. PR-N8 R1 dropped the
+``coalesce(x, '')`` wrapper and hardened outer filters to
+``size(trim(x)) > 0``. That closed the whitespace-only-LHS false-
+match vector. BUT a separate remaining hazard existed in Q2:
+
+  - m.attributed_to = "  "  (whitespace-only)
+  - m.aliases = ["SomeAlias"]  (non-empty)
+  - a.aliases = ["foo", "  ", "bar"]  (contains a whitespace entry)
+
+Q2's outer ORs through the ``m.aliases non-empty`` leg even when
+m.attributed_to is whitespace-only → inner runs. Branch 2's
+comprehension ``[x IN a.aliases | toLower(trim(x))]`` yields
+``["foo", "", "bar"]``. Then ``"" IN ["foo", "", "bar"]`` →
+TRUE → spurious ATTRIBUTED_TO edge to every ThreatActor with a
+malformed alias entry.
+
+Fix: filter the list comprehensions to ``[x IN coalesce(..., [])
+WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))]``,
+so NULL and whitespace-only aliases are removed BEFORE the IN
+comparison.
+
+## Fix B — MERGE observability (audit finding B6)
+
+The 7-agent audit (PR-N0) flagged Prod Readiness #2: ``merge_
+indicators_batch`` / ``merge_vulnerabilities_batch`` use
+``len(batch)`` as the success_count regardless of what Neo4j
+actually wrote. If the write path silently fails (missing Source
+node, constraint violation, schema drift), the caller thinks
+every item succeeded.
+
+Fix: inspect ``result.consume().counters`` after every batch. If
+``nodes_created + nodes_updated + properties_set + rels_created +
+rels_updated == 0`` on a non-empty batch, emit ERROR log + increment
+``edgeguard_neo4j_merge_ineffective_batch_total{label, source}``.
+
+Analog of the PR-N4 ``edgeguard_misp_push_permanent_failure_total``
+on the MISPWriter side — now Neo4j has the same silent-data-loss
+signal.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n9")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n9")
+
+
+# ===========================================================================
+# Fix A — Q2 / Q9 alias list-comprehension filters NULL/empty entries
+# ===========================================================================
+
+
+class TestFixANullEmptyAliasFilter:
+    """List comprehensions over ``m.aliases`` / ``a.aliases`` must
+    filter out NULL and whitespace-only entries before the IN
+    comparison, so a single malformed alias can't produce a
+    spurious match via ``"" IN ["foo", "", "bar"]``."""
+
+    def _src(self) -> str:
+        return (SRC / "build_relationships.py").read_text()
+
+    def test_q2_inner_list_comprehensions_filter_null_and_whitespace(self):
+        """Q2 inner has two list comprehensions (a.aliases + m.aliases).
+        Both must carry the ``WHERE x IS NOT NULL AND size(trim(x)) > 0``
+        filter."""
+        src = self._src()
+        # Find Q2 block
+        step2_idx = src.find("[LINK] 2/12 Malware → ThreatActor")
+        step3_idx = src.find("[LINK] 3a/12", step2_idx)
+        block = src[step2_idx:step3_idx]
+
+        # Must have filter in both a.aliases and m.aliases comprehensions
+        a_alias_filter = "x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0"
+        m_alias_filter = "x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0"
+        assert a_alias_filter in block, "Q2 a.aliases comprehension must filter NULL/whitespace entries"
+        assert m_alias_filter in block, "Q2 m.aliases comprehension must filter NULL/whitespace entries"
+
+    def test_q9_inner_list_comprehension_filters_null_and_whitespace(self):
+        """Q9 inner has one list comprehension (m.aliases). Must carry
+        the same filter."""
+        src = self._src()
+        # Find Q9 inner
+        q9_idx = src.find("_q9_inner")
+        next_assignment = src.find("_q9_skip", q9_idx)
+        block = src[q9_idx:next_assignment]
+        m_alias_filter = "x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0"
+        assert m_alias_filter in block, "Q9 inner m.aliases comprehension must filter NULL/whitespace entries"
+
+    def test_q9_skip_list_comprehension_filters_null_and_whitespace(self):
+        """Q9's skip-query mirrors the inner's shape — must also filter."""
+        src = self._src()
+        q9_skip_idx = src.find("_q9_skip")
+        next_assignment = src.find("if not _safe_run_batched", q9_skip_idx)
+        block = src[q9_skip_idx:next_assignment]
+        m_alias_filter = "x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0"
+        assert m_alias_filter in block, "Q9 skip m.aliases comprehension must filter NULL/whitespace entries"
+
+    def test_no_bare_list_comprehension_without_filter(self):
+        """Regression pin: any ``[x IN coalesce(..., []) | toLower(...)]``
+        form WITHOUT the WHERE filter must NOT appear in build_relationships.py
+        for the alias-comprehension pattern.
+
+        Uses a targeted substring search rather than AST because we're
+        looking at Cypher embedded in Python strings."""
+        src = self._src()
+        # The specific unsafe forms (Q2 a.aliases / m.aliases, Q9 m.aliases)
+        unsafe_patterns = [
+            "[x IN coalesce(a.aliases, []) | toLower",
+            "[x IN coalesce(m.aliases, []) | toLower",
+        ]
+        for pat in unsafe_patterns:
+            assert pat not in src, (
+                f"Regression: unsafe bare comprehension {pat!r} must not "
+                "appear — wrap with `WHERE x IS NOT NULL AND size(trim(x)) > 0`"
+            )
+
+
+# ===========================================================================
+# Fix B — MERGE observability (B6)
+# ===========================================================================
+
+
+class TestFixBMergeObservability:
+    """``_record_batch_counters`` must exist, be called from both batch
+    methods, and the Prometheus metric must be declared."""
+
+    def _src(self) -> str:
+        return (SRC / "neo4j_client.py").read_text()
+
+    def _metrics(self) -> str:
+        return (SRC / "metrics_server.py").read_text()
+
+    def test_metric_declared_with_bounded_labels(self):
+        m = self._metrics()
+        assert "NEO4J_MERGE_INEFFECTIVE_BATCH = Counter(" in m
+        assert '"edgeguard_neo4j_merge_ineffective_batch_total"' in m
+        # Bounded cardinality: label + source, no event_id or other unbounded axes
+        assert '["label", "source"]' in m, (
+            "metric must use bounded label set [label, source] — no cardinality explosion"
+        )
+
+    def test_helper_function_defined(self):
+        src = self._src()
+        assert "def _record_batch_counters(" in src
+        # Must inspect the canonical counter fields
+        for counter_field in (
+            "nodes_created",
+            "nodes_updated",
+            "properties_set",
+            "relationships_created",
+        ):
+            assert counter_field in src, f"_record_batch_counters must inspect counters.{counter_field}"
+
+    def test_helper_emits_error_log_on_zero_effect(self):
+        """The ERROR log must fire when total_touched == 0 and
+        batch_len > 0."""
+        src = self._src()
+        fn_idx = src.find("def _record_batch_counters(")
+        assert fn_idx != -1
+        next_def = src.find("\ndef ", fn_idx + 1)
+        body = src[fn_idx : next_def if next_def != -1 else fn_idx + 5000]
+        assert "logger.error" in body, "must emit ERROR log on ineffective batch"
+        assert "batch_len > 0 and total_touched == 0" in body, "zero-effect detection must use the exact condition"
+
+    def test_helper_never_raises(self):
+        """Counter-inspection failures must NOT propagate — observability
+        code must not break production writes."""
+        src = self._src()
+        fn_idx = src.find("def _record_batch_counters(")
+        next_def = src.find("\ndef ", fn_idx + 1)
+        body = src[fn_idx : next_def if next_def != -1 else fn_idx + 5000]
+        # Outer try/except wrapping the entire body
+        assert "except Exception as _inspect_err:" in body, "must catch inspection exceptions to avoid breaking writes"
+
+    def test_helper_guards_metric_on_none(self):
+        """Uses the PR-N5 R1 pattern — explicit is-not-None check so the
+        nested-import fallback (older metrics_server) doesn't AttributeError."""
+        src = self._src()
+        fn_idx = src.find("def _record_batch_counters(")
+        next_def = src.find("\ndef ", fn_idx + 1)
+        body = src[fn_idx : next_def if next_def != -1 else fn_idx + 5000]
+        assert "_NEO4J_MERGE_INEFFECTIVE_BATCH is not None" in body, (
+            "metric increment must be guarded by explicit is-not-None check"
+        )
+
+    def test_merge_indicators_batch_calls_helper(self):
+        """The Indicator batch must invoke the helper after session.run."""
+        src = self._src()
+        fn_idx = src.find("def merge_indicators_batch(")
+        next_def = src.find("\n    def ", fn_idx + 1)
+        body = src[fn_idx : next_def if next_def != -1 else fn_idx + 5000]
+        assert "_record_batch_counters(" in body, "merge_indicators_batch must call _record_batch_counters"
+        # Specifically with label="Indicator"
+        assert 'label="Indicator"' in body
+
+    def test_merge_vulnerabilities_batch_calls_helper(self):
+        src = self._src()
+        fn_idx = src.find("def merge_vulnerabilities_batch(")
+        next_def = src.find("\n    def ", fn_idx + 1)
+        body = src[fn_idx : next_def if next_def != -1 else fn_idx + 5000]
+        assert "_record_batch_counters(" in body
+        assert 'label="Vulnerability"' in body
+
+    def test_optional_import_graceful_degradation(self):
+        """The nested counter import must be inside a try/except so older
+        metrics_server deploys don't break the PR-N4/N5 counters."""
+        src = self._src()
+        assert "NEO4J_MERGE_INEFFECTIVE_BATCH as _NEO4J_MERGE_INEFFECTIVE_BATCH" in src
+        assert "_NEO4J_MERGE_INEFFECTIVE_BATCH = None" in src, (
+            "must set to None on nested ImportError (graceful degradation)"
+        )
+
+    # --- Behavioural ---
+
+    def test_behaviour_zero_counters_triggers_error(self, caplog):
+        """Given a mocked result whose consume().counters show
+        everything at 0 on a non-empty batch, the helper must emit an
+        ERROR log."""
+        import importlib
+        import logging
+
+        if "neo4j_client" in sys.modules:
+            del sys.modules["neo4j_client"]
+        neo4j_client = importlib.import_module("neo4j_client")
+
+        # Build a mock result with all-zero counters
+        counters = MagicMock()
+        counters.nodes_created = 0
+        counters.nodes_updated = 0
+        counters.properties_set = 0
+        counters.relationships_created = 0
+        counters.relationships_updated = 0
+        # Make hasattr() work for nodes_updated / relationships_updated
+        # (otherwise getattr returns the MagicMock auto-attr, not 0).
+        # The MagicMock above already satisfies hasattr.
+
+        result = MagicMock()
+        result.consume.return_value.counters = counters
+
+        with caplog.at_level(logging.ERROR, logger="neo4j_client"):
+            neo4j_client._record_batch_counters(
+                label="Indicator",
+                source_id="otx",
+                batch_len=100,
+                result=result,
+            )
+
+        assert any("MERGE-INEFFECTIVE" in rec.message for rec in caplog.records), (
+            f"expected ineffective-batch ERROR; got: {[r.message for r in caplog.records]}"
+        )
+
+    def test_behaviour_nonzero_counters_no_error(self, caplog):
+        """Given a mocked result with ANY non-zero counter, the helper
+        must NOT emit the ineffective-batch ERROR."""
+        import importlib
+        import logging
+
+        if "neo4j_client" in sys.modules:
+            del sys.modules["neo4j_client"]
+        neo4j_client = importlib.import_module("neo4j_client")
+
+        counters = MagicMock()
+        counters.nodes_created = 5
+        counters.nodes_updated = 0
+        counters.properties_set = 20
+        counters.relationships_created = 5
+        counters.relationships_updated = 0
+
+        result = MagicMock()
+        result.consume.return_value.counters = counters
+
+        with caplog.at_level(logging.ERROR, logger="neo4j_client"):
+            neo4j_client._record_batch_counters(
+                label="Indicator",
+                source_id="otx",
+                batch_len=100,
+                result=result,
+            )
+
+        ineffective = [r for r in caplog.records if "MERGE-INEFFECTIVE" in r.message]
+        assert not ineffective, (
+            f"ineffective-batch ERROR must NOT fire when writes happened; got: {[r.message for r in ineffective]}"
+        )
+
+    def test_behaviour_empty_batch_no_error(self, caplog):
+        """batch_len == 0 is not ineffective (nothing to do). No ERROR."""
+        import importlib
+        import logging
+
+        if "neo4j_client" in sys.modules:
+            del sys.modules["neo4j_client"]
+        neo4j_client = importlib.import_module("neo4j_client")
+
+        counters = MagicMock()
+        counters.nodes_created = 0
+        counters.nodes_updated = 0
+        counters.properties_set = 0
+        counters.relationships_created = 0
+        counters.relationships_updated = 0
+
+        result = MagicMock()
+        result.consume.return_value.counters = counters
+
+        with caplog.at_level(logging.ERROR, logger="neo4j_client"):
+            neo4j_client._record_batch_counters(
+                label="Indicator",
+                source_id="otx",
+                batch_len=0,  # empty batch — legitimately no writes
+                result=result,
+            )
+
+        ineffective = [r for r in caplog.records if "MERGE-INEFFECTIVE" in r.message]
+        assert not ineffective, "empty batch must not trigger ineffective-batch ERROR"
+
+    def test_behaviour_consume_exception_swallowed(self, caplog):
+        """If result.consume() itself raises, the helper must not
+        propagate — observability code never breaks production writes."""
+        import importlib
+        import logging
+
+        if "neo4j_client" in sys.modules:
+            del sys.modules["neo4j_client"]
+        neo4j_client = importlib.import_module("neo4j_client")
+
+        result = MagicMock()
+        result.consume.side_effect = RuntimeError("simulated driver error")
+
+        with caplog.at_level(logging.DEBUG, logger="neo4j_client"):
+            # Must not raise
+            neo4j_client._record_batch_counters(
+                label="Indicator",
+                source_id="otx",
+                batch_len=100,
+                result=result,
+            )
+
+        # DEBUG log captured (the inspection-failure breadcrumb)
+        assert any("result-counter inspection failed" in rec.message for rec in caplog.records)
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_build_relationships_imports(self):
+        import build_relationships  # noqa: F401
+
+    def test_neo4j_client_imports(self):
+        import neo4j_client  # noqa: F401


### PR DESCRIPTION
## Summary

Two independent merge-logic robustness themes bundled — both small, both low-risk, both close findings from the audit series.

### Fix A — NULL/empty filter in Q2/Q9 alias list comprehensions

Follow-up to PR-N8 R1 Bugbot. A whitespace-only `m.attributed_to` can still reach Q2's inner (via the OR outer's `m.aliases` non-empty leg). If any `a.aliases` entry is NULL or whitespace-only, `"" IN [..., "", ...]` → TRUE → **spurious `ATTRIBUTED_TO` edge to every ThreatActor with a malformed alias**.

Walk table (post-PR-N8-R1, pre-PR-N9):
| `m.attr` | `m.aliases` | `a.aliases` | Outer | Inner branch 2 | Result |
|---|---|---|---|---|---|
| `"  "` | `["x"]` | `["foo"]` | pass (via aliases leg) | `"" IN ["foo"]` → FALSE | no match ✓ |
| `"  "` | `["x"]` | `["foo", "  "]` | pass | `"" IN ["foo", ""]` → **TRUE** | **🔴 spurious match** |

Fix: filter `[x IN coalesce(..., []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))]`. Applied to 4 sites (Q2 inner × 2 comprehensions, Q9 inner, Q9 skip).

### Fix B — MERGE observability (audit finding B6)

`merge_indicators_batch` / `merge_vulnerabilities_batch` used `len(batch)` as success_count regardless of what Neo4j actually wrote. Silent failures (missing Source, constraint violation, schema drift) went undetected.

Fix:
- New counter `edgeguard_neo4j_merge_ineffective_batch_total{label, source}` in `metrics_server.py`
- New `_record_batch_counters()` helper in `neo4j_client.py` — inspects `result.consume().counters` for `nodes_created + nodes_updated + properties_set + relationships_created + relationships_updated`. If total == 0 on a non-empty batch: ERROR log + metric increment.
- Invoked from both batch methods.
- **Bounded labels** (no event_id / no unbounded axes — PR-N4 R2 cardinality discipline)
- **Optional-import graceful degradation** for older metrics_server deploys (PR-N5 C7 pattern)
- **Never propagates** — observability can't break production writes

Analog of the PR-N4 `edgeguard_misp_push_permanent_failure_total` on the MISPWriter side — now Neo4j gets the same silent-data-loss signal.

## Test plan

- [x] 18 new regression tests in `tests/test_pr_n9_merge_robustness_bundle.py`
  - 4 source pins on the alias-filter sites + regression pin against un-filtered comprehensions
  - 7 source pins on the observability helper + metric
  - 4 behavioural (zero counters → ERROR, non-zero → no ERROR, empty batch → no ERROR, consume() exception swallowed)
  - 2 import-cleanliness
  - 1 optional-import fallback
- [x] `ruff format` ✓ / `ruff check` ✓ / `mypy src/` ✓
- [x] Full suite: **1313 passed**, 3 skipped, 3 xfailed (was 1295 + 18 new)

## Operator notes

- **Grafana alert:** `rate(edgeguard_neo4j_merge_ineffective_batch_total[5m]) > 0` for 5 min → silent-write failure on Neo4j side, detectable within 5 min.
- **Q2 ATTRIBUTED_TO edges** no longer include spurious matches to ThreatActors with malformed aliases.

## Audit-finding status (what's still outstanding after PR-N9)

Closed today across PR-N4 → PR-N9 (all BLOCK + HIGH findings):
- ✅ Q9 calibrator re-inflation (PR-N8 BLOCK)
- ✅ Enrichment edge timestamps (PR-N8 HIGH)
- ✅ Narrow exception catch (PR-N8 HIGH)
- ✅ Canonicalization parity (PR-N8 HIGH + R1 + this PR's alias-filter)
- ✅ MERGE observability (this PR — B6 HIGH)

Remaining from the 5-agent audit (MED/LOW, can defer):
- MED: Sector edges (7a/7b) missing `match_type` / `source_id` — provenance gap
- MED: Confidence-score ceiling no single source of truth — helpers in `neo4j_client.py` vs `build_relationships.py` disagree
- MED: UNWIND of un-deduped `uses_techniques` arrays — wasted MERGE work
- LOW: PR-N7 AST guard pattern-specific (`<> ''` only) — variants bypass
- LOW: `_safe_run` (singular) dead code
- LOW: 75% test literal-pinning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are narrow Cypher predicate hardening plus additive metrics/logging around batch MERGE results, with regression tests. Main risk is unintentionally reducing matches when alias data contains edge-case whitespace/NULL values or consuming query results for counter inspection.
> 
> **Overview**
> Prevents spurious graph edges by filtering NULL/whitespace-only values out of alias list comprehensions in `build_relationships.py` (Q2 `Malware → ThreatActor` and Q9 `Indicator → Malware`, including the Q9 skip query).
> 
> Adds a new Prometheus counter `edgeguard_neo4j_merge_ineffective_batch_total{label,source}` and a `_record_batch_counters()` helper in `neo4j_client.py` to detect and log/metric non-empty batch MERGEs that result in zero Neo4j counter-visible writes; wired into both `merge_indicators_batch` and `merge_vulnerabilities_batch` with optional-import fallback.
> 
> Introduces a dedicated test bundle covering the alias-filter regression, the new metric declaration, and the ineffective-batch detection behavior (including “never raise” guards).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 48e1d9182b99d8e14cc1bdb384f6099c0e878af2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->