### PR TITLE
fix(audit): PR-N12 — pre-baseline alert-wiring bundle (5 BLOCK)

### DIFF
--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -59,10 +59,19 @@ groups:
         # both sides to `source` with `on (source)`, drop the
         # regex allow-list — `source_health==1` already scopes to
         # known-to-pipeline sources.
+        #
+        # PR-N12 Fix #5 follow-up (cursor-bugbot 2026-04-21 Medium):
+        # use `max by (source)` rather than `sum by (source)` on the
+        # source_health aggregation. A source can be emitted with
+        # health=1 in multiple zones (e.g. OTX reports into both
+        # "global" and "healthcare"); `sum == 1` fails on multi-zone
+        # sources and reintroduces the silent-alert bug we just fixed.
+        # `max == 1` correctly expresses "is this source healthy in any
+        # zone" without depending on zone cardinality.
         expr: |
           sum by (source) (increase(edgeguard_indicators_collected_total[1h])) == 0
           and on (source)
-          sum by (source) (edgeguard_source_health) == 1
+          max by (source) (edgeguard_source_health) == 1
         for: 30m
         labels:
           severity: warning
@@ -240,13 +249,24 @@ groups:
         # (a timestamp); use `changes()` over a window to detect restarts.
         # Falls back to `kube_pod_container_status_restarts_total` if a
         # Kubernetes/kubelet scrape is also present (harmless when it's not).
+        #
+        # PR-N12 Fix #2 follow-up (cursor-bugbot 2026-04-21 Low): cAdvisor
+        # labels the container as `name`; kubelet labels it as
+        # `container`. The prior annotation only referenced
+        # `{{ $labels.name }}`, so kubelet-branch fires rendered
+        # "Container  is in a restart loop" (empty). `label_replace`
+        # normalizes the kubelet `container` label into `name` on the
+        # second branch so the annotation works uniformly.
         expr: |
           (
             changes(container_start_time_seconds{name=~"edgeguard.*"}[1h]) > 3
           )
           or
           (
-            increase(kube_pod_container_status_restarts_total{container=~"edgeguard.*"}[1h]) > 3
+            label_replace(
+              increase(kube_pod_container_status_restarts_total{container=~"edgeguard.*"}[1h]),
+              "name", "$1", "container", "(.*)"
+            ) > 3
           )
         for: 5m
         labels:

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -9,12 +9,27 @@ groups:
   - name: edgeguard_collection
     rules:
       - alert: EdgeGuardCollectionHighFailureRate
+        # PR-N12 Fix #3 (cursor-audit 2026-04-21 BLOCK): the prior expr
+        # used `rate(collected) > 0` as the denominator filter, which
+        # DROPS the series when the rate is zero — producing NO RESULT
+        # (undefined ratio) exactly when the collector has stopped
+        # producing anything, which is the scenario where the alert
+        # matters most. Fix: put total ATTEMPTS (successes + failures)
+        # in the denominator, clamp_min to avoid 0/0, and require at
+        # least one attempt. "Zero collected, any failures" is covered
+        # by EdgeGuardNoIndicatorsCollected.
         expr: |
           (
             sum by (source) (rate(edgeguard_collection_failures_total[5m]))
             /
-            sum by (source) (rate(edgeguard_indicators_collected_total[5m]) > 0)
+            clamp_min(
+              sum by (source) (rate(edgeguard_indicators_collected_total[5m]))
+              + sum by (source) (rate(edgeguard_collection_failures_total[5m])),
+              0.001
+            )
           ) > 0.2
+          and
+          sum by (source) (rate(edgeguard_collection_failures_total[5m])) > 0
         for: 5m
         labels:
           severity: warning
@@ -34,10 +49,20 @@ groups:
           description: "No successful collection from {{ $labels.source }} in over 1 hour."
 
       - alert: EdgeGuardNoIndicatorsCollected
