### PR TITLE
fix(audit): PR-N16 — overnight merge-audit BLOCKs + HIGHs (4 findings)

### DIFF
--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2172,9 +2172,31 @@ class Neo4jClient:
             ConnectionError,
             TimeoutError,
         ):
-            raise  # let @retry_with_backoff handle transient errors
+            raise  # let outer @retry_with_backoff (on merge_node_with_source) handle transient errors
         except Exception as e:
-            logger.warning(f"SOURCED_FROM relationship error: {e}")
+            # PR-N16 follow-up #3 (cursor-bugbot 2026-04-22):
+            # ``except Exception: return False`` was swallowing
+            # ``DatabaseError``-wrapped transients (the exact error
+            # class PR-N16 Fix #3 targets). After removing the inner
+            # @retry_with_backoff (follow-up #2, to avoid nested retry
+            # stacking), the OUTER decorator on merge_node_with_source
+            # can only retry if this inner method propagates the
+            # exception. Swallowing + return False short-circuits that.
+            #
+            # Fix: use the same _is_retryable_neo4j_error classifier +
+            # re-raise pattern as merge_node_with_source. Terminal
+            # errors (schema / syntax / constraint) still log + return
+            # False so one bad row doesn't crash the calling sync.
+            if _is_retryable_neo4j_error(e):
+                code = getattr(e, "code", "")
+                logger.warning(
+                    "_upsert_sourced_relationship: retryable %s%s for %s — re-raising for outer decorator retry",
+                    type(e).__name__,
+                    f" [{code}]" if code else "",
+                    label,
+                )
+                raise
+            logger.warning("SOURCED_FROM relationship error (terminal): %s: %s", type(e).__name__, e)
             return False
 
     def merge_vulnerability(self, data: Dict, source_id: str = "nvd") -> bool:

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1983,6 +1983,29 @@ class Neo4jClient:
             # Let @retry_with_backoff at the calling layer handle these.
             raise
         except Exception as e:
+            # PR-N16 follow-up (cursor-bugbot 2026-04-22): the prior
+            # ``except Exception: return False`` silently swallowed
+            # ``DatabaseError``-wrapped transients (e.g. deadlocks
+            # surfacing as ``Neo.DatabaseError.Statement.ExecutionFailed``)
+            # — the @retry_with_backoff decorator's classifier never got
+            # to see them because ``return False`` short-circuited the
+            # propagation. PR-N15 fix #1 explicitly handles this code
+            # class but only when it reaches the decorator.
+            #
+            # Fix: re-raise on retryable conditions via the same
+            # ``_is_retryable_neo4j_error`` classifier the decorator
+            # uses. Truly terminal errors (schema / syntax / constraint)
+            # still log + return False so one bad row doesn't crash
+            # the whole sync.
+            if _is_retryable_neo4j_error(e):
+                code = getattr(e, "code", "")
+                logger.warning(
+                    "merge_node_with_source: retryable %s%s for %s — re-raising for decorator retry",
+                    type(e).__name__,
+                    f" [{code}]" if code else "",
+                    label,
+                )
+                raise
             # PR (S5) (Bug Hunter #3 HIGH): log with FULL
             # diagnostic context (label + key) and increment a counter
             # so silent drops are visible to operators. Previously this

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1589,11 +1589,24 @@ class Neo4jClient:
             logger.error(f"Error applying sector labels: {e}")
             return 0
 
