### PR TITLE
fix(audit): PR-N19 — post-baseline follow-ups from Bravo's 2026-04-22 run

### DIFF
--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -546,7 +546,28 @@ def _zone_override_global_clause(node_var: str, source_expr: str) -> str:
     # ``_dedup_concat_clause`` and tests/test_pr33_bugbot_fixes.py:2430.
     union = _dedup_concat_clause(f"{node_var}.zone", source_expr)
     specifics = f"[z IN {union} WHERE z <> 'global']"
-    return f"{node_var}.zone = CASE WHEN size({specifics}) > 0 THEN {specifics} ELSE {union} END"
+    # PR-N19 Fix #2 (post-baseline 2026-04-22, from Bravo's baseline-run
+    # audit): wrap the final zone expression in ``apoc.coll.sort`` to
+    # guarantee canonical ordering across writes. Pre-PR-N19,
+    # ``apoc.coll.toSet`` dedup'd exact-string entries but did NOT
+    # sort, so two nodes seeing the same zones in different ingest
+    # order produced different ``n.zone`` arrays:
+    #   Node A: ["healthcare", "energy"]  (count=1)
+    #   Node B: ["energy", "healthcare"]  (count=448)
+    # ``MATCH (n) RETURN n.zone, count(n)`` groups by exact array
+    # equality → fragmented sector stats + unstable STIX export
+    # (any consumer hashing the zone array saw duplicate "sectors").
+    #
+    # Fix: canonical alphabetic sort at write time. Existing legacy
+    # nodes can be repaired with one-shot Cypher migration:
+    #   MATCH (n) WHERE n.zone IS NOT NULL
+    #   SET n.zone = apoc.coll.sort(apoc.coll.toSet(n.zone))
+    # documented in docs/RUNBOOK.md.
+    return (
+        f"{node_var}.zone = CASE WHEN size({specifics}) > 0 "
+        f"THEN apoc.coll.sort({specifics}) "
+        f"ELSE apoc.coll.sort({union}) END"
+    )
 
 
 # --------------------------------------------------------------------------- #
@@ -2353,6 +2374,23 @@ class Neo4jClient:
             extra_props["severity"] = data["severity"]
         if data.get("attack_vector"):
             extra_props["attack_vector"] = data["attack_vector"]
+        # PR-N19 Fix #1 (post-baseline 2026-04-22, from Bravo's
+        # baseline-run audit): promote NVD ``published`` +
+        # ``last_modified`` to node properties. Pre-PR-N19 the data
+        # was correctly rehydrated from NVD_META into
+        # ``item["published"]`` / ``item["last_modified"]``
+        # (``run_misp_to_neo4j.py:2487-2488``) but this extra_props
+        # builder never included them — so ``c.published`` and
+        # ``c.last_modified`` stayed NULL on every NVD CVE. Only
+        # ``c.first_imported_at`` (the EdgeGuard DB-local fact) had
+        # a date. The ResilMesh-native ``merge_resilmesh_cve`` at
+        # L5051 correctly writes both; the MISP-sourced path (the
+        # one used for the 99,664 CVEs in the 2026-04-22 baseline)
+        # did not. Fixes the gap Bravo caught.
+        if data.get("published"):
+            extra_props["published"] = data["published"]
+        if data.get("last_modified"):
+            extra_props["last_modified"] = data["last_modified"]
 
         ok = self.merge_node_with_source("CVE", key_props, data, source_id, extra_props=extra_props or None)
         if not ok:

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -3066,9 +3066,26 @@ class MISPToNeo4jSync:
                 for vuln in rich_vulns:
                     src = vuln.get("tag", "misp")
                     try:
-                        self.neo4j.merge_cve(vuln, source_id=src)
-                        success += 1
-                        self.stats["vulnerabilities_synced"] += 1
+                        # PR-N19 Fix #3 follow-up: pre-PR-N19 this loop
+                        # did not check merge_cve's return value —
+                        # CVEs that silently failed via return-False
+                        # (e.g. unresolvable cve_id) were counted as
+                        # success. Mirrors the plain_vulns loop below.
+                        if self.neo4j.merge_cve(vuln, source_id=src):
+                            success += 1
+                            self.stats["vulnerabilities_synced"] += 1
+                        else:
+                            cve_id = (
+                                resolve_vulnerability_cve_id(vuln) or vuln.get("cve_id") or vuln.get("value") or "?"
+                            )
+                            logger.warning(
+                                "[MERGE-RETURNED-FALSE] rich CVE %s source=%s — merge_cve returned False. "
+                                "Likely cause: resolve_vulnerability_cve_id returned falsy (missing/empty "
+                                "cve_id), or the underlying merge_node_with_source hit a terminal error.",
+                                str(cve_id)[:30],
+                                src,
+                            )
+                            errors += 1
                     except Exception as e:
                         logger.warning(
                             "merge_cve error for %s: %s",
@@ -3089,6 +3106,20 @@ class MISPToNeo4jSync:
                             self.stats["vulnerabilities_synced"] += 1
                             success += 1
                         else:
+                            # PR-N19 Fix #3 (post-baseline 2026-04-22, from
+                            # Bravo's report): identify which CVE failed so
+                            # the operator can trace the "N merge/load errors"
+                            # summary to specific entities. Pre-PR-N19 the
+                            # count was anonymous — the "4 errors" mystery
+                            # in Event 3 was exactly this.
+                            cve_id = (vuln.get("cve_id") or vuln.get("value") or "?")[:30]
+                            logger.warning(
+                                "[MERGE-RETURNED-FALSE] plain CVE %s source=%s — merge_cve returned False. "
+                                "Likely cause: resolve_vulnerability_cve_id returned falsy, or "
+                                "merge_node_with_source hit a terminal error. See earlier logs.",
+                                cve_id,
+                                src,
+                            )
                             errors += 1
                     except Exception as e:
                         # PR-G1 Bug Hunter audit (HIGH): defensive ``or``
@@ -3109,6 +3140,14 @@ class MISPToNeo4jSync:
                         self.stats["tactics_synced"] += 1
                         success += 1
                     else:
+                        # PR-N19 Fix #3: identify the tactic on merge-returned-False.
+                        tactic_id = (tactic.get("mitre_id") or tactic.get("name") or "?")[:30]
+                        logger.warning(
+                            "[MERGE-RETURNED-FALSE] Tactic %s source=%s — merge_tactic returned False. "
+                            "Likely cause: missing/empty mitre_id (PR-N13 None-guard), or terminal Neo4j error.",
+                            tactic_id,
+                            source_id,
+                        )
                         errors += 1
                 except Exception as e:
                     logger.warning(f"Error syncing tactic: {e}")
@@ -3124,6 +3163,14 @@ class MISPToNeo4jSync:
                         self.stats["techniques_synced"] += 1
                         success += 1
                     else:
+                        # PR-N19 Fix #3: identify the technique on merge-returned-False.
+                        tech_id = (technique.get("mitre_id") or technique.get("name") or "?")[:30]
+                        logger.warning(
+                            "[MERGE-RETURNED-FALSE] Technique %s source=%s — merge_technique returned False. "
+                            "Likely cause: missing/empty mitre_id (PR-N13 None-guard), or terminal Neo4j error.",
+                            tech_id,
+                            source_id,
+                        )
                         errors += 1
                 except Exception as e:
                     logger.warning(f"Error syncing technique: {e}")
@@ -3139,6 +3186,15 @@ class MISPToNeo4jSync:
                         self.stats["malware_synced"] += 1
                         success += 1
                     else:
+                        # PR-N19 Fix #3: identify the malware on merge-returned-False.
+                        m_name = (malware.get("name") or "?")[:30]
+                        logger.warning(
+                            "[MERGE-RETURNED-FALSE] Malware %s source=%s — merge_malware returned False. "
+                            "Likely cause: placeholder-name reject (PR-N10 _REJECTED_PLACEHOLDER_NAMES), "
+                            "or terminal Neo4j error.",
+                            m_name,
+                            source_id,
+                        )
                         errors += 1
                 except Exception as e:
                     logger.warning(f"Error syncing malware: {e}")
@@ -3154,6 +3210,14 @@ class MISPToNeo4jSync:
                         self.stats["actors_synced"] += 1
                         success += 1
                     else:
+                        # PR-N19 Fix #3: identify the actor on merge-returned-False.
+                        a_name = (actor.get("name") or "?")[:30]
+                        logger.warning(
+                            "[MERGE-RETURNED-FALSE] ThreatActor %s source=%s — merge_actor returned False. "
+                            "Likely cause: placeholder-name reject (PR-N10), or terminal Neo4j error.",
+                            a_name,
+                            source_id,
+                        )
                         errors += 1
                 except Exception as e:
                     # PR-G1 Bug Hunter audit (HIGH): ``or`` chain guards
@@ -3175,6 +3239,14 @@ class MISPToNeo4jSync:
                         self.stats["tools_synced"] += 1
                         success += 1
                     else:
+                        # PR-N19 Fix #3: identify the tool on merge-returned-False.
+                        t_id = (tool.get("mitre_id") or tool.get("name") or "?")[:30]
+                        logger.warning(
+                            "[MERGE-RETURNED-FALSE] Tool %s source=%s — merge_tool returned False. "
+                            "Likely cause: missing/empty mitre_id (PR-N13 None-guard), or terminal Neo4j error.",
+                            t_id,
+                            source_id,
+                        )
                         errors += 1
                 except Exception as e:
                     # PR-G1 Bug Hunter audit (HIGH): ``or`` chain guards
@@ -4026,8 +4098,15 @@ class MISPToNeo4jSync:
                 record_collection_success("misp_to_neo4j")
 
             if total_errors != 0:
+                # PR-N19 Fix #3: point operators at the new [MERGE-RETURNED-FALSE]
+                # grep token so the "N errors" summary is traceable to specific
+                # entities. Pre-PR-N19 the message said "see logs above" but no
+                # per-entity log actually existed for return-False cases —
+                # only for thrown exceptions. Fixed Bravo's "4 mystery errors".
                 self._last_sync_failure_reason = (
-                    f"sync_to_neo4j reported {total_errors} merge/load error(s); see logs above"
+                    f"sync_to_neo4j reported {total_errors} merge/load error(s); "
+                    "grep '[MERGE-RETURNED-FALSE]' or '[MERGE-REJECT]' in the logs above for "
+                    "per-entity detail (CVE id / Malware name / Actor name / MITRE id)"
                 )
 
             return total_errors == 0

--- a/tests/test_pr33_bugbot_fixes.py
+++ b/tests/test_pr33_bugbot_fixes.py
@@ -2583,16 +2583,27 @@ def test_zone_clause_semantic_matrix_via_ephemeral_cypher():
 
     # The ELSE branch must be the full union (including 'global' if that's
     # all we have) — otherwise a legitimate ['global']-only node would lose
-    # its zone on merge.
-    else_pattern = r"ELSE apoc\.coll\.toSet\(coalesce\(n\.zone, \[\]\) \+ \$zone\) END"
+    # its zone on merge. PR-N19 Fix #2 wraps both branches in
+    # ``apoc.coll.sort(...)`` for canonical ordering; the underlying union
+    # expression must still appear intact inside the sort wrapper.
+    else_pattern = r"ELSE apoc\.coll\.sort\(apoc\.coll\.toSet\(coalesce\(n\.zone, \[\]\) \+ \$zone\)\) END"
     assert re.search(else_pattern, clause), (
-        "ELSE branch must preserve the full union — otherwise global-only nodes would be emptied"
+        "ELSE branch must preserve the full union (wrapped in apoc.coll.sort per PR-N19 Fix #2) "
+        "— otherwise global-only nodes would be emptied"
     )
 
     # And the condition must be strictly greater than zero (so an empty
     # specifics set falls through to ELSE).
     assert "size(" in clause and "> 0" in clause, (
         "CASE condition must be ``size(specifics) > 0`` — not ``>= 1`` or negation"
+    )
+
+    # PR-N19 Fix #2: both branches must be wrapped in apoc.coll.sort() so
+    # two nodes seeing the same zones in different ingest order produce
+    # the same canonical array (eliminates the fragmented-sector-stats bug
+    # Bravo caught in the 2026-04-22 baseline).
+    assert clause.count("apoc.coll.sort(") >= 2, (
+        "both CASE branches must be wrapped in apoc.coll.sort() for canonical ordering (PR-N19 Fix #2)"
     )
 
 

--- a/tests/test_pr_n19_baseline_followups.py
+++ b/tests/test_pr_n19_baseline_followups.py
@@ -1,0 +1,245 @@
+"""
+PR-N19 — post-baseline follow-up bundle from Bravo's baseline-run audit.
+
+The 2026-04-22 baseline (ran before PR #100/#101/#102 merged) surfaced
+three bugs that none of the overnight PRs covered. Bravo ran sample
+Cypher queries and noticed:
+
+1. **CVE dates missing.** Every CVE in Neo4j had ``first_imported_at``
+   set but ``published`` and ``last_modified`` were NULL — even for
+   recent NVD-sourced CVEs that clearly had these fields upstream.
+
+2. **Zone array duplicate combos.** ``MATCH (n) RETURN n.zone, count(n)``
+   returned fragmented stats: ``["healthcare","energy"]`` and
+   ``["energy","healthcare"]`` showed as different groups because
+   Cypher groups by exact array equality.
+
+3. **"4 merge/load error(s)" with no per-entity detail.** When
+   ``_sync_single_item``'s merge_* calls returned False (not threw),
+   only the count was incremented — no log line naming which CVE /
+   Malware / Actor / MITRE id was rejected. The "see logs above"
+   hint in the summary pointed at nothing.
+
+## Fix #1 — merge_cve promotes published + last_modified
+
+``merge_cve`` (the MISP-sourced CVE path used for 99,664 CVEs in the
+baseline) built its ``extra_props`` dict with description, cvss_score,
+severity, attack_vector, cisa_*... but NEVER included the NVD date
+fields. The data flowed: NVD collector → NVD_META → MISP comment →
+run_misp_to_neo4j rehydration into ``item["published"]`` /
+``item["last_modified"]`` — then was dropped on the floor by the
+extra_props builder. The ResilMesh-native ``merge_resilmesh_cve``
+correctly wrote both; the MISP path didn't.
+
+Fix: 4 lines in ``merge_cve`` extra_props builder to promote both
+fields when present.
+
+## Fix #2 — canonical sort on zone arrays
+
+``_zone_override_global_clause`` built the accumulator via
+``apoc.coll.toSet(coalesce(n.zone, []) + new_zone)`` which dedupes
+exact-string entries but does NOT sort. Two nodes seeing the same
+zones in different ingest order ended up with different arrays:
+
+  Node A: n.zone = ["healthcare", "energy"]  (count=1)
+  Node B: n.zone = ["energy", "healthcare"]  (count=448)
+
+Cypher grouping by exact array equality treated them as different,
+fragmenting sector stats. Also broke any STIX-export consumer that
+hashed the zone array — same logical zones produced different hashes.
+
+Fix: wrap the union + specifics in ``apoc.coll.sort(...)`` so all
+writes produce canonical alphabetic ordering. One-shot Cypher
+migration for pre-PR-N19 legacy data (documented in PR body).
+
+## Fix #3 — per-entity logging on merge-returned-False
+
+Six call sites in ``_sync_single_item`` incremented ``errors`` on
+merge_* returning False with no log line:
+  - merge_cve (rich_vulns + plain_vulns)
+  - merge_tactic / merge_technique / merge_tool
+  - merge_malware / merge_actor
+
+Now each site emits ``[MERGE-RETURNED-FALSE]`` WARN with the entity
+identifier (cve_id / mitre_id / name). The summary error message at
+the end of ``run()`` points operators at the new grep token.
+
+Bonus: the ``rich_vulns`` loop used to discard merge_cve's return
+value entirely — CVEs that silently failed were counted as success.
+Fixed to match the ``plain_vulns`` shape.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n19")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n19")
+
+
+# ===========================================================================
+# Fix #1 — merge_cve promotes published + last_modified
+# ===========================================================================
+
+
+class TestFix1CvePublishedLastModified:
+    def test_merge_cve_extra_props_includes_published(self):
+        """AST pin: merge_cve must conditionally add 'published' to extra_props."""
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef):
+                for node in cls.body:
+                    if isinstance(node, ast.FunctionDef) and node.name == "merge_cve":
+                        body = ast.unparse(node)
+                        assert 'extra_props["published"]' in body or "extra_props['published']" in body, (
+                            "merge_cve must promote data['published'] to extra_props "
+                            "(PR-N19 Fix #1; Bravo caught NULL c.published on 99K CVEs)"
+                        )
+                        return
+        raise AssertionError("merge_cve not found")
+
+    def test_merge_cve_extra_props_includes_last_modified(self):
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef):
+                for node in cls.body:
+                    if isinstance(node, ast.FunctionDef) and node.name == "merge_cve":
+                        body = ast.unparse(node)
+                        assert 'extra_props["last_modified"]' in body or "extra_props['last_modified']" in body, (
+                            "merge_cve must promote data['last_modified'] to extra_props (PR-N19 Fix #1)"
+                        )
+                        return
+        raise AssertionError("merge_cve not found")
+
+    def test_merge_cve_behavior_promotes_both_fields(self):
+        """Behavioral pin: invoke merge_cve with data containing
+        published + last_modified; confirm both reach extra_props via
+        merge_node_with_source mock."""
+        from neo4j_client import Neo4jClient
+
+        c = Neo4jClient.__new__(Neo4jClient)
+        c.driver = MagicMock()
+        c.merge_node_with_source = MagicMock(return_value=True)
+
+        data = {
+            "cve_id": "CVE-2021-44228",
+            "description": "Log4Shell",
+            "cvss_score": 10.0,
+            "severity": "CRITICAL",
+            "published": "2021-12-10T10:15:09.143",
+            "last_modified": "2024-04-03T17:02:49.887",
+        }
+        assert c.merge_cve(data) is True
+        # Inspect the extra_props passed to merge_node_with_source.
+        call_kwargs = c.merge_node_with_source.call_args.kwargs
+        extra_props = call_kwargs.get("extra_props", {})
+        assert extra_props.get("published") == "2021-12-10T10:15:09.143", (
+            f"merge_cve must pass published to extra_props; got {extra_props.get('published')!r}"
+        )
+        assert extra_props.get("last_modified") == "2024-04-03T17:02:49.887"
+
+
+# ===========================================================================
+# Fix #2 — zone array canonical sort
+# ===========================================================================
+
+
+class TestFix2ZoneCanonicalSort:
+    def test_zone_clause_wraps_in_apoc_coll_sort(self):
+        """The generated Cypher must wrap the zone expression in
+        apoc.coll.sort() for canonical ordering across writes."""
+        from neo4j_client import _zone_override_global_clause
+
+        clause = _zone_override_global_clause("n", "$zone")
+        assert "apoc.coll.sort(" in clause, (
+            "_zone_override_global_clause must canonicalize zone ordering "
+            "via apoc.coll.sort to eliminate duplicate-combo bug "
+            "(['healthcare','energy'] vs ['energy','healthcare']). PR-N19 Fix #2."
+        )
+        # Both branches of the CASE (specifics + union-only) must sort.
+        # Count: we expect at least 2 apoc.coll.sort calls in the clause
+        # (one for the specifics-branch, one for the else-union-branch).
+        assert clause.count("apoc.coll.sort(") >= 2, (
+            "both CASE branches (specifics-branch + else-union-branch) must be sorted"
+        )
+
+    def test_zone_clause_preserves_drop_global_semantics(self):
+        """Regression pin: the specifics-override-global rule (PR-N6/N8
+        behaviour) must be preserved under the new sort wrapping."""
+        from neo4j_client import _zone_override_global_clause
+
+        clause = _zone_override_global_clause("n", "$zone")
+        assert "z <> 'global'" in clause, "specifics filter must still exclude 'global' when other sectors are present"
+        assert "CASE WHEN size(" in clause
+
+
+# ===========================================================================
+# Fix #3 — per-entity logging on merge-returned-False
+# ===========================================================================
+
+
+class TestFix3PerEntityMergeFalseLogging:
+    def _src(self) -> str:
+        return (REPO_ROOT / "src" / "run_misp_to_neo4j.py").read_text()
+
+    def test_plain_cve_logs_cve_id_on_false(self):
+        src = self._src()
+        assert "[MERGE-RETURNED-FALSE] plain CVE" in src, (
+            "plain CVE branch must emit [MERGE-RETURNED-FALSE] on return-False"
+        )
+
+    def test_rich_cve_checks_return_value_and_logs(self):
+        """Regression pin: pre-PR-N19 the rich_vulns loop did NOT check
+        merge_cve's return — silent failures counted as success."""
+        src = self._src()
+        assert "[MERGE-RETURNED-FALSE] rich CVE" in src, (
+            "rich CVE branch must now check merge_cve return + emit "
+            "[MERGE-RETURNED-FALSE] on false (PR-N19 Fix #3 follow-up)"
+        )
+        # Confirm it uses if-check (the specific fix shape).
+        assert "if self.neo4j.merge_cve(vuln, source_id=src):" in src
+
+    def test_tactic_technique_tool_log_on_false(self):
+        src = self._src()
+        for label in ["Tactic", "Technique", "Tool"]:
+            assert f"[MERGE-RETURNED-FALSE] {label} " in src, (
+                f"{label} branch must emit [MERGE-RETURNED-FALSE] on return-False"
+            )
+
+    def test_malware_actor_log_on_false(self):
+        src = self._src()
+        assert "[MERGE-RETURNED-FALSE] Malware " in src
+        assert "[MERGE-RETURNED-FALSE] ThreatActor " in src
+
+    def test_sync_summary_points_at_new_grep_token(self):
+        """The ``_last_sync_failure_reason`` message must point operators
+        at the new [MERGE-RETURNED-FALSE] / [MERGE-REJECT] tokens so
+        the error count becomes traceable."""
+        src = self._src()
+        assert "[MERGE-RETURNED-FALSE]" in src and "grep" in src and "MERGE-REJECT" in src, (
+            "sync failure-reason message must reference the grep tokens operators need to trace errors"
+        )
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_neo4j_client_imports(self):
+        import neo4j_client  # noqa: F401
+
+    def test_run_misp_to_neo4j_imports(self):
+        import run_misp_to_neo4j  # noqa: F401


### PR DESCRIPTION
## Summary

Post-baseline follow-up bundle surfacing **3 bugs from Bravo Vanko's 2026-04-22 baseline run** (the run that preceded the PR #100 / #101 / #102 merge train). None of the overnight PRs covered these because they were discovered only after Bravo ran sample Cypher queries over the resulting graph.

- **Fix #1**: `merge_cve` now promotes `published` + `last_modified` to `extra_props` (was silently dropped; 99,664 baseline CVEs had `c.published = NULL`)
- **Fix #2**: `_zone_override_global_clause` wraps both CASE branches in `apoc.coll.sort(...)` for canonical ordering (fragmented-sector-stats bug: `['healthcare','energy']` and `['energy','healthcare']` counted as different groups)
- **Fix #3**: Six `_sync_single_item` sites now emit `[MERGE-RETURNED-FALSE]` WARN with the entity identifier when `merge_*` returns False (baseline summary said "4 merge/load error(s)" with no per-entity detail). Bonus: the `rich_vulns` loop used to discard `merge_cve`'s return value entirely — silent failures counted as success. Fixed.

## Context (Bravo's Slack thread)

> The 2026-04-22 baseline ran cleanly at the sync layer, but three adjacent problems showed up in the graph itself:
>
> 1. **CVE dates missing** — every CVE had `first_imported_at` but `published` and `last_modified` were NULL, even for recent NVD-sourced CVEs that clearly had these fields upstream.
> 2. **Zone array duplicate combos** — `MATCH (n) RETURN n.zone, count(n)` returned fragmented stats because Cypher groups by exact array equality.
> 3. **"4 merge/load error(s)" with no per-entity detail** — when `_sync_single_item`'s `merge_*` calls returned False (not threw), only the count was incremented. "See logs above" pointed at nothing.

## Why these slipped through the overnight PRs

- PR-N15/N16 targeted the Neo4j session-retry + error-classifier path. They catch thrown exceptions, not clean `return False` returns. Fix #3 closes the observability hole.
- PR-N17 targeted the NVD silent-window-drop at the collector layer, not MISP-rehydration-side field mapping. Fix #1 closes the MISP-sourced CVE field gap.
- PR-N18 consolidated the RUNBOOK + observability. It didn't re-audit the per-merge Cypher generator. Fix #2 closes the zone-ordering write-time contract.

## Test plan

- [x] 12 new regression pins: `tests/test_pr_n19_baseline_followups.py`
  - AST pins for `merge_cve` extra_props (`published`, `last_modified`)
  - Behavioral pin for `merge_cve` with `MagicMock(merge_node_with_source)`
  - Shape pins for `apoc.coll.sort(` wrapping both CASE branches
  - Source-grep pins for `[MERGE-RETURNED-FALSE]` at six call sites + `rich_vulns` if-check shape + summary grep token
- [x] Pre-existing shape-pin (`test_zone_clause_semantic_matrix_via_ephemeral_cypher`) updated to accept the new `apoc.coll.sort(...)` wrap — regression pin for legacy-shape removal
- [x] Full suite: **1512 passed, 3 skipped, 3 xfailed** in 219s
- [x] `ruff format --check src/ tests/` — 158 files clean
- [x] `ruff check src/ tests/` — all checks passed
- [x] `mypy src/` — exit 0

## Operator notes

Legacy nodes with unsorted `n.zone` arrays can be repaired post-deploy with a one-shot migration (documented inline in the clause comment):
```cypher
MATCH (n) WHERE n.zone IS NOT NULL
SET n.zone = apoc.coll.sort(apoc.coll.toSet(n.zone))
```

After deploy, grep tokens for tracing merge errors:
```bash
docker compose logs run_misp_to_neo4j | grep -E '\[MERGE-RETURNED-FALSE\]|\[MERGE-REJECT\]'
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates Neo4j write-time property generation and CVE node properties, which can change stored graph data and downstream query results. Logging/control-flow changes in the MISP→Neo4j sync loop may alter success/error counts and operational behavior.
> 
> **Overview**
> Fixes a baseline data-quality gap by having `merge_cve` persist NVD `published` and `last_modified` onto `:CVE` nodes (previously dropped in the MISP-sourced path).
> 
> Canonicalizes `zone` arrays at write time by wrapping `_zone_override_global_clause` results in `apoc.coll.sort(...)`, preventing logically-identical zone sets with different ingest order from being stored as distinct arrays.
> 
> Improves sync observability and accounting in `run_misp_to_neo4j`: the rich-CVE loop now checks `merge_cve`’s return value, and multiple `merge_*` call sites emit `[MERGE-RETURNED-FALSE]` warnings with entity identifiers; the final error summary now points operators at these grep tokens. Tests are updated/added to pin the new Cypher shape and logging behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 73553a440a831e4f5d0f257dd9e8efd04b5e9b48. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->