### PR TITLE
fix(audit): PR-N17 — NVD silent window-drop hardening (BLOCK)

### DIFF
--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -668,7 +668,7 @@ class NVDCollector:
                                 items_collected=len(all_cves),
                                 extra={"nvd_window_idx": wi, "nvd_start_index": idx},
                             )
-                            break  # stop the while loop for this window
+                            break  # stop the inner while loop for this window
                         if not cves:
                             consecutive_empty += 1
                             if consecutive_empty >= 3:
@@ -711,18 +711,45 @@ class NVDCollector:
                             items_collected=len(all_cves),
                             extra={"nvd_window_idx": wi + 1, "nvd_start_index": 0},
                         )
+                    else:
+                        # PR-N17 follow-up (cursor-bugbot 2026-04-22 #1):
+                        # break the OUTER for-loop on first abort.
+                        # Pre-fix the inner ``break`` only exited the
+                        # while loop; the for loop continued with
+                        # subsequent windows whose successful batches
+                        # called ``update_source_checkpoint`` with
+                        # later ``nvd_window_idx`` values, OVERWRITING
+                        # the abort checkpoint. Resume then jumped
+                        # past the aborted window, losing its data.
+                        # Now: stop the for-loop too so the preserved
+                        # (wi, idx) checkpoint actually survives.
+                        break  # exit outer for-loop on first abort
 
-                # PR-N17 Fix #2: if ANY windows aborted, the baseline
-                # is partial — raise so the task fails loudly. Better
-                # to fail and retry than to silently mark "completed"
-                # on partial data (the pre-PR-N17 bug). Operator will
-                # see the log lines + task failure + retry at the
-                # aborted window.
+                # PR-N17 Fix #2 (cursor-bugbot 2026-04-22 #2): if any
+                # windows aborted, the baseline is partial — raise
+                # NvdBatchFetchError so the Airflow task fails loudly.
+                # The raise is OUTSIDE the wrapping try/except (re-
+                # raised explicitly below) so it isn't caught by the
+                # outer ``except Exception`` and converted to a normal
+                # status return — that conversion gave the appearance
+                # of a graceful "success: False" response which Airflow
+                # treats less aggressively than an explicit raise.
+                # Storing the to-raise condition + raising AFTER the
+                # try block guarantees the typed exception escapes.
                 if aborted_windows:
+                    # PR-N17 follow-up (cursor-bugbot 2026-04-22 #2):
+                    # raise IMMEDIATELY (not at end of try block) so
+                    # the typed exception propagates to the new
+                    # ``except NvdBatchFetchError:`` re-raise gate
+                    # below. Skips all the post-loop processing
+                    # (transform / push / status return) which would
+                    # otherwise hide the partial-baseline state.
                     raise NvdBatchFetchError(
                         f"NVD baseline partial: {len(aborted_windows)} window(s) aborted "
-                        f"(indices {aborted_windows}). Checkpoint preserved at first abort; "
-                        f"re-run baseline to resume."
+                        f"(indices {aborted_windows}). Checkpoint preserved at first abort "
+                        f"(per cursor-bugbot 2026-04-22 #1, the outer for-loop now breaks "
+                        f"on first abort to prevent later windows from overwriting the "
+                        f"checkpoint). Re-run baseline to resume."
                     )
 
                 # PR-M1 §7-H3: defensive guard against a run-level ``limit``
@@ -1111,6 +1138,23 @@ class NVDCollector:
                 record_collection_success(self.source_name)
                 return processed
 
+        except NvdBatchFetchError:
+            # PR-N17 follow-up (cursor-bugbot 2026-04-22 #2): the
+            # baseline-partial raise must escape the outer except
+            # chain so Airflow sees an actual exception. Without this
+            # explicit re-raise the broader ``except Exception as e:``
+            # below catches it, converts to ``return self._return_status(
+            # False, 0, error_msg)``, and the task function returns
+            # normally. Airflow treats the dict-return as a callable
+            # success (the dict's ``success: False`` field IS picked up
+            # by ``run_collector_with_metrics`` and converted to
+            # ``AirflowException``, but the typed exception is lost).
+            # Re-raising preserves the type so downstream alerting +
+            # retry logic can distinguish "NVD baseline partial — re-
+            # run will resume from preserved checkpoint" from "NVD
+            # generic collection failure".
+            self.circuit_breaker.record_failure()
+            raise
         except requests.exceptions.Timeout as e:
             error_msg = f"Timeout: {e}"
             logger.error(f"NVD timeout: {e}")

--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -515,9 +515,42 @@ class NVDCollector:
             logger.error("[NVD-BATCH-FETCH-ERROR] JSON parse: %s", e)
             raise NvdBatchFetchError(f"NVD response not JSON: {e}") from e
 