+    @retry_with_backoff(max_retries=3)
     def merge_node_with_source(
         self, label: str, key_props: Dict, data: Dict, source_id: str, extra_props: Dict = None
     ) -> bool:
         """
         Merge a node with proper source tracking.
+
+        PR-N16 Fix #3 (HIGH, 2026-04-22 pre-baseline merge-audit):
+        decorated with ``@retry_with_backoff`` so single-item merge
+        paths (``merge_indicator``, ``merge_malware``, ``merge_actor``,
+        ``merge_technique``, ``merge_tactic``, ``merge_tool``,
+        ``merge_cve``, ``merge_vulnerability``, topology mergers) retry
+        on Neo4j transient errors (deadlock, lock timeout, GC pause,
+        cluster failover) — not just the batched paths that PR-N15
+        hardened. At 730-day baseline scale, single-item merges of
+        Malware/Actor/MITRE nodes are foundational — a transient that
+        drops one Malware node silently breaks every downstream
+        `create_misp_relationships_batch` INDICATES edge referencing it.
 
         Args:
             label: Node label (e.g., 'Indicator', 'Vulnerability')
@@ -1821,7 +1834,47 @@ class Neo4jClient:
             for prop_name, prop_value in extra_props.items():
                 _validate_prop_name(prop_name)
                 if prop_value is not None and prop_value != "":
-                    if prop_name in _ARRAY_ACCUMULATE_PROPS and isinstance(prop_value, list):
+                    # PR-N16 Fix #1 (BLOCK, 2026-04-22 pre-baseline merge-audit):
+                    # for accumulating-array props, ALWAYS take the list
+                    # accumulation path — coerce scalars to a single-
+                    # element list if the caller passed a string.
+                    # Pre-PR-N16 the ``isinstance(prop_value, list)``
+                    # check silently fell through to the scalar SET
+                    # branch (``SET n.aliases = $aliases``), which
+                    # OVERWROTE the accumulated list with a scalar
+                    # string — destroying every alias from previous
+                    # syncs. MISP objects emit string-typed
+                    # ``aliases`` / ``malware_types`` attributes
+                    # commonly (misp_collector.py:385,410,478,498);
+                    # this bug fired on every overlap and broke
+                    # downstream alias-based relationship MATCHes
+                    # (Q2/Q9 + create_malware_actor_relationship).
+                    if prop_name in _ARRAY_ACCUMULATE_PROPS:
+                        if isinstance(prop_value, (list, tuple)):
+                            prop_value = list(prop_value)
+                        elif isinstance(prop_value, str):
+                            # Scalar string → single-element list.
+                            # Strip whitespace; empty-after-strip →
+                            # skip (same semantic as the outer
+                            # ``!= ""`` gate).
+                            stripped = prop_value.strip()
+                            if not stripped:
+                                continue
+                            prop_value = [stripped]
+                        else:
+                            # Non-list / non-string (int, dict, …) —
+                            # cannot safely merge into an array. Log
+                            # + skip rather than corrupt.
+                            logger.warning(
+                                "PR-N16: %s[%s] skipped — incoming value type %s "
+                                "is neither list nor string; cannot merge into "
+                                "accumulating-array property. value=%r",
+                                label,
+                                prop_name,
+                                type(prop_value).__name__,
+                                prop_value,
+                            )
+                            continue
                         prop_value = _sanitize_array_value(prop_name, prop_value)
                         if not prop_value:
                             # Sanitization left an empty list — skip
@@ -2416,6 +2469,42 @@ class Neo4jClient:
             extra_props["resource_level"] = data["resource_level"]
         return self.merge_node_with_source("ThreatActor", key_props, data, source_id, extra_props=extra_props)
 
+    def _normalize_mitre_id(self, raw: Any, *, label: str, data: Dict) -> Optional[str]:
+        """PR-N16 Fix #2 (BLOCK, 2026-04-22): normalize a MITRE ATT&CK
+        id (T####, TA####, S####, G####) to canonical UPPERCASE +
+        None-guard.
+
+        Pre-PR-N16, ``merge_technique`` / ``merge_tactic`` /
+        ``merge_tool`` stored mitre_ids as-received. ``compute_node_uuid``
+        goes through ``canonical_node_key`` which ``.lower()`` the
+        joined canonical string — so ``"T1056"`` and ``"t1056"`` compute
+        the SAME uuid. But the Cypher ``MERGE (n:Technique {mitre_id:
+        $mitre_id})`` is case-sensitive, so two distinct nodes get
+        created sharing one uuid. Cross-environment delta-sync hits
+        either node non-deterministically → split subgraphs.
+
+        Same asymmetry class as PR #37 (Indicator value canonicalization
+        — fixed then) but in MITRE helpers missed at that time.
+
+        MITRE ID convention: uppercase throughout
+        (https://attack.mitre.org/techniques/T1056/). Normalize at
+        ingest to uppercase so both MERGE key AND uuid match. Strip
+        surrounding whitespace.
+        """
+        mitre_id = nonempty_graph_string(raw)
+        if mitre_id is None:
+            logger.warning(
+                "[MERGE-REJECT] %s MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
+                label,
+                raw,
+                data.get("name"),
+            )
+            return None
+        # PR-N16 Fix #2: canonicalize to uppercase — matches both the
+        # MITRE spec AND the canonical_node_key's .lower() so the
+        # Cypher MERGE key and the uuid don't diverge.
+        return mitre_id.upper()
+
     def merge_technique(self, data: Dict, source_id: str = "mitre_attck") -> bool:
         """MERGE a Technique node with source tracking.
 
@@ -2425,14 +2514,15 @@ class Neo4jClient:
         hijacks the sentinel ``(Technique {mitre_id: null})`` node
         that every subsequent None-keyed row also collapses into.
         Mirrors the PR-N10 placeholder-name guard for Malware / Actor.
+
+        PR-N16 Fix #2 (2026-04-22 BLOCK): canonicalize mitre_id to
+        uppercase via ``_normalize_mitre_id`` so the case-sensitive
+        Cypher MERGE key agrees with the case-insensitive uuid
+        computation. Prevents split-node / shared-uuid bugs on
+        MISP peers storing lowercase ids.
         """
-        mitre_id = nonempty_graph_string(data.get("mitre_id"))
+        mitre_id = self._normalize_mitre_id(data.get("mitre_id"), label="Technique", data=data)
         if mitre_id is None:
-            logger.warning(
-                "[MERGE-REJECT] Technique MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
-                data.get("mitre_id"),
-                data.get("name"),
-            )
             return False
         key_props = {"mitre_id": mitre_id}
         extra_props: Dict[str, Any] = {"tactic_phases": data.get("tactic_phases", [])}
@@ -2447,14 +2537,9 @@ class Neo4jClient:
     def merge_tactic(self, data: Dict, source_id: str = "mitre_attck") -> bool:
         """MERGE a Tactic node with source tracking.
 
-        PR-N13 Fix #2: same None-guard pattern as ``merge_technique``."""
-        mitre_id = nonempty_graph_string(data.get("mitre_id"))
+        PR-N13 Fix #2 + PR-N16 Fix #2: None-guard + uppercase canonicalization."""
+        mitre_id = self._normalize_mitre_id(data.get("mitre_id"), label="Tactic", data=data)
         if mitre_id is None:
-            logger.warning(
-                "[MERGE-REJECT] Tactic MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
-                data.get("mitre_id"),
-                data.get("name"),
-            )
             return False
         key_props = {"mitre_id": mitre_id}
         extra_props: Dict[str, Any] = {"shortname": data.get("shortname", "")}
@@ -2467,14 +2552,9 @@ class Neo4jClient:
     def merge_tool(self, data: Dict, source_id: str = "mitre_attck") -> bool:
         """MERGE a Tool node with source tracking.
 
-        PR-N13 Fix #2: same None-guard pattern as ``merge_technique``."""
-        mitre_id = nonempty_graph_string(data.get("mitre_id"))
+        PR-N13 Fix #2 + PR-N16 Fix #2: None-guard + uppercase canonicalization."""
+        mitre_id = self._normalize_mitre_id(data.get("mitre_id"), label="Tool", data=data)
         if mitre_id is None:
-            logger.warning(
-                "[MERGE-REJECT] Tool MERGE refused: mitre_id=%r (None / empty / whitespace-only). name=%r",
-                data.get("mitre_id"),
-                data.get("name"),
-            )
             return False
         key_props = {
             "mitre_id": mitre_id,
@@ -3981,12 +4061,67 @@ class Neo4jClient:
             nonlocal total
             if not rows:
                 return
-            try:
-                session.run(query, rows=rows, timeout=_REL_QUERY_TIMEOUT)
-                total += len(rows)
-            except Exception as e:
-                # Each UNWIND is auto-committed; do not zero the whole batch on one failure.
-                logger.warning("MISP relationship batch %s failed (%s rows): %s", label, len(rows), e)
+            # PR-N16 Fix #4 (HIGH, 2026-04-22 pre-baseline merge-audit):
+            # retry on transient errors instead of silently logging a
+            # WARN + dropping the batch. Sibling bug-class to PR-N15
+            # (which hardened merge_indicators_batch /
+            # merge_vulnerabilities_batch but missed this relationship
+            # batch path). At 700K-relationship baseline scale, a single
+            # Neo4j GC pause mid-batch dropped up to 1000 relationships
+            # with no counter, no retry, just a WARN log — the exact
+            # class of silent data loss PR-N15 closed elsewhere.
+            #
+            # Exponential backoff: 2s → 4s → 8s, 3 retries. On
+            # permanent failure, emit
+            # ``edgeguard_neo4j_batch_permanent_failure_total{label=<rel>,
+            # source, reason}`` via the shared helper so operators can
+            # alert on silent relationship-loss.
+            max_retries = 3
+            base_delay = 2.0
+            last_exc: Optional[BaseException] = None
+            for attempt in range(max_retries + 1):
+                try:
+                    session.run(query, rows=rows, timeout=_REL_QUERY_TIMEOUT)
+                    total += len(rows)
+                    return
+                except Exception as e:
+                    last_exc = e
+                    if not _is_retryable_neo4j_error(e):
+                        logger.error(
+                            "[BATCH-PERMANENT-FAILURE] MISP relationship batch %s (%d rows) — non-retryable %s: %s",
+                            label,
+                            len(rows),
+                            type(e).__name__,
+                            e,
+                        )
+                        _emit_batch_permanent_failure(label=label, source_id=source_id, reason="non_retryable")
+                        return
+                    if attempt >= max_retries:
+                        break
+                    delay = base_delay * (2**attempt)
+                    code = getattr(e, "code", "")
+                    logger.warning(
+                        "[BATCH-RETRY] MISP relationship batch %s (%d rows) attempt=%d/%d: %s%s — retrying in %.1fs",
+                        label,
+                        len(rows),
+                        attempt + 1,
+                        max_retries + 1,
+                        type(e).__name__,
+                        f" [{code}]" if code else "",
+                        delay,
+                    )
+                    time.sleep(delay)
+            # Retries exhausted.
+            logger.error(
+                "[BATCH-PERMANENT-FAILURE] MISP relationship batch %s (%d rows) — "
+                "transient persisted after %d retries: %s: %s",
+                label,
+                len(rows),
+                max_retries,
+                type(last_exc).__name__ if last_exc else "UNKNOWN",
+                last_exc,
+            )
+            _emit_batch_permanent_failure(label=label, source_id=source_id, reason="retries_exhausted")
 
         with self.driver.session() as session:
             _run_rows(session, "EMPLOYS_TECHNIQUE_actor", q_actor_employs, actor_employs_rows)

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2028,7 +2028,20 @@ class Neo4jClient:
             )
             return False
 
-    @retry_with_backoff(max_retries=3)
+    # PR-N16 follow-up (cursor-bugbot 2026-04-22): the inner
+    # @retry_with_backoff was REMOVED. Pre-fix this method had its
+    # own decorator AND was called from merge_node_with_source which
+    # ALSO has @retry_with_backoff (added in PR-N16 Fix #3). On a
+    # transient: inner decorator retries 3 times → propagates → outer
+    # decorator retries 3 times → each outer retry calls this method
+    # which retries 3 times internally. Total: 4 × 4 = 16 attempts
+    # with 14s × 4 = ~70s of waiting per upsert.
+    #
+    # Now: only the outer @retry_with_backoff on merge_node_with_source
+    # retries (4 attempts, ~14s max waiting). _upsert_sourced_relationship
+    # is private and only called from merge_node_with_source, so
+    # removing the inner decorator is safe — exception classification
+    # happens at the outer level via _is_retryable_neo4j_error.
     def _upsert_sourced_relationship(
         self,
         label: str,

--- a/tests/test_pr_n16_merge_corruption_blocks.py
+++ b/tests/test_pr_n16_merge_corruption_blocks.py
@@ -217,6 +217,48 @@ class TestFix2MitreCaseAsymmetry:
 
 
 class TestFix3MergeNodeHasRetryDecorator:
+    def test_merge_node_with_source_inner_except_reraises_retryable(self):
+        """Cursor-bugbot 2026-04-22: the @retry_with_backoff decorator
+        on merge_node_with_source can ONLY retry exceptions that
+        propagate out — but the function's inner `except Exception:
+        return False` was silently swallowing
+        DatabaseError-wrapped transients (e.g. deadlocks surfacing as
+        Neo.DatabaseError.Statement.ExecutionFailed).
+
+        The fix re-raises retryable exceptions via the
+        _is_retryable_neo4j_error classifier so the decorator gets
+        a chance to retry. Terminal errors (schema/syntax/constraint)
+        still log + return False (one bad row doesn't crash the batch).
+        """
+        import ast
+
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef):
+                for node in cls.body:
+                    if isinstance(node, ast.FunctionDef) and node.name == "merge_node_with_source":
+                        body = ast.unparse(node)
+                        # The inner `except Exception` must reroute
+                        # retryable to raise (not swallow with return False).
+                        assert "_is_retryable_neo4j_error(e)" in body, (
+                            "merge_node_with_source inner `except Exception` must "
+                            "reroute retryable errors to raise (cursor-bugbot 2026-04-22)"
+                        )
+                        # The retryable branch must `raise`, not `return False`.
+                        # Find the if-block and confirm.
+                        # Substring check: a `raise` between the classifier check
+                        # and the terminal log/return path.
+                        idx = body.find("_is_retryable_neo4j_error(e)")
+                        assert idx != -1
+                        # Within ~500 chars after the check, there must be a raise.
+                        post = body[idx : idx + 500]
+                        assert "raise" in post, (
+                            "retryable branch must `raise` to let decorator retry"
+                        )
+                        return
+        raise AssertionError("merge_node_with_source not found")
+
     def test_merge_node_with_source_decorated_with_retry(self):
         """Regression pin: the function must be decorated with
         ``@retry_with_backoff`` so transient errors retry instead of

--- a/tests/test_pr_n16_merge_corruption_blocks.py
+++ b/tests/test_pr_n16_merge_corruption_blocks.py
@@ -275,6 +275,41 @@ class TestFix3MergeNodeHasRetryDecorator:
                 return
         raise AssertionError("merge_node_with_source not found")
 
+    def test_upsert_sourced_relationship_inner_except_reraises_retryable(self):
+        """Cursor-bugbot 2026-04-22 #3: after removing the inner
+        @retry_with_backoff from _upsert_sourced_relationship (to avoid
+        nested retry stacking), the method's ``except Exception: return
+        False`` was STILL swallowing DatabaseError-wrapped transients
+        before they could propagate to the outer decorator on
+        merge_node_with_source. The SOURCED_FROM edge write path
+        therefore had ZERO retry coverage for deadlock-wrapped errors
+        — contradicting the stated safety claim of PR-N16 Fix #3.
+
+        Fix: mirror merge_node_with_source's pattern — classify via
+        ``_is_retryable_neo4j_error(e)`` and re-raise on retryable.
+        Terminal errors still log + return False.
+        """
+        import ast
+
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef):
+                for node in cls.body:
+                    if isinstance(node, ast.FunctionDef) and node.name == "_upsert_sourced_relationship":
+                        body = ast.unparse(node)
+                        assert "_is_retryable_neo4j_error(e)" in body, (
+                            "_upsert_sourced_relationship must classify + re-raise "
+                            "retryable errors (cursor-bugbot 2026-04-22 #3)"
+                        )
+                        # Retryable branch must raise, not return False.
+                        idx = body.find("_is_retryable_neo4j_error(e)")
+                        assert idx != -1
+                        post = body[idx : idx + 400]
+                        assert "raise" in post, "retryable branch must raise to let outer decorator retry"
+                        return
+        raise AssertionError("_upsert_sourced_relationship not found")
+
     def test_no_nested_retry_stacking_on_inner_helper(self):
         """Cursor-bugbot 2026-04-22: ``_upsert_sourced_relationship``
         is the inner-most retry-friendly helper, called only from

--- a/tests/test_pr_n16_merge_corruption_blocks.py
+++ b/tests/test_pr_n16_merge_corruption_blocks.py
@@ -253,9 +253,7 @@ class TestFix3MergeNodeHasRetryDecorator:
                         assert idx != -1
                         # Within ~500 chars after the check, there must be a raise.
                         post = body[idx : idx + 500]
-                        assert "raise" in post, (
-                            "retryable branch must `raise` to let decorator retry"
-                        )
+                        assert "raise" in post, "retryable branch must `raise` to let decorator retry"
                         return
         raise AssertionError("merge_node_with_source not found")
 
@@ -276,6 +274,37 @@ class TestFix3MergeNodeHasRetryDecorator:
                 )
                 return
         raise AssertionError("merge_node_with_source not found")
