### PR TITLE
fix(audit): PR-N10 — pre-baseline BLOCK-MERGE bundle (3 findings)

### DIFF
--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -17,8 +17,18 @@ import logging
 
 from config import VALID_ZONES
 from neo4j_client import Neo4jClient
-from node_identity import compute_node_uuid
+from node_identity import _REJECTED_PLACEHOLDER_NAMES, compute_node_uuid
 from query_pause import query_pause
+
+# PR-N10 (7-agent audit): defense-in-depth placeholder filter for Q2/Q9
+# MATCH clauses. The merge-time reject in neo4j_client.merge_malware /
+# merge_actor blocks the primary vector (feeds emitting "unknown" as a
+# default name), but there may be PRE-EXISTING Malware/ThreatActor
+# nodes in the graph from before PR-N10 that carry placeholder names.
+# Embed the rejected set as a Cypher literal list so Q2/Q9 also filter
+# at query time. Sorted for stable generated Cypher across Python runs
+# (frozenset iteration order is implementation-defined).
+_PLACEHOLDER_NAMES_CYPHER_LIST = "[" + ", ".join(f'"{name}"' for name in sorted(_REJECTED_PLACEHOLDER_NAMES)) + "]"
 
 try:
     from metrics_server import record_neo4j_relationships
@@ -399,8 +409,35 @@ def build_relationships():
         # ATTRIBUTED_TO edge to every ThreatActor with a malformed
         # alias. Unlikely in clean data but observable on noisy
         # threat-intel feeds. Filter restores robustness.
-        _outer = "MATCH (m:Malware) WHERE (m.attributed_to IS NOT NULL AND size(trim(m.attributed_to)) > 0) OR size(coalesce(m.aliases, [])) > 0 RETURN m"
-        _inner = 'WITH $m AS m MATCH (a:ThreatActor) WHERE toLower(trim(m.attributed_to)) = toLower(trim(a.name)) OR toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] MERGE (m)-[r:ATTRIBUTED_TO]->(a) ON CREATE SET r.confidence_score = 1.0, r.match_type = "exact", r.created_at = datetime() SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, m.uuid), r.trg_uuid = coalesce(r.trg_uuid, a.uuid)'
+        # PR-N10 defense-in-depth: filter pre-existing placeholder-named
+        # Malware/Actor nodes (created before the merge-time reject
+        # shipped in neo4j_client.py). The placeholder check for
+        # ``m.attributed_to`` lives INSIDE the attributed_to OR-branch
+        # (not at the end with an AND) so that a row with NULL
+        # attributed_to but non-empty ``m.aliases`` still passes the
+        # outer via the aliases branch. Putting the NOT IN check at
+        # the end with AND would make NULL-propagation kill those
+        # legitimate rows (NULL IN […] → NULL → falsy → AND … → falsy).
+        # Inner separately rejects placeholder ``a.name``.
+        _outer = (
+            "MATCH (m:Malware) "
+            "WHERE (m.attributed_to IS NOT NULL "
+            "       AND size(trim(m.attributed_to)) > 0 "
+            f"       AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST}) "
+            "   OR size(coalesce(m.aliases, [])) > 0 "
+            "RETURN m"
+        )
+        _inner = (
+            "WITH $m AS m MATCH (a:ThreatActor) "
+            # PR-N10: reject placeholder actor names at the inner
+            f"WHERE NOT toLower(trim(a.name)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
+            "AND (toLower(trim(m.attributed_to)) = toLower(trim(a.name)) "
+            "   OR toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] "
+            "   OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))]) "
+            "MERGE (m)-[r:ATTRIBUTED_TO]->(a) "
+            'ON CREATE SET r.confidence_score = 1.0, r.match_type = "exact", r.created_at = datetime() '
+            "SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, m.uuid), r.trg_uuid = coalesce(r.trg_uuid, a.uuid)"
+        )
         if not _safe_run_batched(client, "Malware → ThreatActor", _outer, _inner, stats, "attributed_to"):
             failures += 1
         query_pause()
@@ -692,8 +729,21 @@ def build_relationships():
         # so whitespace-only values (e.g. ``"   "``) are rejected
         # before they reach the comparison. Prevents the spurious-
         # match chain described below on the inner query.
+        # PR-N10 defense-in-depth: drop Indicators whose malware_family
+        # canonicalizes to a placeholder (e.g. "unknown", "Unknown
+        # malware", "N/A"). See node_identity._REJECTED_PLACEHOLDER_NAMES
+        # for the full list. The merge-time reject in neo4j_client.
+        # merge_malware blocks the primary vector at ingest; this
+        # defense catches legacy indicators already in the graph AND
+        # placeholder values on Indicator.malware_family that come from
+        # collector default fallbacks (vt_collector.py:425,
+        # global_feed_collector.py:322, misp_collector.py:403).
         _q9_outer = (
-            "MATCH (i:Indicator) WHERE i.malware_family IS NOT NULL AND size(trim(i.malware_family)) > 0 RETURN i"
+            "MATCH (i:Indicator) "
+            "WHERE i.malware_family IS NOT NULL "
+            "AND size(trim(i.malware_family)) > 0 "
+            f"AND NOT toLower(trim(i.malware_family)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
+            "RETURN i"
         )
         # PR-M3c §8-RI-S3-Q9 (HIGH): this is the overwrite site. The SAME
         # INDICATES edge may already exist from Q4 (co-occurrence) with
