### PR TITLE
fix(audit): PR-N11 — pre-baseline ops readiness (alerts + kill-switch + runbook)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -1,0 +1,172 @@
+# EdgeGuard On-Call Runbook
+
+**Audience:** on-call operator responding to an alert or incident during
+a baseline or incremental sync.
+
+**Scope:** the five failure modes observed during pre-PR-N7 730d baselines
++ the kill-switches added in PR-N11 to let on-call revert a specific PR-Nx
+semantic change without a code revert.
+
+---
+
+## Quick reference — kill-switches
+
+Each kill-switch is a process environment variable read at request time
+(not module import), so toggling requires a task restart, not a redeploy.
+
+| Env var | Default | When to set | What it reverts |
+|---|---|---|---|
+| `EDGEGUARD_RESPECT_CALIBRATOR` | unset (guard active) | Calibrator demotions causing false negatives after PR-N10; operator wants pre-N10 overwrite behaviour | `_confidence_respect_calibrator` emits bare literal (pre-PR-N10), not CASE guard |
+| `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION` | unset (inspection active) | Result-counter inspection itself throwing (driver API drift, double-consume) — mid-baseline | `_record_batch_counters` short-circuits to no-op (pre-PR-N9 B6) |
+
+Set via task env (one-off):
+
+```bash
+EDGEGUARD_RESPECT_CALIBRATOR=0 airflow tasks run edgeguard_incremental sync …
+```
+
+or in the Airflow connection / .env (persistent):
+
+```
+EDGEGUARD_RESPECT_CALIBRATOR=0
+EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION=1
+```
+
+Restart the affected DAG / worker for the change to take effect. Revert
+by unsetting and restarting.
+
+---
+
+## Top 5 failure modes
+
+Each entry: symptom → detection signal → remediation → runbook link.
+
+### 1. MISP batch permanent failure (5xx exhaustion)
+
+- **Symptom.** One or more 500-attribute batches lost; post-baseline
+  `MATCH (i:Indicator {source: 'otx'}) RETURN count(i)` is lower than
+  `edgeguard_indicators_collected_total{source="otx"}` counter value.
+- **Prom alert.** `EdgeGuardMispBatchPermanentFailure` — fires when
+  `rate(edgeguard_misp_push_permanent_failure_total[5m]) > 0` for 5m.
+- **Root cause.** MISPWriter's `@retry_with_backoff(max_retries=4)` gave
+  up after four attempts. Typical triggers: MISP PHP memory_limit below
+  event-size threshold, MySQL `innodb_buffer_pool_size` too small for
+  working set, MISP worker OOM.
+- **Remediation.**
+  1. `kubectl logs <misp-pod> --tail=500 | grep -i "out of memory\|segfault"`
+  2. Check `/proc/meminfo` on the MISP host.
+  3. Tune per `docs/MISP_TUNING.md` § PHP & MySQL.
+  4. Retry the specific batch via `python -m src.collectors.misp_writer
+     --replay-failed --since <timestamp>`.
+
+### 2. MISP sustained backoff (flap vs overload)
+
+- **Symptom.** Ingest stalling in 5-minute waves; nightly incremental
+  runs exceeding 1-hour SLO.
+- **Prom alert.** `EdgeGuardMispSustainedBackoff` — fires when extended
+  cooldown triggers more than once per 15 min.
+- **Root cause.** MISP backend is sustained-degraded (not a transient
+  flap — the adaptive backoff distinguishes them).
+- **Remediation.** Same as (1) — this is usually the early-warning
+  before (1) fires.
+
+### 3. Honest-NULL violation (collector forging timestamps)
+
+- **Symptom.** Calibrator decay runs attribute staleness from
+  `first_seen`, but the data comes out obviously wrong — everything
+  looks ~1 day old regardless of actual source age.
+- **Prom alert.** `EdgeGuardMispHonestNullViolation` — fires when a
+  specific (source, field) pair exceeds 100 violations/hour.
+- **Root cause.** PR-N5 C7 validator caught a collector calling
+  `datetime.now()` as a fallback when the source feed was silent on a
+  timestamp. The violation log line names the collector.
+- **Remediation.**
+  1. `grep EDGE-GUARD-NULL-VIOLATION /var/log/airflow/*.log | tail -50`
+  2. Audit the named collector's extraction path.
+  3. Remove the `datetime.now()` fallback — pass `None` through.
+  4. Ship fix via a hotfix PR; do NOT disable the validator.
+
+### 4. Neo4j ineffective-batch (silent write failure)
+
+- **Symptom.** Incremental sync task reports success, but post-run
+  `MATCH (n:Label) RETURN count(n)` shows no growth for that label.
+- **Prom alert.** `EdgeGuardNeo4jIneffectiveBatch` — fires when a
+  non-empty batch produces ZERO counter-visible writes.
+- **Root cause.** Three common triggers:
+  1. Source node missing (the SOURCED_FROM MATCH returns zero rows; the
+     per-row edge MERGE silently never runs).
+  2. Constraint violation on primary MERGE key.
+  3. Schema drift (new MISP attribute type, stale Cypher).
+- **Remediation.**
+  1. `MATCH (s:Source {source_id: '<source>'}) RETURN s` — if empty,
+     re-run `ensure_sources()` via
+     `python -m src.neo4j_client --bootstrap-sources`.
+  2. Tail Neo4j log for constraint violations:
+     `docker logs edgeguard-neo4j 2>&1 | grep -i constraint | tail -20`.
+  3. For schema drift: diff the failing Cypher against
+     `src/neo4j_client.py` MERGE site; add the missing property coalesce.
+
+### 5. Placeholder-name MERGE spike (feed regression or attack)
+
+- **Symptom.** Growing volume of `MERGE-REJECT: placeholder name` WARN
+  log lines; Malware / ThreatActor node count flatlined despite sync
+  activity.
+- **Detection.** `grep MERGE-REJECT /var/log/airflow/*.log | sort | uniq -c | sort -rn | head`.
+  (A Prometheus counter + alert for this lands in PR-N12.)
+- **Root cause.** A collector is emitting Malware / ThreatActor nodes
+  with placeholder names (`unknown`, `N/A`, `generic`, …). Feed
+  regression (upstream schema change) or, in the worst case, an
+  adversary injecting malicious `Malware{name: "unknown"}` nodes to
+  cause false-attribution storms via Q9 edges.
+- **Remediation.**
+  1. Identify the offending collector from the log lines' source tag.
+  2. If feed regression: file an issue against the feed upstream;
+     extend the collector's normalization to skip placeholder names
+     before they reach `merge_malware()`.
+  3. If suspected injection: freeze the source, audit that MISP event's
+     attributes, purge with
+     `MATCH (m:Malware)-[r]->() WHERE m.name IN ['unknown','N/A','generic'] DELETE r, m`.
+  4. PR-N10's merge-time reject already blocked the actual writes —
+     the graph is safe. Focus on finding WHY the collector started
+     emitting them.
+
+---
+
+## Baseline-day protocol
+
+Before a 730d baseline run:
+
+1. **Smoke test.** Run a 7-day window first (baseline=7 instead of 730).
+   Success criteria: no ERROR lines, metrics look sane, spot-check 10
+   random Indicators via Neo4j Browser.
+2. **Prometheus dashboard.** Verify
+   `edgeguard_pipeline_observability` rule group is loaded
+   (`promtool check rules prometheus/alerts.yml`).
+3. **Kill-switches staged.** Decide in advance — what signal would make
+   you set `EDGEGUARD_RESPECT_CALIBRATOR=0`? Write it down before the
+   run starts so you're not making the call in an outage.
+
+During the run:
+
+- Monitor the 4 `edgeguard_pipeline_observability` alerts every hour.
+- Any BLOCK alert (batch permanent failure, ineffective batch) → pause
+  the DAG, triage, then resume. Do NOT let it continue silently.
+
+After the run:
+
+- Diff `count(*)` of each node label vs. previous baseline.
+- Diff `MATCH ()-[r]->() WHERE r.calibrated_at IS NOT NULL AND
+  r.confidence_score > 0.5 RETURN count(r)` — expect ~0 (calibrator-
+  demoted edges that still read as high-confidence = PR-N10 Fix #2
+  regression).
+
+---
+
+## See also
+
+- `docs/MISP_TUNING.md` — backend tuning for failure modes 1-2
+- `docs/KNOWLEDGE_GRAPH.md` — schema reference
+- `docs/VERSIONING.md` — CalVer release cadence
+- `prometheus/alerts.yml` — alert rule source of truth
+- `src/neo4j_client.py:_record_batch_counters` — ineffective-batch detector (PR-N9 B6)
+- `src/neo4j_client.py:_confidence_respect_calibrator` — calibrator-respect helper (PR-N10)

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -381,3 +381,99 @@ groups:
             {{ $labels.mountpoint }} has {{ $value | humanizePercentage }}
             inodes free. airflow_logs creates many small files; ext4
             volumes can exhaust inodes well before bytes. Prune logs.