+
+    def test_no_nested_retry_stacking_on_inner_helper(self):
+        """Cursor-bugbot 2026-04-22: ``_upsert_sourced_relationship``
+        is the inner-most retry-friendly helper, called only from
+        ``merge_node_with_source``. Pre-fix BOTH had
+        ``@retry_with_backoff`` decorators, so a transient triggered
+        4 outer × 4 inner = 16 retries with ~70s of cumulative wait.
+
+        Fix: removed the inner decorator from ``_upsert_sourced_relationship``.
+        Only the outer decorator on ``merge_node_with_source`` retries.
+        Regression pin: the inner method MUST NOT be decorated."""
+        src = (SRC / "neo4j_client.py").read_text()
+        # Find the def line. The lines immediately above must NOT
+        # include an @retry_with_backoff decorator. Walk up past
+        # blanks + comments.
+        lines = src.split("\n")
+        for i, line in enumerate(lines):
+            if "def _upsert_sourced_relationship(" in line:
+                j = i - 1
+                while j >= 0 and (lines[j].strip() == "" or lines[j].lstrip().startswith("#")):
+                    j -= 1
+                if j >= 0:
+                    prev = lines[j].strip()
+                    assert not prev.startswith("@retry_with_backoff"), (
+                        "REGRESSION: _upsert_sourced_relationship must NOT be "
+                        "decorated with @retry_with_backoff (would create nested "
+                        "retry stacking with merge_node_with_source's outer decorator). "
+                        "Cursor-bugbot 2026-04-22 caught this — see PR-N16 follow-up."
+                    )
+                return
+        raise AssertionError("_upsert_sourced_relationship not found")
 
 
 # ===========================================================================