@@ -766,14 +816,20 @@ def build_relationships():
         # hardened to ``size(trim(...)) > 0`` as belt-and-suspenders.
         _q9_inner = (
             "WITH $i AS i MATCH (m:Malware) "
-            "WHERE toLower(trim(m.name)) = toLower(trim(i.malware_family)) "
+            # PR-N10 defense-in-depth: skip Malware nodes whose canonical
+            # name is a placeholder — the merge-time reject at
+            # neo4j_client.merge_malware blocks new creation, but legacy
+            # "unknown" Malware nodes from pre-PR-N10 graphs could still
+            # hub false edges here.
+            f"WHERE NOT toLower(trim(m.name)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
+            "AND (toLower(trim(m.name)) = toLower(trim(i.malware_family)) "
             # PR-N9: filter NULL/whitespace aliases (see Q2 comment for
             # rationale). Q9's outer filter already ensures
             # trim(i.malware_family) is non-empty so the LHS can't
             # produce a false-match via "" = "", but defense-in-depth
             # keeps the shape symmetric with Q2.
             "   OR toLower(trim(i.malware_family)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] "
-            "   OR toLower(trim(m.family)) = toLower(trim(i.malware_family)) "
+            "   OR toLower(trim(m.family)) = toLower(trim(i.malware_family))) "
             "MERGE (i)-[r:INDICATES]->(m) "
             "ON CREATE SET r.created_at = datetime() "
             "SET r.confidence_score = CASE "
@@ -794,14 +850,20 @@ def build_relationships():
         # _q9_inner with the coalesce DROPPED (see _q9_inner comment
         # above for rationale). Outer filter also uses size(trim(...)).
         _q9_skip = (
-            "MATCH (i:Indicator) WHERE i.malware_family IS NOT NULL AND size(trim(i.malware_family)) > 0 "
+            "MATCH (i:Indicator) WHERE i.malware_family IS NOT NULL "
+            "AND size(trim(i.malware_family)) > 0 "
+            # PR-N10: exclude placeholder malware_family (so orphan
+            # count matches actual match behaviour post-placeholder-filter)
+            f"AND NOT toLower(trim(i.malware_family)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
             "AND NOT EXISTS { "
             "  MATCH (m:Malware) "
-            "  WHERE toLower(trim(m.name)) = toLower(trim(i.malware_family)) "
+            # PR-N10: same Malware-name placeholder filter as _q9_inner
+            f"  WHERE NOT toLower(trim(m.name)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
+            "  AND (toLower(trim(m.name)) = toLower(trim(i.malware_family)) "
             # PR-N9: same NULL/whitespace filter as _q9_inner above so
             # the orphan count matches actual match behaviour.
             "     OR toLower(trim(i.malware_family)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] "
-            "     OR toLower(trim(m.family)) = toLower(trim(i.malware_family)) "
+            "     OR toLower(trim(m.family)) = toLower(trim(i.malware_family))) "
             "} "
             "RETURN count(i) AS c"
         )

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -20,6 +20,7 @@ from neo4j_client import Neo4jClient
 from node_identity import _REJECTED_PLACEHOLDER_NAMES, compute_node_uuid
 from query_pause import query_pause
 
+
 # PR-N10 (7-agent audit): defense-in-depth placeholder filter for Q2/Q9
 # MATCH clauses. The merge-time reject in neo4j_client.merge_malware /
 # merge_actor blocks the primary vector (feeds emitting "unknown" as a
@@ -28,7 +29,28 @@ from query_pause import query_pause
 # Embed the rejected set as a Cypher literal list so Q2/Q9 also filter
 # at query time. Sorted for stable generated Cypher across Python runs
 # (frozenset iteration order is implementation-defined).
-_PLACEHOLDER_NAMES_CYPHER_LIST = "[" + ", ".join(f'"{name}"' for name in sorted(_REJECTED_PLACEHOLDER_NAMES)) + "]"
+#
+# PR-N10 follow-up (cursor-bugbot 2026-04-21, Low): escape ``"`` and
+# ``\`` in each entry before embedding into the double-quoted Cypher
+# literal. All current entries are safe, but future additions (e.g. a
+# feed emitting ``unknown (vendor="n/a")`` as a placeholder) could
+# otherwise produce malformed Cypher or, worse, unintended query
+# behaviour — and this list is interpolated into security-critical
+# WHERE clauses in Q2 + Q9. The escaping rule mirrors Neo4j's string-
+# literal grammar: backslash → ``\\``, double quote → ``\"``. We can't
+# use query parameters here because the list is part of the Cypher
+# template string passed to apoc.periodic.iterate, which evaluates
+# parameters per-row, not at template-substitution time.
+def _escape_cypher_double_quoted(value: str) -> str:
+    """Escape ``\\`` and ``"`` for embedding in a Cypher double-quoted
+    string literal. Order matters: escape backslash FIRST, otherwise
+    the replacement's ``\\"`` would itself be re-escaped."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+_PLACEHOLDER_NAMES_CYPHER_LIST = (
+    "[" + ", ".join(f'"{_escape_cypher_double_quoted(name)}"' for name in sorted(_REJECTED_PLACEHOLDER_NAMES)) + "]"
+)
 
 try:
     from metrics_server import record_neo4j_relationships
@@ -427,13 +449,36 @@ def build_relationships():
             "   OR size(coalesce(m.aliases, [])) > 0 "
             "RETURN m"
         )
+        # PR-N10 follow-up (cursor-bugbot 2026-04-21, Medium): placeholder
+        # filter for ``m.attributed_to`` must be scoped to branches 1 + 2
+        # (the ones that READ attributed_to), not at the top level — a
+        # top-level guard would filter out rows with NULL attributed_to
+        # even when branch 3 (alias-only path) should still match. The
+        # PR-N8 R1 pin forbids ``coalesce(m.attributed_to, '')`` because
+        # it breaks NULL propagation (NULL trim/compare → NULL → falsy
+        # is the correct filter behaviour for the outer).
+        #
+        # So: attr_present gate applied INSIDE branches 1+2 and nowhere
+        # else. Alias comprehensions on both sides additionally drop
+        # placeholder entries as defense-in-depth.
         _inner = (
             "WITH $m AS m MATCH (a:ThreatActor) "
-            # PR-N10: reject placeholder actor names at the inner
+            # PR-N10: reject placeholder actor names at the inner.
             f"WHERE NOT toLower(trim(a.name)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
-            "AND (toLower(trim(m.attributed_to)) = toLower(trim(a.name)) "
-            "   OR toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))] "
-            "   OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 | toLower(trim(x))]) "
+            "AND ("
+            # Branch 1: m.attributed_to = a.name — requires non-placeholder attributed_to
+            "   (m.attributed_to IS NOT NULL AND size(trim(m.attributed_to)) > 0 "
+            f"       AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
+            "       AND toLower(trim(m.attributed_to)) = toLower(trim(a.name))) "
+            # Branch 2: m.attributed_to ∈ actor.aliases — same gate,
+            # plus aliases comprehension drops placeholder entries.
+            "   OR (m.attributed_to IS NOT NULL AND size(trim(m.attributed_to)) > 0 "
+            f"       AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
+            f"       AND toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 AND NOT toLower(trim(x)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} | toLower(trim(x))]) "
+            # Branch 3: a.name ∈ malware.aliases — doesn't read
+            # attributed_to, reachable when attributed_to is NULL.
+            f"   OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 AND NOT toLower(trim(x)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} | toLower(trim(x))]"
+            ") "
             "MERGE (m)-[r:ATTRIBUTED_TO]->(a) "
             'ON CREATE SET r.confidence_score = 1.0, r.match_type = "exact", r.created_at = datetime() '
             "SET r.updated_at = datetime(), r.src_uuid = coalesce(r.src_uuid, m.uuid), r.trg_uuid = coalesce(r.trg_uuid, a.uuid)"

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -982,6 +982,20 @@ class MISPWriter:
                 "otx_industries": indicator.get("otx_industries", []),
                 "description": indicator.get("description", ""),
                 "pulse_name": indicator.get("pulse_name", ""),
+                # PR-N10 Fix #3 (7-agent audit Logic Tracker B1, 2026-04-21):
+                # include ``malware_family`` and ``attributed_to`` so they
+                # survive the MISP round-trip to Neo4j. Pre-fix, OTX_META
+                # had neither field — an OTX pulse providing a malware
+                # family ("Emotet") or actor attribution ("APT29") was
+                # serialized to MISP without these keys. On read-back
+                # (``run_misp_to_neo4j.py`` _attribute_to_stix21 / the
+                # Indicator reconstruction around L2917) ``i.malware_family``
+                # was NULL, so Q9 INDICATES edges never fired for OTX.
+                # TF_META below already carries ``malware_family``; this
+                # brings OTX to parity. ``attributed_to`` is a new field
+                # in both meta blocks (TF_META extended in mirror below).
+                "malware_family": indicator.get("malware_family", ""),
+                "attributed_to": indicator.get("attributed_to", ""),
             }
             comment = "OTX_META:" + json.dumps(otx_meta, default=str)
             if len(comment) > 4000:
@@ -997,6 +1011,10 @@ class MISPWriter:
                 "threat_type_desc": indicator.get("threat_type_desc", ""),
                 "malware_family": indicator.get("malware_family", ""),
                 "reporter": indicator.get("reporter", ""),
+                # PR-N10 Fix #3: mirror OTX_META's new ``attributed_to``
+                # so TF-sourced indicators also carry the attribution
+                # hint through the MISP round-trip.
+                "attributed_to": indicator.get("attributed_to", ""),
             }
             comment = "TF_META:" + json.dumps(tf_meta, default=str)
             if len(comment) > 4000:

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -34,7 +34,12 @@ except ImportError:
 # src/node_identity.py for the namespace, canonicalization rules, and the
 # per-label natural-key map.
 import source_registry  # noqa: E402  — single-source-of-truth for SOURCES dict (chip 5a refactor)
-from node_identity import canonicalize_merge_key, compute_node_uuid, edge_endpoint_uuids  # noqa: E402
+from node_identity import (  # noqa: E402
+    canonicalize_merge_key,
+    compute_node_uuid,
+    edge_endpoint_uuids,
+    is_placeholder_name,
+)
 from query_pause import query_pause  # noqa: E402
 
 # Configure logging
@@ -151,6 +156,45 @@ def _record_batch_counters(*, label: str, source_id: str, batch_len: int, result
             _inspect_err,
             exc_info=True,
         )
+
+
+def _confidence_respect_calibrator(value) -> str:
+    """PR-N10 (7-agent audit Cross-Checker BLOCK 1, 2026-04-21): return
+    a Cypher ``CASE`` expression for ``r.confidence_score`` writes that
+    respects the calibrator's demotion stamp.
+
+    Background: PR-N8 added a calibrator-respect guard to Q9 in
+    ``build_relationships.py:817`` so Q9's max-wins floor doesn't
+    re-inflate calibrator-demoted edges (0.30 → 0.8). But the cross-
+    checker audit found that 6 ``create_*_relationship`` helpers in
+    this module + ``create_misp_relationships_batch._set_clause``
+    ALSO unconditionally SET ``r.confidence_score``, undoing the
+    calibrator on every sync. The flap was bidirectional:
+
+        Enrichment  → calibrator sets 0.30 + r.calibrated_at
+        Next sync   → create_*_relationship UNCONDITIONALLY sets 0.7
+                      (or 0.5, 0.6, 1.0 depending on helper)
+                      → calibrator's work erased
+
+    This helper generates the same CASE pattern Q9 uses, so a SET like
+
+        SET r.confidence_score = 0.7
+
+    becomes
+
+        SET r.confidence_score = CASE
+            WHEN r.calibrated_at IS NOT NULL THEN r.confidence_score
+            ELSE 0.7
+        END
+
+    Usage in an f-string Cypher template:
+
+        f"SET r.confidence_score = {_confidence_respect_calibrator(0.7)}"
+
+    Accepts numeric literals or Cypher expressions (e.g. the ``$conf``
+    parameter in the batched `_set_clause` path).
+    """
+    return f"CASE WHEN r.calibrated_at IS NOT NULL THEN r.confidence_score ELSE {value} END"
 
 
 # Configuration constants
@@ -1790,8 +1834,42 @@ class Neo4jClient:
         original Cypher-side case-sensitive MERGE was the only thing
         creating duplicates). Operators who relied on display case can
         recover the variant strings from ``n.aliases[]``.
+
+        PR-N10 (2026-04-21 7-agent audit Bug Hunter P1, Red Team #1):
+        reject MERGE when ``name`` canonicalizes to a placeholder
+        sentinel like "unknown", "Unknown malware", "N/A", "none", etc.
+        Three failure modes pre-fix:
+          (1) Feeds emitting default ``"unknown"`` (VT fallback, OTX
+              pulse-author fallback, MISPCollector meta-category
+              fallback, ThreatFox malware_printable) create a single
+              ``Malware{name:"unknown"}`` node. Q9 then links every
+              Indicator with family="unknown" to it.
+          (2) A compromised MISP peer (or low-privilege MISP user)
+              creates ``Malware{name:"unknown", attributed_to:"APT29"}``.
+              Q9 → thousands of false INDICATES; Q2 → false ATTRIBUTED_TO
+              edge to real APT29 ThreatActor. Adversarial attribution.
+          (3) ``build_campaign_nodes`` treats the placeholder-"unknown"
+              Malware as a campaign anchor → false campaign absorbs
+              indicators from dozens of unrelated threats.
+        Defense-in-depth: Q2/Q9 Cypher WHERE also filter placeholders.
         """
-        key_props = canonicalize_merge_key("Malware", {"name": data.get("name")})
+        # PR-N10: reject placeholder names at ingest. Canonicalization
+        # (NFC + strip + lower) happens inside is_placeholder_name so
+        # "Unknown", "UNKNOWN", "  unknown  " all normalize identically.
+        raw_name = data.get("name")
+        if is_placeholder_name(raw_name):
+            logger.warning(
+                "[MERGE-REJECT] Malware name=%r is a placeholder sentinel — "
+                "skipping MERGE. Source=%s. This is defense against feeds "
+                "emitting 'unknown'/'N/A'/'Generic' as default names and "
+                "against adversarial MISP attribution hijack (audit Bug "
+                "Hunter P1, Red Team #1). See node_identity."
+                "_REJECTED_PLACEHOLDER_NAMES for the full list.",
+                raw_name,
+                source_id,
+            )
+            return False
+        key_props = canonicalize_merge_key("Malware", {"name": raw_name})
         # Store malware types and aliases on the node for easier querying
         malware_types = data.get("malware_types", [])
         aliases = data.get("aliases", [])
@@ -1817,8 +1895,23 @@ class Neo4jClient:
         actor-rename problem — e.g. APT29 → Cozy Bear → Midnight Blizzard
         — that's Tier A A1 and needs an alias-graph resolution pass,
         not just casing.)
