### PR TITLE
fix(audit): PR-N14 — pre-baseline adversarial-input bounds (5 findings)

### DIFF
--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -544,6 +544,69 @@ def nonempty_graph_string(value: Any) -> Optional[str]:
     return s if s else None
 
 
+def clamp_cvss_score(value: Any) -> Optional[float]:
+    """PR-N14 (pre-baseline audit Fix #1, 2026-04-21): clamp a CVSS
+    base_score to the valid [0.0, 10.0] range + reject non-finite.
+
+    Pre-PR-N14, an attacker-controlled NVD_META with ``base_score:
+    "1e309"`` reached ``float(...)`` → Python ``inf`` → landed on the
+    CVE node as ``n.cvss_score = Infinity``. Two consequences:
+
+      * GraphQL ``vulnerabilities(min_cvss: 9.0) ORDER BY n.cvss_score
+        DESC`` permanently placed the forged CVE at the top of the
+        triage queue, masking real P1s.
+      * STIX export emitted `"cvss_score": Infinity` which is NOT valid
+        JSON — downstream parsers crashed.
+
+    Returns None for unparseable / non-finite / out-of-range values so
+    callers can propagate NULL (honest-NULL per PR-N5 C7). Valid inputs
+    pass through as floats.
+    """
+    import math
+
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(f):
+        # inf / -inf / NaN — reject (honest-NULL).
+        return None
+    if f < 0.0 or f > 10.0:
+        # Outside the NIST-defined CVSS range.
+        return None
+    return f
+
+
+def clamp_confidence_score(value: Any) -> Optional[float]:
+    """PR-N14 (pre-baseline audit Fix #2, 2026-04-21): clamp
+    confidence_score to [0.0, 1.0] + reject non-finite.
+
+    Pre-PR-N14, the max-wins CASE in every ``_upsert_sourced_relationship``
+    and batched UNWIND happily accepted ``$confidence = inf`` from a
+    compromised feed and pinned ``r.confidence_score = Infinity``
+    forever — defeating calibrator demotion, and corrupting every
+    query that sorts or filters on confidence.
+
+    Returns None for unparseable / non-finite / out-of-range so callers
+    can fall back to the documented default (0.5 at most sites).
+    """
+    import math
+
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(f):
+        return None
+    if f < 0.0 or f > 1.0:
+        return None
+    return f
+
+
 def normalize_cve_id_for_graph(value: Any) -> Optional[str]:
     """
     Return a canonical CVE id string for graph keys/relationships, or None if unknown.
@@ -1324,7 +1387,24 @@ class Neo4jClient:
 
             raw_data_json = json.dumps(raw_data, default=str)
 
-            confidence = data.get("confidence_score", 0.5)
+            # PR-N14 Fix #2 (2026-04-21 pre-baseline audit): clamp
+            # confidence_score to [0.0, 1.0] + reject non-finite (inf/
+            # nan). A compromised feed shipping ``confidence_score:
+            # "1e309"`` would otherwise pin ``r.confidence_score = inf``
+            # on every max-wins upsert, permanently defeating the
+            # calibrator. Fall back to 0.5 on bad input (same default
+            # as the missing-field case).
+            _claimed_conf = data.get("confidence_score")
+            _clamped_conf = clamp_confidence_score(_claimed_conf)
+            if _claimed_conf is not None and _clamped_conf is None:
+                logger.warning(
+                    "confidence_score rejected by clamp for %s/%s (claimed=%r) — "
+                    "falling back to 0.5. Compromised feed?",
+                    label,
+                    source_id,
+                    _claimed_conf,
+                )
+            confidence = _clamped_conf if _clamped_conf is not None else 0.5
             zone = data.get("zone", ["global"])  # zone is an array
             # Accumulate tag into tags array (tag removed from MERGE key)
             tag_value = data.get("tag", source_id)
@@ -1427,12 +1507,82 @@ class Neo4jClient:
                     "tactic_phases",
                 }
             )
+            # PR-N14 Fix #3 (2026-04-21 pre-baseline audit): cardinality
+            # cap + placeholder-entry filter for accumulating array
+            # properties. A compromised feed can otherwise ship
+            # ``aliases=["a1",...,"a100000"]`` and grow a Malware
+            # node's aliases to 10M entries over several syncs —
+            # ``calibrate_cooccurrence_confidence`` + Q2 alias-match
+            # then walk that array per-row, OOM-crashing the entire
+            # enrichment pass. Also drop placeholder-name entries
+            # (``"unknown"``, ``"n/a"``, …) to mirror the PR-N10
+            # reject of placeholder node NAMES to their aliases lists.
+            #
+            # 50 is generous — MITRE / Malpedia malware corpora have
+            # p99 ≈ 30 aliases per family. Truncation policy: keep
+            # the FIRST 50 non-placeholder entries (stable order),
+            # log-and-drop the rest.
+            _MAX_ARRAY_ITEMS = 50
+            _MAX_ARRAY_ITEM_LEN = 200  # chars per individual entry
+
+            def _sanitize_array_value(prop: str, items: list) -> list:
+                """Drop placeholder entries, truncate overlong strings,
+                cap cardinality. Returns a new list (does NOT mutate)."""
+                out: list = []
+                dropped_placeholder = 0
+                for entry in items:
+                    if not isinstance(entry, str):
+                        # Non-strings pass through (e.g. numeric
+                        # malware_types in some feeds); only placeholder
+                        # name fields are filtered.
+                        out.append(entry)
+                        continue
+                    stripped = entry.strip()
+                    if not stripped:
+                        continue
+                    # Filter placeholder-name entries from accumulating
+                    # arrays. Uses the same canonical set as PR-N10's
+                    # merge-key reject.
+                    if prop == "aliases" and is_placeholder_name(stripped):
+                        dropped_placeholder += 1
+                        continue
+                    if len(stripped) > _MAX_ARRAY_ITEM_LEN:
+                        stripped = stripped[:_MAX_ARRAY_ITEM_LEN]
+                    out.append(stripped)
+                if dropped_placeholder:
+                    logger.info(
+                        "PR-N14: dropped %d placeholder entries from %s[%s] during merge "
+                        "(e.g. 'unknown'/'apt'/'n/a' — would otherwise create false-hub "
+                        "alias matches in Q2/Q9)",
+                        dropped_placeholder,
+                        label,
+                        prop,
+                    )
+                if len(out) > _MAX_ARRAY_ITEMS:
+                    logger.warning(
+                        "PR-N14: %s[%s] incoming size %d exceeds cap %d — truncating to "
+                        "first %d entries (stable order). A compromised feed may be "
+                        "shipping an unbounded alias list.",
+                        label,
+                        prop,
+                        len(out),
+                        _MAX_ARRAY_ITEMS,
+                        _MAX_ARRAY_ITEMS,
+                    )
+                    out = out[:_MAX_ARRAY_ITEMS]
+                return out
+
             extra_props = extra_props or {}
             params_extra = {}
             for prop_name, prop_value in extra_props.items():
                 _validate_prop_name(prop_name)
                 if prop_value is not None and prop_value != "":
                     if prop_name in _ARRAY_ACCUMULATE_PROPS and isinstance(prop_value, list):
+                        prop_value = _sanitize_array_value(prop_name, prop_value)
+                        if not prop_value:
+                            # Sanitization left an empty list — skip
+                            # emitting the SET clause entirely.
+                            continue
                         query += f", n.{prop_name} = {_dedup_concat_clause(f'n.{prop_name}', f'${prop_name}')}"
                     else:
                         query += f", n.{prop_name} = ${prop_name}"
@@ -2351,7 +2501,13 @@ class Neo4jClient:
                         "tag": tag,
                         "source_id": source_id,
                         "source_array": source_list,
-                        "confidence": item.get("confidence_score", 0.5),
+                        # PR-N14 Fix #2: clamp confidence to [0,1]; fall
+                        # back to 0.5 on inf/nan/negative/>1.
+                        "confidence": (
+                            clamp_confidence_score(item.get("confidence_score"))
+                            if clamp_confidence_score(item.get("confidence_score")) is not None
+                            else 0.5
+                        ),
                         "zone": zone,
                         "raw_data": json.dumps(raw_data, default=str),
                         "node_uuid": node_uuid,
@@ -2582,7 +2738,13 @@ class Neo4jClient:
                         "tag": item.get("tag", "default"),
                         "source_id": source_id,
                         "source_array": source_list,
-                        "confidence": item.get("confidence_score", 0.5),
+                        # PR-N14 Fix #2: clamp confidence to [0,1]; fall
+                        # back to 0.5 on inf/nan/negative/>1.
+                        "confidence": (
+                            clamp_confidence_score(item.get("confidence_score"))
+                            if clamp_confidence_score(item.get("confidence_score")) is not None
+                            else 0.5
+                        ),
                         "zone": zone,
                         "raw_data": json.dumps(raw_data, default=str),
                         "node_uuid": node_uuid,

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -607,6 +607,35 @@ def clamp_confidence_score(value: Any) -> Optional[float]:
     return f
 
 
+def _clamp_confidence_with_log(raw: Any, label: str, source_id: str, default: float = 0.5) -> float:
+    """PR-N14 follow-up (cursor-bugbot 2026-04-21 Medium):
+    single evaluation of ``clamp_confidence_score`` + WARN-on-reject,
+    so the batch paths in ``merge_indicators_batch`` and
+    ``merge_vulnerabilities_batch`` don't (a) call the clamp twice per
+    row in the hot loop, and (b) silently swallow rejects — the
+    single-item ``merge_node_with_source`` path emits a WARN and the
+    batch paths MUST emit the same signal so operators can identify
+    the offending feed uniformly.
+
+    Returns ``clamped`` on success, ``default`` (0.5) on reject.
+    Never returns None — callers use the return value as a Cypher
+    param.
+    """
+    if raw is None:
+        return default
+    clamped = clamp_confidence_score(raw)
+    if clamped is None:
+        logger.warning(
+            "confidence_score rejected by clamp for %s/%s (claimed=%r) — falling back to %.2f. Compromised feed?",
+            label,
+            source_id,
+            raw,
+            default,
+        )
+        return default
+    return clamped
+
+
 def normalize_cve_id_for_graph(value: Any) -> Optional[str]:
     """
     Return a canonical CVE id string for graph keys/relationships, or None if unknown.