+        # PR-N12 Fix #5 (cursor-audit 2026-04-21 BLOCK): two issues in
+        # the prior expr: (1) LHS was `sum by (source)` which DROPPED
+        # the `zone` label that RHS `edgeguard_source_health` carries,
+        # so the vector `and` had no matching labels and the alert was
+        # silent; (2) the hard-coded allow-list `source=~"otx|nvd|cisa|
+        # abuseipdb"` silently excluded every new source (ThreatFox,
+        # URLhaus, CyberCure, Feodo, SSLBL, MITRE, …). Fix: collapse
+        # both sides to `source` with `on (source)`, drop the
+        # regex allow-list — `source_health==1` already scopes to
+        # known-to-pipeline sources.
         expr: |
           sum by (source) (increase(edgeguard_indicators_collected_total[1h])) == 0
-          and
-          edgeguard_source_health{source=~"otx|nvd|cisa|abuseipdb"} == 1
+          and on (source)
+          sum by (source) (edgeguard_source_health) == 1
         for: 30m
         labels:
           severity: warning
@@ -135,7 +160,15 @@ groups:
           description: "Pipeline {{ $labels.pipeline_type }} 95th percentile duration is over 5 minutes."
 
       - alert: EdgeGuardNeo4jSyncStale
-        expr: time() - (edgeguard_neo4j_sync_duration_seconds_count > 0) > 259200
+        # PR-N12 Fix #1 (cursor-audit 2026-04-21 BLOCK): the prior expr
+        # `time() - (X > 0) > 259200` subtracted a histogram COUNT (int
+        # like 42) from current time and was permanently firing or silent
+        # depending on eval semantics. Use a dedicated
+        # `edgeguard_neo4j_sync_last_success_timestamp` gauge
+        # stamped at end of each successful sync.
+        expr: |
+          time() - edgeguard_neo4j_sync_last_success_timestamp > 259200
+          and edgeguard_neo4j_sync_last_success_timestamp > 0
         for: 1h
         labels:
           severity: warning
@@ -201,8 +234,20 @@ groups:
   - name: edgeguard_containers
     rules:
       - alert: EdgeGuardContainerRestartLoop
+        # PR-N12 Fix #2 (cursor-audit 2026-04-21 BLOCK): prior expr used
+        # `container_restart_count` which cAdvisor does NOT export — the
+        # alert was silently inert. cAdvisor exports `container_start_time_seconds`
+        # (a timestamp); use `changes()` over a window to detect restarts.
+        # Falls back to `kube_pod_container_status_restarts_total` if a
+        # Kubernetes/kubelet scrape is also present (harmless when it's not).
         expr: |
-          increase(container_restart_count{name=~"edgeguard.*"}[1h]) > 3
+          (
+            changes(container_start_time_seconds{name=~"edgeguard.*"}[1h]) > 3
+          )
+          or
+          (
+            increase(kube_pod_container_status_restarts_total{container=~"edgeguard.*"}[1h]) > 3
+          )
         for: 5m
         labels:
           severity: critical

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -209,6 +209,22 @@ NEO4J_SYNC_DURATION = Histogram(
     buckets=[1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0],
 )
 
+# PR-N12 (pre-baseline audit Fix #1, 2026-04-21): dedicated gauge for the
+# last successful MISP→Neo4j sync wall-clock. Pre-PR-N12 the
+# EdgeGuardNeo4jSyncStale alert used the nonsensical expression
+# ``time() - (edgeguard_neo4j_sync_duration_seconds_count > 0) > 259200``
+# which subtracted a histogram COUNT (e.g. 42) from current time; the
+# alert was permanently firing or permanently silent depending on eval
+# semantics. Either way it carried no signal. This gauge is written on
+# every successful sync completion and read by the alert as
+# ``time() - edgeguard_neo4j_sync_last_success_timestamp > 259200``.
+NEO4J_SYNC_LAST_SUCCESS = Gauge(
+    "edgeguard_neo4j_sync_last_success_timestamp",
+    "Unix timestamp (seconds) of the last successful MISP→Neo4j sync "
+    "completion. Used by EdgeGuardNeo4jSyncStale alert. Set on every "
+    "successful run of MISPToNeo4jSync.run() after counters are flushed.",
+)
+
 # Distribution of accumulator-list sizes on Neo4j nodes/relationships.
 # Sampled periodically (NOT per-write) — see ``record_neo4j_list_dedup_size``
 # in this module and the ``scrape_list_dedup_sizes`` helper in neo4j_client.