--- a/tests/test_pr_n16_merge_corruption_blocks.py
+++ b/tests/test_pr_n16_merge_corruption_blocks.py
@@ -1,0 +1,290 @@
+"""
+PR-N16 — overnight merge-logic audit BLOCK + HIGH bundle.
+
+Four findings from the overnight deep-merge-logic audit that PR-N10
+through PR-N15 missed. Two BLOCK-severity (data-corruption vectors
+that fire on every baseline sync with MISP-federated peers) + two
+HIGH-severity (silent data loss on Neo4j transients).
+
+## Fix #1 (BLOCK) — aliases-as-scalar corruption in merge_node_with_source
+
+``_ARRAY_ACCUMULATE_PROPS = {"aliases", "malware_types",
+"uses_techniques", "tactic_phases"}`` are meant to ACCUMULATE
+(dedup-append) across sources, but ``merge_node_with_source``'s
+extra_props loop gated the accumulation path on
+``isinstance(prop_value, list)``. MISP objects emit string-typed
+``aliases`` / ``malware_types`` attributes commonly
+(``misp_collector.py:385,410,478,498``).
+
+So: first sync writes ``n.aliases = ["Cozy Bear", "Nobelium"]`` via
+the list path. Second sync with string-typed aliases falls through to
+the scalar branch ``SET n.aliases = "APT29"`` — silently overwriting
+the accumulated list with a scalar string. Neo4j stores it.
+Downstream: every alias-based Q2 / Q9 / ATTRIBUTED_TO MATCH
+(``$actor_name IN coalesce(a.aliases, [])``) evaluates
+``IN scalar_string`` = nonsense, returns zero rows, silently drops
+edges.
+
+Fix: in the extra_props loop, for ``_ARRAY_ACCUMULATE_PROPS``,
+unconditionally coerce to list before sanitization. Scalar string →
+``[stripped]``. Non-list-non-string → log WARN + skip (don't corrupt).
+
+## Fix #2 (BLOCK) — MITRE mitre_id case asymmetry
+
+``merge_technique`` / ``merge_tactic`` / ``merge_tool`` stored
+mitre_id as received from MISP. The Cypher ``MERGE (n:Technique
+{mitre_id: $mitre_id})`` is case-sensitive, but ``compute_node_uuid``
+goes through ``canonical_node_key.lower()`` so the uuid is the same
+for ``T1056`` and ``t1056``.
+
+Result: two distinct Neo4j nodes (``T1056`` and ``t1056``) share the
+same ``n.uuid``. Cross-environment delta-sync + STIX export hits
+either node non-deterministically.
+
+Same class as PR #37 (Indicator value canonicalization — fixed there)
+but missed for MITRE. Verified: ``compute_node_uuid("Technique",
+{"mitre_id": "T1056"}) == compute_node_uuid("Technique", {"mitre_id":
+"t1056"})``.
+
+Fix: new ``_normalize_mitre_id`` helper uppercases (matches MITRE's
+own canonical convention) + None-guards. Applied in all three
+MITRE merge helpers.
+
+## Fix #3 (HIGH) — single-item merge paths have no retry on transient Neo4j errors
+
+PR-N15 added ``_execute_batch_with_retry`` for ``merge_indicators_batch``
+and ``merge_vulnerabilities_batch``. But the single-item paths
+(``merge_indicator``, ``merge_malware``, ``merge_actor``,
+``merge_technique``, ``merge_tactic``, ``merge_tool``, ``merge_cve``,
+``merge_vulnerability``, topology mergers) all route through
+``merge_node_with_source`` which had NO retry decorator.
+
+At 730d baseline scale, single-item merges of foundation nodes
+(Malware / Actor / Technique) hit transient errors too. Losing one
+Malware silently breaks every downstream batch-indicator INDICATES
+edge that would have matched it.
+
+Fix: decorate ``merge_node_with_source`` with
+``@retry_with_backoff(max_retries=3)`` — uses the PR-N15 classifier
+(``_is_retryable_neo4j_error``) so it retries on
+``TransientError`` / ``ServiceUnavailable`` / ``DatabaseError`` with
+retryable code.
+
+## Fix #4 (HIGH) — ``_run_rows`` in create_misp_relationships_batch has no retry
+
+``_run_rows`` (the 7-template UNWIND dispatcher for MISP-derived
+relationships) had a bare ``except Exception: logger.warning``. No
+retry, no permanent-failure counter. Same class as PR-N15 but in a
+sibling code path.
+
+At 700k-relationship baseline scale, a single Neo4j GC pause drops
+~1000 relationships per batch with no retry. Over 30 sync cycles,
+hundreds of silent drops of INDICATES / ATTRIBUTED_TO / EMPLOYS_TECHNIQUE
+edges.
+
+Fix: inline the same exponential-backoff + permanent-failure-counter
+pattern ``_execute_batch_with_retry`` uses, with the ``_run_rows``
+signature retained (it's a nested helper with access to
+``nonlocal total``). Emits ``edgeguard_neo4j_batch_permanent_failure_total``
+on exhaustion.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n16")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n16")
+
+
+# ===========================================================================
+# Fix #1 — aliases-as-scalar corruption
+# ===========================================================================
+
+
+class TestFix1AliasesAsScalarCorruption:
+    def test_sanitizer_coerces_string_to_list_before_accumulate(self):
+        """AST pin: the extra_props loop must coerce string → [string]
+        for accumulating-array props BEFORE the sanitize call, not
+        fall through to the scalar SET branch."""
+        src = (SRC / "neo4j_client.py").read_text()
+        idx = src.find("_ARRAY_ACCUMULATE_PROPS = frozenset(")
+        assert idx != -1
+        # Scan the extra_props loop for the new coerce logic.
+        block = src[idx : idx + 6000]
+        # Must branch on membership in accumulate-props WITHOUT the
+        # old isinstance-list guard dropping strings.
+        assert "if prop_name in _ARRAY_ACCUMULATE_PROPS:" in block
+        assert "elif isinstance(prop_value, str):" in block, (
+            "scalar-string coerce path missing — corruption vector reintroduced"
+        )
+        # Legacy failure mode: `if prop_name in _ARRAY_ACCUMULATE_PROPS and isinstance(prop_value, list):`
+        # must NOT be present (that was the bug).
+        assert "if prop_name in _ARRAY_ACCUMULATE_PROPS and isinstance(prop_value, list):" not in block, (
+            "regression: the old scalar-to-SET fallthrough is back"
+        )
+
+    def test_module_imports_with_new_coerce_logic(self):
+        """Behavioral sanity: module imports cleanly after the patch."""
+        import neo4j_client  # noqa: F401
+
+    def test_merge_node_sanitize_function_handles_string_input(self):
+        """Walk the module AST, find ``_sanitize_array_value`` function
+        definition, and confirm the coerce-to-list logic lives above
+        it in the extra_props loop (the sanitizer itself already
+        handles lists; the coerce is the caller's job)."""
+        src = (SRC / "neo4j_client.py").read_text()
+        # Find the `for prop_name, prop_value in extra_props.items():` loop
+        idx = src.find("for prop_name, prop_value in extra_props.items():")
+        assert idx != -1
+        # Scan forward for both the coerce + the sanitize call.
+        block = src[idx : idx + 4000]
+        assert "prop_value = [stripped]" in block, "scalar-string → single-element-list coerce missing"
+        assert "_sanitize_array_value(prop_name, prop_value)" in block, "sanitizer must still be invoked after coerce"
+
+
+# ===========================================================================
+# Fix #2 — MITRE mitre_id case asymmetry
+# ===========================================================================
+
+
+class TestFix2MitreCaseAsymmetry:
+    def _client(self):
+        from neo4j_client import Neo4jClient
+
+        c = Neo4jClient.__new__(Neo4jClient)
+        c.driver = MagicMock()
+        return c
+
+    def test_helper_uppercases_lowercase_input(self):
+        """``_normalize_mitre_id`` must return uppercase."""
+        c = self._client()
+        result = c._normalize_mitre_id("t1056", label="Technique", data={"name": "Phishing"})
+        assert result == "T1056", f"expected uppercase 'T1056'; got {result!r}"
+
+    def test_helper_passes_already_uppercase(self):
+        c = self._client()
+        assert c._normalize_mitre_id("T1056", label="Technique", data={"name": "Phishing"}) == "T1056"
+
+    def test_helper_rejects_none_empty_whitespace(self, caplog):
+        """Preserves the PR-N13 None-guard."""
+        import logging
+
+        c = self._client()
+        with caplog.at_level(logging.WARNING, logger="neo4j_client"):
+            assert c._normalize_mitre_id(None, label="Technique", data={}) is None
+            assert c._normalize_mitre_id("", label="Technique", data={}) is None
+            assert c._normalize_mitre_id("   ", label="Technique", data={}) is None
+        # Each reject emits a MERGE-REJECT log.
+        reject_logs = [r for r in caplog.records if "[MERGE-REJECT]" in r.message]
+        assert len(reject_logs) == 3
+
+    def test_merge_technique_uses_normalize_helper(self):
+        """AST pin: merge_technique must route mitre_id through _normalize_mitre_id,
+        not through nonempty_graph_string alone."""
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == "merge_technique":
+                body = ast.unparse(node)
+                assert "_normalize_mitre_id" in body, "merge_technique must call _normalize_mitre_id (PR-N16 Fix #2)"
+                return
+        raise AssertionError("merge_technique not found")
+
+    def test_merge_tactic_and_tool_use_normalize_helper(self):
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        found = {"merge_tactic": False, "merge_tool": False}
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name in found:
+                if "_normalize_mitre_id" in ast.unparse(node):
+                    found[node.name] = True
+        assert all(found.values()), f"not all MITRE helpers use _normalize_mitre_id: {found}"
+
+
+# ===========================================================================
+# Fix #3 — merge_node_with_source has @retry_with_backoff
+# ===========================================================================
+
+
+class TestFix3MergeNodeHasRetryDecorator:
+    def test_merge_node_with_source_decorated_with_retry(self):
+        """Regression pin: the function must be decorated with
+        ``@retry_with_backoff`` so transient errors retry instead of
+        propagating as one-shot failures to the caller."""
+        src = (SRC / "neo4j_client.py").read_text()
+        # Find the function + look at the line IMMEDIATELY above it.
+        lines = src.split("\n")
+        for i, line in enumerate(lines):
+            if "def merge_node_with_source(" in line:
+                # Walk up past def line + any other decorators.
+                # The decorator must appear before the def.
+                preceding = "\n".join(lines[max(0, i - 5) : i])
+                assert "@retry_with_backoff" in preceding, (
+                    "merge_node_with_source must be decorated with @retry_with_backoff (PR-N16 Fix #3)"
+                )
+                return
+        raise AssertionError("merge_node_with_source not found")
+
+
+# ===========================================================================
+# Fix #4 — _run_rows retry-on-transient
+# ===========================================================================
+
+
+class TestFix4RunRowsRetry:
+    def _extract_run_rows_body(self) -> str:
+        """Helper: extract the nested ``_run_rows`` function body from
+        ``create_misp_relationships_batch``."""
+        src = (SRC / "neo4j_client.py").read_text()
+        idx = src.find("def _run_rows(session")
+        assert idx != -1, "_run_rows not found"
+        # _run_rows is a nested def — scan for its next sibling def at
+        # same indent or any return to outer scope.
+        end = src.find("\n        with self.driver.session() as session:", idx)
+        if end == -1:
+            end = idx + 5000
+        return src[idx:end]
+
+    def test_run_rows_retries_on_transient(self):
+        body = self._extract_run_rows_body()
+        # Must use the classifier.
+        assert "_is_retryable_neo4j_error" in body, "_run_rows must use the PR-N15 retryable classifier"
+        # Must use exponential backoff (max_retries loop + time.sleep).
+        assert "max_retries" in body and "time.sleep" in body
+        # Must emit permanent-failure counter.
+        assert "_emit_batch_permanent_failure" in body, "_run_rows must emit permanent-failure counter on exhaustion"
+
+    def test_run_rows_no_bare_warning_only_pattern(self):
+        """Regression pin: the old bare ``logger.warning(...)`` + return
+        pattern must be gone. The only acceptable warning path is
+        per-attempt BATCH-RETRY (not the old silent swallow)."""
+        body = self._extract_run_rows_body()
+        # Old bug shape: `logger.warning("MISP relationship batch %s failed` + no retry after.
+        assert "MISP relationship batch" not in body or "BATCH-RETRY" in body or "BATCH-PERMANENT-FAILURE" in body, (
+            "regression: old silent-swallow logger.warning shape reappears"
+        )
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_neo4j_client_imports(self):
+        import neo4j_client  # noqa: F401
+
+    def test_normalize_mitre_id_is_method(self):
+        from neo4j_client import Neo4jClient
+
+        assert hasattr(Neo4jClient, "_normalize_mitre_id"), "_normalize_mitre_id must be a Neo4jClient method"


### PR DESCRIPTION
## Summary

Overnight deep merge-logic audit (2026-04-22) found **2 silent-data-corruption BLOCKs + 2 retry-gap HIGHs** that PR-N10 through PR-N15 missed. All four fire at 730d baseline scale.

| # | Sev | Finding | Impact |
|---|---|---|---|
| 1 | BLOCK | `merge_node_with_source` silently converts accumulating-array props to scalars when MISP sends string-typed aliases | `n.aliases = ["APT29","Cozy Bear"]` → `n.aliases = "APT29"` on next sync. Q2/Q9 alias-match silently drops every edge thereafter |
| 2 | BLOCK | MITRE `mitre_id` stored as-received; uuid is always lowercase → `T1056` and `t1056` = same uuid, different nodes | Cross-environment delta-sync + STIX export resolves non-deterministically |
| 3 | HIGH | `merge_node_with_source` has no retry decorator — single-item merges fail permanently on Neo4j transients | A dropped Malware node silently breaks every downstream INDICATES edge at 730d scale |
| 4 | HIGH | `_run_rows` in `create_misp_relationships_batch` has no retry — same class as PR-N15 in sibling path | 1000-row relationship batches dropped silently on each transient |

## Files

- `src/neo4j_client.py` — 4 fixes, 162 insertions:
  - Extra_props loop: string → `[stripped]` coerce for array-accumulate props
  - New `_normalize_mitre_id` helper (uppercase + None-guard); applied in 3 MITRE merge helpers
  - `@retry_with_backoff(max_retries=3)` decorator on `merge_node_with_source`
  - `_run_rows` rewritten with exponential backoff + permanent-failure counter emission
- `tests/test_pr_n16_merge_corruption_blocks.py` — 13 regression tests

## Test plan

- [x] 13/13 PR-N16 tests pass
- [x] Full suite: 1459 passed, 3 skipped, 3 xfailed (up from 1446 on main)
- [x] ruff format + check clean
- [x] mypy clean
- [ ] Operator: verify existing pre-PR-N16 Malware/Actor nodes with scalar `n.aliases` via `MATCH (m:Malware) WHERE m.aliases IS NOT NULL AND NOT m.aliases :: LIST<STRING> RETURN count(m)` — if non-zero, run a one-shot repair: `MATCH (m) WHERE m.aliases IS NOT NULL AND NOT m.aliases :: LIST<STRING> SET m.aliases = [m.aliases]`

## Pre-baseline priority

**Both BLOCKs should ship before the 730d baseline.** Fix #1 (aliases-as-scalar) in particular fires on every MISP-federated sync; without it, the baseline destroys accumulated aliases data across ~30 sync cycles and silently drops thousands of alias-match edges.

## Context — overnight audit findings

This PR addresses 4 of 14 findings from the 2 parallel deep audits (merge-logic + collection pipeline). Remaining findings split:

- **PR-N17 (next)**: NVD `_fetch_cves_batch` silent window-drop (BLOCK) + per-window memory fix (HIGH)
- **PR-N18**: RUNBOOK drift + missing placeholder-reject counter + PR-N15 alert rule + kill-switch doc gaps
- **Deferred**: aliases attribution hijack (needs design), circuit-breaker gaps on AbuseIPDB/VT/MISPCollector/ThreatFox, response-size caps

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches core Neo4j write paths (node merges and relationship batch upserts) and changes normalization/retry behavior, which can affect data integrity and operational characteristics (retry timing, error propagation).
> 
> **Overview**
> Fixes multiple Neo4j ingest/merge failure modes that could silently corrupt graph data or drop writes at scale.
> 
> `merge_node_with_source` now (1) always treats accumulating-array `extra_props` (e.g. `aliases`, `malware_types`) as lists by coercing scalar strings and skipping unsupported types, and (2) is wrapped in `@retry_with_backoff` while ensuring retryable Neo4j `DatabaseError`-wrapped transients are re-raised for the decorator to handle. MITRE merges (`merge_technique`/`merge_tactic`/`merge_tool`) now normalize `mitre_id` to uppercase via a new `_normalize_mitre_id` helper to prevent case-split nodes sharing a UUID.
> 
> Relationship creation in `create_misp_relationships_batch` now retries transient failures with exponential backoff and emits a permanent-failure metric on exhaustion, instead of just logging and dropping the batch. Adds a new regression test suite (`tests/test_pr_n16_merge_corruption_blocks.py`) pinning these behaviors via AST and import checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3b70641dae89f56a5d292a23289a8b0f749f5270. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->