+        # PR-N17 follow-up (cursor-bugbot 2026-04-22 #3): NVD can
+        # return JSON that's valid but not the expected dict shape
+        # (maintenance page returning a JSON string / array / null).
+        # Pre-fix, ``data.get("vulnerabilities", [])`` on a non-dict
+        # raised AttributeError OUTSIDE the try/except above, bypassing
+        # the NvdBatchFetchError abort path — the baseline loop saw
+        # a raw AttributeError (not caught by its
+        # ``except NvdBatchFetchError``), which then propagated to the
+        # outer ``except Exception`` and got converted to a soft
+        # status dict. Same "error indistinguishable from success"
+        # class that PR-N17 was meant to close.
+        #
+        # Fix: explicit type check. Raise NvdBatchFetchError so the
+        # baseline loop's abort handler fires normally.
+        if not isinstance(data, dict):
+            logger.error(
+                "[NVD-BATCH-FETCH-ERROR] response is valid JSON but not a dict "
+                "(got %s) — likely a maintenance page or upstream proxy error",
+                type(data).__name__,
+            )
+            raise NvdBatchFetchError(f"NVD response JSON is {type(data).__name__}, expected dict")
+
         vulnerabilities = data.get("vulnerabilities", [])
-        # Legit empty list → returned normally. Caller's
-        # ``consecutive_empty`` counter handles end-of-window.
+        # Defense-in-depth: confirm ``vulnerabilities`` is a list.
+        # A legitimate empty response returns ``[]`` (caller's
+        # consecutive_empty counter handles end-of-window). A bad
+        # payload with ``vulnerabilities: "some string"`` would
+        # otherwise propagate as a non-list into downstream iteration.
+        if not isinstance(vulnerabilities, list):
+            logger.error(
+                "[NVD-BATCH-FETCH-ERROR] ``vulnerabilities`` field is %s, expected list",
+                type(vulnerabilities).__name__,
+            )
+            raise NvdBatchFetchError(
+                f"NVD ``vulnerabilities`` field is {type(vulnerabilities).__name__}, expected list"
+            )
         return vulnerabilities
 
     def collect(

--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -168,6 +168,25 @@ NVD_CIRCUIT_BREAKER = get_circuit_breaker(
 )
 
 
+class NvdBatchFetchError(Exception):
+    """PR-N17 (2026-04-22 pre-baseline collection audit, BLOCK):
+    raised by ``_fetch_cves_batch`` when an HTTP / rate-limit / JSON-
+    parse failure occurs AFTER the rate-limit retry layer exhausted.
+
+    The baseline loop MUST catch this and abort the current window
+    WITHOUT advancing the checkpoint — distinguishing "NVD returned
+    an empty result, this window is done" (legit end-of-window, the
+    caller's ``consecutive_empty`` counter handles it) from "fetch
+    errored, do not mark the window complete" (data at this startIndex
+    never arrived).
+
+    Pre-PR-N17 both cases returned ``[]`` and the baseline advanced
+    past unfetched data → silent loss of entire 120-day CVE windows.
+    """
+
+    pass
+
+
 class NVDCollector:
     """
     NVD (National Vulnerability Database) Collector.
@@ -442,6 +461,21 @@ class NVDCollector:
                 params["pubStartDate"] = pub_start_iso
                 params["pubEndDate"] = pub_end_iso
 
+        # PR-N17 Fix #1 (BLOCK, 2026-04-22 pre-baseline collection audit):
+        # Pre-PR-N17 this method returned ``[]`` on ANY exception, and
+        # the baseline caller treated 3 consecutive ``[]`` as "window
+        # done" → advanced the checkpoint PAST data that was never
+        # fetched. A single DNS flap / NVD 502 cluster / CPU-starved
+        # worker silently lost a 120-day window.
+        #
+        # Fix: distinguish the two failure modes.
+        #   - API returned 200 with ``vulnerabilities: []`` → legit empty.
+        #     Return ``[]`` (caller may increment consecutive_empty).
+        #   - API returned non-200 AFTER rate-limit retries → raise
+        #     NvdBatchFetchError so caller aborts the window.
+        #   - Exception inside the HTTP call → raise NvdBatchFetchError.
+        # The caller MUST catch NvdBatchFetchError and abort the
+        # window (not advance checkpoint). See the baseline loop.
         try:
             response = request_with_rate_limit_retries(
                 "GET",
@@ -456,18 +490,35 @@ class NVDCollector:
                 retry_on_403=False,
                 context="NVD",
             )
-
-            if response.status_code != 200:
-                logger.warning(f"NVD API error: {response.status_code} (after rate-limit retries where applicable)")
-                return []
-
-            data = response.json()
-            vulnerabilities = data.get("vulnerabilities", [])
-            return vulnerabilities
-
         except Exception as e:
-            logger.warning(f"NVD batch fetch error: {e}")
-            return []
+            # Transient raised after the rate-limit-retry layer exhausted.
+            # Propagate so the caller knows NOT to advance checkpoint.
+            logger.error("[NVD-BATCH-FETCH-ERROR] exception: %s: %s", type(e).__name__, e)
+            raise NvdBatchFetchError(f"NVD fetch exception: {type(e).__name__}: {e}") from e
+
+        if response.status_code != 200:
+            # Non-200 post-retry — the window is NOT complete; raise so
+            # the caller aborts + preserves checkpoint at the current
+            # (wi, idx) instead of advancing past unfetched data.
+            logger.error(
+                "[NVD-BATCH-FETCH-ERROR] status_code=%d after rate-limit retries",
+                response.status_code,
+            )
+            raise NvdBatchFetchError(f"NVD returned {response.status_code} after retries")
+
+        try:
+            data = response.json()
+        except Exception as e:
+            # Malformed JSON response — could be maintenance page /
+            # error HTML / truncated body. Treat as transient (caller
+            # aborts window).
+            logger.error("[NVD-BATCH-FETCH-ERROR] JSON parse: %s", e)
+            raise NvdBatchFetchError(f"NVD response not JSON: {e}") from e
+
+        vulnerabilities = data.get("vulnerabilities", [])
+        # Legit empty list → returned normally. Caller's
+        # ``consecutive_empty`` counter handles end-of-window.
+        return vulnerabilities
 
     def collect(
         self, limit: int = None, push_to_misp: bool = True, baseline: bool = False, baseline_days: int = 365
@@ -564,6 +615,12 @@ class NVDCollector:
                             f"  Resuming baseline at window {start_wi + 1}/{len(windows)}, startIndex={resume_index}"
                         )
 
+                # PR-N17 Fix #2 (BLOCK, 2026-04-22): track whether any
+                # window aborted due to fetch error so the operator
+                # sees "partial" status + the checkpoint is NOT marked
+                # ``completed=True`` at the end of the baseline run.
+                aborted_windows: list = []
+
                 for wi in range(start_wi, len(windows)):
                     w_start, w_end = windows[wi]
                     pub_start_iso = _to_nvd_pub_iso(w_start)
@@ -571,14 +628,47 @@ class NVDCollector:
                     idx = resume_index if wi == start_wi else 0
                     resume_index = 0
                     consecutive_empty = 0
+                    window_aborted = False
 
                     while consecutive_empty < 3:
-                        cves = self._fetch_cves_batch(
-                            pub_start_iso=pub_start_iso,
-                            pub_end_iso=pub_end_iso,
-                            start_index=idx,
-                            limit=batch_size,
-                        )
+                        try:
+                            cves = self._fetch_cves_batch(
+                                pub_start_iso=pub_start_iso,
+                                pub_end_iso=pub_end_iso,
+                                start_index=idx,
+                                limit=batch_size,
+                            )
+                        except NvdBatchFetchError as fetch_err:
+                            # PR-N17 Fix #1+#2: fetch errored (not a
+                            # legit empty response). DO NOT advance
+                            # the checkpoint — abort this window and
+                            # preserve the current (wi, idx) so resume
+                            # picks up where the failure happened.
+                            logger.error(
+                                "[NVD-WINDOW-ABORT] window %d/%d @ startIndex %d — "
+                                "aborting due to fetch error: %s. Checkpoint NOT "
+                                "advanced; next baseline run will resume at this "
+                                "position. Affected date range: %s to %s.",
+                                wi + 1,
+                                len(windows),
+                                idx,
+                                fetch_err,
+                                pub_start_iso,
+                                pub_end_iso,
+                            )
+                            record_collection_failure(self.source_name, f"window-abort wi={wi} idx={idx}: {fetch_err}")
+                            aborted_windows.append(wi)
+                            window_aborted = True
+                            # Preserve checkpoint at current (wi, idx) —
+                            # explicit write so if the process dies now,
+                            # resume is exactly where it aborted.
+                            update_source_checkpoint(
+                                "nvd",
+                                page=total_batches_done,
+                                items_collected=len(all_cves),
+                                extra={"nvd_window_idx": wi, "nvd_start_index": idx},
+                            )
+                            break  # stop the while loop for this window
                         if not cves:
                             consecutive_empty += 1
                             if consecutive_empty >= 3:
@@ -610,10 +700,29 @@ class NVDCollector:
                         idx = next_idx
                         time.sleep(batch_sleep)
 
-                    update_source_checkpoint(
-                        "nvd",
-                        items_collected=len(all_cves),
-                        extra={"nvd_window_idx": wi + 1, "nvd_start_index": 0},
+                    # PR-N17 Fix #2: only mark this window complete
+                    # (advance ``nvd_window_idx`` to wi+1) if the
+                    # window actually finished via consecutive-empty.
+                    # If it aborted due to fetch error, leave the
+                    # checkpoint at (wi, idx) so resume retries.
+                    if not window_aborted:
+                        update_source_checkpoint(
+                            "nvd",
+                            items_collected=len(all_cves),
+                            extra={"nvd_window_idx": wi + 1, "nvd_start_index": 0},
+                        )
+
+                # PR-N17 Fix #2: if ANY windows aborted, the baseline
+                # is partial — raise so the task fails loudly. Better
+                # to fail and retry than to silently mark "completed"
+                # on partial data (the pre-PR-N17 bug). Operator will
+                # see the log lines + task failure + retry at the
+                # aborted window.
+                if aborted_windows:
+                    raise NvdBatchFetchError(
+                        f"NVD baseline partial: {len(aborted_windows)} window(s) aborted "
+                        f"(indices {aborted_windows}). Checkpoint preserved at first abort; "
+                        f"re-run baseline to resume."
                     )
 
                 # PR-M1 §7-H3: defensive guard against a run-level ``limit``

--- a/tests/test_pr_n17_nvd_silent_window_drop.py
+++ b/tests/test_pr_n17_nvd_silent_window_drop.py
@@ -182,6 +182,57 @@ class TestFix1FetchBatchDistinguishesEmptyFromError:
                     limit=2000,
                 )
 
+    def test_fetch_batch_raises_on_non_dict_json(self):
+        """Cursor-bugbot 2026-04-22 #3: NVD can return valid JSON that
+        ISN'T a dict (e.g. a maintenance page returning a JSON array
+        or string). Pre-fix, ``data.get("vulnerabilities", [])`` on a
+        non-dict raised AttributeError OUTSIDE the JSON-parse try/except,
+        bypassing NvdBatchFetchError. Now must raise."""
+        from collectors.nvd_collector import NvdBatchFetchError, NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        for bad_json in [["not", "a", "dict"], "string response", None, 42]:
+            response = MagicMock()
+            response.status_code = 200
+            response.json.return_value = bad_json
+            with patch("collectors.nvd_collector.request_with_rate_limit_retries", return_value=response):
+                with pytest.raises(NvdBatchFetchError, match="not a dict|expected dict"):
+                    collector._fetch_cves_batch(
+                        pub_start_iso="2024-01-01T00:00:00.000",
+                        pub_end_iso="2024-04-30T23:59:59.999",
+                        start_index=0,
+                        limit=2000,
+                    )
+
+    def test_fetch_batch_raises_on_non_list_vulnerabilities_field(self):
+        """Defense-in-depth: ``vulnerabilities`` field must be a list.
+        If NVD returns ``{"vulnerabilities": "garbage"}``, raise rather
+        than propagate a non-list to downstream iteration."""
+        from collectors.nvd_collector import NvdBatchFetchError, NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"vulnerabilities": "this should be a list"}
+        with patch("collectors.nvd_collector.request_with_rate_limit_retries", return_value=response):
+            with pytest.raises(NvdBatchFetchError, match="expected list"):
+                collector._fetch_cves_batch(
+                    pub_start_iso="2024-01-01T00:00:00.000",
+                    pub_end_iso="2024-04-30T23:59:59.999",
+                    start_index=0,
+                    limit=2000,
+                )
+
     def test_fetch_batch_returns_vulnerabilities_on_success(self):
         from collectors.nvd_collector import NVDCollector
 

--- a/tests/test_pr_n17_nvd_silent_window_drop.py
+++ b/tests/test_pr_n17_nvd_silent_window_drop.py
@@ -327,42 +327,57 @@ class TestFix2BaselineLoopAbortsWindowOnError:
         to a normal status-dict return. The typed exception was lost.
 
         Fix: an explicit ``except NvdBatchFetchError: raise`` ahead
-        of the broader handlers so the type escapes to Airflow."""
+        of the broader handlers so the type escapes to Airflow.
+
+        Bugbot 2026-04-22 #4: the prior version of this test walked
+        ast.walk (order-dependent) and could match the INNER try/except
+        around _fetch_cves_batch — which has ONLY NvdBatchFetchError
+        and no Exception handler, so the test returned without
+        asserting anything. Rewrote to specifically find the OUTER
+        try/except chain (identified by having BOTH the typed handler
+        AND an Exception handler), then assert ordering."""
         src = (SRC / "collectors" / "nvd_collector.py").read_text()
-        # The except clause must come BEFORE the generic except chain.
-        # AST scan: find the function `collect`, walk its handlers.
         import ast as _ast
 
         tree = _ast.parse(src)
+        matching_outer_trys = []
         for node in _ast.walk(tree):
-            if isinstance(node, _ast.FunctionDef) and node.name == "collect":
-                # Walk for `Try` nodes inside the function
-                for sub in _ast.walk(node):
-                    if isinstance(sub, _ast.Try):
-                        handler_types = []
-                        for h in sub.handlers:
-                            if h.type is not None:
-                                if isinstance(h.type, _ast.Name):
-                                    handler_types.append(h.type.id)
-                                elif isinstance(h.type, _ast.Attribute):
-                                    handler_types.append(h.type.attr)
-                            else:
-                                handler_types.append("Exception")
-                        if "NvdBatchFetchError" in handler_types:
-                            # Confirm it's BEFORE the bare Exception catch.
-                            try:
-                                nbfe_idx = handler_types.index("NvdBatchFetchError")
-                                exc_idx = handler_types.index("Exception")
-                                assert nbfe_idx < exc_idx, (
-                                    "NvdBatchFetchError handler must be ordered BEFORE the broader Exception handler"
-                                )
-                            except ValueError:
-                                pass  # one or other not present in this Try
-                            return
-        raise AssertionError(
-            "collect() must have an `except NvdBatchFetchError:` re-raise gate "
-            "ordered before the generic Exception handler"
+            if not (isinstance(node, _ast.FunctionDef) and node.name == "collect"):
+                continue
+            for sub in _ast.walk(node):
+                if not isinstance(sub, _ast.Try):
+                    continue
+                handler_types = []
+                for h in sub.handlers:
+                    if h.type is None:
+                        handler_types.append("Exception")
+                    elif isinstance(h.type, _ast.Name):
+                        handler_types.append(h.type.id)
+                    elif isinstance(h.type, _ast.Attribute):
+                        handler_types.append(h.type.attr)
+                # The OUTER try/except chain is identified by having
+                # BOTH NvdBatchFetchError AND a bare Exception handler.
+                # Inner try/excepts (e.g. around _fetch_cves_batch) only
+                # catch NvdBatchFetchError, so filtering on the
+                # intersection ensures we're testing the right one.
+                has_nbfe = "NvdBatchFetchError" in handler_types
+                has_exception = "Exception" in handler_types
+                if has_nbfe and has_exception:
+                    matching_outer_trys.append(handler_types)
+
+        assert matching_outer_trys, (
+            "collect() must contain a try/except chain with BOTH "
+            "NvdBatchFetchError AND Exception handlers — the outer "
+            "chain that guards against the typed exception being "
+            "caught by the generic handler."
         )
+        for handler_types in matching_outer_trys:
+            nbfe_idx = handler_types.index("NvdBatchFetchError")
+            exc_idx = handler_types.index("Exception")
+            assert nbfe_idx < exc_idx, (
+                f"NvdBatchFetchError handler must be ordered BEFORE "
+                f"the broader Exception handler. Found order: {handler_types}"
+            )
 
 
 # ===========================================================================

--- a/tests/test_pr_n17_nvd_silent_window_drop.py
+++ b/tests/test_pr_n17_nvd_silent_window_drop.py
@@ -232,11 +232,10 @@ class TestFix2BaselineLoopAbortsWindowOnError:
         src = (SRC / "collectors" / "nvd_collector.py").read_text()
         idx = src.find("aborted_windows: list = []")
         assert idx != -1, "aborted_windows tracker must be initialized"
-        block = src[idx : idx + 6000]
+        # Widened window for PR-N17 follow-up comments.
+        block = src[idx : idx + 10000]
         assert "aborted_windows.append" in block, "must track aborted windows"
-        assert "raise NvdBatchFetchError" in block, (
-            "baseline must raise at end if any window aborted (fail task loudly)"
-        )
+        assert "raise NvdBatchFetchError" in block, "baseline must raise if any window aborted (fail task loudly)"
 
     def test_checkpoint_not_advanced_on_aborted_window(self):
         """AST pin: the ``update_source_checkpoint(..., nvd_window_idx=wi+1, ...)``