+
+        PR-N10: same placeholder-name reject as merge_malware. See that
+        function's docstring for the full rationale. Without this guard,
+        ``ThreatActor{name:"unknown"}`` becomes a false-hub to every
+        Malware whose attributed_to is "unknown" / "unspecified" / etc.
         """
-        key_props = canonicalize_merge_key("ThreatActor", {"name": data.get("name")})
+        raw_name = data.get("name")
+        if is_placeholder_name(raw_name):
+            logger.warning(
+                "[MERGE-REJECT] ThreatActor name=%r is a placeholder sentinel — "
+                "skipping MERGE. Source=%s. See merge_malware docstring for "
+                "rationale (PR-N10 audit Bug Hunter P3, Red Team #2).",
+                raw_name,
+                source_id,
+            )
+            return False
+        key_props = canonicalize_merge_key("ThreatActor", {"name": raw_name})
         aliases = data.get("aliases", [])
         description = data.get("description", "")
         # uses_techniques: list of MITRE technique IDs this actor explicitly uses,
@@ -2523,7 +2616,7 @@ class Neo4jClient:
         MERGE (a)-[r:EMPLOYS_TECHNIQUE]->(t)
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.7,
+            r.confidence_score = {_confidence_respect_calibrator(0.7)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, a.uuid),
@@ -2573,7 +2666,7 @@ class Neo4jClient:
         MERGE (m)-[r:ATTRIBUTED_TO]->(a)
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.7,
+            r.confidence_score = {_confidence_respect_calibrator(0.7)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, m.uuid),
@@ -2636,7 +2729,7 @@ class Neo4jClient:
         MERGE (i)-[r:INDICATES]->(v)
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.5,
+            r.confidence_score = {_confidence_respect_calibrator(0.5)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, i.uuid),
@@ -2649,7 +2742,7 @@ class Neo4jClient:
         MERGE (i)-[r:INDICATES]->(v)
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.5,
+            r.confidence_score = {_confidence_respect_calibrator(0.5)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, i.uuid),
@@ -2704,7 +2797,7 @@ class Neo4jClient:
         MERGE (i)-[r:INDICATES]->(m)
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.6,
+            r.confidence_score = {_confidence_respect_calibrator(0.6)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, i.uuid),
@@ -2770,7 +2863,7 @@ class Neo4jClient:
         MERGE (i)-[r:TARGETS]->(s)
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.5,
+            r.confidence_score = {_confidence_respect_calibrator(0.5)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, i.uuid),
@@ -2834,7 +2927,7 @@ class Neo4jClient:
         rel_props = f"""
         SET r.sources = {_dedup_concat_clause("r.sources", "[$source_id]")},
             r.source_id = $source_id,
-            r.confidence_score = 0.5,
+            r.confidence_score = {_confidence_respect_calibrator(0.5)},
             r.imported_at = coalesce(r.imported_at, datetime()),
             r.updated_at = datetime(),
             r.src_uuid = coalesce(r.src_uuid, v.uuid),
@@ -3177,10 +3270,18 @@ class Neo4jClient:
                 "r.misp_event_ids", "row.misp_event_id", require_nonempty_string=True
             )
             extra = f"\n            {extra_set}," if extra_set else ""