@@ -2501,12 +2530,16 @@ class Neo4jClient:
                         "tag": tag,
                         "source_id": source_id,
                         "source_array": source_list,
-                        # PR-N14 Fix #2: clamp confidence to [0,1]; fall
-                        # back to 0.5 on inf/nan/negative/>1.
-                        "confidence": (
-                            clamp_confidence_score(item.get("confidence_score"))
-                            if clamp_confidence_score(item.get("confidence_score")) is not None
-                            else 0.5
+                        # PR-N14 Fix #2 (follow-up 2026-04-21): clamp confidence to
+                        # [0,1]; fall back to 0.5 on inf/nan/negative/>1. Use the
+                        # single-evaluation helper so (a) the clamp doesn't run
+                        # twice per row in this hot loop, and (b) the batch path
+                        # emits the same WARN-on-reject that
+                        # merge_node_with_source does (cursor-bugbot Medium).
+                        "confidence": _clamp_confidence_with_log(
+                            item.get("confidence_score"),
+                            label="Indicator",
+                            source_id=source_id,
                         ),
                         "zone": zone,
                         "raw_data": json.dumps(raw_data, default=str),
@@ -2738,12 +2771,16 @@ class Neo4jClient:
                         "tag": item.get("tag", "default"),
                         "source_id": source_id,
                         "source_array": source_list,
-                        # PR-N14 Fix #2: clamp confidence to [0,1]; fall
-                        # back to 0.5 on inf/nan/negative/>1.
-                        "confidence": (
-                            clamp_confidence_score(item.get("confidence_score"))
-                            if clamp_confidence_score(item.get("confidence_score")) is not None
-                            else 0.5
+                        # PR-N14 Fix #2 (follow-up 2026-04-21): clamp confidence to
+                        # [0,1]; fall back to 0.5 on inf/nan/negative/>1. Use the
+                        # single-evaluation helper so (a) the clamp doesn't run
+                        # twice per row in this hot loop, and (b) the batch path
+                        # emits the same WARN-on-reject that
+                        # merge_node_with_source does (cursor-bugbot Medium).
+                        "confidence": _clamp_confidence_with_log(
+                            item.get("confidence_score"),
+                            label="Vulnerability",
+                            source_id=source_id,
                         ),
                         "zone": zone,
                         "raw_data": json.dumps(raw_data, default=str),

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -46,6 +46,7 @@ from config import (
 from misp_health import MISPHealthCheck
 from neo4j_client import (
     Neo4jClient,
+    clamp_cvss_score,
     normalize_cve_id_for_graph,
     resolve_vulnerability_cve_id,
 )
@@ -2399,18 +2400,40 @@ class MISPToNeo4jSync:
                     attack_vector = nvd_meta["attack_vector"]
                 else:
                     attack_vector = "UNKNOWN"
-                # Exact CVSS score from v3.1 or v2 metadata takes priority over tag category
+                # Exact CVSS score from v3.1 or v2 metadata takes priority over tag category.
+                #
+                # PR-N14 (pre-baseline audit Fix #1, 2026-04-21): use
+                # ``clamp_cvss_score`` instead of raw ``float(...)`` to
+                # reject inf / nan / negative / > 10.0. A compromised
+                # federated MISP peer can otherwise ship
+                # ``base_score: "1e309"`` → Python `inf` → forged CVE
+                # permanently tops GraphQL sort + corrupts STIX export.
+                # Returns None on bad input; we then fall through to the
+                # tag-derived score already computed above.
                 v31 = nvd_meta.get("cvss_v31_data") or {}
                 v2 = nvd_meta.get("cvss_v2_data") or {}
-                try:
-                    if v31.get("base_score") is not None and v31["base_score"] != "":
-                        cvss_score = float(v31["base_score"])
-                        severity = (v31.get("base_severity") or severity or "UNKNOWN").upper()
-                    elif v2.get("base_score") is not None and v2["base_score"] != "":
-                        cvss_score = float(v2["base_score"])
-                        severity = (v2.get("base_severity") or severity or "UNKNOWN").upper()
-                except (ValueError, TypeError):
-                    logger.debug("Non-numeric base_score in NVD_META for %s, using tag-derived score", value)
+                _v31_score = (
+                    clamp_cvss_score(v31.get("base_score")) if v31.get("base_score") not in (None, "") else None
+                )
+                _v2_score = clamp_cvss_score(v2.get("base_score")) if v2.get("base_score") not in (None, "") else None
+                if _v31_score is not None:
+                    cvss_score = _v31_score
+                    severity = (v31.get("base_severity") or severity or "UNKNOWN").upper()
+                elif _v2_score is not None:
+                    cvss_score = _v2_score
+                    severity = (v2.get("base_severity") or severity or "UNKNOWN").upper()
+                elif v31.get("base_score") not in (None, "") or v2.get("base_score") not in (None, ""):
+                    # Source claimed a score but it was rejected by clamp
+                    # (non-finite / out-of-range). Honest-NULL: fall
+                    # through to tag-derived score + emit WARN so
+                    # operators can investigate the offending feed.
+                    logger.warning(
+                        "CVSS base_score rejected by clamp for %s (v31=%r v2=%r) — "
+                        "falling back to tag-derived score. Compromised feed?",
+                        value,
+                        v31.get("base_score"),
+                        v2.get("base_score"),
+                    )
             else:
                 description = raw_comment
                 attack_vector = "NETWORK"

--- a/src/run_pipeline.py
+++ b/src/run_pipeline.py
@@ -468,8 +468,15 @@ class EdgeGuardPipeline:
                                 "zone": self._extract_zones_from_stix_labels(obj),
                                 "tag": "stix_import",
                                 "source": [obj.get("x_edgeguard_source", "unknown")],  # Source as array (like zone)
-                                "first_seen": obj.get("created", datetime.now(timezone.utc).isoformat()),
-                                "last_updated": obj.get("modified", datetime.now(timezone.utc).isoformat()),
+                                # PR-N14 Fix #4 (2026-04-21 pre-baseline audit): pass
+                                # None through when STIX has no ``created`` / ``modified``
+                                # — do NOT substitute wall-clock NOW. The prior
+                                # ``datetime.now(...).isoformat()`` default violated PR-N5
+                                # C7 honest-NULL: re-importing an old CVE-2013 bundle today
+                                # stamped ``first_seen=2026-04-21``, poisoning the
+                                # calibrator's age calculations.
+                                "first_seen": obj.get("created") or None,
+                                "last_updated": obj.get("modified") or None,
                                 "confidence_score": 0.7,
                                 "misp_event_id": None,
                             },
@@ -495,8 +502,10 @@ class EdgeGuardPipeline:
                                 "zone": self._extract_zones_from_stix_labels(obj),
                                 "tag": "stix_import",
                                 "source": [obj.get("x_edgeguard_source", "unknown")],  # Source as array (like zone)
-                                "first_seen": obj.get("created", datetime.now(timezone.utc).isoformat()),
-                                "last_updated": obj.get("modified", datetime.now(timezone.utc).isoformat()),
+                                # PR-N14 Fix #4: honest-NULL on STIX re-import — see
+                                # Indicator block above for rationale.
+                                "first_seen": obj.get("created") or None,
+                                "last_updated": obj.get("modified") or None,
                                 "confidence_score": 0.7,
                                 "misp_event_id": None,
                             },
@@ -625,8 +634,15 @@ class EdgeGuardPipeline:
                                 "zone": self._extract_zones_from_stix_labels(obj),
                                 "tag": "stix_import",
                                 "source": [obj.get("x_edgeguard_source", "unknown")],
-                                "first_seen": datetime.now(timezone.utc).isoformat(),
-                                "last_updated": datetime.now(timezone.utc).isoformat(),
+                                # PR-N14 Fix #4: STIX observables (IPv4 / domain /
+                                # URL / …) have no native ``created`` / ``modified``
+                                # properties. Pass None instead of wall-clock NOW —
+                                # the downstream merge's ON CREATE SET +
+                                # ``last_updated = datetime()`` clauses will stamp
+                                # server-side timestamps correctly, without forging
+                                # a ``first_seen`` the source never claimed.
+                                "first_seen": None,
+                                "last_updated": None,
                                 "confidence_score": 0.7,
                                 "misp_event_id": None,
                             },