+
+  # ================================================================================
+  # PR-N4 / PR-N5 / PR-N9 observability metrics (PR-N11 follow-up)
+  # ================================================================================
+  # These rules surface the counters added in PR-N4 (MISP-at-scale),
+  # PR-N5 (C7 honest-NULL validator), and PR-N9 (Neo4j MERGE
+  # ineffective-batch). Pre-PR-N11, the metrics existed but no alert
+  # fired — the observability investment was invisible to operators.
+  #
+  # Baseline on-call: during the 730d baseline run, a non-zero rate
+  # on ANY of these alerts means silent data loss or semantic drift.
+  # Pre-PR-N7/N8/N9 the symptoms (multi-hour stalls, missing edges,
+  # confidence flaps) were only diagnosed post-hoc; these alerts flip
+  # detection latency from hours to 5-15 minutes.
+  - name: edgeguard_pipeline_observability
+    rules:
+      - alert: EdgeGuardMispBatchPermanentFailure
+        expr: sum by (source) (rate(edgeguard_misp_push_permanent_failure_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          component: misp_writer
+        annotations:
+          summary: "EdgeGuard losing MISP batches permanently ({{ $labels.source }})"
+          description: |
+            MISPWriter rejected one or more attribute batches after
+            ``@retry_with_backoff(max_retries=4)`` exhausted. Each
+            failure is ~500 attributes lost. Pre-PR-N4 this was a
+            hand-counted log-line; now alertable.
+
+            Remediation:
+              1. Check MISP backend RAM / PHP memory_limit
+              2. Check MySQL innodb_buffer_pool_size
+              3. See docs/MISP_TUNING.md and docs/RUNBOOK.md § MISP OOM
+
+      - alert: EdgeGuardMispSustainedBackoff
+        expr: sum by (source) (rate(edgeguard_misp_push_backoff_triggered_total[15m])) > 1
+        for: 15m
+        labels:
+          severity: warning
+          component: misp_writer
+        annotations:
+          summary: "EdgeGuard MISPWriter in extended cooldown >1×/15min ({{ $labels.source }})"
+          description: |
+            MISPWriter is hitting consecutive 5xx failures often enough
+            to enter the 5-minute extended cooldown more than once per
+            15 minutes. Backend is sustained-degraded. Distinguishes
+            "occasional flap" from "sustained overload."
+
+      - alert: EdgeGuardMispHonestNullViolation
+        expr: sum by (source, field) (rate(edgeguard_misp_honest_null_violation_total[1h])) > 100
+        for: 1h
+        labels:
+          severity: warning
+          component: misp_writer
+        annotations:
+          summary: "EdgeGuard honest-NULL invariant violated at high rate ({{ $labels.source }}/{{ $labels.field }})"
+          description: |
+            A collector appears to be manufacturing wall-clock-NOW
+            values for {{ $labels.field }} instead of passing NULL
+            through when the source is silent. Rate > 100/hr suggests
+            systematic violation, not occasional federation drift.
+
+            Remediation: audit the {{ $labels.source }} collector's
+            {{ $labels.field }} extraction path for ``datetime.now()``
+            fallbacks. See PR-N5 C7 + PR-N10 honest-NULL docs.
+
+      - alert: EdgeGuardNeo4jIneffectiveBatch
+        expr: sum by (label, source) (rate(edgeguard_neo4j_merge_ineffective_batch_total[5m])) > 0
+        for: 5m
+        labels:
+          severity: critical
+          component: neo4j_client
+        annotations:
+          summary: "EdgeGuard Neo4j MERGE batch silently producing zero writes ({{ $labels.label }}/{{ $labels.source }})"
+          description: |
+            A non-empty batch of {{ $labels.label }} nodes for source
+            {{ $labels.source }} completed with ZERO counter-visible
+            writes (no nodes_created, nodes_updated, properties_set,
+            rels_created, rels_updated). Typical causes:
+
+              * Source node missing (ensure_sources() misfire)
+              * Constraint violation
+              * Schema drift / wrong label
+
+            Remediation:
+              1. Check Neo4j logs for constraint errors on {{ $labels.label }}
+              2. Query ``MATCH (s:Source {source_id: '{{ $labels.source }}'}) RETURN s``
+                 to confirm Source node exists
+              3. See docs/RUNBOOK.md § Neo4j silent-write failures
+
+      # NOTE: a placeholder-reject alert (tracks spikes in the PR-N10
+      # Fix #1 merge-reject rate) requires a counter that isn't wired
+      # yet; it'll land in a PR-N12 follow-up alongside the counter
+      # definition so the alert rule and its backing metric ship
+      # atomically. Do not add here without the counter.

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -417,7 +417,11 @@ groups:
               3. See docs/MISP_TUNING.md and docs/RUNBOOK.md § MISP OOM
 
       - alert: EdgeGuardMispSustainedBackoff
-        expr: sum by (source) (rate(edgeguard_misp_push_backoff_triggered_total[15m])) > 1
+        # Use `increase()` (absolute count over window), NOT `rate()`
+        # which returns a per-second average — `rate(...) > 1` would
+        # mean >1/sec = >900/15min, 900x the intended threshold.
+        # Cursor-bugbot 2026-04-21 HIGH.
+        expr: sum by (source) (increase(edgeguard_misp_push_backoff_triggered_total[15m])) > 1
         for: 15m
         labels:
           severity: warning
@@ -431,7 +435,11 @@ groups:
             "occasional flap" from "sustained overload."
 
       - alert: EdgeGuardMispHonestNullViolation
-        expr: sum by (source, field) (rate(edgeguard_misp_honest_null_violation_total[1h])) > 100
+        # Use `increase()` (absolute count over window), NOT `rate()`
+        # which returns a per-second average — `rate(...) > 100` would
+        # mean >100/sec = >360,000/hr, 3600x the intended threshold.
+        # Cursor-bugbot 2026-04-21 HIGH.
+        expr: sum by (source, field) (increase(edgeguard_misp_honest_null_violation_total[1h])) > 100
         for: 1h
         labels:
           severity: warning
@@ -441,8 +449,8 @@ groups:
           description: |
             A collector appears to be manufacturing wall-clock-NOW
             values for {{ $labels.field }} instead of passing NULL
-            through when the source is silent. Rate > 100/hr suggests
-            systematic violation, not occasional federation drift.
+            through when the source is silent. >100 violations/hour
+            suggests systematic violation, not occasional federation drift.
 
             Remediation: audit the {{ $labels.source }} collector's
             {{ $labels.field }} extraction path for ``datetime.now()``

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -40,6 +40,36 @@ from query_pause import query_pause  # noqa: E402
 # Configure logging
 logger = logging.getLogger(__name__)
 
+
+def _log_merge_counter_inspection_kill_switch_once() -> None:
+    """PR-N11 follow-up (cursor-bugbot 2026-04-21, Medium): emit ONE
+    WARN log at module import when ``EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION``
+    is set to a truthy value. Promised by the docstring on
+    ``_record_batch_counters`` — without this, an on-call operator who
+    flips the kill-switch has no log confirmation that the flag took
+    effect. In a production incident that's exactly when you need the
+    signal most.
+
+    Called unconditionally at module import; short-circuits (no log)
+    when the switch is disabled (the default). When enabled, emits
+    at WARNING so the line survives the default operator log filter
+    but doesn't escalate to ERROR for what is a deliberate ops choice.
+    """
+    import os as _os
+
+    _val = _os.environ.get("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION", "").strip().lower()
+    if _val in ("1", "true", "yes", "on"):
+        logger.warning(
+            "[KILL-SWITCH-ACTIVE] EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION=%r — "
+            "_record_batch_counters will short-circuit to no-op. "
+            "Ineffective-batch detection (PR-N9 B6) is DISABLED for this process. "
+            "This is an ops escape hatch; unset the env var and restart to re-enable.",
+            _val,
+        )
+
+
+_log_merge_counter_inspection_kill_switch_once()
+
 # Prometheus metrics (optional – gracefully degrade when metrics_server is not importable)
 try:
     from metrics_server import NEO4J_QUERIES, NEO4J_QUERY_DURATION
@@ -73,8 +103,11 @@ def _record_batch_counters(*, label: str, source_id: str, batch_len: int, result
     the inspection itself turned out to have a bug mid-baseline
     (double-consume, API drift, etc.) on-call would be helpless. Set
     env to any truthy value (``1``, ``true``, ``yes``) to short-circuit
-    the helper into a no-op. Logged once per baseline at startup via
-    the module-load warning below.
+    the helper into a no-op. A module-load WARN log (see
+    ``_log_merge_counter_inspection_kill_switch_once`` below) emits
+    ONE line at startup when the kill-switch is active, so on-call
+    can confirm the flag took effect without reading every per-batch
+    DEBUG line.
 
     **The bug this closes:** ``merge_indicators_batch`` and
     ``merge_vulnerabilities_batch`` historically used ``len(batch)``

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -67,6 +67,15 @@ def _record_batch_counters(*, label: str, source_id: str, batch_len: int, result
     """PR-N9 B6 (audit 09 Prod Readiness #2, 2026-04-21): inspect Neo4j
     result counters to detect silent-write failures.
 
+    PR-N11 (2026-04-21 pre-baseline ops readiness): honor the
+    ``EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION`` env var. Pre-PR-N11
+    there was no way to disable this helper without a code revert — if
+    the inspection itself turned out to have a bug mid-baseline
+    (double-consume, API drift, etc.) on-call would be helpless. Set
+    env to any truthy value (``1``, ``true``, ``yes``) to short-circuit
+    the helper into a no-op. Logged once per baseline at startup via
+    the module-load warning below.
+
     **The bug this closes:** ``merge_indicators_batch`` and
     ``merge_vulnerabilities_batch`` historically used ``len(batch)``
     as the success_count regardless of what Neo4j actually wrote. If
@@ -96,6 +105,20 @@ def _record_batch_counters(*, label: str, source_id: str, batch_len: int, result
     bug can't break production writes. The metric increment itself
     is None-guarded (PR-N5 R1 pattern).
     """
+    # PR-N11 kill-switch: if the helper itself turns out to have a bug
+    # mid-baseline (driver API drift, double-consume, etc.) the
+    # operator sets EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION=1 and
+    # restarts the task. Checked every call (cheap env read) so the
+    # toggle takes effect on the next batch without a code change.
+    import os as _os  # local import to avoid polluting module-level os reuse
+
+    if _os.environ.get("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION", "").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    ):
+        return
     try:
         counters = result.consume().counters
         # ``counters`` exposes attributes as ints; absent attrs default

--- a/tests/test_pr_n11_ops_readiness.py
+++ b/tests/test_pr_n11_ops_readiness.py
@@ -121,6 +121,46 @@ class TestFix1AlertRulesWired:
                     f"alert {rule['alert']!r} groups by forbidden high-cardinality label {label!r}"
                 )
 
+    def test_absolute_count_thresholds_use_increase_not_rate(self):
+        """Cursor-bugbot 2026-04-21 (HIGH x2): a threshold expressed as
+        an absolute count over a window (e.g. ">1/15min", ">100/hr")
+        must use ``increase()``, not ``rate()``. ``rate()`` returns the
+        per-SECOND average, so ``rate(...[15m]) > 1`` means >1/sec =
+        >900/15min, 900x the intended threshold.
+
+        The two alerts whose annotations document a per-window
+        threshold (sustained-backoff > 1/15min, honest-NULL > 100/hr)
+        must both use ``increase()``. The two that use ``rate(...) > 0``
+        are fine — a non-zero per-second rate IS a non-zero count.
+        """
+        group = self._rules()
+        # Map: alert name → expected functor.
+        expected_functor = {
+            "EdgeGuardMispBatchPermanentFailure": "rate",  # > 0 is fine
+            "EdgeGuardMispSustainedBackoff": "increase",  # > 1/15min
+            "EdgeGuardMispHonestNullViolation": "increase",  # > 100/hr
+            "EdgeGuardNeo4jIneffectiveBatch": "rate",  # > 0 is fine
+        }
+        for rule in group["rules"]:
+            name = rule["alert"]
+            expected = expected_functor.get(name)
+            if expected is None:
+                continue
+            expr = rule["expr"]
+            # The functor must appear immediately before the counter
+            # name inside parentheses, e.g. "increase(edgeguard_..."
+            expected_pattern = f"{expected}(edgeguard_"
+            assert expected_pattern in expr, (
+                f"alert {name!r} must use {expected}() (not the other functor) — expr={expr!r}"
+            )
+            # And must NOT use the wrong functor with a counter.
+            other = "rate" if expected == "increase" else "increase"
+            wrong_pattern = f"{other}(edgeguard_"
+            assert wrong_pattern not in expr, (
+                f"alert {name!r} uses {other}() on the counter but should use {expected}() — "
+                f"likely per-second vs per-window confusion"
+            )
+
 
 # ===========================================================================
 # Fix #2 — EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION kill-switch

--- a/tests/test_pr_n11_ops_readiness.py
+++ b/tests/test_pr_n11_ops_readiness.py
@@ -188,6 +188,45 @@ class TestFix2CounterInspectionKillSwitch:
                 return
         raise AssertionError("_record_batch_counters not found in neo4j_client.py")
 
+    def test_module_load_logs_once_when_kill_switch_active(self, monkeypatch, caplog):
+        """Cursor-bugbot 2026-04-21 Medium: the docstring promises a
+        module-load WARN log when the kill-switch is active. Without it,
+        an on-call operator who flips the switch has no log confirmation
+        the flag took effect. The helper
+        ``_log_merge_counter_inspection_kill_switch_once`` emits a
+        single WARNING containing ``[KILL-SWITCH-ACTIVE]``."""
+        import logging
+
+        import neo4j_client
+
+        monkeypatch.setenv("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION", "1")
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            # Call the helper directly; importlib.reload would re-import
+            # the whole module (slow + has side effects). The helper is
+            # the unit under test, and it's called unconditionally at
+            # module import, so invoking it mirrors the import-time path.
+            neo4j_client._log_merge_counter_inspection_kill_switch_once()
+        assert any("[KILL-SWITCH-ACTIVE]" in r.message for r in caplog.records), (
+            "kill-switch activation must emit the [KILL-SWITCH-ACTIVE] WARN"
+        )
+        assert any("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION" in r.message for r in caplog.records), (
+            "log line must name the env var so operators can grep for it"
+        )
+
+    def test_module_load_silent_when_kill_switch_unset(self, monkeypatch, caplog):
+        """Default (kill-switch OFF) must NOT log — otherwise every
+        process-start WARNs, polluting the log."""
+        import logging
+
+        import neo4j_client
+
+        monkeypatch.delenv("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION", raising=False)
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            neo4j_client._log_merge_counter_inspection_kill_switch_once()
+        assert not any("[KILL-SWITCH-ACTIVE]" in r.message for r in caplog.records), (
+            "must not emit WARN when kill-switch is inactive"
+        )
+
     def test_kill_switch_short_circuits(self, monkeypatch):
         """Setting the env var to 1/true/yes/on makes the helper return
         without touching result.consume()."""

--- a/tests/test_pr_n11_ops_readiness.py
+++ b/tests/test_pr_n11_ops_readiness.py
@@ -1,0 +1,226 @@
+"""
+PR-N11 — ops-readiness bundle.
+
+Pre-PR-N11 gaps flagged by the 7-agent pre-baseline audit
+Prod-Readiness pass:
+
+1. PR-N4/N5/N9 metrics exist but no Prometheus alert fires. Counters
+   were visible in Grafana but not actionable — on-call would not be
+   paged on silent data loss or sustained MISP backoff. PR-N11 adds a
+   new ``edgeguard_pipeline_observability`` rule group in
+   ``prometheus/alerts.yml`` with 4 rules (placeholder-reject alert
+   deferred to PR-N12 — see below).
+
+2. No kill-switch for PR-N9 B6 ``_record_batch_counters``. If the
+   counter inspection itself turned out to have a bug mid-baseline
+   (driver API drift, double-consume), on-call had no way to disable
+   it without a code revert. PR-N11 adds
+   ``EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION`` env kill-switch.
+
+3. No on-call runbook — the five failure modes observed during the
+   pre-PR-N7 730d baseline had no documented remediation. PR-N11 ships
+   ``docs/RUNBOOK.md`` v0 covering top-5 modes + kill-switch reference.
+
+Note: the PR-N10 placeholder-reject alert
+(``edgeguard_merge_reject_placeholder_total``) requires a Prometheus
+counter that isn't wired yet. That alert + its counter land atomically
+in PR-N12. This test suite intentionally verifies the alert is NOT
+present in PR-N11 so the deferral is explicit.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n11")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n11")
+
+
+# ===========================================================================
+# Fix #1 — Prometheus alert rules wired for PR-N4 / PR-N5 / PR-N9 metrics
+# ===========================================================================
+
+
+class TestFix1AlertRulesWired:
+    """Alert rule group ``edgeguard_pipeline_observability`` must exist
+    in ``prometheus/alerts.yml`` with 4 rules, each expr referencing a
+    metric that actually exists in ``src/metrics_server.py``."""
+
+    def _rules(self) -> dict:
+        alerts_yaml = (REPO_ROOT / "prometheus" / "alerts.yml").read_text()
+        parsed = yaml.safe_load(alerts_yaml)
+        for group in parsed["groups"]:
+            if group["name"] == "edgeguard_pipeline_observability":
+                return group
+        raise AssertionError("edgeguard_pipeline_observability group missing from alerts.yml")
+
+    def test_rule_group_exists(self):
+        group = self._rules()
+        assert group["name"] == "edgeguard_pipeline_observability"
+        assert "rules" in group
+
+    def test_four_rules_present(self):
+        """Placeholder-reject alert deferred to PR-N12 so exactly 4 rules."""
+        group = self._rules()
+        names = {rule["alert"] for rule in group["rules"]}
+        assert names == {
+            "EdgeGuardMispBatchPermanentFailure",
+            "EdgeGuardMispSustainedBackoff",
+            "EdgeGuardMispHonestNullViolation",
+            "EdgeGuardNeo4jIneffectiveBatch",
+        }, f"unexpected rule set: {names}"
+
+    def test_placeholder_alert_deferred_not_present(self):
+        """PR-N12 follow-up adds this; must not be in PR-N11 without
+        the counter wire."""
+        group = self._rules()
+        names = {rule["alert"] for rule in group["rules"]}
+        assert "EdgeGuardMergeRejectPlaceholder" not in names, (
+            "Placeholder-reject alert requires edgeguard_merge_reject_placeholder_total "
+            "counter (not wired yet); must not ship in PR-N11"
+        )
+
+    def test_every_alert_references_existing_metric(self):
+        """Each alert's expr must reference a counter defined in
+        metrics_server.py. Prevents shipping alerts against counters
+        that don't exist — a Prom-side silence."""
+        metrics_src = (SRC / "metrics_server.py").read_text()
+        group = self._rules()
+        for rule in group["rules"]:
+            expr = rule["expr"]
+            # Extract the counter name (anything ending in _total inside rate())
+            import re
+
+            counter_names = re.findall(r"edgeguard_\w+_total", expr)
+            assert counter_names, f"alert {rule['alert']!r} expr references no counter: {expr}"
+            for counter in counter_names:
+                assert counter in metrics_src, (
+                    f"alert {rule['alert']!r} references counter {counter!r} "
+                    f"that is not defined in src/metrics_server.py"
+                )
+
+    def test_every_alert_has_bounded_labels(self):
+        """Per Prometheus guidance, alert expr should group by
+        bounded-cardinality labels (source, label), not high-cardinality
+        ones (user_id, event_id, etc.). Regression pin."""
+        group = self._rules()
+        forbidden = {"event_id", "user_id", "indicator_id", "attribute_id", "uuid", "trace_id"}
+        for rule in group["rules"]:
+            expr = rule["expr"]
+            for label in forbidden:
+                assert label not in expr, (
+                    f"alert {rule['alert']!r} groups by forbidden high-cardinality label {label!r}"
+                )
+
+
+# ===========================================================================
+# Fix #2 — EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION kill-switch
+# ===========================================================================
+
+
+class TestFix2CounterInspectionKillSwitch:
+    """PR-N9 B6 ``_record_batch_counters`` honors
+    ``EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION``."""
+
+    def test_helper_reads_env_var(self):
+        """Function body must check the env var before touching the
+        result object. AST-level pin so a future refactor doesn't drop
+        the check."""
+        import ast
+
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "_record_batch_counters":
+                body_src = ast.unparse(node)
+                assert "EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION" in body_src, (
+                    "_record_batch_counters must check the disable env var"
+                )
+                return
+        raise AssertionError("_record_batch_counters not found in neo4j_client.py")
+
+    def test_kill_switch_short_circuits(self, monkeypatch):
+        """Setting the env var to 1/true/yes/on makes the helper return
+        without touching result.consume()."""
+        # Build a MagicMock that would raise if touched
+        from unittest.mock import MagicMock
+
+        from neo4j_client import _record_batch_counters
+
+        for enable_val in ("1", "true", "yes", "on", "TRUE", "On"):
+            monkeypatch.setenv("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION", enable_val)
+            bomb = MagicMock()
+            bomb.consume.side_effect = RuntimeError(
+                "kill-switch failed: helper should have no-op'd before touching result"
+            )
+            # Must not raise
+            _record_batch_counters(label="Indicator", source_id="otx", batch_len=10, result=bomb)
+            bomb.consume.assert_not_called()
+
+    def test_default_keeps_inspection_active(self, monkeypatch):
+        """Unset or empty-value env → helper proceeds as normal."""
+        from unittest.mock import MagicMock
+
+        from neo4j_client import _record_batch_counters
+
+        monkeypatch.delenv("EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION", raising=False)
+
+        # result.consume() must be called. Build a mock that returns a
+        # counters namespace with the expected attrs.
+        counters_mock = MagicMock()
+        counters_mock.nodes_created = 5
+        counters_mock.nodes_deleted = 0
+        counters_mock.relationships_created = 0
+        counters_mock.relationships_deleted = 0
+        counters_mock.properties_set = 10
+        result_mock = MagicMock()
+        result_mock.consume.return_value.counters = counters_mock
+
+        _record_batch_counters(label="Indicator", source_id="otx", batch_len=10, result=result_mock)
+        result_mock.consume.assert_called_once()
+
+
+# ===========================================================================
+# Fix #3 — docs/RUNBOOK.md v0
+# ===========================================================================
+
+
+class TestFix3RunbookShipped:
+    """``docs/RUNBOOK.md`` exists and covers the minimum set of topics
+    on-call needs during a baseline run."""
+
+    def _runbook(self) -> str:
+        path = REPO_ROOT / "docs" / "RUNBOOK.md"
+        assert path.exists(), "docs/RUNBOOK.md must exist for on-call"
+        return path.read_text()
+
+    def test_runbook_covers_top_5_failure_modes(self):
+        runbook = self._runbook()
+        required_topics = [
+            "MISP batch permanent failure",
+            "MISP sustained backoff",
+            "Honest-NULL violation",
+            "ineffective-batch",
+            "Placeholder",
+        ]
+        for topic in required_topics:
+            assert topic.lower() in runbook.lower(), f"RUNBOOK missing top-5 topic: {topic!r}"
+
+    def test_runbook_documents_kill_switches(self):
+        runbook = self._runbook()
+        assert "EDGEGUARD_RESPECT_CALIBRATOR" in runbook
+        assert "EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION" in runbook
+
+    def test_runbook_has_baseline_day_protocol(self):
+        runbook = self._runbook()
+        assert "baseline" in runbook.lower()
+        assert "7-day" in runbook or "7 day" in runbook.lower(), "RUNBOOK must reference the 7-day smoke recommendation"


### PR DESCRIPTION
## Summary

- Wire Prometheus alert rules for the PR-N4 / PR-N5 / PR-N9 observability counters so on-call gets paged on silent data loss (was: metrics visible but not actionable)
- Add `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION` env kill-switch so on-call can disable PR-N9 B6 without a code revert
- Ship `docs/RUNBOOK.md` v0 — top-5 failure modes + kill-switch quick reference + baseline-day protocol

Pre-baseline audit (7-agent, 2026-04-21) Prod-Readiness pass flagged three gaps that would have left on-call blind during the 730d baseline:

1. **PR-N4/N5/N9 metrics existed but no alert fired.** The observability investment was invisible — on-call would not be paged on MISP batch permanent failure, sustained backoff, honest-NULL violation, or Neo4j ineffective-batch silent writes.

2. **No kill-switch for PR-N9 B6 `_record_batch_counters`.** If the result-counter inspection itself had a bug mid-baseline (driver API drift, double-consume), on-call had no escape hatch.

3. **No on-call runbook.** The five failure modes observed during the pre-PR-N7 730d baseline had no documented remediation — each response was from-scratch tribal knowledge.

## Fixes

**Fix #1 — `prometheus/alerts.yml`:** new `edgeguard_pipeline_observability` rule group with 4 rules:

| Alert | Metric | Severity | For |
|---|---|---|---|
| `EdgeGuardMispBatchPermanentFailure` | `edgeguard_misp_push_permanent_failure_total` | critical | 5m |
| `EdgeGuardMispSustainedBackoff` | `edgeguard_misp_push_backoff_triggered_total` | warning | 15m |
| `EdgeGuardMispHonestNullViolation` | `edgeguard_misp_honest_null_violation_total` | warning | 1h |
| `EdgeGuardNeo4jIneffectiveBatch` | `edgeguard_neo4j_merge_ineffective_batch_total` | critical | 5m |

Labels are bounded (`source`, `label`) — no high-cardinality axes. Test `test_every_alert_has_bounded_labels` pins the guard.

A placeholder-reject alert for PR-N10 Fix #1 is **intentionally deferred to PR-N12** along with its counter wire, so the alert + metric ship atomically. `test_placeholder_alert_deferred_not_present` pins the deferral so a future maintainer doesn't add the alert without the counter.

**Fix #2 — `src/neo4j_client.py:_record_batch_counters`:** honor `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION` (`1`/`true`/`yes`/`on`) to short-circuit the helper into a no-op. Cheap env read per call so the toggle takes effect on the next batch without a code change. AST-level regression pin + monkeypatch behaviour tests.

**Fix #3 — `docs/RUNBOOK.md` v0:**
- Kill-switch quick-reference table (both PR-N10 `EDGEGUARD_RESPECT_CALIBRATOR` and this PR's counter-inspection switch)
- Top-5 failure modes with symptom → Prom alert → root cause → remediation steps
- Baseline-day protocol: pre-run smoke test recommendation, in-run alert monitoring, post-run diff checklist (including the PR-N10 Fix #2 regression query: `MATCH ()-[r]->() WHERE r.calibrated_at IS NOT NULL AND r.confidence_score > 0.5 RETURN count(r)`)

## Test plan

- [x] `tests/test_pr_n11_ops_readiness.py` — 11 new regression tests (3 classes covering all fixes), all pass
- [x] `ruff format --check src/ tests/` clean
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean
- [x] Full suite: 1324 passed, 3 skipped, 3 xfailed (no regressions)
- [ ] Manual: `promtool check rules prometheus/alerts.yml` before merge (operator task)
- [ ] Manual: load alerts.yml into Grafana dashboard after merge and verify all 4 new rules appear

## Notes

This PR depends on `edgeguard_misp_push_permanent_failure_total` (PR-N4), `edgeguard_misp_push_backoff_triggered_total` (PR-N4), `edgeguard_misp_honest_null_violation_total` (PR-N5), and `edgeguard_neo4j_merge_ineffective_batch_total` (PR-N9) — all already merged to main. Alert rules reference existing counters only; `test_every_alert_references_existing_metric` enforces this.

Does **NOT** depend on PR-N10 (#94). The placeholder-reject alert that would depend on PR-N10 is deferred to PR-N12 as noted above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Prometheus alerting and a runtime kill-switch in `neo4j_client` that can change production monitoring/diagnostics behavior; misconfiguration could suppress detection or increase paging noise.
> 
> **Overview**
> Adds operator-facing *baseline readiness* safeguards: a new `edgeguard_pipeline_observability` Prometheus rule group that alerts on existing MISP/Neo4j integrity counters (permanent batch failures, sustained backoff, honest-NULL violations, and Neo4j ineffective batches).
> 
> Introduces an env-based kill-switch, `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION`, to short-circuit `_record_batch_counters` plus a one-time startup WARNING when the switch is active, and ships a new `docs/RUNBOOK.md` covering kill-switch usage, top failure modes, and baseline-day protocol; accompanying tests pin the alert set/PromQL choices and kill-switch behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09c99c05f988011150cae52e43b9cc10ee9db51f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->