+            # PR-N10 (7-agent audit Cross-Checker BLOCK 1): respect the
+            # calibrator's demotion stamp. Pre-fix this batched helper
+            # (the chokepoint for create_misp_relationships_batch, called
+            # on every sync) unconditionally SET ``r.confidence_score =
+            # row.confidence``, undoing the calibrator's 0.30 demotion
+            # the next time the sync ran. Post-fix the CASE preserves
+            # any value written after ``r.calibrated_at`` was stamped.
+            confidence_expr = _confidence_respect_calibrator("row.confidence")
             return (
                 f"SET r.sources = {sources_dedup},\n"
                 f"            r.source_id = row.source_id,\n"
-                f"            r.confidence_score = row.confidence,{extra}\n"
+                f"            r.confidence_score = {confidence_expr},{extra}\n"
                 f"            r.misp_event_ids = {misp_dedup},\n"
                 f"            r.imported_at = coalesce(r.imported_at, datetime()),\n"
                 f"            r.updated_at = datetime(),\n"

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -193,7 +193,20 @@ def _confidence_respect_calibrator(value) -> str:
 
     Accepts numeric literals or Cypher expressions (e.g. the ``$conf``
     parameter in the batched `_set_clause` path).
+
+    Kill-switch: setting ``EDGEGUARD_RESPECT_CALIBRATOR`` to one of
+    ``0``/``false``/``no``/``off`` restores the pre-PR-N10 behaviour
+    (unconditional overwrite). Intended for on-call operators to revert
+    the semantic change without a code revert if a regression is
+    discovered post-deploy. Default (unset or any other value) keeps
+    the calibrator-respect guard active.
     """
+    import os as _os
+
+    _disable_values = ("0", "false", "no", "off")
+    if _os.environ.get("EDGEGUARD_RESPECT_CALIBRATOR", "").strip().lower() in _disable_values:
+        # Pre-PR-N10 behaviour: unconditional overwrite. Ops-only escape hatch.
+        return f"{value}"
     return f"CASE WHEN r.calibrated_at IS NOT NULL THEN r.confidence_score ELSE {value} END"
 
 

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -439,6 +439,78 @@ _CASE_INSENSITIVE_INDICATOR_TYPES = frozenset(
 )
 
 
+# PR-N10 (2026-04-21 7-agent pre-baseline audit): placeholder strings
+# that a threat-intel feed might emit as a "no value" sentinel. If any
+# of these reach a Neo4j MERGE key, two failure modes follow:
+#   (1) Every item whose natural key canonicalizes to a placeholder
+#       cross-joins the single node with that placeholder name, creating
+#       spurious relationships (Bug Hunter P1/P3: an attacker who posts a
+#       Malware{name:"unknown", attributed_to:"APT29"} to MISP gets every
+#       "unknown"-family Indicator attributed to APT29 via Q9 + Q2).
+#   (2) Legitimate feeds producing "unknown" as a default (e.g. OTX
+#       ingest fallback paths at ``run_misp_to_neo4j.py:3107,3128``,
+#       ``neo4j_client.py:4098``) create garbage nodes that pollute the
+#       graph with no provenance.
+#
+# Canonical values (after NFC+strip+lower) that are rejected as identity-
+# carrying names. Kept intentionally small and uncontroversial — everything
+# here is a *structural* no-op, never a meaningful malware/actor name.
+# Additions should be justified by a specific producer site emitting that
+# literal as a placeholder.
+_REJECTED_PLACEHOLDER_NAMES: frozenset = frozenset(
+    {
+        # Generic unknowns (canonicalized: lower + strip)
+        "",  # empty-string already caught by existing filters; included for completeness
+        "unknown",
+        "unknown malware",
+        "unspecified",
+        "undefined",
+        "null",
+        "none",
+        # Format variations
+        "n/a",
+        "na",
+        "not applicable",
+        "not available",
+        "not specified",
+        # Work-in-progress markers from hand-curated feeds
+        "tbd",
+        "tbc",
+        "todo",
+        "fixme",
+        # Symbol-placeholders
+        "-",
+        "--",
+        "---",
+        "..",
+        "...",
+        "?",
+        "??",
+        # Threat-intel-specific catch-alls
+        "generic",
+        "test",
+        "example",
+    }
+)
+
+
+def is_placeholder_name(value: Any) -> bool:
+    """Return True if ``value`` canonicalizes to a known placeholder
+    string. Used by merge_malware / merge_actor / merge_tool to reject
+    MERGE on placeholder natural keys (PR-N10).
+
+    Canonicalization mirrors ``canonicalize_merge_key``'s name handling:
+    NFC-normalize, strip, lowercase. Non-string inputs (None, int, etc.)
+    return True (a non-string is definitionally not a meaningful name,
+    and returning True means "reject the MERGE" — the caller then treats
+    the item as having no valid identity).
+    """
+    if not isinstance(value, str):
+        return True
+    canonical = unicodedata.normalize("NFC", value).strip().lower()
+    return canonical in _REJECTED_PLACEHOLDER_NAMES
+
+
 def canonicalize_merge_key(label: str, key_dict: Dict[str, Any]) -> Dict[str, Any]:
     """Return a copy of ``key_dict`` with the natural-key field lowercased
     + NFC-normalized + stripped, IF the (label, indicator_type) pair is
@@ -450,6 +522,12 @@ def canonicalize_merge_key(label: str, key_dict: Dict[str, Any]) -> Dict[str, An
     matching what ``compute_node_uuid`` does on its hash input).
 
     Returns a NEW dict — caller's dict is never mutated.
+
+    **Note**: this function does NOT reject placeholder names — that's
+    ``is_placeholder_name``'s job, called separately by merge callers.
+    Keeping the canonicalize/reject responsibilities split lets tests
+    distinguish "key was malformed" from "key was a valid-looking
+    placeholder."
     """
     out: Dict[str, Any] = dict(key_dict)
     canonical_label = (label or "").lower().strip()

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -490,6 +490,33 @@ _REJECTED_PLACEHOLDER_NAMES: frozenset = frozenset(
         "generic",
         "test",
         "example",
+        # Generic category names (PR-N10 follow-up, cursor-bugbot 2026-04-21).
+        # Feeds commonly emit the category label itself as a fallback when
+        # a specific family/actor name is unavailable (e.g. OTX pulse tagged
+        # only with "malware", NVD description containing "ransomware" with
+        # no specific family). A Malware{name:"malware"} / ThreatActor{name:
+        # "apt"} node becomes the same false-hub Red Team #1 flagged for
+        # "unknown" — every category-default Indicator attributes to it via
+        # Q9 + Q2. The entries below are the generic-category strings that
+        # must never survive as an identity-carrying name.
+        "malware",
+        "trojan",
+        "backdoor",
+        "virus",
+        "worm",
+        "ransomware",
+        "spyware",
+        "adware",
+        "rootkit",
+        "actor",
+        "threat",
+        "threat actor",
+        "attack",
+        "attacker",
+        "hacker",
+        "apt",
+        "apt group",
+        "adversary",
     }
 )
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2906,6 +2906,14 @@ class MISPToNeo4jSync:
                 item["pulse_tlp"] = otx_meta.get("pulse_tlp", "")
                 item["otx_industries"] = otx_meta.get("otx_industries", [])
                 item["description"] = otx_meta.get("description", "")
+                # PR-N10 Fix #3 (7-agent audit Logic Tracker B1): pull
+                # ``malware_family`` and ``attributed_to`` out of OTX_META
+                # now that misp_writer.py serializes them. Pre-fix, these
+                # were never in OTX_META → ``i.malware_family`` was NULL
+                # on every OTX-sourced Indicator → Q9 INDICATES edges
+                # never fired for OTX items (the biggest source).
+                item["malware_family"] = otx_meta.get("malware_family", "")
+                item["attributed_to"] = otx_meta.get("attributed_to", "")
 
             # Enrich indicator with ThreatFox metadata
             if tf_meta:
@@ -2916,6 +2924,8 @@ class MISPToNeo4jSync:
                 item["threat_type_desc"] = tf_meta.get("threat_type_desc", "")
                 item["malware_family"] = tf_meta.get("malware_family", "")
                 item["reporter"] = tf_meta.get("reporter", "")
+                # PR-N10 Fix #3: mirror OTX_META ``attributed_to`` pull-out.
+                item["attributed_to"] = tf_meta.get("attributed_to", "")
 
             return item, relationships
 

--- a/tests/test_pr_n10_block_bundle.py
+++ b/tests/test_pr_n10_block_bundle.py
@@ -1,0 +1,362 @@
+"""
+PR-N10 — BLOCK-MERGE bundle from 7-agent pre-baseline audit.
+
+Three BLOCK-severity findings from the audit run before the next 730d
+baseline. All three are cross-agent-corroborated or trace-verified.
+
+## Fix #1 — Placeholder-name reject at merge + Cypher defense-in-depth
+
+Bug Hunter P1/P3 traced feed emissions of "unknown" / "Unknown malware"
+/ "N/A" to Malware and ThreatActor node keys. Red Team #1 demonstrated
+an adversarial attribution hijack (attacker creates Malware{name:
+"unknown", attributed_to:"APT29"}; Q9 then links every Indicator with
+family="unknown" — a very common feed default — to that Malware; Q2
+edges that Malware to real APT29; false attribution corruption at
+scale). Devil's Advocate #4 argued for fixing at ingest, not Cypher.
+
+Fix: `_REJECTED_PLACEHOLDER_NAMES` frozenset in node_identity + a
+`is_placeholder_name(name) -> bool` helper. `merge_malware` and
+`merge_actor` in neo4j_client.py return False on placeholder names
+(logging a MERGE-REJECT warning). Defense-in-depth: Q2 outer + Q9
+outer/inner/skip Cypher WHERE clauses filter placeholders via
+`NOT toLower(trim(x)) IN [...]`.
+
+## Fix #2 — Extend PR-N8 calibrator-respect to 6 create_*_relationship helpers + _set_clause
+
+Cross-Checker BLOCK 1: PR-N8's calibrator-respect was incomplete. Q9
+in build_relationships.py honored `r.calibrated_at IS NOT NULL`, but
+6 Python helpers + `create_misp_relationships_batch._set_clause` still
+unconditionally SET `r.confidence_score = <constant>`. Next sync
+undoes calibrator's demotion.
+
+Fix: new `_confidence_respect_calibrator(value)` helper generating
+`CASE WHEN r.calibrated_at IS NOT NULL THEN r.confidence_score ELSE
+{value} END`. Applied at all 7 sites:
+  - create_actor_technique_relationship (0.7)
+  - create_malware_actor_relationship (0.7)
+  - create_indicator_vulnerability_relationship (0.5 x 2 branches)
+  - create_indicator_malware_relationship (0.6)
+  - create_indicator_sector_relationship (0.5)
+  - create_vulnerability_sector_relationship (0.5)
+  - create_misp_relationships_batch._set_clause (row.confidence param)
+
+## Fix #3 — OTX_META carries malware_family + attributed_to
+
+Logic Tracker B1: walked one OTX indicator end-to-end and found
+`misp_writer.py:974-985` OTX_META dict omits `malware_family` and
+`attributed_to`. Only TF_META's `malware_family` survived the MISP
+round-trip. Net: `i.malware_family` is NULL for every OTX-sourced
+Indicator → Q9 INDICATES edges never fire for OTX (the biggest source).
+
+Fix: add both fields to OTX_META serialization; add `attributed_to`
+to TF_META for parity; rehydrate both in `run_misp_to_neo4j.py`
+read-back path.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n10")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n10")
+
+
+# ===========================================================================
+# Fix #1 — placeholder-name reject
+# ===========================================================================
+
+
+class TestFix1PlaceholderNameReject:
+    """``is_placeholder_name`` + merge_malware/merge_actor reject guard +
+    Cypher defense-in-depth in Q2/Q9."""
+
+    # -- is_placeholder_name helper --
+
+    def test_helper_rejects_canonical_placeholders(self):
+        from node_identity import is_placeholder_name
+
+        # Core unknowns
+        for name in ["unknown", "Unknown", "UNKNOWN", "  unknown  "]:
+            assert is_placeholder_name(name), f"must reject {name!r}"
+        # Variants
+        for name in ["Unknown malware", "N/A", "n/a", "NA", "none", "None", "null", "NULL"]:
+            assert is_placeholder_name(name), f"must reject {name!r}"
+        # Symbol placeholders
+        for name in ["-", "--", "--- ", "?", "??", ".."]:
+            assert is_placeholder_name(name), f"must reject {name!r}"
+        # Threat-intel catch-alls
+        for name in ["generic", "Generic", "TEST", "example"]:
+            assert is_placeholder_name(name), f"must reject {name!r}"
+
+    def test_helper_accepts_legitimate_names(self):
+        from node_identity import is_placeholder_name
+
+        for name in ["Emotet", "emotet", "APT29", "apt29", "Cozy Bear", "TrickBot"]:
+            assert not is_placeholder_name(name), f"must NOT reject {name!r}"
+
+    def test_helper_rejects_non_string(self):
+        """Non-string input → rejected (None, int, etc. are not meaningful names)."""
+        from node_identity import is_placeholder_name
+
+        for val in [None, 12345, [], {}, True]:
+            assert is_placeholder_name(val), f"non-string {val!r} must be rejected"
+
+    # -- merge_malware / merge_actor guards --
+
+    def test_merge_malware_rejects_placeholder_name(self, caplog):
+        import logging
+
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()  # satisfies downstream checks
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            result = client.merge_malware({"name": "Unknown malware"}, source_id="otx")
+        assert result is False, "merge_malware must return False for placeholder name"
+        assert any("MERGE-REJECT" in r.message for r in caplog.records), "must emit MERGE-REJECT warning"
+
+    def test_merge_malware_rejects_n_a(self):
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        assert client.merge_malware({"name": "N/A"}) is False
+        assert client.merge_malware({"name": "  unknown  "}) is False
+        assert client.merge_malware({"name": None}) is False
+
+    def test_merge_actor_rejects_placeholder_name(self, caplog):
+        import logging
+
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            result = client.merge_actor({"name": "unknown"}, source_id="mitre_attck")
+        assert result is False
+        assert any("MERGE-REJECT" in r.message for r in caplog.records)
+
+    # -- Cypher defense-in-depth in Q2/Q9 --
+
+    def test_q2_outer_filters_placeholders(self):
+        """Q2 outer's attributed_to OR-branch must include placeholder
+        NOT IN filter. The filter lives INSIDE the branch (not at the
+        end with AND) so that aliases-only rows with NULL attributed_to
+        still pass. See _outer docstring for the NULL-propagation
+        rationale."""
+        src = (SRC / "build_relationships.py").read_text()
+        step2_idx = src.find("[LINK] 2/12 Malware → ThreatActor")
+        step3_idx = src.find("[LINK] 3a/12", step2_idx)
+        block = src[step2_idx:step3_idx]
+        # Must filter placeholder attributed_to in outer (no coalesce —
+        # the branch has already asserted IS NOT NULL so coalesce would
+        # be redundant and would also create a false-match of NULL→"").
+        assert "NOT toLower(trim(m.attributed_to)) IN" in block, (
+            "Q2 outer must filter placeholder attributed_to via NOT IN list"
+        )
+
+    def test_q2_inner_filters_placeholder_actor_names(self):
+        src = (SRC / "build_relationships.py").read_text()
+        step2_idx = src.find("[LINK] 2/12 Malware → ThreatActor")
+        step3_idx = src.find("[LINK] 3a/12", step2_idx)
+        block = src[step2_idx:step3_idx]
+        assert "NOT toLower(trim(a.name)) IN" in block, "Q2 inner must filter placeholder ThreatActor names"
+
+    def test_q9_outer_filters_placeholder_malware_family(self):
+        src = (SRC / "build_relationships.py").read_text()
+        q9_start = src.find("[LINK] 9/12")
+        q10_start = src.find("[LINK] 10/12")
+        block = src[q9_start:q10_start]
+        # The outer must include the NOT IN filter
+        q9_outer_idx = block.find("_q9_outer")
+        q9_outer_end = block.find("_q9_inner", q9_outer_idx)
+        outer = block[q9_outer_idx:q9_outer_end]
+        assert "NOT toLower(trim(i.malware_family)) IN" in outer, "Q9 outer must filter placeholder malware_family"
+
+    def test_q9_inner_filters_placeholder_malware_names(self):
+        src = (SRC / "build_relationships.py").read_text()
+        q9_start = src.find("[LINK] 9/12")
+        q10_start = src.find("[LINK] 10/12")
+        block = src[q9_start:q10_start]
+        q9_inner_idx = block.find("_q9_inner")
+        q9_skip_idx = block.find("_q9_skip", q9_inner_idx)
+        inner = block[q9_inner_idx:q9_skip_idx]
+        assert "NOT toLower(trim(m.name)) IN" in inner, "Q9 inner must filter placeholder Malware names"
+
+    def test_q9_skip_mirrors_inner_filter(self):
+        src = (SRC / "build_relationships.py").read_text()
+        q9_start = src.find("[LINK] 9/12")
+        q10_start = src.find("[LINK] 10/12")
+        block = src[q9_start:q10_start]
+        q9_skip_idx = block.find("_q9_skip")
+        next_assignment_idx = block.find("if not _safe_run_batched", q9_skip_idx)
+        skip = block[q9_skip_idx:next_assignment_idx]
+        # Skip must mirror both outer (malware_family) and inner (m.name) filters
+        assert "NOT toLower(trim(i.malware_family)) IN" in skip
+        assert "NOT toLower(trim(m.name)) IN" in skip
+
+
+# ===========================================================================
+# Fix #2 — calibrator-respect completion
+# ===========================================================================
+
+
+class TestFix2CalibratorRespectComplete:
+    """``_confidence_respect_calibrator`` helper applied at all 7 sites:
+    6 create_*_relationship helpers + _set_clause in batched path."""
+
+    def _src(self) -> str:
+        return (SRC / "neo4j_client.py").read_text()
+
+    def test_helper_defined(self):
+        src = self._src()
+        assert "def _confidence_respect_calibrator(" in src
+
+    def test_helper_correct_shape(self):
+        from neo4j_client import _confidence_respect_calibrator
+
+        result = _confidence_respect_calibrator(0.7)
+        assert result == "CASE WHEN r.calibrated_at IS NOT NULL THEN r.confidence_score ELSE 0.7 END"
+
+    def test_helper_accepts_cypher_param_expression(self):
+        """Must work with `$param` expressions for the batched path."""
+        from neo4j_client import _confidence_respect_calibrator
+
+        result = _confidence_respect_calibrator("row.confidence")
+        assert "ELSE row.confidence END" in result
+
+    def test_all_7_sites_use_helper(self):
+        """Count the usages — must be 7 executable sites + 1 _set_clause
+        call. The docstring example is in a comment/docstring so it's
+        inside a string literal."""
+        src = self._src()
+        # Count executable invocations (exclude docstring example)
+        # Docstring example is on line 192 area: `f"SET r.confidence_score = {_confidence_respect_calibrator(0.7)}"`
+        # Real sites are in the 6 helpers + _set_clause body
+        count = src.count("_confidence_respect_calibrator(")
+        # Helper definition (1) + docstring example (1) + 7 helper sites + 1 _set_clause = 10
+        assert count >= 9, f"expected >=9 usages (def + docstring + 7 helpers + _set_clause); got {count}"
+
+    def test_no_unconditional_confidence_writes_remaining(self):
+        """Regression pin: no `r.confidence_score = <literal>` should
+        appear in executable code (only in docstring examples). AST walk."""
+        import ast
+
+        src = self._src()
+        tree = ast.parse(src)
+        # Walk JoinedStr (f-strings) and plain Str constants, search for
+        # `r.confidence_score = <numeric-literal>` pattern.
+        for node in ast.walk(tree):
+            # Look for string literals containing "r.confidence_score = 0."
+            # except inside the docstring helper definition.
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                s = node.value
+                if (
+                    "r.confidence_score = 0.5" in s
+                    or "r.confidence_score = 0.6" in s
+                    or "r.confidence_score = 0.7" in s
+                ):
+                    # Must be in a context that ALSO has ELSE (calibrator-wrapped)
+                    # or be explicit documentation
+                    if "CASE WHEN r.calibrated_at" not in s and "ELSE " not in s:
+                        # The only legitimate occurrence is the docstring
+                        # example at line ~181 which has "SET r.confidence_score = 0.7"
+                        # as the PRE-fix shape being explained
+                        if "SET r.confidence_score = 0.7\n" not in s:
+                            raise AssertionError(
+                                f"Fix #2 regression: unconditional confidence write "
+                                f"found in string literal: {s[:200]!r}"
+                            )
+
+
+# ===========================================================================
+# Fix #3 — OTX_META completion
+# ===========================================================================
+
+
+class TestFix3OtxMetaCompletion:
+    """OTX_META (serialize) and run_misp_to_neo4j read-back carry
+    malware_family + attributed_to."""
+
+    def test_otx_meta_includes_malware_family_and_attributed_to(self):
+        src = (SRC / "collectors" / "misp_writer.py").read_text()
+        # Find the OTX_META dict. Use a wide scan window because the
+        # breadcrumb comment block eats ~600 chars.
+        idx = src.find('"attack_ids": indicator.get("attack_ids"')
+        assert idx != -1, "OTX_META dict not found"
+        block = src[idx : idx + 3000]
+        assert '"malware_family": indicator.get("malware_family"' in block, (
+            "OTX_META must include malware_family (Fix #3)"
+        )
+        assert '"attributed_to": indicator.get("attributed_to"' in block, "OTX_META must include attributed_to (Fix #3)"
+
+    def test_tf_meta_includes_attributed_to(self):
+        """TF_META already had malware_family; Fix #3 adds attributed_to
+        for parity with OTX_META."""
+        src = (SRC / "collectors" / "misp_writer.py").read_text()
+        idx = src.find('"malware_malpedia": indicator.get("malware_malpedia"')
+        assert idx != -1
+        block = src[idx : idx + 3000]
+        assert '"attributed_to": indicator.get("attributed_to"' in block, "TF_META must include attributed_to (Fix #3)"
+
+    def test_run_misp_to_neo4j_rehydrates_otx_malware_family(self):
+        """run_misp_to_neo4j's OTX-meta read-back must populate
+        item['malware_family'] and item['attributed_to']."""
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        idx = src.find('item["attack_ids"] = otx_meta.get("attack_ids"')
+        assert idx != -1, "OTX-meta rehydration block not found"
+        # Wider window because the new breadcrumb comment block is ~500 chars
+        block = src[idx : idx + 2500]
+        assert 'item["malware_family"] = otx_meta.get("malware_family"' in block, (
+            "Fix #3: OTX rehydrate must populate malware_family"
+        )
+        assert 'item["attributed_to"] = otx_meta.get("attributed_to"' in block, (
+            "Fix #3: OTX rehydrate must populate attributed_to"
+        )
+
+    def test_run_misp_to_neo4j_rehydrates_tf_attributed_to(self):
+        """TF read-back now also pulls attributed_to (already had
+        malware_family)."""
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        idx = src.find('item["malware_malpedia"] = tf_meta.get("malware_malpedia"')
+        assert idx != -1
+        block = src[idx : idx + 2500]
+        assert 'item["attributed_to"] = tf_meta.get("attributed_to"' in block, (
+            "Fix #3: TF rehydrate must populate attributed_to"
+        )
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_build_relationships_imports(self):
+        import build_relationships  # noqa: F401
+
+    def test_neo4j_client_imports(self):
+        import neo4j_client  # noqa: F401
+
+    def test_node_identity_exports(self):
+        from node_identity import (
+            _REJECTED_PLACEHOLDER_NAMES,
+            canonicalize_merge_key,
+            is_placeholder_name,
+        )
+
+        assert callable(is_placeholder_name)
+        assert len(_REJECTED_PLACEHOLDER_NAMES) >= 20, (
+            "placeholder set should have ~20+ entries; if this fails, check the frozenset wasn't accidentally shrunk"
+        )
+        assert callable(canonicalize_merge_key)