--- a/src/source_truthful_timestamps.py
+++ b/src/source_truthful_timestamps.py
@@ -282,16 +282,64 @@ def is_reliable_first_seen_source(source_id: Optional[str]) -> bool:
 # ---------------------------------------------------------------------------
 
 
+# PR-N14 Fix #5 (2026-04-21 pre-baseline audit): the earliest date
+# EdgeGuard accepts as a source-truthful timestamp. Anything older is
+# rejected (returned as None — honest-NULL) because it's either a feed
+# bug, a collector substituting ``datetime(1,1,1)`` as a "missing"
+# sentinel, or an adversarial attempt to hide a campaign from
+# recent-threat filters via a year-0001 ``first_seen``.
+#
+# Default: 1995-01-01 — before the mainstream-internet threat-intel era.
+# Configurable via ``EDGEGUARD_EARLIEST_IOC_DATE`` env var (ISO date).
+# An operator importing deep historical corpora can loosen it; the
+# bound never hurts ingest of modern threat intel (defaults are
+# decades in the past).
+_DEFAULT_EARLIEST_IOC_DATE = "1995-01-01"
+
+
+def _earliest_allowed_date() -> datetime:
+    """Resolve the earliest-allowed-date floor, env-overridable.
+
+    Read per-call (cheap; datetime.fromisoformat is fast) so an
+    operator can tune the floor mid-baseline without a restart.
+    """
+    import os as _os
+
+    raw = _os.environ.get("EDGEGUARD_EARLIEST_IOC_DATE", "").strip() or _DEFAULT_EARLIEST_IOC_DATE
+    try:
+        parsed = datetime.fromisoformat(raw)
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return parsed
+    except (ValueError, TypeError):
+        logger.warning(
+            "EDGEGUARD_EARLIEST_IOC_DATE=%r is not a valid ISO date; falling back to default %r",
+            raw,
+            _DEFAULT_EARLIEST_IOC_DATE,
+        )
+        return datetime.fromisoformat(_DEFAULT_EARLIEST_IOC_DATE).replace(tzinfo=timezone.utc)
+
+
 def _clamp_future_to_now(iso: Optional[str]) -> Optional[str]:
-    """Clamp a future-dated ISO timestamp to UTC now.
+    """Clamp a future-dated ISO timestamp to UTC now, AND reject
+    implausibly-ancient timestamps via honest-NULL.
 
     Defensive: an upstream feed bug or operator clock drift could
-    produce a value like 2099-01-01. We never trust the future —
-    silently clamp + WARNING log so it surfaces in operator dashboards.
+    produce a value like 2099-01-01 (future) or 0001-01-01 (sentinel-
+    default or adversarial). We never trust the future — silently
+    clamp + WARNING log. We never trust pre-1995 (configurable via
+    ``EDGEGUARD_EARLIEST_IOC_DATE``) — return None so downstream
+    sees honest-NULL rather than a forged ancient date.
 
-    Returns the original string when the value is in the past or
-    parse fails (we'd rather pass an unparseable string downstream
-    than swallow it; the merge layer already handles odd inputs).
+    Returns the original string when the value is in the acceptable
+    window [earliest, now] or parse fails (we'd rather pass an
+    unparseable string downstream than swallow it; the merge layer
+    already handles odd inputs).
+
+    PR-N14 Fix #5 (cursor-audit 2026-04-21 MEDIUM): the earliest-date
+    floor closes the "make a real campaign disappear from the
+    recent-threats dashboard by spoofing its first_seen to year
+    0001" attack flagged by the red-team audit.
     """
     if not iso:
         return iso
@@ -306,6 +354,20 @@ def _clamp_future_to_now(iso: Optional[str]) -> Optional[str]:
         return iso
 
     now = datetime.now(timezone.utc)
+
+    # Past bound (PR-N14 Fix #5) — reject pre-1995 (configurable).
+    earliest = _earliest_allowed_date()
+    if parsed < earliest:
+        logger.warning(
+            "Source-truthful timestamp %s is before earliest-allowed %s — "
+            "rejecting as honest-NULL. Likely upstream feed bug, sentinel "
+            "default, or adversarial input trying to hide in the distant past.",
+            iso,
+            earliest.isoformat(),
+        )
+        _metric_future_clamp()  # reuse the existing counter surface — same class of drop
+        return None
+
     if parsed > now:
         logger.warning(
             "Source-truthful timestamp %s is in the future (now=%s) — clamping to now. "

--- a/tests/test_pr_n14_adversarial_bounds.py
+++ b/tests/test_pr_n14_adversarial_bounds.py
@@ -1,0 +1,329 @@
+"""
+PR-N14 — pre-baseline adversarial-input bounds bundle.
+
+Five findings from the 7-agent pre-baseline audit's Red-Team pass.
+Each is an adversarial-input class where a compromised or malconfigured
+feed could corrupt the graph at scale during the 730-day baseline.
+
+## Fix #1 — CVSS bounds clamp (inf / nan / negative / >10)
+
+An attacker-controlled NVD_META with ``base_score: "1e309"`` reached
+``float(...)`` → Python ``inf`` → pinned ``n.cvss_score = Infinity``.
+GraphQL ``vulnerabilities(min_cvss: 9.0) ORDER BY DESC`` permanently
+placed the forged CVE at the top of the triage queue; STIX export
+emitted invalid JSON.
+
+Fix: ``clamp_cvss_score(value)`` helper rejects non-finite + out-of-
+[0.0, 10.0]. Applied at ``run_misp_to_neo4j.py`` base_score parse.
+
+## Fix #2 — confidence bounds clamp [0.0, 1.0]
+
+``r.confidence_score`` is max-wins CASE-updated in every upsert. A
+source shipping ``confidence_score: "1e309"`` would pin the edge
+confidence to inf permanently, defeating calibrator demotion.
+
+Fix: ``clamp_confidence_score(value)`` helper. Applied in
+``merge_node_with_source`` and both batched UNWIND paths.
+
+## Fix #3 — accumulating-array cardinality cap + placeholder filter
+
+``n.aliases[]``, ``n.malware_types[]``, ``n.uses_techniques[]``,
+``n.tactic_phases[]`` are accumulated (deduplicated) across sources.
+A compromised feed shipping ``aliases=["a1",...,"a100000"]`` repeatedly
+grows the array unboundedly; ``calibrate_cooccurrence_confidence`` +
+Q2/Q9 alias-match then OOM-crash the entire enrichment pass.
+
+Fix: ``_sanitize_array_value`` helper in ``merge_node_with_source``:
+- Drops placeholder entries (``"unknown"``/``"apt"``/etc.) from
+  ``aliases`` specifically — mirrors PR-N10's node-name reject.
+- Truncates entries >200 chars.
+- Caps at 50 items per incoming list (p99 alias count in
+  MITRE/Malpedia is ~30; generous).
+
+## Fix #4 — STIX re-import honest-NULL
+
+``run_pipeline.py`` re-imports STIX bundles back into EdgeGuard (e.g.
+ResilMesh feedback loop). Three sites substituted
+``datetime.now(...).isoformat()`` when STIX lacked ``created`` /
+``modified`` fields. Re-importing CVE-2013 today stamped
+``first_seen=2026-04-21``, poisoning calibrator age math (PR-N5 C7
+violation).
+
+Fix: pass None through (honest-NULL). The merge layer's ``ON CREATE
+SET`` clauses stamp server-side timestamps correctly without forging
+the source's ``first_seen``.
+
+## Fix #5 — past-date clamp on source-truthful timestamps
+
+``_clamp_future_to_now`` rejected future dates but had no LOWER bound.
+A compromised feed emitting ``first_seen: "0001-01-01"`` would pin a
+campaign's ``c.first_seen`` to year 0001, dropping it from every
+age-filtered recent-threat dashboard. Effectively a "hide in plain
+sight" attack.
+
+Fix: new earliest-allowed-date floor (default 1995-01-01,
+configurable via ``EDGEGUARD_EARLIEST_IOC_DATE``). Pre-floor values
+return None (honest-NULL).
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n14")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n14")
+
+
+# ===========================================================================
+# Fix #1 — clamp_cvss_score
+# ===========================================================================
+
+
+class TestFix1CvssClamp:
+    def test_rejects_infinity(self):
+        from neo4j_client import clamp_cvss_score
+
+        assert clamp_cvss_score(float("inf")) is None
+        assert clamp_cvss_score(float("-inf")) is None
+        assert clamp_cvss_score("1e309") is None, "string that parses to inf must be rejected"
+
+    def test_rejects_nan(self):
+        from neo4j_client import clamp_cvss_score
+
+        assert clamp_cvss_score(float("nan")) is None
+
+    def test_rejects_out_of_range(self):
+        from neo4j_client import clamp_cvss_score
+
+        assert clamp_cvss_score(-0.1) is None
+        assert clamp_cvss_score(10.1) is None
+        assert clamp_cvss_score(100) is None
+        assert clamp_cvss_score(-1000) is None
+
+    def test_accepts_valid_range(self):
+        from neo4j_client import clamp_cvss_score
+
+        assert clamp_cvss_score(0.0) == 0.0
+        assert clamp_cvss_score(9.8) == 9.8
+        assert clamp_cvss_score(10.0) == 10.0
+        assert clamp_cvss_score("7.5") == 7.5  # string parse OK
+
+    def test_none_and_unparseable_return_none(self):
+        from neo4j_client import clamp_cvss_score
+
+        assert clamp_cvss_score(None) is None
+        assert clamp_cvss_score("not a number") is None
+        assert clamp_cvss_score("") is None
+        assert clamp_cvss_score([]) is None
+
+
+# ===========================================================================
+# Fix #2 — clamp_confidence_score
+# ===========================================================================
+
+
+class TestFix2ConfidenceClamp:
+    def test_rejects_infinity_and_nan(self):
+        from neo4j_client import clamp_confidence_score
+
+        assert clamp_confidence_score(float("inf")) is None
+        assert clamp_confidence_score(float("nan")) is None
+        assert clamp_confidence_score("1e309") is None
+
+    def test_rejects_out_of_range(self):
+        from neo4j_client import clamp_confidence_score
+
+        assert clamp_confidence_score(-0.01) is None
+        assert clamp_confidence_score(1.01) is None
+        assert clamp_confidence_score(1e10) is None
+
+    def test_accepts_valid_range(self):
+        from neo4j_client import clamp_confidence_score
+
+        assert clamp_confidence_score(0.0) == 0.0
+        assert clamp_confidence_score(0.5) == 0.5
+        assert clamp_confidence_score(1.0) == 1.0
+        assert clamp_confidence_score("0.75") == 0.75
+
+    def test_merge_node_applies_clamp_with_fallback(self):
+        """Regression pin: the merge_node_with_source read site uses
+        the clamp + falls back to 0.5 on rejection."""
+        src = (SRC / "neo4j_client.py").read_text()
+        # The read site must include both the clamp call and the 0.5 fallback.
+        idx = src.find("def merge_node_with_source")
+        assert idx != -1
+        block = src[idx : idx + 12000]  # full function
+        assert "clamp_confidence_score(_claimed_conf)" in block, (
+            "merge_node_with_source must clamp confidence via helper"
+        )
+        assert "confidence = _clamped_conf if _clamped_conf is not None else 0.5" in block, (
+            "merge_node_with_source must fall back to 0.5 on clamp reject"
+        )
+
+
+# ===========================================================================
+# Fix #3 — accumulating-array cardinality cap + placeholder filter
+# ===========================================================================
+
+
+class TestFix3ArrayBounds:
+    def test_sanitizer_exists_in_merge_node(self):
+        """Helper must be defined inside merge_node_with_source (Cypher
+        string builder scope)."""
+        src = (SRC / "neo4j_client.py").read_text()
+        assert "_sanitize_array_value" in src, "sanitizer helper must exist"
+        assert "_MAX_ARRAY_ITEMS = 50" in src, "cap constant must be 50 (p99 ≈ 30)"
+        assert "_MAX_ARRAY_ITEM_LEN = 200" in src, "per-entry length cap must be 200"
+
+    def test_aliases_drops_placeholder_entries(self):
+        """AST/regex pin: the placeholder filter uses is_placeholder_name
+        and is scoped to the aliases prop (only — other arrays like
+        uses_techniques are MITRE IDs that shouldn't be placeholder-
+        filtered)."""
+        src = (SRC / "neo4j_client.py").read_text()
+        idx = src.find("_sanitize_array_value")
+        assert idx != -1
+        block = src[idx : idx + 3000]
+        assert 'if prop == "aliases" and is_placeholder_name(' in block, (
+            "placeholder filter must be scoped to aliases prop"
+        )
+
+    def test_cardinality_truncation_emits_warn(self):
+        """If an incoming list exceeds the cap, a WARN must fire so
+        operators see the compromised-feed signal."""
+        src = (SRC / "neo4j_client.py").read_text()
+        idx = src.find("_sanitize_array_value")
+        assert idx != -1
+        block = src[idx : idx + 3000]
+        assert "logger.warning" in block
+        assert "exceeds cap" in block
+
+
+# ===========================================================================
+# Fix #4 — STIX re-import honest-NULL
+# ===========================================================================
+
+
+class TestFix4StixReimportHonestNull:
+    def test_no_wall_clock_substitution_for_indicator_reimport(self):
+        """Prior code: ``obj.get("created", datetime.now(...).isoformat())``.
+        Must now pass None through."""
+        src = (REPO_ROOT / "src" / "run_pipeline.py").read_text()
+        # The three problem sites at ~L471, ~L498, ~L628 must NOT use
+        # ``datetime.now(...)`` as a default for STIX ``created`` / ``modified``.
+        # Check that ``obj.get("created", datetime.now`` pattern is gone.
+        assert 'obj.get("created", datetime.now' not in src, (
+            "regression: STIX ``created`` must not default to wall-clock NOW (PR-N5 C7 violation)"
+        )
+        assert 'obj.get("modified", datetime.now' not in src, (
+            "regression: STIX ``modified`` must not default to wall-clock NOW"
+        )
+
+    def test_observable_reimport_uses_none_not_now(self):
+        """The ipv4-addr observable path at ~L628 used to hard-code
+        ``datetime.now(...)``. Must now pass None."""
+        src = (REPO_ROOT / "src" / "run_pipeline.py").read_text()
+        # Find the STIX observables block
+        idx = src.find('obj_type in ["ipv4-addr", "ipv6-addr", "domain-name", "url"]')
+        assert idx != -1, "STIX observable block not found"
+        block = src[idx : idx + 2500]
+        # The observable MERGE must NOT have wall-clock-NOW for first_seen.
+        # It's fine to reference datetime elsewhere in the function.
+        assert '"first_seen": datetime.now(' not in block, (
+            "STIX observable MERGE must pass None for first_seen, not wall-clock NOW"
+        )
+        assert '"last_updated": datetime.now(' not in block, (
+            "STIX observable MERGE must pass None for last_updated, not wall-clock NOW"
+        )
+
+
+# ===========================================================================
+# Fix #5 — past-date clamp on source-truthful timestamps
+# ===========================================================================
+
+
+class TestFix5PastDateClamp:
+    def test_rejects_year_0001(self, monkeypatch):
+        """Adversarial: feed claims IOC first-seen in year 0001 to hide
+        from recent-threat dashboards. Must return None (honest-NULL)."""
+        monkeypatch.delenv("EDGEGUARD_EARLIEST_IOC_DATE", raising=False)
+        from source_truthful_timestamps import _clamp_future_to_now
+
+        assert _clamp_future_to_now("0001-01-01T00:00:00+00:00") is None
+        assert _clamp_future_to_now("1969-12-31T23:59:59+00:00") is None
+
+    def test_accepts_modern_timestamps(self, monkeypatch):
+        monkeypatch.delenv("EDGEGUARD_EARLIEST_IOC_DATE", raising=False)
+        from source_truthful_timestamps import _clamp_future_to_now
+
+        # 2020 is well after the 1995 floor — must pass through
+        assert _clamp_future_to_now("2020-06-15T12:00:00+00:00") == "2020-06-15T12:00:00+00:00"
+        # Exactly at the default floor (inclusive or not? we use <
+        # earliest, so 1995-01-01 itself passes)
+        assert _clamp_future_to_now("1995-01-01T00:00:00+00:00") == "1995-01-01T00:00:00+00:00"
+
+    def test_env_var_overrides_floor(self, monkeypatch):
+        """Operator tuning: an import of a 1970s-era corpus needs a
+        looser floor. EDGEGUARD_EARLIEST_IOC_DATE accepts this."""
+        monkeypatch.setenv("EDGEGUARD_EARLIEST_IOC_DATE", "1970-01-01")
+        from source_truthful_timestamps import _clamp_future_to_now
+
+        # Now 1975 is allowed
+        assert _clamp_future_to_now("1975-07-04T00:00:00+00:00") == "1975-07-04T00:00:00+00:00"
+        # But 1960 still rejected
+        assert _clamp_future_to_now("1960-01-01T00:00:00+00:00") is None
+
+    def test_invalid_env_var_falls_back_to_default(self, monkeypatch, caplog):
+        import logging
+
+        monkeypatch.setenv("EDGEGUARD_EARLIEST_IOC_DATE", "not-a-date")
+        from source_truthful_timestamps import _clamp_future_to_now
+
+        with caplog.at_level(logging.WARNING, logger="source_truthful_timestamps"):
+            # Invalid env → fall back to default 1995-01-01
+            assert _clamp_future_to_now("1990-01-01T00:00:00+00:00") is None
+            assert _clamp_future_to_now("2000-01-01T00:00:00+00:00") == "2000-01-01T00:00:00+00:00"
+        assert any("not a valid ISO date" in r.message for r in caplog.records), "invalid env var must warn"
+
+    def test_future_clamp_behaviour_preserved(self, monkeypatch):
+        """Future-date clamping (pre-PR-N14 behaviour) must still work."""
+        monkeypatch.delenv("EDGEGUARD_EARLIEST_IOC_DATE", raising=False)
+        from source_truthful_timestamps import _clamp_future_to_now
+
+        future = "2099-01-01T00:00:00+00:00"
+        clamped = _clamp_future_to_now(future)
+        assert clamped != future  # was clamped
+        assert clamped is not None  # future becomes NOW, not None
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_neo4j_client_exports_new_helpers(self):
+        from neo4j_client import clamp_confidence_score, clamp_cvss_score  # noqa: F401
+
+    def test_source_truthful_earliest_helper_exists(self):
+        from source_truthful_timestamps import _earliest_allowed_date
+
+        result = _earliest_allowed_date()
+        from datetime import datetime
+
+        assert isinstance(result, datetime)
+
+    def test_run_pipeline_imports(self):
+        # run_pipeline sits at src/run_pipeline.py; verify it imports
+        # cleanly after the STIX re-import edit.
+        import run_pipeline  # noqa: F401
+
+    def test_run_misp_to_neo4j_imports(self):
+        import run_misp_to_neo4j  # noqa: F401