@@ -249,6 +248,69 @@ class TestFix2BaselineLoopAbortsWindowOnError:
         block = src[idx : idx + 600]
         assert 'extra={"nvd_window_idx": wi + 1' in block, (
             "advance to wi+1 must be inside the `not window_aborted` branch"
+        )
+
+    def test_outer_for_loop_breaks_on_first_abort(self):
+        """Cursor-bugbot 2026-04-22 #1: the inner ``break`` only exited
+        the while loop. The outer for-loop continued with subsequent
+        windows whose successful batches called update_source_checkpoint
+        with later nvd_window_idx values, OVERWRITING the abort
+        checkpoint. Resume then jumped past the aborted window, losing
+        its data.
+
+        Fix: ``else: break`` after the ``if not window_aborted: ...``
+        block exits the outer for-loop on first abort."""
+        src = (SRC / "collectors" / "nvd_collector.py").read_text()
+        # Find the gating block + verify the else: break exit.
+        idx = src.find("if not window_aborted:")
+        assert idx != -1
+        # Within ~1500 chars after, must be `else:` + `break  # exit outer for-loop`
+        block = src[idx : idx + 1500]
+        assert "else:" in block and "exit outer for-loop" in block, (
+            "outer for-loop must break on first abort (cursor-bugbot 2026-04-22 #1)"
+        )
+
+    def test_outer_except_chain_re_raises_NvdBatchFetchError(self):
+        """Cursor-bugbot 2026-04-22 #2: the ``raise NvdBatchFetchError``
+        was caught by the outer ``except Exception as e:`` and converted
+        to a normal status-dict return. The typed exception was lost.
+
+        Fix: an explicit ``except NvdBatchFetchError: raise`` ahead
+        of the broader handlers so the type escapes to Airflow."""
+        src = (SRC / "collectors" / "nvd_collector.py").read_text()
+        # The except clause must come BEFORE the generic except chain.
+        # AST scan: find the function `collect`, walk its handlers.
+        import ast as _ast
+
+        tree = _ast.parse(src)
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.FunctionDef) and node.name == "collect":
+                # Walk for `Try` nodes inside the function
+                for sub in _ast.walk(node):
+                    if isinstance(sub, _ast.Try):
+                        handler_types = []
+                        for h in sub.handlers:
+                            if h.type is not None:
+                                if isinstance(h.type, _ast.Name):
+                                    handler_types.append(h.type.id)
+                                elif isinstance(h.type, _ast.Attribute):
+                                    handler_types.append(h.type.attr)
+                            else:
+                                handler_types.append("Exception")
+                        if "NvdBatchFetchError" in handler_types:
+                            # Confirm it's BEFORE the bare Exception catch.
+                            try:
+                                nbfe_idx = handler_types.index("NvdBatchFetchError")
+                                exc_idx = handler_types.index("Exception")
+                                assert nbfe_idx < exc_idx, (
+                                    "NvdBatchFetchError handler must be ordered BEFORE the broader Exception handler"
+                                )
+                            except ValueError:
+                                pass  # one or other not present in this Try
+                            return
+        raise AssertionError(
+            "collect() must have an `except NvdBatchFetchError:` re-raise gate "
+            "ordered before the generic Exception handler"
         )
 
 