@@ -731,8 +747,15 @@ def record_misp_unmapped_attribute_type(attr_type: str, count: int = 1):
 
 
 def record_neo4j_sync(node_counts: Dict[str, int], duration: float):
-    """Record Neo4j sync metrics."""
+    """Record Neo4j sync metrics.
+
+    PR-N12 (2026-04-21): also stamp ``NEO4J_SYNC_LAST_SUCCESS`` with
+    the current wall-clock so ``EdgeGuardNeo4jSyncStale`` has a real
+    signal to alert on. Called at the END of a sync, so a crashed
+    sync does NOT update the gauge (which is exactly the behaviour the
+    staleness alert needs)."""
     NEO4J_SYNC_DURATION.observe(duration)
+    NEO4J_SYNC_LAST_SUCCESS.set(time.time())
     for label, count in node_counts.items():
         zone = "unknown"
         if ":" in label:

--- a/tests/test_pr_n12_alert_wiring.py
+++ b/tests/test_pr_n12_alert_wiring.py
@@ -164,6 +164,24 @@ class TestFix2ContainerRestartLoopMetric:
         uses_kubelet = "kube_pod_container_status_restarts_total" in expr
         assert uses_cadvisor or uses_kubelet, "must reference a metric that a real Prometheus target exports"
 
+    def test_kubelet_branch_normalizes_container_label_to_name(self):
+        """Cursor-bugbot 2026-04-21 Low: cAdvisor labels the container as
+        `name`; kubelet labels it as `container`. If the kubelet branch
+        fires without a label rewrite, the annotation renders
+        `{{ $labels.name }}` as empty string. `label_replace` must copy
+        the kubelet `container` into `name` so both branches populate
+        the annotation uniformly."""
+        rule = _find_rule("EdgeGuardContainerRestartLoop")
+        expr = rule["expr"]
+        # The kubelet branch must be wrapped in label_replace that
+        # copies `container` into `name`.
+        if "kube_pod_container_status_restarts_total" in expr:
+            assert "label_replace(" in expr, (
+                "kubelet branch needs label_replace to normalize `container` → `name` "
+                "so the annotation `{{ $labels.name }}` isn't empty"
+            )
+            assert '"name"' in expr and '"container"' in expr, "label_replace must target `name` from `container`"
+
 
 # ===========================================================================
 # Fix #3 — CollectionHighFailureRate denominator is NaN-safe