--- a/tests/test_pr_n14_adversarial_bounds.py
+++ b/tests/test_pr_n14_adversarial_bounds.py
@@ -152,6 +152,55 @@ class TestFix2ConfidenceClamp:
         assert clamp_confidence_score(1.0) == 1.0
         assert clamp_confidence_score("0.75") == 0.75
 
+    def test_batch_paths_use_single_evaluation_helper(self, caplog):
+        """Cursor-bugbot PR #98 Medium (2026-04-21): the batch paths
+        must (a) call the clamp ONCE per item, not twice, and (b) emit
+        a WARN on reject so operators see the compromised-feed signal
+        (parity with the single-item merge_node_with_source path).
+        Behavioral test — call the helper with a bad value + observe
+        both return value and log output."""
+        import logging
+
+        from neo4j_client import _clamp_confidence_with_log
+
+        # Bad value → fall back to default + emit WARN
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            result = _clamp_confidence_with_log(float("inf"), label="Indicator", source_id="otx")
+        assert result == 0.5, "must fall back to default on reject"
+        assert any("rejected by clamp" in r.message for r in caplog.records), (
+            "batch-path helper must emit WARN on reject (parity with single-item path)"
+        )
+
+        # None → default (None is legitimately "no claim", not a reject)
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            result = _clamp_confidence_with_log(None, label="Indicator", source_id="otx")
+        assert result == 0.5
+        assert not any("rejected by clamp" in r.message for r in caplog.records), (
+            "None must NOT WARN (it's not a reject, it's a missing field)"
+        )
+
+        # Valid value → pass through unchanged
+        assert _clamp_confidence_with_log(0.8, label="Indicator", source_id="otx") == 0.8
+
+    def test_batch_paths_no_duplicate_clamp_call(self):
+        """Regression pin: both merge_indicators_batch and
+        merge_vulnerabilities_batch must use the helper, not the
+        old double-call ternary pattern."""
+        src = (SRC / "neo4j_client.py").read_text()
+        # The old pattern was:
+        #     clamp_confidence_score(item.get("confidence_score"))
+        #     if clamp_confidence_score(item.get("confidence_score")) is not None
+        #     else 0.5
+        # Must NOT appear (regression forbid).
+        assert 'if clamp_confidence_score(item.get("confidence_score")) is not None' not in src, (
+            "regression: batch paths must NOT call clamp_confidence_score twice per row "
+            "(use _clamp_confidence_with_log instead)"
+        )
+        # The helper must be referenced at least twice (one per batch path).
+        count = src.count("_clamp_confidence_with_log(")
+        assert count >= 3, f"helper must be used in both batch paths (+ definition); got {count}"
+
     def test_merge_node_applies_clamp_with_fallback(self):
         """Regression pin: the merge_node_with_source read site uses
         the clamp + falls back to 0.5 on rejection."""


