### PR TITLE
fix(audit): PR-N13 — pre-baseline data-integrity bundle (6 findings)

### DIFF
--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -996,6 +996,20 @@ class MISPWriter:
                 # in both meta blocks (TF_META extended in mirror below).
                 "malware_family": indicator.get("malware_family", ""),
                 "attributed_to": indicator.get("attributed_to", ""),
+                # PR-N13 (2026-04-21 pre-baseline audit Fix #5): preserve
+                # ``pulse_id`` (OTX native pulse UUID — the stable
+                # cross-deployment dedup key for re-sync against OTX),
+                # ``indicator_role`` (e.g. "C2" / "dropper" — drives
+                # MITRE-killchain mapping and is LIVE-WIRED at
+                # ``neo4j_client.merge_indicators_batch:~L2169`` which
+                # currently reads None because OTX_META never carried
+                # it), and ``is_active`` (source-side activity state).
+                # All three were emitted by
+                # ``otx_collector.py:462,479-488`` and silently dropped
+                # on the MISP round-trip.
+                "pulse_id": indicator.get("pulse_id", ""),
+                "indicator_role": indicator.get("indicator_role", ""),
+                "is_active": indicator.get("is_active", True),
             }
             comment = "OTX_META:" + json.dumps(otx_meta, default=str)
             if len(comment) > 4000:
@@ -1015,6 +1029,19 @@ class MISPWriter:
                 # so TF-sourced indicators also carry the attribution
                 # hint through the MISP round-trip.
                 "attributed_to": indicator.get("attributed_to", ""),
+                # PR-N13 (2026-04-21 pre-baseline audit Fix #4): preserve
+                # ``threat_type`` (payload / C2 / exfil category),
+                # ``ioc_id`` (canonical ThreatFox ID — the stable
+                # cross-system dedup key for re-ingest across daily
+                # CSV exports), and ``malware_alias`` (alternate
+                # names). All three were emitted by
+                # ``global_feed_collector.py:240-243`` and silently
+                # dropped here, losing ``ioc_id`` cross-day dedup +
+                # losing the alias signal Q2/Q9 consumes. Mirror of
+                # the OTX_META ``malware_family`` fix in PR-N10 #3.
+                "threat_type": indicator.get("threat_type", ""),
+                "ioc_id": indicator.get("ioc_id", ""),
+                "malware_alias": indicator.get("malware_alias", ""),
             }
             comment = "TF_META:" + json.dumps(tf_meta, default=str)
             if len(comment) > 4000:
@@ -1131,6 +1158,22 @@ class MISPWriter:
             "cisa_action_due": vuln.get("cisa_action_due", ""),
             "cisa_required_action": vuln.get("cisa_required_action", ""),
             "cisa_vulnerability_name": vuln.get("cisa_vulnerability_name", ""),