@@ -287,13 +305,30 @@ class TestFix5NoIndicatorsCollectedLabelMatch:
 
     def test_both_sides_reduced_to_source_only(self):
         """LHS and RHS both aggregate by `source` so `and on (source)`
-        has matching label sets."""
+        has matching label sets. RHS uses `max by (source)` (not `sum`)
+        to correctly handle multi-zone healthy sources — see
+        test_source_health_uses_max_not_sum below."""
         rule = _find_rule("EdgeGuardNoIndicatorsCollected")
         expr = rule["expr"]
-        # Both `sum by (source)` calls should be present
-        # (one on indicators_collected, one on source_health)
-        count = expr.count("sum by (source)")
-        assert count >= 2, f"expected >=2 `sum by (source)` aggregations; got {count}"
+        assert "sum by (source)" in expr, "LHS must sum indicator rates by source"
+        assert "max by (source)" in expr, "RHS must max source_health by source"
+
+    def test_source_health_uses_max_not_sum(self):
+        """Cursor-bugbot 2026-04-21 Medium: `sum by (source)
+        (edgeguard_source_health) == 1` silently fails when a source
+        is emitted in multiple zones (e.g. OTX healthy in both `global`
+        and `healthcare` → sum == 2, not 1). That reintroduces the same
+        silent-alert class Fix #5 was meant to eliminate. `max by
+        (source) == 1` correctly captures "healthy in ANY zone"."""
+        rule = _find_rule("EdgeGuardNoIndicatorsCollected")
+        expr = rule["expr"]
+        assert "max by (source) (edgeguard_source_health)" in expr, (
+            "edgeguard_source_health must be aggregated with max by (source), "
+            "not sum — sum == 1 fails on multi-zone healthy sources"
+        )
+        assert "sum by (source) (edgeguard_source_health)" not in expr, (
+            "regression: sum by (source) on source_health reintroduces the multi-zone silent-alert bug"
+        )
 
 
 # ===========================================================================

--- a/tests/test_pr_n12_alert_wiring.py
+++ b/tests/test_pr_n12_alert_wiring.py
@@ -198,7 +198,7 @@ class TestFix3CollectionHighFailureRateDenominator:
         rule = _find_rule("EdgeGuardCollectionHighFailureRate")
         expr = rule["expr"]
         # Must use clamp_min or explicit > 0 denominator guard
-        assert "clamp_min(" in expr, "denominator must use clamp_min to handle zero-rate case; got {expr!r}"
+        assert "clamp_min(" in expr, f"denominator must use clamp_min to handle zero-rate case; got {expr!r}"
         # Total attempts in denominator = collected + failed
         assert "rate(edgeguard_indicators_collected_total" in expr
         assert "rate(edgeguard_collection_failures_total" in expr

--- a/tests/test_pr_n12_alert_wiring.py
+++ b/tests/test_pr_n12_alert_wiring.py
@@ -1,0 +1,330 @@
+"""
+PR-N12 — pre-baseline alert-wiring bundle.
+
+Five BLOCK-severity findings from the pre-baseline 7-agent audit's
+Observability pass. Each was silently dead (alert never fires) and
+would have left on-call blind during the 730-day baseline.
+
+## Fix #1 — ``EdgeGuardNeo4jSyncStale`` nonsensical expr
+
+Prior expr ``time() - (edgeguard_neo4j_sync_duration_seconds_count > 0)
+> 259200`` subtracted a Histogram ``_count`` (int like 42) from current
+time, producing either a permanently-firing or permanently-silent alert
+depending on eval semantics. Either way it carried no signal.
+
+Fix: new dedicated ``NEO4J_SYNC_LAST_SUCCESS`` gauge
+(``edgeguard_neo4j_sync_last_success_timestamp``) stamped at the end
+of every successful sync via ``record_neo4j_sync()``. Alert now reads
+``time() - edgeguard_neo4j_sync_last_success_timestamp > 259200 and
+<gauge> > 0``.
+
+## Fix #2 — ``EdgeGuardContainerRestartLoop`` nonexistent metric
+
+Prior expr referenced ``container_restart_count{...}`` which cAdvisor
+does NOT export (that name is from kubelet). Alert was silently inert.
+
+Fix: use cAdvisor's ``container_start_time_seconds`` with
+``changes()`` over a window, OR kubelet's
+``kube_pod_container_status_restarts_total`` if a kubelet scrape is
+present. Both covered via PromQL ``or``; harmless when one of the two
+scrape jobs isn't configured.
+
+## Fix #3 — ``EdgeGuardCollectionHighFailureRate`` NaN denominator
+
+Prior denominator ``rate(collected) > 0`` DROPPED the series when rate
+was zero — producing no-result (undefined ratio) exactly when the
+collector had stopped producing anything, which is the scenario the
+alert is meant to catch.
+
+Fix: denominator = ``rate(collected) + rate(failed)`` (total attempts),
+``clamp_min(..., 0.001)`` to avoid 0/0, plus an explicit
+``rate(failed) > 0`` guard so a collector doing nothing at all doesn't
+trigger a meaningless alert (covered by EdgeGuardNoIndicatorsCollected).
+
+## Fix #4 — Collector staleness coverage audit (regression pin only)
+
+The audit claimed ``edgeguard_last_success_timestamp`` was set for only
+3 of 11 collectors. The claim was WRONG — the central dispatcher at
+``dags/edgeguard_pipeline.py:755`` calls
+``set_last_success_timestamp(collector_name)`` on every successful
+collection, covering ALL registered collectors. This test pins the
+dispatcher wiring so a future refactor that drops the call surfaces
+immediately (preventing the audit's hypothetical from becoming real).
+
+## Fix #5 — ``EdgeGuardNoIndicatorsCollected`` label mismatch + hard-coded allow-list
+
+Two bugs in the prior expr:
+- LHS ``sum by (source)`` dropped the ``zone`` label while RHS
+  ``edgeguard_source_health`` kept it → PromQL ``and`` found no match
+  → alert was silent.
+- Hard-coded regex ``source=~"otx|nvd|cisa|abuseipdb"`` silently
+  excluded every new source (ThreatFox, URLhaus, CyberCure, Feodo,
+  SSLBL, MITRE, MISP federated, …).
+
+Fix: collapse both sides via ``and on (source)``; drop the allow-list.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n12")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n12")
+
+
+def _load_alerts() -> dict:
+    alerts_yaml = (REPO_ROOT / "prometheus" / "alerts.yml").read_text()
+    return yaml.safe_load(alerts_yaml)
+
+
+def _find_rule(alert_name: str) -> dict:
+    alerts = _load_alerts()
+    for group in alerts["groups"]:
+        for rule in group.get("rules", []):
+            if rule.get("alert") == alert_name:
+                return rule
+    raise AssertionError(f"alert {alert_name!r} not found in prometheus/alerts.yml")
+
+
+# ===========================================================================
+# Fix #1 — EdgeGuardNeo4jSyncStale fixed + dedicated gauge
+# ===========================================================================
+
+
+class TestFix1NeoSyncStale:
+    def test_new_gauge_declared_in_metrics_server(self):
+        """NEO4J_SYNC_LAST_SUCCESS must be a Gauge exporting
+        ``edgeguard_neo4j_sync_last_success_timestamp``."""
+        src = (SRC / "metrics_server.py").read_text()
+        assert "NEO4J_SYNC_LAST_SUCCESS" in src, "gauge variable missing"
+        assert '"edgeguard_neo4j_sync_last_success_timestamp"' in src, "prometheus metric name missing"
+        # Must be a Gauge — not a Counter (Counters don't support .set)
+        assert "NEO4J_SYNC_LAST_SUCCESS = Gauge(" in src
+
+    def test_record_neo4j_sync_stamps_gauge(self):
+        """On every successful sync, ``record_neo4j_sync`` must stamp
+        the gauge with current wall-clock. Pin via AST so a refactor
+        that drops the call surfaces."""
+        import ast
+
+        src = (SRC / "metrics_server.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "record_neo4j_sync":
+                body_src = ast.unparse(node)
+                assert "NEO4J_SYNC_LAST_SUCCESS.set(" in body_src, (
+                    "record_neo4j_sync must stamp NEO4J_SYNC_LAST_SUCCESS"
+                )
+                return
+        raise AssertionError("record_neo4j_sync function not found")
+
+    def test_alert_uses_new_gauge_not_histogram_count(self):
+        """Regression pin: the prior expr subtracted
+        ``edgeguard_neo4j_sync_duration_seconds_count`` (a histogram
+        count int) from ``time()``. Must not happen again."""
+        rule = _find_rule("EdgeGuardNeo4jSyncStale")
+        expr = rule["expr"]
+        assert "edgeguard_neo4j_sync_last_success_timestamp" in expr, "must use the new last-success timestamp gauge"
+        assert "edgeguard_neo4j_sync_duration_seconds_count" not in expr, (
+            "regression: must NOT subtract histogram _count from time()"
+        )
+        # Must also guard against `> 0` so fresh instances (gauge = 0)
+        # don't trigger spurious alerts before the first sync.
+        assert "> 0" in expr, "must guard against gauge == 0 (pre-first-sync)"
+
+
+# ===========================================================================
+# Fix #2 — ContainerRestartLoop uses a metric that actually exists
+# ===========================================================================
+
+
+class TestFix2ContainerRestartLoopMetric:
+    def test_alert_no_longer_uses_nonexistent_metric(self):
+        rule = _find_rule("EdgeGuardContainerRestartLoop")
+        expr = rule["expr"]
+        assert "container_restart_count" not in expr, "regression: container_restart_count is NOT exported by cAdvisor"
+
+    def test_alert_uses_cadvisor_or_kubelet_metric(self):
+        """Accept either cAdvisor's ``container_start_time_seconds``
+        (via ``changes()``) or kubelet's
+        ``kube_pod_container_status_restarts_total`` (via
+        ``increase()``). Deployment may have either or both."""
+        rule = _find_rule("EdgeGuardContainerRestartLoop")
+        expr = rule["expr"]
+        uses_cadvisor = "container_start_time_seconds" in expr
+        uses_kubelet = "kube_pod_container_status_restarts_total" in expr
+        assert uses_cadvisor or uses_kubelet, "must reference a metric that a real Prometheus target exports"
+
+
+# ===========================================================================
+# Fix #3 — CollectionHighFailureRate denominator is NaN-safe
+# ===========================================================================
+
+
+class TestFix3CollectionHighFailureRateDenominator:
+    def test_denominator_cannot_be_undefined_when_collector_silent(self):
+        """Prior expr used ``rate(collected) > 0`` as denominator, which
+        drops the series when the rate is zero — producing a
+        NO-RESULT vector exactly when the collector has stopped. The
+        fix puts total ATTEMPTS in the denominator (collected + failed)
+        with ``clamp_min`` to avoid division-by-zero."""
+        rule = _find_rule("EdgeGuardCollectionHighFailureRate")
+        expr = rule["expr"]
+        # Must use clamp_min or explicit > 0 denominator guard
+        assert "clamp_min(" in expr, "denominator must use clamp_min to handle zero-rate case; got {expr!r}"
+        # Total attempts in denominator = collected + failed
+        assert "rate(edgeguard_indicators_collected_total" in expr
+        assert "rate(edgeguard_collection_failures_total" in expr
+
+    def test_denominator_does_not_use_zero_filter_pattern(self):
+        """The `> 0` filter on the denominator is the specific bug —
+        ensure it's not back in any form."""
+        rule = _find_rule("EdgeGuardCollectionHighFailureRate")
+        expr = rule["expr"]
+        # The `> 0` filter on `rate(collected)` as denominator was the bug.
+        # The fix uses clamp_min instead. The expr may still have `> 0`
+        # for the guard on failures > 0 — that's fine.
+        # Count occurrences — at most one (for the failures > 0 guard).
+        import re
+
+        zero_filters = re.findall(r"rate\([^)]+\)\s*>\s*0", expr)
+        assert len(zero_filters) <= 1, (
+            f"too many `rate(...) > 0` filters ({len(zero_filters)}); the denominator-filter bug may be back"
+        )
+
+
+# ===========================================================================
+# Fix #4 — Collector staleness dispatcher coverage (regression pin)
+# ===========================================================================
+
+
+class TestFix4DispatcherCoversAllCollectors:
+    """The central dispatcher at ``dags/edgeguard_pipeline.py``
+    ``run_collector_with_metrics`` calls ``set_last_success_timestamp``
+    on every successful collection. This writes the
+    ``edgeguard_last_success_timestamp`` gauge the
+    ``EdgeGuardCollectionStale`` alert depends on. Pin the wiring."""
+
+    def test_dispatcher_calls_set_last_success_timestamp(self):
+        """AST pin: `set_last_success_timestamp(collector_name)` must
+        appear inside `run_collector_with_metrics` (the central
+        dispatcher)."""
+        import ast
+
+        src = (REPO_ROOT / "dags" / "edgeguard_pipeline.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "run_collector_with_metrics":
+                body_src = ast.unparse(node)
+                assert "set_last_success_timestamp(" in body_src, (
+                    "central dispatcher must stamp the last-success gauge on "
+                    "every successful collector run — regression would break "
+                    "EdgeGuardCollectionStale alert for all collectors"
+                )
+                return
+        raise AssertionError("run_collector_with_metrics not found in dags/edgeguard_pipeline.py")
+
+    def test_set_last_success_timestamp_writes_the_expected_gauge(self):
+        """The function must write to the ``LAST_SUCCESS`` gauge
+        (exported as ``edgeguard_last_success_timestamp``) — the same
+        gauge the ``EdgeGuardCollectionStale`` alert watches."""
+        import ast
+
+        src = (REPO_ROOT / "dags" / "edgeguard_pipeline.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "set_last_success_timestamp":
+                body_src = ast.unparse(node)
+                assert "LAST_SUCCESS.labels" in body_src, "must write to the LAST_SUCCESS gauge"
+                assert ".set(time.time())" in body_src, "must stamp wall-clock seconds"
+                return
+        raise AssertionError("set_last_success_timestamp not found")
+
+    def test_collection_stale_alert_watches_the_same_metric(self):
+        """Close the loop: the alert reads the metric the dispatcher
+        writes."""
+        rule = _find_rule("EdgeGuardCollectionStale")
+        expr = rule["expr"]
+        assert "edgeguard_last_success_timestamp" in expr, "alert must read the gauge the dispatcher writes"
+
+
+# ===========================================================================
+# Fix #5 — NoIndicatorsCollected label set matches + no hard-coded allow-list
+# ===========================================================================
+
+
+class TestFix5NoIndicatorsCollectedLabelMatch:
+    def test_label_sets_match_on_source(self):
+        """The two halves of the ``and`` must join on ``source`` via
+        ``on (source)`` — otherwise the different label sets on LHS
+        (source) vs RHS (source, zone) produce no matches."""
+        rule = _find_rule("EdgeGuardNoIndicatorsCollected")
+        expr = rule["expr"]
+        assert "on (source)" in expr, (
+            "the vector `and` must explicitly join on `source` — without this, label-set mismatch silences the alert"
+        )
+
+    def test_no_hard_coded_source_allowlist(self):
+        """The prior expr hard-coded
+        ``source=~"otx|nvd|cisa|abuseipdb"``, silently excluding every
+        new collector. Drop the allow-list; let ``source_health`` scope
+        to pipeline-known sources."""
+        rule = _find_rule("EdgeGuardNoIndicatorsCollected")
+        expr = rule["expr"]
+        assert 'source=~"otx|nvd|cisa|abuseipdb"' not in expr, (
+            "hard-coded source allow-list re-introduced; would silently "
+            "exclude ThreatFox, URLhaus, CyberCure, Feodo, SSLBL, MITRE, …"
+        )
+
+    def test_both_sides_reduced_to_source_only(self):
+        """LHS and RHS both aggregate by `source` so `and on (source)`
+        has matching label sets."""
+        rule = _find_rule("EdgeGuardNoIndicatorsCollected")
+        expr = rule["expr"]
+        # Both `sum by (source)` calls should be present
+        # (one on indicators_collected, one on source_health)
+        count = expr.count("sum by (source)")
+        assert count >= 2, f"expected >=2 `sum by (source)` aggregations; got {count}"
+
+
+# ===========================================================================
+# Alerts file overall sanity
+# ===========================================================================
+
+
+class TestAlertsFileSanity:
+    def test_alerts_yaml_is_valid(self):
+        """The edits must leave the file as valid YAML + a valid
+        Prometheus rules document (groups → rules → alert/expr/for)."""
+        alerts = _load_alerts()
+        assert "groups" in alerts
+        for group in alerts["groups"]:
+            assert "name" in group
+            assert "rules" in group
+            for rule in group["rules"]:
+                assert "alert" in rule or "record" in rule, f"every rule must have `alert` or `record`: {rule}"
+                if "alert" in rule:
+                    assert "expr" in rule
+                    assert "labels" in rule
+                    assert "severity" in rule["labels"]
+
+    def test_all_five_fixed_alerts_still_present(self):
+        """Regression: the 5 alerts PR-N12 fixed must still exist after
+        any future edits."""
+        for alert_name in [
+            "EdgeGuardNeo4jSyncStale",
+            "EdgeGuardContainerRestartLoop",
+            "EdgeGuardCollectionHighFailureRate",
+            "EdgeGuardCollectionStale",
+            "EdgeGuardNoIndicatorsCollected",
+        ]:
+            _find_rule(alert_name)  # raises if missing


### PR DESCRIPTION
## Summary

Five BLOCK-severity alert-wiring bugs from the pre-baseline 7-agent audit's Observability pass. Each alert was silently DEAD — never fires, or permanently fires with no signal. During the 730-day baseline, operators had zero signal for several critical failure modes.

| # | Alert | Was | Fix |
|---|---|---|---|
| 1 | `EdgeGuardNeo4jSyncStale` | `time() - (histogram_count > 0) > 259200` — subtracts a count from time(); either permanently silent or firing | New `NEO4J_SYNC_LAST_SUCCESS` gauge stamped on every successful sync; alert reads `time() - gauge > 259200 and gauge > 0` |
| 2 | `EdgeGuardContainerRestartLoop` | `container_restart_count` — not exported by cAdvisor | OR-combine `changes(container_start_time_seconds)` + `increase(kube_pod_container_status_restarts_total)` |
| 3 | `EdgeGuardCollectionHighFailureRate` | `rate(failures) / (rate(collected) > 0)` — denominator drops when rate=0 → no-result exactly when collector stops | `failures / clamp_min(collected + failures, 0.001) > 0.2 and failures > 0` |
| 4 | `EdgeGuardCollectionStale` coverage audit | Audit claimed only 3 of 11 collectors stamp the gauge | **False positive** — dispatcher at `dags/edgeguard_pipeline.py:755` covers all collectors. Regression pin added. |
| 5 | `EdgeGuardNoIndicatorsCollected` | Label-set mismatch + hard-coded `source=~"otx\|nvd\|cisa\|abuseipdb"` excluding every new collector | Both sides via `sum by (source)`, join via `and on (source)`, drop allow-list |

## Files

- `prometheus/alerts.yml` — edit 4 existing alerts (Fix #1/#2/#3/#5)
- `src/metrics_server.py` — add `NEO4J_SYNC_LAST_SUCCESS` gauge; stamp it in `record_neo4j_sync()` (Fix #1)
- `tests/test_pr_n12_alert_wiring.py` — 15 new regression tests (3-4 per fix) incl. AST-level pins

## Test plan

- [x] 15/15 new PR-N12 tests pass
- [x] Full suite: 1361 passed, 3 skipped, 3 xfailed (up from 1346 on main)
- [x] `ruff format --check src/ tests/` clean
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean
- [ ] Manual: `promtool check rules prometheus/alerts.yml` (operator)
- [ ] Manual: simulate each alert's metric conditions on staging Prom (operator)

## Dependencies / ordering

- **Rebased on** main (includes PR-N10 merged as c8592d6)
- **Does NOT depend on** PR #95 (PR-N11); the two PRs touch DISJOINT parts of `prometheus/alerts.yml` — PR-N11 adds a new `edgeguard_pipeline_observability` group; PR-N12 edits existing alerts in `edgeguard_collection`, `edgeguard_pipeline`, `edgeguard_containers` groups. Clean merge either order.

## Context

Part of the pre-baseline hardening series (PR-N1 through PR-N12). This is Tier-1 of the 7-agent audit findings; Tier-2 (the None-guards, silent field drops, aliases hijack, CVSS bounds clamp, `execute_write` migration) lands in PR-N13+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes modify PromQL alert semantics and add a new Neo4j sync timestamp metric; misconfiguration could cause missed or noisy alerts, but scope is limited to observability rules/metrics.
> 
> **Overview**
> Fixes multiple silently-broken Prometheus alerts so they actually evaluate and page on real failure modes.
> 
> Updates alert expressions to use valid/robust metrics and label joins: `EdgeGuardNeo4jSyncStale` now keys off a new last-success timestamp gauge; `EdgeGuardContainerRestartLoop` detects restarts via `changes(container_start_time_seconds)` and/or kubelet restart counters (with label normalization); `EdgeGuardCollectionHighFailureRate` uses a NaN-safe attempts denominator; and `EdgeGuardNoIndicatorsCollected` removes the hard-coded source allow-list and correctly joins on `source` (handling multi-zone health via `max`).
> 
> Adds `edgeguard_neo4j_sync_last_success_timestamp` in `metrics_server.py` (stamped in `record_neo4j_sync`) and introduces a new test suite (`test_pr_n12_alert_wiring.py`) that pins the updated alert rules and critical wiring (including the dispatcher’s `set_last_success_timestamp` call) to prevent regressions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c937074c27893138399c54636ffe35fcd4373f4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->