### PR DESCRIPTION
## Summary

Five adversarial-input findings from the 7-agent pre-baseline audit's Red-Team pass. Each is a vector where a compromised federated MISP peer or malconfigured feed could corrupt the graph at scale during the 730-day baseline.

| # | Sev | Attack vector | Mitigation |
|---|---|---|---|
| 1 | BLOCK | `base_score: "1e309"` in NVD_META → `float()` = `inf` → CVE permanently tops GraphQL sort; STIX emits invalid JSON | `clamp_cvss_score` rejects non-finite + out-of-[0.0, 10.0] |
| 2 | BLOCK | `confidence_score: "1e309"` → `r.confidence_score = inf` permanently via max-wins CASE, defeats calibrator forever | `clamp_confidence_score` + fall back to 0.5 on reject |
| 3 | HIGH | `aliases=["a1",...,"a100000"]` → unbounded array → calibrator + Q2/Q9 alias-match OOM-crash enrichment | Cap 50 items + 200 chars/entry + placeholder filter scoped to `aliases` |
| 4 | HIGH | STIX re-import defaults `created`/`modified` to `datetime.now()` → re-importing CVE-2013 stamps `first_seen=2026-04-21` (PR-N5 C7 violation) | Pass None through; merge layer stamps server-side |
| 5 | MEDIUM | `first_seen: "0001-01-01"` hides campaign from age-filtered recent-threat dashboards | Earliest-date floor (1995-01-01 default, env-configurable) |