--- a/tests/test_pr_n10_block_bundle.py
+++ b/tests/test_pr_n10_block_bundle.py
@@ -376,6 +376,169 @@ class TestFix3OtxMetaCompletion:
 
 
 # ===========================================================================
+# PR-N10 follow-up — cursor-bugbot 2026-04-21 findings
+# ===========================================================================
+
+
+class TestBugbotFollowupGenericCategoryBlocklist:
+    """Medium — blocklist must cover generic-category hub names."""
+
+    def test_generic_category_names_in_blocklist(self):
+        from node_identity import _REJECTED_PLACEHOLDER_NAMES
+
+        required = {
+            "malware",
+            "trojan",
+            "backdoor",
+            "virus",
+            "worm",
+            "ransomware",
+            "spyware",
+            "adware",
+            "rootkit",
+            "actor",
+            "threat",
+            "threat actor",
+            "attack",
+            "attacker",
+            "hacker",
+            "apt",
+            "apt group",
+            "adversary",
+        }
+        missing = required - set(_REJECTED_PLACEHOLDER_NAMES)
+        assert not missing, f"blocklist missing generic-category names: {missing}"
+
+    def test_malware_category_name_rejected_at_merge(self):
+        from unittest.mock import MagicMock
+
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        for name in ["Malware", "MALWARE", "  malware  ", "apt", "APT", "ransomware"]:
+            assert client.merge_malware({"name": name}) is False, f"must reject generic-category malware name {name!r}"
+
+    def test_actor_category_name_rejected_at_merge(self):
+        from unittest.mock import MagicMock
+
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        for name in ["actor", "Threat Actor", "APT group", "adversary", "hacker"]:
+            assert client.merge_actor({"name": name}) is False, f"must reject generic-category actor name {name!r}"
+
+
+class TestBugbotFollowupQ2InnerAttributedToFilter:
+    """Medium — Q2 inner must reject placeholder m.attributed_to so
+    branch 2 (attributed_to ∈ actor aliases) can't fire on a placeholder
+    alias match. Alias comprehensions on both sides also drop placeholder
+    entries as defense-in-depth."""
+
+    def _q2_block(self) -> str:
+        import ast
+
+        src = (SRC / "build_relationships.py").read_text()
+        tree = ast.parse(src)
+        # Find `_inner` assignment under the function scope that contains
+        # the "[LINK] 2/12 Malware → ThreatActor" log line.
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not (
+                len(node.targets) == 1 and isinstance(node.targets[0], ast.Name) and node.targets[0].id == "_inner"
+            ):
+                continue
+            rendered = ast.unparse(node)
+            if "ATTRIBUTED_TO" in rendered and "a:ThreatActor" in rendered:
+                return rendered
+        raise AssertionError("Q2 inner _inner = ... not found")
+
+    def test_q2_inner_rejects_placeholder_attributed_to(self):
+        """Branches 1 and 2 (the ones that READ attributed_to) must each
+        gate on ``NOT toLower(trim(m.attributed_to)) IN [...]``. Scoped
+        per-branch (not at the top level) so branch 3 (alias-only) can
+        still fire when attributed_to is NULL. The PR-N8 R1 pin forbids
+        ``coalesce(m.attributed_to, '')`` here — NULL-propagation is the
+        correct filter behaviour for the outer."""
+        inner = self._q2_block()
+        # At least two occurrences of the attributed_to placeholder guard
+        # (one per branch that reads attributed_to).
+        count = inner.count("NOT toLower(trim(m.attributed_to)) IN")
+        assert count >= 2, f"both attributed_to-reading branches must filter placeholders; found {count}, expected >=2"
+        # And must NOT use coalesce — PR-N8 R1 invariant.
+        assert "coalesce(m.attributed_to" not in inner, (
+            "PR-N8 R1 forbids coalesce(m.attributed_to, ...); use IS NOT NULL + per-branch gate"
+        )
+
+    def test_q2_inner_alias_comprehensions_filter_placeholders(self):
+        """Both alias-side comprehensions (actor.aliases and malware.aliases)
+        drop placeholder entries before matching."""
+        inner = self._q2_block()
+        # Count occurrences of the placeholder NOT IN guard in alias comprehensions
+        # Two comprehensions, each should have one guard
+        comprehension_guard = "AND NOT toLower(trim(x)) IN"
+        count = inner.count(comprehension_guard)
+        assert count >= 2, f"both alias comprehensions must filter placeholders; found {count} of 2 expected"
+
+
+class TestBugbotFollowupCypherStringEscaping:
+    """Low — _PLACEHOLDER_NAMES_CYPHER_LIST must escape ``\"`` and ``\\``
+    in entries so future blocklist additions can't break Cypher."""
+
+    def test_escape_helper_exists(self):
+        from build_relationships import _escape_cypher_double_quoted
+
+        # Backslash escapes first (order matters)
+        assert _escape_cypher_double_quoted("path\\to") == "path\\\\to"
+        # Double-quote escapes
+        assert _escape_cypher_double_quoted('say "hi"') == 'say \\"hi\\"'
+        # Combined — backslash must be escaped before the double-quote
+        # replacement introduces its own backslash
+        assert _escape_cypher_double_quoted('"\\') == '\\"\\\\'
+        # Safe values pass through
+        assert _escape_cypher_double_quoted("unknown") == "unknown"
+        assert _escape_cypher_double_quoted("") == ""
+
+    def test_cypher_list_uses_escape(self):
+        """Regression pin: _PLACEHOLDER_NAMES_CYPHER_LIST must build via
+        the escape helper, not raw f-string interpolation."""
+        import ast
+
+        src = (SRC / "build_relationships.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if not isinstance(node, ast.Assign):
+                continue
+            if not (
+                len(node.targets) == 1
+                and isinstance(node.targets[0], ast.Name)
+                and node.targets[0].id == "_PLACEHOLDER_NAMES_CYPHER_LIST"
+            ):
+                continue
+            rendered = ast.unparse(node)
+            assert "_escape_cypher_double_quoted" in rendered, "_PLACEHOLDER_NAMES_CYPHER_LIST must use escape helper"
+            return
+        raise AssertionError("_PLACEHOLDER_NAMES_CYPHER_LIST assignment not found")
+
+    def test_cypher_list_is_syntactically_valid_cypher(self):
+        """The generated list should be a valid Cypher literal list of
+        double-quoted strings. Smoke-test: parse it as a JSON-like array."""
+        import json
+
+        from build_relationships import _PLACEHOLDER_NAMES_CYPHER_LIST
+
+        # Cypher double-quoted strings align with JSON for the subset we emit
+        parsed = json.loads(_PLACEHOLDER_NAMES_CYPHER_LIST)
+        assert isinstance(parsed, list)
+        assert all(isinstance(x, str) for x in parsed)
+        # All current entries should pass through unchanged (none contain " or \)
+        assert "unknown" in parsed
+        assert "malware" in parsed  # PR-N10 follow-up addition
+
+
+# ===========================================================================
 # Module import sanity
 # ===========================================================================
 

--- a/tests/test_pr_n10_block_bundle.py
+++ b/tests/test_pr_n10_block_bundle.py
@@ -247,6 +247,45 @@ class TestFix2CalibratorRespectComplete:
         # Helper definition (1) + docstring example (1) + 7 helper sites + 1 _set_clause = 10
         assert count >= 9, f"expected >=9 usages (def + docstring + 7 helpers + _set_clause); got {count}"
 
+    def test_kill_switch_reverts_to_unconditional_overwrite(self):
+        """``EDGEGUARD_RESPECT_CALIBRATOR=0`` restores pre-PR-N10 behaviour.
+        Ops escape hatch — must produce a bare literal, no CASE expr."""
+        import os
+
+        from neo4j_client import _confidence_respect_calibrator
+
+        for disable_val in ("0", "false", "no", "off", "FALSE", "Off", " 0 "):
+            os.environ["EDGEGUARD_RESPECT_CALIBRATOR"] = disable_val
+            try:
+                result = _confidence_respect_calibrator(0.7)
+                assert result == "0.7", f"kill-switch value {disable_val!r} should produce bare literal; got {result!r}"
+                assert "CASE" not in result
+                assert "calibrated_at" not in result
+            finally:
+                os.environ.pop("EDGEGUARD_RESPECT_CALIBRATOR", None)
+
+    def test_kill_switch_unset_or_true_keeps_guard(self):
+        """Default (unset) or any non-disable value keeps the CASE guard."""
+        import os
+
+        from neo4j_client import _confidence_respect_calibrator
+
+        # Unset
+        os.environ.pop("EDGEGUARD_RESPECT_CALIBRATOR", None)
+        result = _confidence_respect_calibrator(0.7)
+        assert "CASE WHEN r.calibrated_at IS NOT NULL" in result
+
+        # Explicit enable values
+        for enable_val in ("1", "true", "yes", "on", ""):
+            os.environ["EDGEGUARD_RESPECT_CALIBRATOR"] = enable_val
+            try:
+                result = _confidence_respect_calibrator(0.7)
+                assert "CASE WHEN r.calibrated_at IS NOT NULL" in result, (
+                    f"value {enable_val!r} should keep guard; got {result!r}"
+                )
+            finally:
+                os.environ.pop("EDGEGUARD_RESPECT_CALIBRATOR", None)
+
     def test_no_unconditional_confidence_writes_remaining(self):
         """Regression pin: no `r.confidence_score = <literal>` should
         appear in executable code (only in docstring examples). AST walk."""

--- a/tests/test_pr_n7_build_relationships_hotfix.py
+++ b/tests/test_pr_n7_build_relationships_hotfix.py
@@ -85,25 +85,44 @@ class TestFix1QuoteEscapeBugEliminated:
 
     def test_step2_malware_threatactor_no_unsafe_literal(self):
         """Step 2: Malware → ThreatActor ATTRIBUTED_TO. Outer query
-        must not contain ``<> ''`` anywhere."""
+        must not contain ``<> ''`` anywhere.
+
+        PR-N10 refactored ``_outer`` to a multi-line tuple-of-strings
+        shape (to accommodate the placeholder NOT IN filter inline
+        with the OR branches). AST-extract the full resolved string
+        rather than the source-file line."""
+        import ast
+
         src = self._src()
-        # Find the _outer assignment for step 2 (first one after the
-        # step 2 log line).
+        # Scan a window around step 2 to find the _outer assignment.
         step2_idx = src.find("[LINK] 2/12 Malware → ThreatActor")
-        assert step2_idx != -1
-        # Next _outer = line
-        outer_idx = src.find("_outer =", step2_idx)
-        assert outer_idx != -1
-        # Extract the line
-        line = src[outer_idx : src.find("\n", outer_idx)]
-        assert "<> ''" not in line, f"Step 2 outer still has unsafe `<> ''`: {line}"
-        # PR-N8 R1 Bugbot LOW hardened the outer filter from bare
-        # size(m.attributed_to) to size(trim(m.attributed_to)) so
-        # whitespace-only values are rejected. Either shape is
-        # quote-escape-safe (PR-N7's primary concern); we accept both
-        # here.
-        assert "size(m.attributed_to) > 0" in line or "size(trim(m.attributed_to)) > 0" in line, (
-            "Step 2 must use a size()-based length check (PR-N8 R1 hardened to size(trim(...)))"
+        step3_idx = src.find("[LINK] 3a/12", step2_idx)
+        assert step2_idx != -1 and step3_idx != -1
+        # Parse the full module so AST walker covers all assignments.
+        tree = ast.parse(src)
+        outer_value = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name) and t.id == "_outer":
+                        # Collect all string Constant values from the RHS
+                        parts: list = []
+                        for sub in ast.walk(node.value):
+                            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                                parts.append(sub.value)
+                        candidate = "".join(parts)
+                        # Is this the step-2 _outer? Step 2 MATCH is (m:Malware).
+                        if "MATCH (m:Malware)" in candidate and "m.attributed_to" in candidate:
+                            outer_value = candidate
+                            break
+                if outer_value:
+                    break
+
+        assert outer_value is not None, "could not locate step-2 _outer via AST"
+        assert "<> ''" not in outer_value, f"Step 2 outer still has unsafe `<> ''`: {outer_value}"
+        assert "size(m.attributed_to) > 0" in outer_value or "size(trim(m.attributed_to)) > 0" in outer_value, (
+            "Step 2 must use a size()-based length check (PR-N8 R1 hardened "
+            "to size(trim(...))); PR-N10 kept this shape."
         )
 
     def test_step3a_3b_cve_no_unsafe_literal(self):
@@ -119,16 +138,38 @@ class TestFix1QuoteEscapeBugEliminated:
         """Step 9: Indicator → Malware (malware_family match). Outer
         query must use size() check.
 
-        PR-N8 R1 Bugbot LOW hardened the outer filter to use
-        ``size(trim(i.malware_family))`` so whitespace-only values
-        are rejected before the comparison. Either shape is
-        quote-escape-safe (PR-N7's primary concern); we accept both
-        here."""
+        PR-N8 R1 hardened outer to ``size(trim(...))``. PR-N10 split
+        the outer into a multi-line tuple for the placeholder NOT IN
+        filter. We check the concatenated parts contain the size-check
+        pattern; the PR-N7 test's primary concern (no `<> ''`) is
+        separately pinned by ``test_no_unsafe_literal_in_any_outer_
+        or_inner_query_string`` which AST-walks the full module."""
         src = self._src()
-        assert (
-            "i.malware_family IS NOT NULL AND size(i.malware_family) > 0" in src
-            or "i.malware_family IS NOT NULL AND size(trim(i.malware_family)) > 0" in src
-        ), "Step 9 outer must use a size()-based length check on malware_family"
+        # Concatenate adjacent quoted string fragments so the multi-line
+        # tuple form (``_q9_outer = ("a " "b " "c")``) matches the same
+        # substring as the pre-PR-N10 single-line form.
+        # Easiest: just check both the OLD single-line form and a more
+        # flexible check on the AST-walked Q9 outer string.
+        import ast
+
+        tree = ast.parse(src)
+        q9_outer_value = None
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Assign):
+                for t in node.targets:
+                    if isinstance(t, ast.Name) and t.id == "_q9_outer":
+                        parts = [
+                            sub.value
+                            for sub in ast.walk(node.value)
+                            if isinstance(sub, ast.Constant) and isinstance(sub.value, str)
+                        ]
+                        q9_outer_value = "".join(parts)
+                        break
+        assert q9_outer_value is not None, "_q9_outer not found"
+        # Accept either the pre-PR-N8-R1 size(x) or the post-R1 size(trim(x))
+        assert "i.malware_family IS NOT NULL" in q9_outer_value and (
+            "size(i.malware_family) > 0" in q9_outer_value or "size(trim(i.malware_family)) > 0" in q9_outer_value
+        ), f"Q9 outer must use a size()-based length check; got: {q9_outer_value!r}"
 
     def test_no_unsafe_literal_in_any_outer_or_inner_query_string(self):
         """AST-walk: verify NO ``<> ''`` appears in any string literal


### PR DESCRIPTION
## Summary

Three BLOCK-severity findings from today's 7-agent pre-baseline audit. Each closes a hole that the prior 9 PRs either introduced or left open. **This PR is required before the 730d baseline runs.**

| # | Agents | Severity | What |
|---|---|---|---|
| **1** | Bug Hunter P1/P3 + Red Team #1 + Devil's Advocate #4 | BLOCK | Placeholder-string `"unknown"` / `"Unknown malware"` / `"N/A"` corrupts graph via false-hub nodes in Q2/Q9 |
| **2** | Cross-Checker BLOCK 1 | BLOCK | PR-N8's calibrator-respect was incomplete — 6 Python helpers + `_set_clause` still clobber `r.confidence_score` every sync |
| **3** | Logic Tracker B1 (trace-verified) | BLOCK | OTX_META drops `malware_family` + `attributed_to` → Q9 never fires for OTX (the biggest source) |

## Fixes

### Fix #1 — Placeholder-name reject at 3 layers

- **Layer 1 (ingest)**: `node_identity._REJECTED_PLACEHOLDER_NAMES` frozenset (26 entries) + `is_placeholder_name()` helper
- **Layer 2 (merge)**: `merge_malware` / `merge_actor` return False with `[MERGE-REJECT]` WARN on placeholder names
- **Layer 3 (Cypher)**: Q2 outer + Q9 outer/inner/skip embed placeholder list as `NOT toLower(trim(x)) IN [...]` filters — defense against legacy placeholder nodes still in the graph

### Fix #2 — Calibrator-respect extended to all 7 write sites

New `_confidence_respect_calibrator(value)` helper generating:
```cypher
CASE WHEN r.calibrated_at IS NOT NULL THEN r.confidence_score ELSE <value> END
```

Applied at 6 `create_*_relationship` helpers + `create_misp_relationships_batch._set_clause`. Fresh edges get helper's default; calibrator-stamped edges preserve calibrator's value.

### Fix #3 — OTX_META carries malware_family + attributed_to

- `misp_writer.py` OTX_META dict: add both keys (TF_META already had `malware_family`; add `attributed_to` for parity)
- `run_misp_to_neo4j.py` read-back: rehydrate both keys into item dict → `i.malware_family` survives round-trip for OTX items → Q9 INDICATES edges fire

## Test plan

- [x] 23 new regression tests (helper + merge-guard behaviour + Q2/Q9 Cypher source pins + OTX/TF meta completeness)
- [x] 3 existing PR-N7/PR-N8 tests updated for Q2/Q9 multi-line tuple shape (AST extraction)
- [x] `ruff format` ✓, `ruff check` ✓, `mypy src/` ✓
- [x] Full suite: **1336 passed**, 3 skipped, 3 xfailed (was 1313 + 23 new)

## Diagnostic for the operator (before baseline)

Per Devil's Advocate #1: we have no empirical evidence Fix #2's calibrator-undo bug fired in production. Run this 30-sec query on existing Neo4j:

```cypher
MATCH ()-[r]->()
WHERE r.calibrated_at IS NOT NULL AND r.confidence_score > 0.5
RETURN count(r) AS post_fix_candidates,
       collect(DISTINCT type(r))[0..10] AS edge_types
```

Non-zero count = bug was firing (the calibrator had demoted these edges but something re-inflated them). Counted edges will NO LONGER re-inflate post-PR-N10.

## What's still outstanding (PR-N11 follow-up)

Ops readiness (non-blocking but should ship before baseline):
- `prometheus/alerts.yml` rules for PR-N4/N5/N9 metrics
- `docs/RUNBOOK.md` v0
- Rollback kill-switches (`EDGEGUARD_RESPECT_CALIBRATOR`, `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION`)
- 7-day dev-Neo4j smoke run as the 10-PR composition gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High risk because it changes Neo4j merge/relationship creation semantics and Cypher filters, which can materially alter graph topology and confidence scoring (including an env-gated behavior change).
> 
> **Overview**
> **Prevents placeholder-name nodes (e.g. "unknown", "n/a", generic categories) from corrupting the graph** by introducing a shared placeholder blocklist (`node_identity._REJECTED_PLACEHOLDER_NAMES` + `is_placeholder_name`) and rejecting `merge_malware`/`merge_actor` writes when names canonicalize to a placeholder.
> 
> Adds *defense-in-depth* placeholder filtering to relationship-building Cypher in `build_relationships.py` (Q2/Q9), including a generated/escaped Cypher literal list to filter legacy placeholder nodes/values at query time.
> 
> Stops relationship sync code from overwriting calibrator-demoted `r.confidence_score` by wrapping confidence writes in a `CASE` via `_confidence_respect_calibrator`, applied across multiple `create_*_relationship` helpers and the batched MISP relationship `_set_clause` (with an `EDGEGUARD_RESPECT_CALIBRATOR` kill-switch).
> 
> Fixes MISP round-trip data loss by adding `malware_family` and `attributed_to` to `OTX_META` (and `attributed_to` to `TF_META`) in `misp_writer.py`, and rehydrating them in `run_misp_to_neo4j.py`, enabling downstream Q9 `INDICATES` linking for OTX-sourced indicators. Extensive new/updated regression tests cover all three fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b3f9e34f8fbe8597bb6e011a6b9cb64b391477f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->