+            # PR-N13 (2026-04-21 pre-baseline audit Fix #3): preserve
+            # ``version_constraints`` (up to 10 per-CPE range entries)
+            # and ``status`` (active / rejected list) through the MISP
+            # round-trip. Pre-PR-N13 both fields were emitted by
+            # ``nvd_collector.py`` (version_constraints at line 975,
+            # status at lines 892+924) but OMITTED here, so every
+            # NVD CVE reached Neo4j with ``version_constraints=None``
+            # and ``status=default``. ``neo4j_client.merge_cve``
+            # already consumes both fields when present (live
+            # JSON-serialize logic at ~line 2389-2431); this closes
+            # the collector-side drop so Neo4j actually sees them.
+            # ``status=["rejected"]`` is especially important — a
+            # withdrawn/duplicate CVE otherwise silently lands as if
+            # active, polluting downstream triage queues.
+            "version_constraints": vuln.get("version_constraints", []),
+            "status": vuln.get("status", []),
         }
         has_nvd_meta = any(
             [

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1729,12 +1729,34 @@ class Neo4jClient:
         Neo4j nodes sharing ONE uuid. The audit-driven batch fix was
         applied in PR #37 commit 3 but the single-item path was missed
         — bugbot caught it.
+
+        PR-N13 (2026-04-21 pre-baseline audit Fix #1): reject None /
+        empty / whitespace-only ``value`` or ``indicator_type`` at
+        entry. The prior code let ``{"indicator_type": None, "value":
+        None}`` reach the Cypher MERGE, which collapses every None-
+        keyed row into ONE sentinel Indicator node. A single malformed
+        OTX pulse emitting ``{"type": "ipv4", "indicator": ""}`` can
+        therefore poison a production hub node that every subsequent
+        empty row cross-joins to. Mirror of ``merge_ip`` / ``merge_host``
+        None-guards (already established pattern).
         """
+        norm_value = nonempty_graph_string(data.get("value"))
+        norm_type = nonempty_graph_string(data.get("indicator_type"))
+        if norm_value is None or norm_type is None:
+            logger.warning(
+                "[MERGE-REJECT] Indicator MERGE refused: indicator_type=%r value=%r "
+                "(one or both are None / empty / whitespace-only). Creating a "
+                "null-keyed Indicator would produce a sentinel hub node that "
+                "every subsequent empty-keyed row collapses into.",
+                data.get("indicator_type"),
+                data.get("value"),
+            )
+            return False
         key_props = canonicalize_merge_key(
             "Indicator",
             {
-                "indicator_type": data.get("indicator_type"),
-                "value": data.get("value"),
+                "indicator_type": norm_type,
+                "value": norm_value,
             },
         )
         # Promote enrichment fields to queryable node properties
@@ -2001,10 +2023,24 @@ class Neo4jClient:
         return self.merge_node_with_source("ThreatActor", key_props, data, source_id, extra_props=extra_props)
 
     def merge_technique(self, data: Dict, source_id: str = "mitre_attck") -> bool:
-        """MERGE a Technique node with source tracking."""
-        key_props = {
-            "mitre_id": data.get("mitre_id"),
-        }
+        """MERGE a Technique node with source tracking.
+
+        PR-N13 (2026-04-21 pre-baseline audit Fix #2): reject None /
+        empty / whitespace-only ``mitre_id``. Without this, a single
+        malformed MITRE tag like ``{"name": "Foo"}`` (no mitre_id)
+        hijacks the sentinel ``(Technique {mitre_id: null})`` node
+        that every subsequent None-keyed row also collapses into.
+        Mirrors the PR-N10 placeholder-name guard for Malware / Actor.
+        """
+        mitre_id = nonempty_graph_string(data.get("mitre_id"))
+        if mitre_id is None:
+            logger.warning(
+                "[MERGE-REJECT] Technique MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
+                data.get("mitre_id"),
+                data.get("name"),
+            )
+            return False
+        key_props = {"mitre_id": mitre_id}
         extra_props: Dict[str, Any] = {"tactic_phases": data.get("tactic_phases", [])}
         extra_props["detection"] = data.get("detection", "")
         extra_props["is_subtechnique"] = data.get("is_subtechnique", False)
@@ -2015,10 +2051,18 @@ class Neo4jClient:
         return self.merge_node_with_source("Technique", key_props, data, source_id, extra_props=extra_props)
 
     def merge_tactic(self, data: Dict, source_id: str = "mitre_attck") -> bool:
-        """MERGE a Tactic node with source tracking."""
-        key_props = {
-            "mitre_id": data.get("mitre_id"),
-        }
+        """MERGE a Tactic node with source tracking.
+
+        PR-N13 Fix #2: same None-guard pattern as ``merge_technique``."""
+        mitre_id = nonempty_graph_string(data.get("mitre_id"))
+        if mitre_id is None:
+            logger.warning(
+                "[MERGE-REJECT] Tactic MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
+                data.get("mitre_id"),
+                data.get("name"),
+            )
+            return False
+        key_props = {"mitre_id": mitre_id}
         extra_props: Dict[str, Any] = {"shortname": data.get("shortname", "")}
         if data.get("name"):
             extra_props["name"] = data["name"]
@@ -2027,9 +2071,19 @@ class Neo4jClient:
         return self.merge_node_with_source("Tactic", key_props, data, source_id, extra_props=extra_props)
 
     def merge_tool(self, data: Dict, source_id: str = "mitre_attck") -> bool:
-        """MERGE a Tool node with source tracking."""
+        """MERGE a Tool node with source tracking.
+
+        PR-N13 Fix #2: same None-guard pattern as ``merge_technique``."""
+        mitre_id = nonempty_graph_string(data.get("mitre_id"))
+        if mitre_id is None:
+            logger.warning(
+                "[MERGE-REJECT] Tool MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
+                data.get("mitre_id"),
+                data.get("name"),
+            )
+            return False
         key_props = {
-            "mitre_id": data.get("mitre_id"),
+            "mitre_id": mitre_id,
         }
         extra_props: Dict[str, Any] = {}
         if data.get("uses_techniques"):
@@ -2252,9 +2306,31 @@ class Neo4jClient:
                     # PR #37 commit X (bugbot LOW): import is hoisted to
                     # module level (line 36) so it doesn't re-resolve
                     # once per item in this hot batch loop.
+                    #
+                    # PR-N13 Fix #1 (2026-04-21): skip rows whose
+                    # natural key is None / empty / whitespace-only
+                    # BEFORE constructing the batch_item. The inner
+                    # Cypher would otherwise MERGE on ``value: null``
+                    # and collapse every such row into a single
+                    # sentinel hub node. merge_indicator (single-item)
+                    # already has this guard; the batch path must
+                    # match.
+                    norm_value = nonempty_graph_string(item.get("value"))
+                    norm_type = nonempty_graph_string(item.get("indicator_type"))
+                    if norm_value is None or norm_type is None:
+                        logger.warning(
+                            "[MERGE-REJECT] merge_indicators_batch: skipping row — "
+                            "indicator_type=%r value=%r (None / empty / "
+                            "whitespace-only). Would otherwise collapse into a "
+                            "sentinel hub Indicator node.",
+                            item.get("indicator_type"),
+                            item.get("value"),
+                        )
+                        error_count += 1
+                        continue
                     canonical_key = canonicalize_merge_key(
                         "Indicator",
-                        {"indicator_type": item.get("indicator_type"), "value": item.get("value")},
+                        {"indicator_type": norm_type, "value": norm_value},
                     )
                     canonical_value = canonical_key.get("value")
 
@@ -2266,11 +2342,11 @@ class Neo4jClient:
                     # state that caused the bug).
                     node_uuid = compute_node_uuid(
                         "Indicator",
-                        {"indicator_type": item.get("indicator_type"), "value": canonical_value},
+                        {"indicator_type": norm_type, "value": canonical_value},
                     )
 
                     batch_item = {
-                        "indicator_type": item.get("indicator_type"),
+                        "indicator_type": norm_type,
                         "value": canonical_value,
                         "tag": tag,
                         "source_id": source_id,

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2487,6 +2487,12 @@ class MISPToNeo4jSync:
                 "cisa_action_due": nvd_meta.get("cisa_action_due", ""),
                 "cisa_required_action": nvd_meta.get("cisa_required_action", ""),
                 "cisa_vulnerability_name": nvd_meta.get("cisa_vulnerability_name", ""),
+                # PR-N13 Fix #3 rehydration: ``version_constraints`` + ``status``
+                # mirror of the NVD_META extension in ``misp_writer.py``.
+                # ``merge_cve`` in neo4j_client.py already consumes both
+                # fields when present (JSON-serialize logic at ~L2389-2431).
+                "version_constraints": nvd_meta.get("version_constraints", []),
+                "status": nvd_meta.get("status", []),
             }
             return item, relationships
 
@@ -2914,6 +2920,16 @@ class MISPToNeo4jSync:
                 # never fired for OTX items (the biggest source).
                 item["malware_family"] = otx_meta.get("malware_family", "")
                 item["attributed_to"] = otx_meta.get("attributed_to", "")
+                # PR-N13 Fix #5 rehydration: pull ``pulse_id``,
+                # ``indicator_role``, ``is_active`` out of OTX_META now
+                # that misp_writer.py serializes them. Pre-PR-N13 all
+                # three were dropped on the round-trip; ``indicator_role``
+                # in particular is LIVE-WIRED at
+                # ``neo4j_client.merge_indicators_batch:~L2169`` which
+                # silently received None for every OTX-sourced row.
+                item["pulse_id"] = otx_meta.get("pulse_id", "")
+                item["indicator_role"] = otx_meta.get("indicator_role", "")
+                item["is_active"] = otx_meta.get("is_active", True)
 
             # Enrich indicator with ThreatFox metadata
             if tf_meta:
@@ -2926,6 +2942,13 @@ class MISPToNeo4jSync:
                 item["reporter"] = tf_meta.get("reporter", "")
                 # PR-N10 Fix #3: mirror OTX_META ``attributed_to`` pull-out.
                 item["attributed_to"] = tf_meta.get("attributed_to", "")
+                # PR-N13 Fix #4 rehydration: pull ``threat_type``,
+                # ``ioc_id``, ``malware_alias`` out of TF_META. Pre-PR-N13
+                # all three were dropped on round-trip; losing ``ioc_id``
+                # specifically broke cross-day ThreatFox dedup.
+                item["threat_type"] = tf_meta.get("threat_type", "")
+                item["ioc_id"] = tf_meta.get("ioc_id", "")
+                item["malware_alias"] = tf_meta.get("malware_alias", "")
 
             return item, relationships
 

--- a/tests/test_pr_n13_data_integrity.py
+++ b/tests/test_pr_n13_data_integrity.py
@@ -1,0 +1,297 @@
+"""
+PR-N13 — pre-baseline data-integrity bundle.
+
+Six findings from the pre-baseline 7-agent audit's Data-Integrity pass.
+Each is a silent-data-loss or hub-collapse vector that would manifest
+at scale during the 730-day baseline.
+
+## Fix #1 — None-guard on merge_indicator + merge_indicators_batch value
+
+Pre-PR-N13, ``merge_indicator({"indicator_type": None, "value": None})``
+canonicalized to ``{"indicator_type": None, "value": None}`` and reached
+Cypher as ``MERGE (i:Indicator {indicator_type: null, value: null})``,
+which collapses EVERY None-keyed row into one sentinel hub node. A
+single malformed OTX pulse at scale (400K indicators/day) could poison
+a production hub node that downstream cross-joins for thousands of
+spurious relationships. ``merge_ip`` / ``merge_host`` already had this
+guard (PR #N, 2025); ``merge_indicator`` did not.
+
+Fix: early reject if ``nonempty_graph_string(value)`` or
+``nonempty_graph_string(indicator_type)`` returns None, with a
+MERGE-REJECT log line. Applied to both the single-item path
+(``merge_indicator``) and the batch path
+(``merge_indicators_batch`` pre-Cypher filter).
+
+## Fix #2 — None-guard on merge_technique / merge_tactic / merge_tool
+
+Same vector on MITRE ATT&CK IDs. A MITRE tag without ``mitre_id``
+(malformed ingest, partial dictionary) silently hijacks the
+``(Technique {mitre_id: null})`` sentinel node — every None-keyed
+Technique row after that collapses into it. Mirrors the PR-N10
+placeholder-name guard for Malware / Actor.
+
+## Fix #3 — NVD_META carries ``version_constraints`` + ``status``
+
+Same silent-drop class as PR-N10 Fix #3 (OTX_META malware_family).
+NVD collector emits per-CPE ``version_constraints`` and the
+``status=["active"]`` / ``["rejected"]`` field. NVD_META in
+``misp_writer.py`` omitted both. ``merge_cve`` in neo4j_client
+already reads both when present. Net: every NVD-sourced CVE
+reached Neo4j with ``version_constraints=None`` and (more
+critically) ``status`` defaulted to active — a withdrawn CVE
+silently lands as if active.
+
+## Fix #4 — TF_META carries ``threat_type`` + ``ioc_id`` + ``malware_alias``
+
+ThreatFox collector emits three fields that were being dropped:
+- ``threat_type`` — payload / C2 / exfil category
+- ``ioc_id`` — canonical ThreatFox ID (stable cross-day dedup key)
+- ``malware_alias`` — alternate names (feeds Q2 / Q9 alias-match)
+
+Loss of ``ioc_id`` in particular broke ThreatFox re-ingest dedup
+across daily CSV exports, so the same IOC was re-created fresh
+every day.
+
+## Fix #5 — OTX_META carries ``pulse_id`` + ``indicator_role`` + ``is_active``
+
+OTX collector emits:
+- ``pulse_id`` — native OTX pulse UUID (cross-deployment dedup key)
+- ``indicator_role`` — "C2" / "dropper" — DRIVES Neo4j property
+  mapping live-wired at ``merge_indicators_batch:~L2169``. Every
+  OTX Indicator was missing this because OTX_META didn't carry it.
+- ``is_active`` — source-side activity state
+
+## Fix #6 — Rehydration for all new fields
+
+``run_misp_to_neo4j.py`` pulls the new fields out of the parsed
+meta dicts and promotes them to the item dict that reaches
+``merge_indicator`` / ``merge_cve``.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n13")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n13")
+
+
+# ===========================================================================
+# Fix #1 — merge_indicator None-guard
+# ===========================================================================
+
+
+class TestFix1MergeIndicatorNoneGuard:
+    def test_merge_indicator_rejects_none_value(self, caplog):
+        import logging
+
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            result = client.merge_indicator({"indicator_type": "ipv4", "value": None})
+        assert result is False, "merge_indicator must reject value=None"
+        assert any("MERGE-REJECT" in r.message for r in caplog.records), "must emit [MERGE-REJECT] warning"
+
+    def test_merge_indicator_rejects_empty_value(self):
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        for bad in ["", " ", "\t", "\n", "   "]:
+            assert client.merge_indicator({"indicator_type": "ipv4", "value": bad}) is False, (
+                f"must reject whitespace-only value {bad!r}"
+            )
+
+    def test_merge_indicator_rejects_none_type(self):
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        for bad in [None, "", "  "]:
+            assert client.merge_indicator({"indicator_type": bad, "value": "203.0.113.5"}) is False, (
+                f"must reject indicator_type={bad!r}"
+            )
+
+    def test_merge_indicators_batch_skips_none_value_rows(self, caplog):
+        """Batch path must filter None/empty BEFORE Cypher — otherwise
+        the UNWIND collapses every None-keyed row into one sentinel."""
+
+        src = (SRC / "neo4j_client.py").read_text()
+        # AST pin: the nonempty_graph_string filter must appear inside
+        # the merge_indicators_batch row loop (surfaced via a MERGE-REJECT
+        # log line).
+        assert 'logger.warning(\n                            "[MERGE-REJECT] merge_indicators_batch:' in src, (
+            "batch path must emit MERGE-REJECT on None/empty value"
+        )
+        # And `nonempty_graph_string(item.get("value"))` must be called.
+        assert 'nonempty_graph_string(item.get("value"))' in src, "batch path must call nonempty_graph_string on value"
+        assert 'nonempty_graph_string(item.get("indicator_type"))' in src, (
+            "batch path must call nonempty_graph_string on indicator_type"
+        )
+
+
+# ===========================================================================
+# Fix #2 — MITRE merge None-guards
+# ===========================================================================
+
+
+class TestFix2MitreNoneGuards:
+    def _client(self):
+        from neo4j_client import Neo4jClient
+
+        c = Neo4jClient.__new__(Neo4jClient)
+        c.driver = MagicMock()
+        return c
+
+    def test_merge_technique_rejects_none_mitre_id(self, caplog):
+        import logging
+
+        c = self._client()
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            result = c.merge_technique({"name": "Foo", "mitre_id": None})
+        assert result is False
+        assert any("MERGE-REJECT" in r.message and "Technique" in r.message for r in caplog.records)
+
+    def test_merge_tactic_rejects_empty_mitre_id(self):
+        c = self._client()
+        for bad in [None, "", "   ", "\t"]:
+            assert c.merge_tactic({"mitre_id": bad, "name": "Foo"}) is False
+
+    def test_merge_tool_rejects_none_mitre_id(self):
+        c = self._client()
+        for bad in [None, "", "   "]:
+            assert c.merge_tool({"mitre_id": bad, "name": "Foo"}) is False
+
+    def test_merge_technique_accepts_valid_mitre_id(self):
+        """Sanity: legitimate mitre_id passes through to the
+        merge_node_with_source call."""
+        c = self._client()
+        # merge_node_with_source reads self.driver — we stubbed it with
+        # MagicMock that has truthy __bool__, so the merge returns truthy.
+        # The test is really: does the code path NOT early-return False?
+        # We monkeypatch merge_node_with_source to return a sentinel.
+        c.merge_node_with_source = MagicMock(return_value=True)
+        assert c.merge_technique({"mitre_id": "T1566", "name": "Phishing"}) is True
+        c.merge_node_with_source.assert_called_once()
+        call_args = c.merge_node_with_source.call_args
+        # key_props is third positional arg
+        key_props = call_args[0][1]
+        assert key_props == {"mitre_id": "T1566"}
+
+
+# ===========================================================================
+# Fix #3 — NVD_META carries version_constraints + status
+# ===========================================================================
+
+
+class TestFix3NvdMetaCompletion:
+    def test_nvd_meta_includes_version_constraints(self):
+        src = (SRC / "collectors" / "misp_writer.py").read_text()
+        # Find the NVD_META block and scan for version_constraints.
+        # Use a wide window since the block includes ~20 fields + a
+        # breadcrumb comment.
+        idx = src.find('"cvss_v40_data": vuln.get("cvss_v40_data")')
+        assert idx != -1, "NVD_META block not found"
+        block = src[idx : idx + 4000]
+        assert '"version_constraints": vuln.get("version_constraints"' in block, (
+            "NVD_META must include version_constraints (Fix #3)"
+        )
+
+    def test_nvd_meta_includes_status(self):
+        src = (SRC / "collectors" / "misp_writer.py").read_text()
+        idx = src.find('"cvss_v40_data": vuln.get("cvss_v40_data")')
+        assert idx != -1
+        block = src[idx : idx + 4000]
+        assert '"status": vuln.get("status"' in block, "NVD_META must include status (Fix #3)"
+
+    def test_run_misp_to_neo4j_rehydrates_version_constraints(self):
+        """Rehydration pin — the value must reach the item dict."""
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        # Find the NVD item-build block (has cvss_v40_data immediately before)
+        idx = src.find('"cvss_v40_data": nvd_meta.get("cvss_v40_data"')
+        assert idx != -1, "NVD item-build block not found"
+        block = src[idx : idx + 2000]
+        assert '"version_constraints": nvd_meta.get("version_constraints"' in block, (
+            "run_misp_to_neo4j must rehydrate version_constraints from NVD_META"
+        )
+        assert '"status": nvd_meta.get("status"' in block, "run_misp_to_neo4j must rehydrate status from NVD_META"
+
+
+# ===========================================================================
+# Fix #4 — TF_META completion
+# ===========================================================================
+
+
+class TestFix4TfMetaCompletion:
+    def test_tf_meta_includes_new_fields(self):
+        src = (SRC / "collectors" / "misp_writer.py").read_text()
+        # Find TF_META's anchor field and scan forward
+        idx = src.find('"malware_malpedia": indicator.get("malware_malpedia"')
+        assert idx != -1
+        block = src[idx : idx + 3500]
+        for field in ("threat_type", "ioc_id", "malware_alias"):
+            assert f'"{field}": indicator.get("{field}"' in block, f"TF_META must include {field} (Fix #4)"
+
+    def test_tf_meta_rehydration(self):
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        # Find the TF rehydrate block
+        idx = src.find('item["malware_malpedia"] = tf_meta.get("malware_malpedia"')
+        assert idx != -1
+        block = src[idx : idx + 2500]
+        for field in ("threat_type", "ioc_id", "malware_alias"):
+            assert f'item["{field}"] = tf_meta.get("{field}"' in block, (
+                f"run_misp_to_neo4j must rehydrate {field} from TF_META"
+            )
+
+
+# ===========================================================================
+# Fix #5 — OTX_META completion
+# ===========================================================================
+
+
+class TestFix5OtxMetaCompletion:
+    def test_otx_meta_includes_new_fields(self):
+        src = (SRC / "collectors" / "misp_writer.py").read_text()
+        idx = src.find('"attack_ids": indicator.get("attack_ids"')
+        assert idx != -1
+        block = src[idx : idx + 3500]
+        for field in ("pulse_id", "indicator_role", "is_active"):
+            assert f'"{field}": indicator.get("{field}"' in block, f"OTX_META must include {field} (Fix #5)"
+
+    def test_otx_meta_rehydration(self):
+        src = (SRC / "run_misp_to_neo4j.py").read_text()
+        # Find the OTX rehydrate block — uses malware_family as anchor
+        idx = src.find('item["malware_family"] = otx_meta.get("malware_family"')
+        assert idx != -1
+        block = src[idx : idx + 2500]
+        for field in ("pulse_id", "indicator_role", "is_active"):
+            assert f'item["{field}"] = otx_meta.get("{field}"' in block, (
+                f"run_misp_to_neo4j must rehydrate {field} from OTX_META"
+            )
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_neo4j_client_imports(self):
+        import neo4j_client  # noqa: F401
+
+    def test_misp_writer_imports(self):
+        from collectors import misp_writer  # noqa: F401
+
+    def test_run_misp_to_neo4j_imports(self):
+        import run_misp_to_neo4j  # noqa: F401


### PR DESCRIPTION
## Summary

Six data-integrity findings from the pre-baseline 7-agent audit. Each is a silent-data-loss or hub-collapse vector that would manifest at scale during the 730-day baseline. Two BLOCK + three HIGH + rehydration wiring.

| # | Sev | What | Impact |
|---|---|---|---|
| 1 | BLOCK | `merge_indicator(value=None)` → `MERGE (Indicator {value:null})` — collapses all None-keyed rows into ONE sentinel hub | A single malformed pulse poisons a hub that downstream cross-joins for thousands of spurious relationships |
| 2 | BLOCK | `merge_technique/tactic/tool(mitre_id=None)` — same sentinel-hub vector for MITRE ATT&CK ids | Same at the tactic/technique layer |
| 3 | HIGH | NVD_META drops `version_constraints` + `status` | Every NVD CVE missing per-CPE ranges; **withdrawn CVEs silently land as active** |
| 4 | HIGH | TF_META drops `threat_type` + `ioc_id` + `malware_alias` | Loss of `ioc_id` breaks cross-day ThreatFox dedup — same IOC re-created every day |
| 5 | HIGH | OTX_META drops `pulse_id` + `indicator_role` + `is_active` | `indicator_role` is live-wired at `merge_indicators_batch:~L2169` but receives None for every OTX row |
| 6 | — | Rehydration wiring for all new fields | Closes the collector → MISP → Neo4j round-trip for Fix #3/#4/#5 |

## Files

- `src/neo4j_client.py` — None-guards on merge_indicator + merge_indicators_batch + merge_technique + merge_tactic + merge_tool (emit `[MERGE-REJECT]` WARN)
- `src/collectors/misp_writer.py` — NVD_META / TF_META / OTX_META serialize new fields
- `src/run_misp_to_neo4j.py` — rehydration pulls new fields out of parsed meta dicts
- `tests/test_pr_n13_data_integrity.py` — 18 regression tests

## Test plan

- [x] 18/18 new PR-N13 tests pass
- [x] Full suite: 1395 passed, 3 skipped, 3 xfailed (no regressions)
- [x] `ruff format --check src/ tests/` clean
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean
- [ ] Post-deploy: run `MATCH (i:Indicator) WHERE i.value IS NULL OR size(trim(i.value)) = 0 RETURN count(i)` to measure pre-existing sentinel-hub damage (operator task)

## Pattern consistency

Each None-guard follows the established PR-N10 shape: `is_placeholder_name` for name fields, `nonempty_graph_string` for value/id fields. The `[MERGE-REJECT]` log prefix is searchable in docs/RUNBOOK.md top-5 failure modes.

The silent-drop fixes in Fix #3-#5 follow the same pattern as PR-N10 Fix #3 (OTX_META malware_family): extend the producer dict in misp_writer, extend the rehydration block in run_misp_to_neo4j. The downstream Neo4j merge path already consumes the fields when present.

## Context — Tier-2 audit progress

Part of the post-baseline audit triage. Tier-1 shipped as PR-N10/N11/N12 (all merged). Tier-2 was estimated as 3 PRs; this is the first:

- **PR-N13** (this) — data-integrity hardening ✅ ready
- **PR-N14** — adversarial input bounds (aliases hijack, CVSS inf clamp, confidence clamp, STIX honest-NULL)
- **PR-N15** — recovery hardening (merge_*_batch retry-on-transient, execute_write migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core Neo4j merge paths and MISP↔Neo4j serialization, so mistakes could drop data or change dedup/graph shape; changes are guarded and covered by new regression tests but affect high-volume ingestion.
> 
> **Overview**
> **Prevents null-key “sentinel hub” node collapses in Neo4j merges.** `neo4j_client.merge_indicator` and `merge_indicators_batch` now reject/skip rows where `indicator_type` or `value` is `None`/empty/whitespace (logging `[MERGE-REJECT]`), and `merge_technique`/`merge_tactic`/`merge_tool` similarly reject missing `mitre_id`.
> 
> **Stops silent metadata loss across the MISP round-trip.** `misp_writer.py` now serializes additional fields into `OTX_META` (`pulse_id`, `indicator_role`, `is_active`), `TF_META` (`threat_type`, `ioc_id`, `malware_alias`), and `NVD_META` (`version_constraints`, `status`), and `run_misp_to_neo4j.py` rehydrates these fields back into the items sent to Neo4j.
> 
> Adds `tests/test_pr_n13_data_integrity.py` to pin the new guards and meta/rehydration wiring.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 40f5d0eee9ccfaf615b704584fa23772ffba7cfb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->