## Files

- `src/neo4j_client.py`: new `clamp_cvss_score` + `clamp_confidence_score` helpers; `_sanitize_array_value` inside `merge_node_with_source`; confidence clamp wired at 3 sites
- `src/run_misp_to_neo4j.py`: CVSS clamp at NVD base_score parse
- `src/run_pipeline.py`: STIX re-import passes None instead of `datetime.now()` at 3 sites (Indicator / CVE / observables)
- `src/source_truthful_timestamps.py`: new `_earliest_allowed_date()` + extended `_clamp_future_to_now` with past-date rejection
- `tests/test_pr_n14_adversarial_bounds.py`: 23 regression tests (all 5 fixes + adversarial matrices)

## Test plan

- [x] 23/23 PR-N14 tests pass
- [x] 105/105 PR-N10→N14 tests pass (no cross-PR regression)
- [x] Full suite: 1418 passed, 3 skipped, 3 xfailed (up from 1395 on main)
- [x] `ruff format --check src/ tests/` clean
- [x] `ruff check src/ tests/` clean
- [x] `mypy src/` clean
- [ ] Post-deploy: `MATCH (n) WHERE n.cvss_score = 1.0/0.0 OR n.cvss_score < 0 OR n.cvss_score > 10 RETURN count(n)` to measure pre-existing Infinity damage (operator)
- [ ] Post-deploy: `MATCH ()-[r]->() WHERE r.confidence_score > 1 OR r.confidence_score < 0 RETURN count(r)` (operator)