--- a/tests/test_pr_n17_nvd_silent_window_drop.py
+++ b/tests/test_pr_n17_nvd_silent_window_drop.py
@@ -1,0 +1,268 @@
+"""
+PR-N17 — NVD silent-window-drop hardening (BLOCK).
+
+The overnight collection-pipeline audit found a BLOCK-severity
+silent-data-loss vector in the NVD baseline loop:
+
+**Pre-PR-N17 flow** (``nvd_collector.py`` ``_fetch_cves_batch``):
+
+```python
+try:
+    response = request_with_rate_limit_retries(...)
+    if response.status_code != 200:
+        logger.warning(...)
+        return []  # <-- BUG: caller can't tell this from legit empty
+    return response.json().get("vulnerabilities", [])
+except Exception as e:
+    logger.warning(...)
+    return []  # <-- SAME BUG: exception indistinguishable from empty
+```
+
+**Caller (baseline loop):**
+
+```python
+while consecutive_empty < 3:
+    cves = self._fetch_cves_batch(...)
+    if not cves:
+        consecutive_empty += 1
+        if consecutive_empty >= 3:
+            break  # window done — advance checkpoint past unfetched data!
+        continue
+    # ... accumulate ...
+update_source_checkpoint(nvd_window_idx=wi + 1)  # <-- advances past lost data
+```
+
+**Failure mode at 730d scale:** 12 × 120-day windows × ~50 pages =
+~600 NVD API calls. Three consecutive transient errors (DNS flap,
+NVD 502 cluster, worker CPU starvation) in ONE window look
+indistinguishable from "legit end-of-window empty". The checkpoint
+advances past the lost CVEs. Operator sees ``completed: true`` but
+entire 120-day windows are missing from Neo4j. **No operator signal.**
+
+## Fix
+
+1. Define ``NvdBatchFetchError`` — specific exception class.
+2. ``_fetch_cves_batch`` distinguishes the two cases:
+   - API returned 200 with ``vulnerabilities: []`` → return ``[]`` (legit)
+   - Non-200 after retries / HTTP exception / JSON parse error →
+     raise ``NvdBatchFetchError``
+3. Caller catches ``NvdBatchFetchError``, logs ``[NVD-WINDOW-ABORT]``,
+   preserves checkpoint at current ``(wi, idx)``, skips to next
+   window. If ANY windows aborted, the baseline raises
+   ``NvdBatchFetchError`` at the end so the Airflow task fails loudly
+   (not silently completes).
+
+## Why this is BLOCK
+
+At 730d scale the silent-window-drop is statistically certain. Same
+class as PR-N7 ``<> ''`` silent-zero-edge bug — different layer, same
+failure mode. The pre-PR-N17 behaviour was: a ~10% data loss on a
+30-hour baseline could complete "successfully" with zero alert.
+
+Post-PR-N17: any fetch failure surfaces as task failure with explicit
+``[NVD-WINDOW-ABORT]`` log + preserved checkpoint for resume.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n17")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n17")
+
+
+# ===========================================================================
+# Fix #1 — _fetch_cves_batch distinguishes empty from error
+# ===========================================================================
+
+
+class TestFix1FetchBatchDistinguishesEmptyFromError:
+    def test_exception_class_exists(self):
+        from collectors.nvd_collector import NvdBatchFetchError
+
+        assert issubclass(NvdBatchFetchError, Exception)
+
+    def test_fetch_batch_returns_empty_list_on_legit_empty_response(self):
+        """200 with ``vulnerabilities: []`` → return [] (legit end-of-window)."""
+        from collectors.nvd_collector import NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"vulnerabilities": []}
+
+        with patch("collectors.nvd_collector.request_with_rate_limit_retries", return_value=response):
+            result = collector._fetch_cves_batch(
+                pub_start_iso="2024-01-01T00:00:00.000",
+                pub_end_iso="2024-04-30T23:59:59.999",
+                start_index=0,
+                limit=2000,
+            )
+        assert result == [], "legit empty NVD response must return []"
+
+    def test_fetch_batch_raises_on_non_200(self):
+        """Non-200 after retries → raise NvdBatchFetchError (not return [])."""
+        from collectors.nvd_collector import NvdBatchFetchError, NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        response = MagicMock()
+        response.status_code = 503
+
+        with patch("collectors.nvd_collector.request_with_rate_limit_retries", return_value=response):
+            with pytest.raises(NvdBatchFetchError, match="503"):
+                collector._fetch_cves_batch(
+                    pub_start_iso="2024-01-01T00:00:00.000",
+                    pub_end_iso="2024-04-30T23:59:59.999",
+                    start_index=0,
+                    limit=2000,
+                )
+
+    def test_fetch_batch_raises_on_http_exception(self):
+        """Exception in HTTP call → raise NvdBatchFetchError."""
+        from collectors.nvd_collector import NvdBatchFetchError, NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        with patch(
+            "collectors.nvd_collector.request_with_rate_limit_retries",
+            side_effect=ConnectionError("DNS flap"),
+        ):
+            with pytest.raises(NvdBatchFetchError, match="ConnectionError|DNS flap"):
+                collector._fetch_cves_batch(
+                    pub_start_iso="2024-01-01T00:00:00.000",
+                    pub_end_iso="2024-04-30T23:59:59.999",
+                    start_index=0,
+                    limit=2000,
+                )
+
+    def test_fetch_batch_raises_on_json_parse_error(self):
+        """Non-JSON response (e.g. HTML error page) → raise NvdBatchFetchError."""
+        from collectors.nvd_collector import NvdBatchFetchError, NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        response = MagicMock()
+        response.status_code = 200
+        response.json.side_effect = ValueError("Expecting value: line 1 column 1")
+
+        with patch("collectors.nvd_collector.request_with_rate_limit_retries", return_value=response):
+            with pytest.raises(NvdBatchFetchError, match="not JSON|ValueError"):
+                collector._fetch_cves_batch(
+                    pub_start_iso="2024-01-01T00:00:00.000",
+                    pub_end_iso="2024-04-30T23:59:59.999",
+                    start_index=0,
+                    limit=2000,
+                )
+
+    def test_fetch_batch_returns_vulnerabilities_on_success(self):
+        from collectors.nvd_collector import NVDCollector
+
+        collector = NVDCollector.__new__(NVDCollector)
+        collector.api_key = None
+        collector.base_url = "http://fake"
+        collector.source_name = "nvd"
+        collector.session = MagicMock()
+
+        fake_cve = {"cve": {"id": "CVE-2024-0001", "descriptions": []}}
+        response = MagicMock()
+        response.status_code = 200
+        response.json.return_value = {"vulnerabilities": [fake_cve]}
+
+        with patch("collectors.nvd_collector.request_with_rate_limit_retries", return_value=response):
+            result = collector._fetch_cves_batch(
+                pub_start_iso="2024-01-01T00:00:00.000",
+                pub_end_iso="2024-04-30T23:59:59.999",
+                start_index=0,
+                limit=2000,
+            )
+        assert result == [fake_cve]
+
+
+# ===========================================================================
+# Fix #2 — Baseline loop aborts window on NvdBatchFetchError
+# ===========================================================================
+
+
+class TestFix2BaselineLoopAbortsWindowOnError:
+    def test_baseline_loop_catches_nvdbatchfetcherror(self):
+        """AST pin: the baseline loop must catch NvdBatchFetchError."""
+        src = (SRC / "collectors" / "nvd_collector.py").read_text()
+        # Find the baseline for loop. The try/except must be structural.
+        idx = src.find("while consecutive_empty < 3:")
+        assert idx != -1
+        # Scan forward for the try/except around _fetch_cves_batch.
+        block = src[idx : idx + 4000]
+        assert "except NvdBatchFetchError" in block, (
+            "baseline loop must catch NvdBatchFetchError to abort window without advancing checkpoint"
+        )
+        assert "[NVD-WINDOW-ABORT]" in block, (
+            "abort path must emit [NVD-WINDOW-ABORT] log marker for on-call visibility"
+        )
+
+    def test_aborted_windows_tracked_and_raised(self):
+        """Baseline must track aborted windows and raise at end if any."""
+        src = (SRC / "collectors" / "nvd_collector.py").read_text()
+        idx = src.find("aborted_windows: list = []")
+        assert idx != -1, "aborted_windows tracker must be initialized"
+        block = src[idx : idx + 6000]
+        assert "aborted_windows.append" in block, "must track aborted windows"
+        assert "raise NvdBatchFetchError" in block, (
+            "baseline must raise at end if any window aborted (fail task loudly)"
+        )
+
+    def test_checkpoint_not_advanced_on_aborted_window(self):
+        """AST pin: the ``update_source_checkpoint(..., nvd_window_idx=wi+1, ...)``
+        call at end of window MUST be conditional on ``not window_aborted``.
+        Pre-PR-N17 it was unconditional."""
+        src = (SRC / "collectors" / "nvd_collector.py").read_text()
+        idx = src.find("if not window_aborted:")
+        assert idx != -1, "the end-of-window checkpoint advance must be gated on `not window_aborted`"
+        # Confirm the advance is inside the if-block.
+        block = src[idx : idx + 600]
+        assert 'extra={"nvd_window_idx": wi + 1' in block, (
+            "advance to wi+1 must be inside the `not window_aborted` branch"
+        )
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_nvd_collector_imports(self):
+        from collectors import nvd_collector  # noqa: F401
+
+    def test_NvdBatchFetchError_is_exported(self):
+        from collectors.nvd_collector import NvdBatchFetchError
+
+        # Must be a distinct class (not `Exception` alias).
+        assert NvdBatchFetchError is not Exception


### PR DESCRIPTION
## Summary

Overnight collection-pipeline audit (2026-04-22) found a **BLOCK-severity silent-data-loss** vector in the NVD baseline loop. At 730d scale this is statistically certain to fire; pre-PR-N17 a ~10% data loss could complete "successfully" with zero alert.

## The bug (in one paragraph)

`_fetch_cves_batch` returned `[]` on ANY failure — non-200, network exception, JSON parse error — **indistinguishable from a legit empty NVD response**. The baseline loop treated 3 consecutive `[]` as "window done" and advanced the checkpoint past unfetched data. At 730d scale: 12 windows × ~50 pages = ~600 NVD API calls. Three consecutive transient errors in one window (DNS flap, 502 cluster, worker CPU starvation) looked identical to "legit end-of-window". Checkpoint advanced past the lost CVEs. Operator saw `completed: true` while entire 120-day CVE windows were missing from Neo4j.

Same class as PR-N7 `<> ''` silent-zero-edge: different layer, same silent-data-loss failure mode.

## Fix

| Change | What |
|---|---|
| New `NvdBatchFetchError` class | Distinct exception type so the baseline loop can react |
| `_fetch_cves_batch` — distinguish | 200-empty (return []) vs error (raise NvdBatchFetchError). Four error conditions covered: non-200, HTTP exception, JSON parse error, response-not-JSON |
| Baseline loop — catch + abort window | On NvdBatchFetchError: log `[NVD-WINDOW-ABORT]` with (wi, idx, date range), preserve checkpoint at current (wi, idx), record collection failure, track in `aborted_windows` |
| Checkpoint advance gated on success | End-of-window `nvd_window_idx = wi + 1` advance is now INSIDE `if not window_aborted:` — pre-PR-N17 it was unconditional (the root cause) |
| Fail-loud at end | If ANY windows aborted, baseline raises NvdBatchFetchError at end → Airflow task fails → operator sees the failure + the `[NVD-WINDOW-ABORT]` logs |

## Files

- `src/collectors/nvd_collector.py` — new `NvdBatchFetchError` class, `_fetch_cves_batch` + baseline loop refactored
- `tests/test_pr_n17_nvd_silent_window_drop.py` — 11 new regression tests (6 behavioral on `_fetch_cves_batch`, 3 AST pins on the baseline loop, 2 module sanity)

## Test plan

- [x] 11/11 PR-N17 tests pass
- [x] Full suite: 1457 passed, 3 skipped, 3 xfailed (no regressions)
- [x] ruff format + check clean
- [x] mypy clean
- [ ] Staging: deliberate transient injection (monkey-patch `request_with_rate_limit_retries` to raise on one window) to verify `[NVD-WINDOW-ABORT]` log + Airflow task failure

## Deferred to follow-up (NOT in this PR)

**HIGH: NVD baseline holds ~1-2 GB CVE dicts in memory.** Per-window push requires refactoring the collect()/transform/push flow — substantial diff risks breaking the incremental path. On 16 GB+ workers this is tolerable. Tracked for PR-N19 or later. Recommended operator check: `free -m` on Airflow worker during baseline kickoff.

## Context

Second PR of the overnight merge-+-collection audit fixes. Prior: PR-N16 (#100, merge-logic BLOCKs). Next: PR-N18 (RUNBOOK drift + observability gaps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes error handling and checkpoint advancement in the NVD baseline collector, affecting whether jobs fail or resume and how much data is ingested. A mistake here could block baselines or still skip data, so it warrants careful review and staging validation.
> 
> **Overview**
> Prevents **silent data loss** in NVD baseline collection by introducing `NvdBatchFetchError` and making `_fetch_cves_batch` *raise on non-200/HTTP exceptions/JSON parse or unexpected payload shapes* instead of returning `[]`.
> 
> Updates the baseline loop in `collect()` to catch `NvdBatchFetchError`, log `[NVD-WINDOW-ABORT]`, **preserve the current `(window_idx, startIndex)` checkpoint**, stop processing further windows to avoid overwriting that checkpoint, and re-raise so Airflow sees a hard failure rather than a status dict. Adds a dedicated regression test suite covering the new error semantics and checkpoint/exception-handling invariants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f84aa99b09646c937f6a5bc5dc937209a2780d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->