## Pattern consistency

- Both clamp helpers return `None` on bad input (honest-NULL per PR-N5 C7 — never fabricate a value), with callers applying documented defaults on reject.
- Log WARN on every reject so operators can identify the offending feed (searchable via `grep 'rejected by clamp' /var/log/*.log`).
- Env-configurable knobs (`EDGEGUARD_EARLIEST_IOC_DATE`) follow the same pattern as PR-N10/N11 kill-switches (`EDGEGUARD_RESPECT_CALIBRATOR`, `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION`).

## Dependencies

- **Rebased cleanly on** main (includes PR-N10/N11/N12/N13)
- **No conflicts** with any pending PR

## Deferred to PR-N15

The Red-Team aliases-hijack finding (`Malware{name:"benign", aliases:["APT29"]}` → false attribution via Q2 branch 3) is a BLOCK but needs design work (source allowlist / corroboration policy) and will land in a follow-up. The cardinality cap + placeholder filter in this PR is a partial mitigation (prevents the unbounded-array DoS; doesn't close the intentional-name-injection vector).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes tighten ingestion validation for CVSS/confidence, array properties, and source timestamps; incorrect clamping or truncation could drop/alter incoming data and affect downstream scoring and queries.
> 
> **Overview**
> Adds **adversarial-input bounds** across ingestion to prevent corrupted graph data from compromised/misconfigured feeds.
> 
> `neo4j_client.py` now clamps CVSS scores to `[0,10]` and relationship `confidence_score` to `[0,1]` (rejecting `inf`/`NaN` with WARN + safe defaults), and sanitizes accumulated array props by filtering placeholder `aliases`, truncating long entries, and capping list size.
> 
> `run_misp_to_neo4j.py` switches NVD `base_score` parsing to the CVSS clamp with fallback to tag-derived scoring, `run_pipeline.py` stops substituting wall-clock timestamps on STIX re-import (passes `None` for missing `created`/`modified`), and `source_truthful_timestamps.py` adds an env-configurable earliest-date floor (default `1995-01-01`) to reject implausibly ancient timestamps.
> 
> Adds a focused regression test suite (`tests/test_pr_n14_adversarial_bounds.py`) covering all five mitigations and logging/behavioral expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a31413cbf32888625cb55e4395c96a95250580a9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->