### PR TITLE
fix(audit): PR-N20 — 730d baseline launch procedure + preflight + follow-ups

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,6 +415,11 @@ docker compose up -d
 #    Quick 7-day smoke test: set EDGEGUARD_BASELINE_DAYS=7 and
 #      EDGEGUARD_BASELINE_COLLECTION_LIMIT=1000 in .env, restart airflow, then trigger.
 #      See docs/BASELINE_SMOKE_TEST.md
+#
+#    ⚠️  IMPORTANT — before you trigger the 730-day baseline, read the
+#        "Running the 730-day baseline" section below. The DAG path
+#        requires pausing 4 incremental DAGs first (Issue #57). The
+#        CLI path handles this automatically — see Option A below.
 
 # 3. Incremental cron DAGs start automatically after baseline:
 #    edgeguard_pipeline    → every 30 min  (OTX)
@@ -459,6 +464,110 @@ edgeguard version             # release CalVer + git short SHA (no .env)
 ```
 
 Release numbering uses **calendar versions** (`YYYY.M.D` in `pyproject.toml`). See [`docs/VERSIONING.md`](docs/VERSIONING.md).
+
+---
+
+## 🚀 Running the 730-day baseline
+
+The 730-day baseline ingests ~2 years of threat intelligence (~99K CVEs, ~115K indicators, ~350K nodes, ~700K relationships) in a single ~26-hour run. This section tells you **what to run, why, and which option to pick** — if you get the launch path wrong, you can lose data like the 2026-04-19 NVD-14.7% incident.
+
+### Why the launch path matters
+
+The Airflow `edgeguard_baseline` DAG does **not** currently acquire the in-process `baseline_lock` sentinel ([Issue #57](https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/issues/57)). Over the ~26h window, the 4 scheduled incremental DAGs (`edgeguard_daily`, `edgeguard_medium_freq`, `edgeguard_pipeline`, `edgeguard_low_freq`) will try to write to MISP + Neo4j in parallel with the baseline. That concurrent-writer pattern caused the 2026-04-19 MISP-PHP-FPM exhaustion and lost 14.7% of NVD data mid-run. Three regression xfails in `tests/test_tier1_sequential_robustness.py` pin this contract until the DB-backed mutex ships.
+
+**Until Issue #57 lands, pick one of the two safe launch paths below.** The decision is not optional — both are documented in depth in [`docs/RUNBOOK.md`](docs/RUNBOOK.md#baseline-day-protocol).
+
+### Step 1 — Preflight check
+
+Run the preflight script first. It checks 10 readiness categories in ~5 seconds:
+
+```bash
+# For the CLI launch path (Option A below)
+./scripts/preflight_baseline.sh --launch-path=cli
+
+# For the DAG launch path (Option B below) — adds DAG-pause state verification
+./scripts/preflight_baseline.sh --launch-path=dag
+```
+
+Exit 0 = safe to launch. Exit 1 = read the ✗ items and fix them first. The script verifies: required env vars, Neo4j + APOC reachability, MISP API auth, Airflow DAG pause state (if `--launch-path=dag`), worker RAM ≥ 4 GB, Prometheus alerts parse, no stale `baseline_lock` sentinel, kill-switch defaults, pytest collection.
+
+### Step 2 — Pick your launch path
+
+#### Option A — CLI (recommended)
+
+The CLI path takes the in-process `baseline_lock` sentinel (`src/run_pipeline.py:1093`). Every scheduled DAG's `baseline_skip_reason()` check then returns a reason → they self-skip for the baseline's duration. **No manual DAG pausing needed.**
+
+```bash
+docker compose exec -T airflow-worker python -m edgeguard baseline --days 730
+```
+
+Or the fresh-baseline shape (wipes existing Neo4j data first — use for a clean re-baseline):
+
+```bash
+docker compose exec -T airflow-worker python -m edgeguard fresh-baseline --days 730
+```
+
+Confirm the sentinel is present mid-run:
+
+```bash
+docker compose exec airflow-worker ls /tmp/edgeguard/baseline_lock.sentinel
+# expected: file exists while baseline runs; auto-removed on completion
+```
+
+#### Option B — DAG + pre-pause the 4 incremental schedulers
+
+If you need the Airflow UI for operational reasons (monitoring, manual retry buttons, etc.), pause the 4 scheduled DAGs first so they can't fire during the ~26h window:
+
+```bash
+# 1. Pause all 4 incremental DAGs BEFORE triggering the baseline
+for dag in edgeguard_daily edgeguard_medium_freq edgeguard_pipeline edgeguard_low_freq; do
+  docker compose exec airflow-worker airflow dags pause "$dag"
+done
+
+# 2. Trigger the baseline
+docker compose exec airflow-worker airflow dags trigger edgeguard_baseline
+
+# 3. AFTER the baseline_complete task fires (check Airflow UI), unpause all 4
+for dag in edgeguard_daily edgeguard_medium_freq edgeguard_pipeline edgeguard_low_freq; do
+  docker compose exec airflow-worker airflow dags unpause "$dag"
+done
+```
+
+### Step 3 — Monitor during the run
+
+- **Prometheus**: watch the 6 `edgeguard_pipeline_observability` alerts. Any **critical** alert → pause the DAG, triage, resume.
+- **Logs**: `docker logs edgeguard-airflow-worker 2>&1 --follow | grep -vE 'DEBUG|INFO'`
+- **Grep tokens for silent failures**: `[MERGE-REJECT]`, `[MERGE-RETURNED-FALSE]`, `[MERGE-INEFFECTIVE]`, `[BATCH-PERMANENT-FAILURE]`, `[honest-NULL]` — each is documented in [`docs/RUNBOOK.md`](docs/RUNBOOK.md#top-6-failure-modes).
+
+### Step 4 — Post-run validation
+
+Run the 5 validation Cypher queries in [`docs/RUNBOOK.md § "After the run"`](docs/RUNBOOK.md#after-the-run). Any non-zero on queries #1–#4 means a regression — file an issue before starting incremental syncs.
+
+### Retrieving raw MISP data from a Neo4j node
+
+Every MISP-sourced node carries three back-pointers, so analysts can always trace a Neo4j finding back to the raw MISP evidence. ⚠️ Note: `n.uuid` is a deterministic UUIDv5 for cross-environment identity + STIX parity — it is **NOT** a foreign key into MISP.
+
+| Retrieval path | Neo4j field | How to use |
+|---|---|---|
+| **Attribute-level** (most granular) | `n.misp_attribute_ids[]` — real MISP attribute UUIDs | `GET /attributes/<uuid>` on the MISP API |
+| **Event-level** (coarser, per-event) | `n.misp_event_ids[]` — stringified MISP event IDs | `GET /events/<id>` on the MISP API |
+| **Raw JSON on edge** (no network call) | `(n)-[r:SOURCED_FROM]->(:Source)` with `r.raw_data` | Full pickled MISP-attribute JSON, per-source |
+
+Example — fetch raw MISP data for an Indicator seen in Neo4j:
+
+```cypher
+MATCH (i:Indicator) WHERE i.value = '203.0.113.5'
+RETURN i.misp_attribute_ids, i.misp_event_ids;
+```
+
+```bash
+curl -H "Authorization: $MISP_API_KEY" -H "Accept: application/json" \
+     "$MISP_URL/attributes/<uuid-from-query-above>"
+```
+
+Coverage: Indicator / CVE / Vulnerability / Malware / ThreatActor / Technique / Tactic / Tool all carry all three paths. Campaign is reachable via inbound edges only; Sector is a fixed vocabulary (healthcare/energy/finance/global), so no MISP back-pointer.
+
+Full coverage matrix + operator protocol in [`docs/RUNBOOK.md § "Retrieving raw MISP data from a Neo4j node"`](docs/RUNBOOK.md#retrieving-raw-misp-data-from-a-neo4j-node).
 
 ---
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -289,13 +289,93 @@ Absence of this line = silent subprocess death (the exact scenario the
 
 ## Baseline-day protocol
 
+### ⚠️ Baseline launch path — PICK ONE (CLI or DAG+pause)
+
+The 730-day baseline runs for ~26h. Over that window, the 4 scheduled
+incremental DAGs will try to write to MISP + Neo4j in parallel with the
+baseline unless you stop them. This is Issue #57 (documented in
+`docs/flow_audits/01_baseline_sequence.md` Finding 1) and was the
+underlying cause of the 2026-04-19 MISP-PHP-FPM exhaustion + 14.7%
+NVD loss. Three regression xfails pin this contract in
+`tests/test_tier1_sequential_robustness.py` — they stay failing until
+Issue #57 ships a DB-backed mutex.
+
+**Until Issue #57 lands, pick one of the two safe launch paths below.**
+
+#### Option A — CLI (recommended)
+
+The CLI path acquires an in-process `baseline_lock` sentinel
+(`src/run_pipeline.py:1093`) that makes every `baseline_skip_reason()`
+check on the scheduled DAGs return a reason — they self-skip.
+
+```bash
+docker compose exec -T airflow-worker \
+  python -m edgeguard baseline --days 730
+```
+
+Or for the fresh-baseline shape (wipes existing Neo4j data first):
+
+```bash
+docker compose exec -T airflow-worker \
+  python -m edgeguard fresh-baseline --days 730
+```
+
+Confirm the lock sentinel is present during tier-1:
+
+```bash
+docker compose exec airflow-worker ls /tmp/edgeguard/baseline_lock.sentinel
+# expect: /tmp/edgeguard/baseline_lock.sentinel  (file present while baseline runs)
+```
+
+#### Option B — DAG + pre-pause the 4 incremental schedulers
+
+If you must use the Airflow UI trigger, pause the 4 scheduled DAGs
+first so they cannot fire during the ~26h window:
+
+```bash
+docker compose exec airflow-worker airflow dags pause edgeguard_daily
+docker compose exec airflow-worker airflow dags pause edgeguard_medium_freq
+docker compose exec airflow-worker airflow dags pause edgeguard_pipeline
+docker compose exec airflow-worker airflow dags pause edgeguard_low_freq
+
+# trigger the baseline
+docker compose exec airflow-worker airflow dags trigger edgeguard_baseline
+
+# AFTER baseline + enrichment complete (watch the baseline_complete task):
+docker compose exec airflow-worker airflow dags unpause edgeguard_daily
+docker compose exec airflow-worker airflow dags unpause edgeguard_medium_freq
+docker compose exec airflow-worker airflow dags unpause edgeguard_pipeline
+docker compose exec airflow-worker airflow dags unpause edgeguard_low_freq
+```
+
+Alternatively, run the preflight helper which verifies the 4 DAGs are
+paused AND the MISP/Neo4j endpoints respond AND env-var prerequisites
+are satisfied before returning exit 0:
+
+```bash
+./scripts/preflight_baseline.sh
+```
+
+Exit non-zero = do NOT launch. Exit zero + green summary = safe to trigger.
+
+#### Why not both CLI + DAG?
+
+CLI delegates to the DAG via `_trigger_baseline_dag` in recent releases
+(`src/edgeguard.py:2377`) but takes the in-process lock FIRST. If you
+trigger the DAG directly without pausing, nothing takes the lock →
+incrementals race.
+
+---
+
 ### Before a 730d baseline run
 
-1. **Smoke test.** Run a 7-day window first (`baseline=True, baseline_days=7`
+1. **Launch path decided.** Per the section above (CLI vs DAG+pause).
+2. **Preflight green.** `./scripts/preflight_baseline.sh` returns exit 0.
+3. **Smoke test.** Run a 7-day window first (`baseline=True, baseline_days=7`
    in the baseline DAG config). Success criteria: no ERROR lines, all
    6 pre-baseline alerts green, spot-check 10 random Indicators via
    Neo4j Browser or `graphql_api`.
-2. **Prometheus rules loaded.** Verify the `edgeguard_pipeline_observability`
+4. **Prometheus rules loaded.** Verify the `edgeguard_pipeline_observability`
    rule group has all 8 alerts (4 from PR-N11/N12 + 2 added in PR-N18 +
    2 Bravo-ops added in PR-N21):
    ```bash
@@ -303,13 +383,13 @@ Absence of this line = silent subprocess death (the exact scenario the
    curl -s localhost:9090/api/v1/rules | \
      jq '.data.groups[] | select(.name=="edgeguard_pipeline_observability") | .rules[].name'
    ```
-3. **Alert paging destinations confirmed.** Test that each alert
+5. **Alert paging destinations confirmed.** Test that each alert
    actually reaches the on-call pager/inbox. Manual metric injection:
    `curl -X POST localhost:9091/metrics/job/manual -d 'edgeguard_neo4j_batch_permanent_failure_total{label="test",source="test",reason="test"} 1'`
-4. **Worker RAM sized.** NVD baseline holds ~1-2 GB of CVE dicts in
+6. **Worker RAM sized.** NVD baseline holds ~1-2 GB of CVE dicts in
    memory (HIGH gap tracked for follow-up). Ensure `airflow-worker`
    container has ≥ 4 GB RAM: `docker inspect edgeguard-airflow-worker | grep -i mem`.
-5. **Kill-switches staged.** Decide in advance what signal would make
+7. **Kill-switches staged.** Decide in advance what signal would make
    you set each:
    - `EDGEGUARD_RESPECT_CALIBRATOR=0` → if edges flap confidence 0.3 ↔ 0.8 nightly (PR-N10 Fix #2 regression signal).
    - `EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION=1` → if `_record_batch_counters` raises persistently in logs.
@@ -359,6 +439,87 @@ RETURN label, c ORDER BY c DESC;
 ```
 
 Any non-zero on #1–#4 = regression; file issue.
+
+---
+
+## Retrieving raw MISP data from a Neo4j node
+
+Three complementary retrieval paths exist for every MISP-sourced node
+(Indicator, CVE, Vulnerability, Malware, ThreatActor, Technique,
+Tactic, Tool). Use whichever fits your consumer.
+
+### ⚠️ `n.uuid` is NOT the MISP link
+
+`n.uuid` is a **deterministic UUIDv5** computed from `(label, natural_key)`
+(`src/node_identity.py:compute_node_uuid`). It's stable across
+environments (local vs cloud Neo4j produce the same `n.uuid` for the
+same logical entity) and has **STIX parity** (the UUID portion of a
+STIX SDO id equals `n.uuid`). It is NOT a foreign key into MISP.
+
+### Path 1 — MISP attribute UUID (most granular)
+
+Every MISP-sourced node carries `n.misp_attribute_ids[]` — the real
+MISP attribute UUID(s) captured at ingest
+(`src/run_misp_to_neo4j.py:2311`).
+
+```cypher
+MATCH (i:Indicator) WHERE i.value = '203.0.113.5'
+RETURN i.misp_attribute_ids;
+// returns e.g. ['5f8d-abcd-...', '61b2-efgh-...']
+```
+
+Fetch raw attribute JSON from MISP:
+
+```bash
+curl -H "Authorization: $MISP_API_KEY" \
+     -H "Accept: application/json" \
+     "$MISP_URL/attributes/5f8d-abcd-..."
+```
+
+### Path 2 — MISP event ID (coarser, per-event context)
+
+`n.misp_event_ids[]` carries stringified MISP event IDs.
+
+```cypher
+MATCH (i:Indicator) WHERE i.value = '203.0.113.5'
+RETURN i.misp_event_ids;
+// returns e.g. ['12345', '12678']
+
+MATCH ()-[r:INDICATES]->(:Malware {name: 'Cobalt Strike'})
+RETURN r.misp_event_ids LIMIT 10;
+```
+
+Fetch the event (contains all related attributes):
+
+```bash
+curl -H "Authorization: $MISP_API_KEY" \
+     "$MISP_URL/events/12345"
+```
+
+### Path 3 — Raw MISP JSON on SOURCED_FROM edge (no network call)
+
+Every per-source ingest carries the raw MISP attribute JSON pickled
+into `r.raw_data` on the `SOURCED_FROM` edge
+(`src/neo4j_client.py:_upsert_sourced_relationship`). Useful when you
+need the original payload without a round-trip to MISP.
+
+```cypher
+MATCH (i:Indicator)-[r:SOURCED_FROM]->(:Source {source_id: 'otx'})
+WHERE i.value = '203.0.113.5'
+RETURN r.raw_data LIMIT 1;
+```
+
+### Coverage
+
+| Node label | Attribute UUID | Event IDs | Raw JSON on edge |
+|---|:-:|:-:|:-:|
+| Indicator | ✅ | ✅ | ✅ |
+| CVE / Vulnerability | ✅ | ✅ | ✅ |
+| Malware | ✅ | ✅ | ✅ |
+| ThreatActor | ✅ | ✅ | ✅ |
+| Technique / Tactic / Tool | ✅ | ✅ | ✅ |
+| Campaign | via inbound edges only | via inbound edges only | — |
+| Sector | — (fixed vocab) | — | — |
 
 ---
 

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -83,11 +83,17 @@ esac
 # [1] required env vars present
 # -----------------------------------------------------------------------------
 hdr "[1] required env vars"
+# NOTE (Bugbot round 1): measure ${#var_value}, not ${#var}. ${#var}
+# returns the length of the variable NAME ("NEO4J_PASSWORD" = 14 chars);
+# we want the length of the indirectly-referenced VALUE so a 40-char
+# API key actually shows 40. The copy says "value not echoed" so the
+# reported count must correspond to the value.
 for var in NEO4J_PASSWORD MISP_API_KEY MISP_URL; do
-  if [[ -z "${!var:-}" ]]; then
+  var_value="${!var:-}"
+  if [[ -z "$var_value" ]]; then
     fail "$var is not set (export it or add to .env + docker compose up -d)"
   else
-    pass "$var is set (${#var} chars — value not echoed)"
+    pass "$var is set (${#var_value} chars — value not echoed)"
   fi
 done
 

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+# -----------------------------------------------------------------------------
+# preflight_baseline.sh — pre-kickoff readiness check for 730d MISP→Neo4j baseline
+# -----------------------------------------------------------------------------
+#
+# Runs a sequence of operator-facing checks that MUST be green before you
+# trigger a 730-day baseline. Designed to catch the exact failure modes that
+# caused the 2026-04-19 MISP-PHP-FPM exhaustion + 14.7% NVD loss and the
+# 2026-04-22 NULL-CVE-date / fragmented-zone-stats issues Bravo surfaced.
+#
+# Exit code:
+#   0 = all checks green; safe to kickoff
+#   1 = one or more checks failed; DO NOT launch
+#
+# Check matrix (all are hard-fail; caveats are WARNed but do not block unless
+# EDGEGUARD_PREFLIGHT_STRICT=1):
+#
+#   [1] required env vars present (NEO4J_PASSWORD, MISP_API_KEY, MISP_URL)
+#   [2] Neo4j reachable + APOC available + baseline-critical indexes present
+#   [3] MISP API reachable + auth valid + server version ≥ 2.4
+#   [4] launch-path decision confirmed (CLI or DAG+pause) — see RUNBOOK
+#   [5] IF DAG launch path: the 4 incremental DAGs are PAUSED (Issue #57)
+#   [6] Airflow worker RAM ≥ 4 GB
+#   [7] Prometheus alerts.yml parses + edgeguard rule group loaded
+#   [8] no stale baseline_lock sentinel from a previous aborted run
+#   [9] kill-switch env vars set to safe defaults (none unexpectedly forced-on)
+#   [10] coverage gate: last full pytest run was green
+#
+# Usage:
+#   ./scripts/preflight_baseline.sh [--launch-path cli|dag]
+#   EDGEGUARD_PREFLIGHT_STRICT=1 ./scripts/preflight_baseline.sh --launch-path dag
+#
+# See docs/RUNBOOK.md § "Baseline-day protocol" for manual equivalents.
+# -----------------------------------------------------------------------------
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+cd "$ROOT"
+
+# Colors (only if stdout is a tty)
+if [ -t 1 ]; then
+  C_RED=$'\033[0;31m'; C_GRN=$'\033[0;32m'; C_YLW=$'\033[1;33m'
+  C_CYN=$'\033[0;36m'; C_OFF=$'\033[0m'
+else
+  C_RED=''; C_GRN=''; C_YLW=''; C_CYN=''; C_OFF=''
+fi
+
+pass() { printf '  %s✓%s %s\n' "$C_GRN" "$C_OFF" "$*"; }
+warn() { printf '  %s!%s %s\n' "$C_YLW" "$C_OFF" "$*" >&2; WARNINGS=$((WARNINGS+1)); }
+fail() { printf '  %s✗%s %s\n' "$C_RED" "$C_OFF" "$*" >&2; FAILURES=$((FAILURES+1)); }
+hdr()  { printf '\n%s== %s ==%s\n' "$C_CYN" "$*" "$C_OFF"; }
+
+WARNINGS=0
+FAILURES=0
+LAUNCH_PATH="${EDGEGUARD_PREFLIGHT_LAUNCH_PATH:-}"
+STRICT="${EDGEGUARD_PREFLIGHT_STRICT:-0}"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --launch-path) LAUNCH_PATH="$2"; shift 2 ;;
+    --launch-path=*) LAUNCH_PATH="${1#*=}"; shift ;;
+    --strict) STRICT=1; shift ;;
+    -h|--help)
+      sed -n '3,35p' "$0"
+      exit 0
+      ;;
+    *) fail "unknown flag: $1"; exit 1 ;;
+  esac
+done
+
+if [[ -z "${LAUNCH_PATH}" ]]; then
+  warn "no --launch-path given; assuming 'cli'. Use --launch-path=dag to enable the DAG-pause check."
+  LAUNCH_PATH="cli"
+fi
+
+case "$LAUNCH_PATH" in
+  cli|dag) ;;
+  *) fail "invalid --launch-path '$LAUNCH_PATH' (must be 'cli' or 'dag')"; exit 1 ;;
+esac
+
+# -----------------------------------------------------------------------------
+# [1] required env vars present
+# -----------------------------------------------------------------------------
+hdr "[1] required env vars"
+for var in NEO4J_PASSWORD MISP_API_KEY MISP_URL; do
+  if [[ -z "${!var:-}" ]]; then
+    fail "$var is not set (export it or add to .env + docker compose up -d)"
+  else
+    pass "$var is set (${#var} chars — value not echoed)"
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# [2] Neo4j reachable + APOC available + baseline-critical indexes present
+# -----------------------------------------------------------------------------
+hdr "[2] Neo4j reachability + indexes"
+NEO4J_URL="${NEO4J_URL:-bolt://localhost:7687}"
+if command -v docker >/dev/null 2>&1 && docker compose ps --services 2>/dev/null | grep -q neo4j; then
+  NEO4J_CMD="docker compose exec -T neo4j cypher-shell -u neo4j -p ${NEO4J_PASSWORD:-test} --format plain"
+else
+  # Fallback: assume cypher-shell is on PATH
+  NEO4J_CMD="cypher-shell -a ${NEO4J_URL} -u neo4j -p ${NEO4J_PASSWORD:-test} --format plain"
+fi
+
+if $NEO4J_CMD "RETURN 1 AS ok;" >/dev/null 2>&1; then
+  pass "Neo4j accepts auth + returns a query"
+else
+  fail "Neo4j not reachable at $NEO4J_URL with current credentials"
+fi
+
+APOC_OK=$($NEO4J_CMD "CALL dbms.procedures() YIELD name WHERE name STARTS WITH 'apoc.coll' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
+if [[ "$APOC_OK" =~ ^[1-9] ]]; then
+  pass "APOC coll procedures present ($APOC_OK procs)"
+else
+  fail "APOC procedures missing (apoc.coll.sort is required for PR-N19 Fix #2 canonical zone ordering)"
+fi
+
+# Critical uniqueness constraints + the n.uuid index (PR #33 when merged)
+INDEX_COUNT=$($NEO4J_CMD "SHOW INDEXES YIELD name WHERE name CONTAINS 'uuid' OR name CONTAINS 'indicator' OR name CONTAINS 'cve' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
+if [[ "$INDEX_COUNT" =~ ^[1-9] ]]; then
+  pass "Neo4j has $INDEX_COUNT baseline-relevant indexes"
+else
+  warn "no baseline-relevant indexes found — did you run create_indexes()? See docs/RUNBOOK.md §4 remediation."
+fi
+
+# -----------------------------------------------------------------------------
+# [3] MISP API reachable + auth valid
+# -----------------------------------------------------------------------------
+hdr "[3] MISP API reachability"
+if [[ -n "${MISP_URL:-}" ]] && [[ -n "${MISP_API_KEY:-}" ]]; then
+  MISP_HTTP=$(curl -k -s -o /tmp/misp_preflight.out -w "%{http_code}" \
+    -H "Authorization: ${MISP_API_KEY}" \
+    -H "Accept: application/json" \
+    "${MISP_URL%/}/servers/getVersion" || echo "000")
+  if [[ "$MISP_HTTP" == "200" ]]; then
+    MISP_VER=$(python3 -c "import json,sys; d=json.load(open('/tmp/misp_preflight.out')); print(d.get('version','?'))" 2>/dev/null || echo "?")
+    pass "MISP auth OK (version $MISP_VER)"
+  elif [[ "$MISP_HTTP" == "401" || "$MISP_HTTP" == "403" ]]; then
+    fail "MISP auth failed (HTTP $MISP_HTTP) — MISP_API_KEY invalid or expired"
+  else
+    fail "MISP unreachable at $MISP_URL (HTTP $MISP_HTTP)"
+  fi
+  rm -f /tmp/misp_preflight.out
+else
+  fail "MISP_URL / MISP_API_KEY missing; cannot probe"
+fi
+
+# -----------------------------------------------------------------------------
+# [4] + [5] launch-path decision (CLI assumed, or DAG+pause verification)
+# -----------------------------------------------------------------------------
+hdr "[4][5] launch-path = $LAUNCH_PATH"
+if [[ "$LAUNCH_PATH" == "cli" ]]; then
+  pass "CLI launch path — in-process baseline_lock will gate incrementals (src/run_pipeline.py:1093)"
+  pass "No DAG pausing needed; baseline_skip_reason() will self-skip the 4 incrementals"
+else
+  # DAG path — verify the 4 incrementals are paused
+  if ! command -v docker >/dev/null 2>&1; then
+    warn "docker not found; cannot verify Airflow DAG pause state automatically"
+  else
+    for dag in edgeguard_daily edgeguard_medium_freq edgeguard_pipeline edgeguard_low_freq; do
+      STATE=$(docker compose exec -T airflow-worker airflow dags details "$dag" 2>/dev/null | grep -iE '^is_paused' | awk '{print $NF}' || echo "")
+      if [[ "$STATE" == "True" ]]; then
+        pass "DAG $dag is PAUSED"
+      elif [[ -z "$STATE" ]]; then
+        warn "DAG $dag state not queryable (airflow-worker unresponsive?)"
+      else
+        fail "DAG $dag is NOT paused — pause it before baseline (docs/RUNBOOK.md Option B). Issue #57."
+      fi
+    done
+  fi
+fi
+
+# -----------------------------------------------------------------------------
+# [6] Airflow worker RAM ≥ 4 GB
+# -----------------------------------------------------------------------------
+hdr "[6] Airflow worker RAM"
+if command -v docker >/dev/null 2>&1; then
+  MEM_BYTES=$(docker inspect edgeguard-airflow-worker 2>/dev/null | python3 -c "import sys,json; d=json.load(sys.stdin); m=d[0].get('HostConfig',{}).get('Memory',0) or 0; print(m)" 2>/dev/null || echo "0")
+  if [[ "$MEM_BYTES" -ge 4294967296 ]]; then
+    pass "airflow-worker memory limit $(($MEM_BYTES / 1024 / 1024)) MB (≥ 4 GB)"
+  elif [[ "$MEM_BYTES" -eq 0 ]]; then
+    warn "airflow-worker has no Docker memory limit set — baseline might get OOM-killed by host"
+  else
+    fail "airflow-worker memory limit $(($MEM_BYTES / 1024 / 1024)) MB is below 4 GB baseline minimum"
+  fi
+else
+  warn "docker not available; skipping memory check"
+fi
+
+# -----------------------------------------------------------------------------
+# [7] Prometheus alerts.yml parses + edgeguard rule group present
+# -----------------------------------------------------------------------------
+hdr "[7] Prometheus alerts"
+if command -v promtool >/dev/null 2>&1; then
+  if promtool check rules prometheus/alerts.yml >/dev/null 2>&1; then
+    pass "prometheus/alerts.yml parses cleanly"
+  else
+    fail "promtool rejected prometheus/alerts.yml (run: promtool check rules prometheus/alerts.yml)"
+  fi
+else
+  warn "promtool not installed; skipping alerts parse check (install Prometheus tools)"
+fi
+
+# Quick structural pin — expect the edgeguard_pipeline_observability rule group with at least 6 alerts.
+ALERT_COUNT=$(grep -cE '^\s+- alert:' prometheus/alerts.yml 2>/dev/null || echo "0")
+if [[ "$ALERT_COUNT" -ge 6 ]]; then
+  pass "prometheus/alerts.yml has $ALERT_COUNT alert rules (≥ 6 required)"
+else
+  fail "prometheus/alerts.yml has only $ALERT_COUNT alerts — expected ≥ 6 per PR-N11/N12/N18"
+fi
+
+# -----------------------------------------------------------------------------
+# [8] no stale baseline_lock sentinel
+# -----------------------------------------------------------------------------
+hdr "[8] baseline_lock sentinel"
+if command -v docker >/dev/null 2>&1; then
+  if docker compose exec -T airflow-worker test -f /tmp/edgeguard/baseline_lock.sentinel 2>/dev/null; then
+    SENTINEL_AGE=$(docker compose exec -T airflow-worker stat -c %Y /tmp/edgeguard/baseline_lock.sentinel 2>/dev/null || echo "0")
+    NOW=$(date +%s)
+    AGE_H=$(( (NOW - SENTINEL_AGE) / 3600 ))
+    if [[ $AGE_H -gt 48 ]]; then
+      fail "stale baseline_lock.sentinel (age ${AGE_H}h) — previous baseline crashed; see baseline_lock.py:corrupt-sentinel-probe"
+    else
+      warn "baseline_lock.sentinel present (age ${AGE_H}h) — another baseline may be running"
+    fi
+  else
+    pass "no stale baseline_lock sentinel"
+  fi
+else
+  warn "docker not available; skipping sentinel check"
+fi
+
+# -----------------------------------------------------------------------------
+# [9] kill-switches not forced on
+# -----------------------------------------------------------------------------
+hdr "[9] kill-switch env vars"
+for sw in EDGEGUARD_RESPECT_CALIBRATOR EDGEGUARD_DISABLE_MERGE_COUNTER_INSPECTION; do
+  if [[ -n "${!sw:-}" ]]; then
+    warn "$sw=${!sw} is set — confirm this is intentional (see RUNBOOK § Kill-switches)"
+  else
+    pass "$sw unset (safe default)"
+  fi
+done
+
+# -----------------------------------------------------------------------------
+# [10] last full pytest run was green (quick syntax pin)
+# -----------------------------------------------------------------------------
+hdr "[10] test suite syntax check"
+if [[ -x ".venv/bin/pytest" ]]; then
+  if .venv/bin/pytest --collect-only -q >/tmp/pytest_collect.out 2>&1; then
+    TEST_COUNT=$(grep -cE '::test_' /tmp/pytest_collect.out || echo "0")
+    pass "pytest collects $TEST_COUNT tests cleanly"
+  else
+    fail "pytest collection failed — see /tmp/pytest_collect.out"
+  fi
+else
+  warn ".venv/bin/pytest not found; skipping collection check"
+fi
+
+# -----------------------------------------------------------------------------
+# Summary
+# -----------------------------------------------------------------------------
+printf '\n%s========================================%s\n' "$C_CYN" "$C_OFF"
+if [[ $FAILURES -eq 0 ]] && { [[ "$STRICT" != "1" ]] || [[ $WARNINGS -eq 0 ]]; }; then
+  printf '%s✓ preflight_baseline: READY%s  (warnings=%d, failures=%d)\n' \
+    "$C_GRN" "$C_OFF" "$WARNINGS" "$FAILURES"
+  printf 'Launch path confirmed: %s\n' "$LAUNCH_PATH"
+  exit 0
+else
+  printf '%s✗ preflight_baseline: NOT READY%s  (warnings=%d, failures=%d)\n' \
+    "$C_RED" "$C_OFF" "$WARNINGS" "$FAILURES"
+  printf 'Address the ✗ items above (and ! items under --strict) before launching.\n'
+  printf 'See docs/RUNBOOK.md § "Baseline-day protocol" for manual equivalents.\n'
+  exit 1
+fi

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -102,20 +102,31 @@ done
 # -----------------------------------------------------------------------------
 hdr "[2] Neo4j reachability + indexes"
 NEO4J_URL="${NEO4J_URL:-bolt://localhost:7687}"
+# NOTE (Bugbot round 2, Low): NEO4J_PASSWORD must NOT be interpolated into
+# the command line — it'd be visible via `ps aux` / /proc/*/cmdline to any
+# user on the system, plus risks word-splitting on spaces or shell
+# metacharacters. Instead:
+#   - Build the command as a bash ARRAY (preserves word boundaries).
+#   - For docker path: pass ``-e NEO4J_PASSWORD`` (by name, no =value) so
+#     docker compose exec forwards the var from the calling shell into the
+#     container env without ever putting the value in argv.
+#   - Omit ``-p`` entirely; cypher-shell reads NEO4J_PASSWORD from its env
+#     automatically when ``-p`` is absent.
+export NEO4J_PASSWORD  # ensure docker compose exec -e NEO4J_PASSWORD sees it
 if command -v docker >/dev/null 2>&1 && docker compose ps --services 2>/dev/null | grep -q neo4j; then
-  NEO4J_CMD="docker compose exec -T neo4j cypher-shell -u neo4j -p ${NEO4J_PASSWORD:-test} --format plain"
+  NEO4J_CMD=(docker compose exec -T -e NEO4J_PASSWORD neo4j cypher-shell -u neo4j --format plain)
 else
-  # Fallback: assume cypher-shell is on PATH
-  NEO4J_CMD="cypher-shell -a ${NEO4J_URL} -u neo4j -p ${NEO4J_PASSWORD:-test} --format plain"
+  # Fallback: assume cypher-shell is on PATH (reads NEO4J_PASSWORD from env)
+  NEO4J_CMD=(cypher-shell -a "${NEO4J_URL}" -u neo4j --format plain)
 fi
 
-if $NEO4J_CMD "RETURN 1 AS ok;" >/dev/null 2>&1; then
+if "${NEO4J_CMD[@]}" "RETURN 1 AS ok;" >/dev/null 2>&1; then
   pass "Neo4j accepts auth + returns a query"
 else
   fail "Neo4j not reachable at $NEO4J_URL with current credentials"
 fi
 
-APOC_OK=$($NEO4J_CMD "CALL dbms.procedures() YIELD name WHERE name STARTS WITH 'apoc.coll' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
+APOC_OK=$("${NEO4J_CMD[@]}" "CALL dbms.procedures() YIELD name WHERE name STARTS WITH 'apoc.coll' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
 if [[ "$APOC_OK" =~ ^[1-9] ]]; then
   pass "APOC coll procedures present ($APOC_OK procs)"
 else
@@ -123,7 +134,7 @@ else
 fi
 
 # Critical uniqueness constraints + the n.uuid index (PR #33 when merged)
-INDEX_COUNT=$($NEO4J_CMD "SHOW INDEXES YIELD name WHERE name CONTAINS 'uuid' OR name CONTAINS 'indicator' OR name CONTAINS 'cve' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
+INDEX_COUNT=$("${NEO4J_CMD[@]}" "SHOW INDEXES YIELD name WHERE name CONTAINS 'uuid' OR name CONTAINS 'indicator' OR name CONTAINS 'cve' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
 if [[ "$INDEX_COUNT" =~ ^[1-9] ]]; then
   pass "Neo4j has $INDEX_COUNT baseline-relevant indexes"
 else
@@ -134,8 +145,26 @@ fi
 # [3] MISP API reachable + auth valid
 # -----------------------------------------------------------------------------
 hdr "[3] MISP API reachability"
+
+# NOTE (Bugbot round 2, Medium): honor EDGEGUARD_SSL_VERIFY / SSL_VERIFY so
+# the preflight TLS posture matches the rest of the stack. Pre-fix, ``curl
+# -k`` unconditionally disabled verification and sent MISP_API_KEY over an
+# unverified TLS connection — MitM risk even when SSL_VERIFY=true was set
+# project-wide. Semantics match src/config.py: only the literal string
+# "true" (case-insensitive, stripped) enables verification; anything else
+# disables (strict allow-list — typos default to disabled).
+SSL_VERIFY_RAW="${EDGEGUARD_SSL_VERIFY:-${SSL_VERIFY:-}}"
+SSL_VERIFY_NORM="$(printf '%s' "${SSL_VERIFY_RAW}" | tr '[:upper:]' '[:lower:]' | xargs 2>/dev/null || echo "")"
+if [[ "$SSL_VERIFY_NORM" == "true" ]]; then
+  CURL_TLS_FLAG=()
+  pass "TLS verification enabled (EDGEGUARD_SSL_VERIFY=true)"
+else
+  CURL_TLS_FLAG=(-k)
+  warn "TLS verification DISABLED (EDGEGUARD_SSL_VERIFY='${SSL_VERIFY_RAW:-unset}'); MISP_API_KEY will be sent over unverified TLS. Set EDGEGUARD_SSL_VERIFY=true for production."
+fi
+
 if [[ -n "${MISP_URL:-}" ]] && [[ -n "${MISP_API_KEY:-}" ]]; then
-  MISP_HTTP=$(curl -k -s -o /tmp/misp_preflight.out -w "%{http_code}" \
+  MISP_HTTP=$(curl "${CURL_TLS_FLAG[@]}" -s -o /tmp/misp_preflight.out -w "%{http_code}" \
     -H "Authorization: ${MISP_API_KEY}" \
     -H "Accept: application/json" \
     "${MISP_URL%/}/servers/getVersion" || echo "000")

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -155,16 +155,30 @@ hdr "[3] MISP API reachability"
 # disables (strict allow-list — typos default to disabled).
 SSL_VERIFY_RAW="${EDGEGUARD_SSL_VERIFY:-${SSL_VERIFY:-}}"
 SSL_VERIFY_NORM="$(printf '%s' "${SSL_VERIFY_RAW}" | tr '[:upper:]' '[:lower:]' | xargs 2>/dev/null || echo "")"
+# Bugbot round 3 (PR #104, Low): pre-fix used
+# ``CURL_TLS_FLAG=()`` (empty bash array) + ``"${CURL_TLS_FLAG[@]}"``
+# expansion. Under bash < 4.4 with ``set -u`` active, expanding an
+# EMPTY array via ``"${arr[@]}"`` raises "unbound variable" and aborts
+# the script. This affects macOS's default bash 3.2 — a common
+# operator workstation. The bug fired on the RECOMMENDED production
+# path (``EDGEGUARD_SSL_VERIFY=true``), causing the script to abort
+# with an unhelpful error instead of completing the MISP probe.
+#
+# Fix: use a plain string ``CURL_TLS_FLAG_STR`` (always set; empty
+# string when verification enabled, ``-k`` when disabled), then
+# expand unquoted so an empty value contributes nothing to argv.
+# Safe across bash 3.2+ and POSIX sh.
 if [[ "$SSL_VERIFY_NORM" == "true" ]]; then
-  CURL_TLS_FLAG=()
+  CURL_TLS_FLAG_STR=""
   pass "TLS verification enabled (EDGEGUARD_SSL_VERIFY=true)"
 else
-  CURL_TLS_FLAG=(-k)
+  CURL_TLS_FLAG_STR="-k"
   warn "TLS verification DISABLED (EDGEGUARD_SSL_VERIFY='${SSL_VERIFY_RAW:-unset}'); MISP_API_KEY will be sent over unverified TLS. Set EDGEGUARD_SSL_VERIFY=true for production."
 fi
 
 if [[ -n "${MISP_URL:-}" ]] && [[ -n "${MISP_API_KEY:-}" ]]; then
-  MISP_HTTP=$(curl "${CURL_TLS_FLAG[@]}" -s -o /tmp/misp_preflight.out -w "%{http_code}" \
+  # shellcheck disable=SC2086  # intentional unquoted: empty string must expand to nothing
+  MISP_HTTP=$(curl $CURL_TLS_FLAG_STR -s -o /tmp/misp_preflight.out -w "%{http_code}" \
     -H "Authorization: ${MISP_API_KEY}" \
     -H "Accept: application/json" \
     "${MISP_URL%/}/servers/getVersion" || echo "000")

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -2268,6 +2268,17 @@ class Neo4jClient:
             extra_props["severity"] = data["severity"]
         if data.get("attack_vector"):
             extra_props["attack_vector"] = data["attack_vector"]
+        # PR-N20 follow-up to PR-N19 Fix #1: preserve symmetry with
+        # ``merge_cve``. The single-row NVD path (``merge_vulnerability``)
+        # is used by alert-pipeline callers and the ``_sync_single_item``
+        # fallback; the batch path (``merge_vulnerabilities_batch``) writes
+        # dates via SOURCED_FROM edges, but the node itself would drop
+        # ``published`` / ``last_modified`` without this promotion — exactly
+        # the same bug shape PR-N19 Fix #1 closed for ``merge_cve``.
+        if data.get("published"):
+            extra_props["published"] = data["published"]
+        if data.get("last_modified"):
+            extra_props["last_modified"] = data["last_modified"]
         return self.merge_node_with_source("Vulnerability", key_props, data, source_id, extra_props=extra_props or None)
 
     def merge_indicator(self, data: Dict, source_id: str = "alienvault_otx") -> bool:

--- a/tests/test_pr_n20_baseline_launch_procedure.py
+++ b/tests/test_pr_n20_baseline_launch_procedure.py
@@ -262,6 +262,42 @@ class TestFix2PreflightScript:
             "Bugbot round 2, PR #104, Medium severity."
         )
 
+    def test_preflight_tls_flag_is_bash3_2_compatible(self):
+        """Bugbot round 3 (PR #104, Low severity): the earlier round-2
+        fix used a bash array ``CURL_TLS_FLAG=()`` expanded as
+        ``"${CURL_TLS_FLAG[@]}"``. Under bash < 4.4 with ``set -u``
+        active, an EMPTY-array expansion raises "unbound variable"
+        and aborts the script. This affects macOS's default bash 3.2
+        — a common operator workstation — on the RECOMMENDED
+        production path (``EDGEGUARD_SSL_VERIFY=true``).
+
+        Fix: plain string ``CURL_TLS_FLAG_STR`` (always set; empty
+        string when verification enabled) expanded UNQUOTED so empty
+        → nothing in argv. Safe across bash 3.2+.
+
+        Pin: (a) no empty-array regression shape present,
+        (b) the plain-string variant IS present."""
+        src = self._script()
+        # Strip comment-only lines so the rationale comment (which
+        # describes the regression shape) doesn't false-fail the
+        # negative assertion.
+        code_only = "\n".join(line for line in src.splitlines() if not line.lstrip().startswith("#"))
+        # Negative: the empty-array pattern ``CURL_TLS_FLAG=()`` must
+        # NOT appear in actual code.
+        assert "CURL_TLS_FLAG=()" not in code_only, (
+            "empty-array ``CURL_TLS_FLAG=()`` is the Bugbot round 3 regression shape "
+            "(crashes bash < 4.4 under set -u when expanded)"
+        )
+        # Also negative: the array expansion ``"${CURL_TLS_FLAG[@]}"``
+        # must not appear in code (same class of bug).
+        assert '"${CURL_TLS_FLAG[@]}"' not in code_only, (
+            "array expansion ``${CURL_TLS_FLAG[@]}`` on a possibly-empty array is unsafe under set -u in bash < 4.4"
+        )
+        # Positive: the string-variant must be present and USED in code.
+        assert "CURL_TLS_FLAG_STR" in code_only, (
+            "fix uses a plain string ``CURL_TLS_FLAG_STR`` (always set) that's safe to expand unquoted across bash 3.2+"
+        )
+
 
 # ===========================================================================
 # Fix #3 — merge_vulnerability promotes published + last_modified (symmetry

--- a/tests/test_pr_n20_baseline_launch_procedure.py
+++ b/tests/test_pr_n20_baseline_launch_procedure.py
@@ -266,6 +266,76 @@ class TestFix4RunbookMispRetrievalPaths:
 
 
 # ===========================================================================
+# Fix #5 — README.md surfaces the launch procedure for colleagues
+# ===========================================================================
+
+
+class TestFix5ReadmeLaunchProcedure:
+    """Colleagues new to the project read the README first, not RUNBOOK.
+    Pin that the baseline-launch options + the MISP retrieval paths live
+    at the README level so they can't get lost in deep docs."""
+
+    def _readme(self) -> str:
+        return (REPO_ROOT / "README.md").read_text()
+
+    def test_readme_has_baseline_launch_section(self):
+        rd = self._readme()
+        assert "Running the 730-day baseline" in rd, (
+            "README must have a top-level 'Running the 730-day baseline' section "
+            "so colleagues see the launch-path decision without hunting through docs/"
+        )
+
+    def test_readme_documents_cli_and_dag_options(self):
+        rd = self._readme()
+        # Both options must be visible; colleague should be able to pick
+        # without having to open RUNBOOK.md first.
+        assert "Option A" in rd and "Option B" in rd, "README must show both launch options (CLI + DAG)"
+        assert "python -m edgeguard baseline" in rd, "README must show the CLI launch command"
+        assert "airflow dags pause" in rd, "README must show the DAG pause command"
+
+    def test_readme_references_preflight_script(self):
+        rd = self._readme()
+        assert "preflight_baseline.sh" in rd, (
+            "README must point to scripts/preflight_baseline.sh as the pre-kickoff check"
+        )
+
+    def test_readme_explains_issue_57_rationale(self):
+        """The 'why' matters as much as the 'what' — colleagues need to
+        understand the 2026-04-19 incident shape to make the right
+        launch-path choice."""
+        rd = self._readme()
+        assert "Issue #57" in rd, "README must cross-reference Issue #57 (DB-backed mutex)"
+        assert "2026-04-19" in rd or "14.7%" in rd, (
+            "README must explain the historical incident that motivates the launch-path decision"
+        )
+
+    def test_readme_documents_misp_retrieval_paths(self):
+        rd = self._readme()
+        assert "misp_attribute_ids" in rd, "README must show Path 1 (attribute UUID)"
+        assert "misp_event_ids" in rd, "README must show Path 2 (event ID)"
+        assert "SOURCED_FROM" in rd and "raw_data" in rd, "README must show Path 3 (raw JSON on edge)"
+
+    def test_readme_clarifies_node_uuid_is_not_misp_link(self):
+        """The user's original question conflated n.uuid with the MISP
+        back-pointer. Pin the clarifying note at the README level."""
+        rd = self._readme()
+        assert "n.uuid" in rd and "NOT" in rd, (
+            "README must clarify n.uuid is a deterministic UUIDv5 for cross-env identity, NOT a foreign key into MISP"
+        )
+
+    def test_airflow_section_warns_about_launch_path(self):
+        """The existing 'Airflow DAG-based workflow' section must point
+        readers at the launch-path decision before they hit the
+        `airflow dags trigger edgeguard_baseline` button."""
+        rd = self._readme()
+        # Look for a warning in the Airflow section that references the
+        # new launch-path decision section.
+        assert "Running the 730-day baseline" in rd and "IMPORTANT" in rd, (
+            "Existing Airflow DAG section must warn readers to consult the baseline launch procedure before triggering"
+        )
+
+
+# ===========================================================================
 # Module import sanity
 # ===========================================================================
 

--- a/tests/test_pr_n20_baseline_launch_procedure.py
+++ b/tests/test_pr_n20_baseline_launch_procedure.py
@@ -160,6 +160,45 @@ class TestFix2PreflightScript:
         assert "exit 1" in src, "preflight must exit 1 when any hard-fail check fails"
         assert "exit 0" in src, "preflight must exit 0 on all-green"
 
+    def test_preflight_env_var_loop_reports_value_length_not_name_length(self):
+        """Bugbot round 1 (PR #104, Medium severity): the env-var loop used
+        ``${#var}`` which measures the length of the variable NAME
+        ("NEO4J_PASSWORD" = 14 chars), not the indirectly-referenced VALUE.
+        The printed copy said "value not echoed" so the reported count
+        had to correspond to the value; a 40-char API key printed "12
+        chars" misleading operators about credential state.
+
+        Pin: the env-var loop MUST (a) capture the indirect value into a
+        local like ``var_value="${!var:-}"``, and (b) measure
+        ``${#var_value}``. Regression-guard against a literal ``${#var}``
+        re-appearing inside that loop."""
+        src = self._script()
+        # Isolate the env-var loop so we don't false-fail on similar
+        # constructs elsewhere in the script (if any are added later).
+        # Rough anchor: the loop starts after the "[1] required env vars" header.
+        loop_start = src.find("for var in NEO4J_PASSWORD MISP_API_KEY MISP_URL")
+        assert loop_start != -1, "env-var loop anchor missing"
+        loop_end = src.find("done", loop_start)
+        assert loop_end != -1, "env-var loop terminator missing"
+        loop_body = src[loop_start:loop_end]
+
+        # Positive: the loop must capture the indirect reference into a
+        # local variable (any name is fine as long as it's used below).
+        assert '"${!var' in loop_body, (
+            'env-var loop must capture the indirect reference (``"${!var..}"``) into a local before measuring length'
+        )
+        # Negative: ``${#var}`` (measuring the name) must NOT appear inside
+        # the loop body. This is the exact Bugbot-flagged regression shape.
+        assert "${#var}" not in loop_body, (
+            "env-var loop reports ${#var} (length of NAME, always 8/12/14) instead of the VALUE length. "
+            'Capture ``var_value="${!var:-}"`` first, then measure ``${#var_value}``. '
+            "Bugbot round 1, PR #104, Medium severity."
+        )
+        # Positive: the correct form (value-length) must appear.
+        assert "${#var_value}" in loop_body or "${#value}" in loop_body, (
+            "env-var loop must report the VALUE length (e.g. ``${#var_value}``) after capturing the indirect reference"
+        )
+
 
 # ===========================================================================
 # Fix #3 — merge_vulnerability promotes published + last_modified (symmetry

--- a/tests/test_pr_n20_baseline_launch_procedure.py
+++ b/tests/test_pr_n20_baseline_launch_procedure.py
@@ -199,6 +199,69 @@ class TestFix2PreflightScript:
             "env-var loop must report the VALUE length (e.g. ``${#var_value}``) after capturing the indirect reference"
         )
 
+    def test_preflight_does_not_embed_neo4j_password_in_command_line(self):
+        """Bugbot round 2 (PR #104, Low severity): NEO4J_PASSWORD was
+        interpolated directly into ``NEO4J_CMD`` (`-p ${NEO4J_PASSWORD:-test}`).
+        Visible to any user on the host via ``ps aux`` or
+        ``/proc/*/cmdline``, and risks word-splitting on spaces/metachars.
+
+        Fix: build NEO4J_CMD as a bash array without ``-p``. For docker
+        path use ``-e NEO4J_PASSWORD`` (by name, no =value) to forward the
+        env var; for host path cypher-shell reads NEO4J_PASSWORD from env.
+
+        Pin the absence of the regression shape."""
+        src = self._script()
+        # Negative: the exact regression shape (``-p`` followed by an
+        # interpolation of NEO4J_PASSWORD into the command string) must
+        # NOT appear.
+        assert "-p ${NEO4J_PASSWORD" not in src, (
+            "cypher-shell invocation must NOT interpolate NEO4J_PASSWORD into argv "
+            "(use ``-e NEO4J_PASSWORD`` + no ``-p`` flag; cypher-shell reads NEO4J_PASSWORD "
+            "from env automatically). Bugbot round 2, PR #104, Low severity."
+        )
+        assert '-p "$NEO4J_PASSWORD' not in src, (
+            "cypher-shell invocation must NOT take the password as a command-line argument — "
+            "use the NEO4J_PASSWORD env var forwarding instead"
+        )
+        # Positive: the new array-based invocation must use -e NEO4J_PASSWORD
+        # (env-var forwarding) for the docker path.
+        assert "-e NEO4J_PASSWORD" in src, (
+            "preflight must forward NEO4J_PASSWORD via ``docker compose exec -e NEO4J_PASSWORD`` "
+            "(by name, not by value) to keep it out of argv"
+        )
+
+    def test_preflight_honors_ssl_verify_for_misp_probe(self):
+        """Bugbot round 2 (PR #104, Medium severity): the MISP probe used
+        ``curl -k`` unconditionally, sending MISP_API_KEY over an
+        unverified TLS connection even when EDGEGUARD_SSL_VERIFY=true was
+        set project-wide. MitM risk for credential interception.
+
+        Fix: read EDGEGUARD_SSL_VERIFY / SSL_VERIFY, match project
+        semantics (only literal "true" enables verification; anything
+        else disables with a WARN), and only add ``-k`` when disabled."""
+        src = self._script()
+        # Positive: script must reference the canonical env var.
+        assert "EDGEGUARD_SSL_VERIFY" in src, (
+            "preflight must honor EDGEGUARD_SSL_VERIFY for the MISP probe (project canonical TLS-verify knob)"
+        )
+        # Positive: must also fall back to the legacy SSL_VERIFY name
+        # (matches src/config.py semantics).
+        assert "SSL_VERIFY" in src, "preflight must also respect the legacy SSL_VERIFY fallback"
+        # Positive: should only pass -k conditionally (not as a fixed
+        # curl arg). The fix uses a bash array CURL_TLS_FLAG that's
+        # empty when verification is enabled.
+        assert "CURL_TLS_FLAG" in src, (
+            "preflight must build a conditional TLS flag array (e.g. CURL_TLS_FLAG) "
+            "that stays empty when verification is enabled"
+        )
+        # Negative: the exact regression shape — curl -k as a hard-coded
+        # argument in the MISP probe — must NOT appear.
+        assert "curl -k -s -o" not in src, (
+            "preflight must NOT hard-code ``curl -k`` in the MISP probe — that would send "
+            "MISP_API_KEY over unverified TLS regardless of EDGEGUARD_SSL_VERIFY. "
+            "Bugbot round 2, PR #104, Medium severity."
+        )
+
 
 # ===========================================================================
 # Fix #3 — merge_vulnerability promotes published + last_modified (symmetry

--- a/tests/test_pr_n20_baseline_launch_procedure.py
+++ b/tests/test_pr_n20_baseline_launch_procedure.py
@@ -1,0 +1,275 @@
+"""
+PR-N20 — 730-day baseline launch procedure + follow-ups.
+
+After PR-N19 merged, a 3-agent readiness audit surfaced three actionable
+items that needed to ship before launching the 730-day baseline:
+
+1. **Launch-path documentation gap.** Three xfails in
+   ``tests/test_tier1_sequential_robustness.py`` pin Issue #57 — the
+   Airflow DAG baseline path does NOT call ``acquire_baseline_lock()``.
+   Over the ~26h baseline, the 4 scheduled incremental DAGs race the
+   baseline for MISP + Neo4j writes, reproducing the 2026-04-19
+   MISP-PHP-FPM exhaustion + 14.7% NVD loss. ``docs/RUNBOOK.md`` didn't
+   surface the workaround. Fix: add a dedicated "Baseline launch path"
+   section with explicit CLI vs DAG+pause procedures.
+
+2. **Preflight script missing.** Operators had no single command to
+   verify env vars + Neo4j + MISP reachability + DAG pause state + RAM
+   + alerts + sentinel cleanup + kill-switch defaults before kicking
+   off the 26h run. Fix: add ``scripts/preflight_baseline.sh``.
+
+3. **``merge_vulnerability`` single-row path symmetry gap.** PR-N19
+   Fix #1 fixed the MISP-sourced CVE date-drop, but the NVD-sourced
+   ``merge_vulnerability`` single-row path (used by the alert pipeline
+   and ``_sync_single_item`` fallback) still dropped ``published`` /
+   ``last_modified``. Same bug shape as the one PR-N19 closed for
+   ``merge_cve``. Fix: symmetric promotion in ``merge_vulnerability``.
+
+Additionally: add a MISP-retrieval-paths section to the RUNBOOK
+answering the operator question "how do I use a Neo4j node to fetch
+the raw MISP data?" (`n.misp_attribute_ids[]` → MISP API).
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+DOCS = REPO_ROOT / "docs"
+SCRIPTS = REPO_ROOT / "scripts"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n20")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n20")
+
+
+# ===========================================================================
+# Fix #1 — RUNBOOK has the launch-path section (CLI vs DAG+pause)
+# ===========================================================================
+
+
+class TestFix1RunbookLaunchPath:
+    def _runbook(self) -> str:
+        return (DOCS / "RUNBOOK.md").read_text()
+
+    def test_runbook_has_baseline_launch_path_section(self):
+        """Pin that the CLI-vs-DAG decision is surfaced in the RUNBOOK,
+        not only in docs/flow_audits/ where an operator might miss it."""
+        rb = self._runbook()
+        assert "Baseline launch path" in rb, (
+            "RUNBOOK must surface the baseline launch-path decision (CLI vs DAG+pause). "
+            "Issue #57 / docs/flow_audits/01_baseline_sequence.md Finding 1."
+        )
+
+    def test_runbook_documents_cli_launch_option(self):
+        rb = self._runbook()
+        # CLI path takes the in-process baseline_lock; every scheduled DAG
+        # then self-skips via baseline_skip_reason(). Pin the recommended
+        # command shape.
+        assert "python -m edgeguard baseline" in rb, (
+            "RUNBOOK must document the CLI launch command (recommended path). "
+            "It takes the in-process baseline_lock (src/run_pipeline.py:1093)."
+        )
+
+    def test_runbook_documents_dag_pause_option(self):
+        rb = self._runbook()
+        # DAG path requires pre-pausing 4 incremental DAGs for the ~26h window.
+        for dag in [
+            "edgeguard_daily",
+            "edgeguard_medium_freq",
+            "edgeguard_pipeline",
+            "edgeguard_low_freq",
+        ]:
+            assert dag in rb, f"RUNBOOK must name {dag} in the DAG-pause procedure"
+        assert "airflow dags pause" in rb, "RUNBOOK must show the `airflow dags pause` command"
+        assert "airflow dags unpause" in rb, "RUNBOOK must show how to restore after baseline completes"
+
+    def test_runbook_cross_references_issue_57(self):
+        rb = self._runbook()
+        # Cross-reference so ops readers can find the root-cause audit.
+        assert "Issue #57" in rb or "01_baseline_sequence.md" in rb, (
+            "RUNBOOK must cross-reference the root-cause audit for the launch-path constraint"
+        )
+
+    def test_runbook_references_preflight_script(self):
+        rb = self._runbook()
+        assert "preflight_baseline.sh" in rb, (
+            "RUNBOOK must reference the preflight script so operators know there's a one-shot check"
+        )
+
+
+# ===========================================================================
+# Fix #2 — preflight_baseline.sh exists + has the expected check matrix
+# ===========================================================================
+
+
+class TestFix2PreflightScript:
+    def _script(self) -> str:
+        return (SCRIPTS / "preflight_baseline.sh").read_text()
+
+    def test_preflight_script_exists(self):
+        path = SCRIPTS / "preflight_baseline.sh"
+        assert path.exists(), "scripts/preflight_baseline.sh must exist"
+        # Must be executable — operators run it directly.
+        assert os.access(path, os.X_OK), "preflight_baseline.sh must be executable (chmod +x)"
+
+    def test_preflight_covers_required_env_vars(self):
+        src = self._script()
+        for var in ["NEO4J_PASSWORD", "MISP_API_KEY", "MISP_URL"]:
+            assert var in src, f"preflight must check that {var} is set"
+
+    def test_preflight_checks_neo4j_reachability(self):
+        src = self._script()
+        assert "Neo4j" in src and ("cypher-shell" in src or "bolt://" in src), (
+            "preflight must verify Neo4j is reachable"
+        )
+
+    def test_preflight_checks_misp_reachability(self):
+        src = self._script()
+        assert ("/servers/getVersion" in src or "MISP" in src) and "curl" in src, (
+            "preflight must hit a MISP API endpoint to verify auth works"
+        )
+
+    def test_preflight_checks_dag_pause_on_dag_launch_path(self):
+        src = self._script()
+        # The DAG path is the one that NEEDS the pause-check. Confirm the
+        # script knows how to verify each of the 4 incrementals.
+        for dag in [
+            "edgeguard_daily",
+            "edgeguard_medium_freq",
+            "edgeguard_pipeline",
+            "edgeguard_low_freq",
+        ]:
+            assert dag in src, f"preflight must verify {dag} pause-state on --launch-path=dag"
+
+    def test_preflight_checks_prometheus_alerts(self):
+        src = self._script()
+        assert "promtool" in src or "alerts.yml" in src, (
+            "preflight must verify Prometheus alert rules parse (promtool check rules)"
+        )
+
+    def test_preflight_exits_nonzero_on_failure(self):
+        src = self._script()
+        assert "exit 1" in src, "preflight must exit 1 when any hard-fail check fails"
+        assert "exit 0" in src, "preflight must exit 0 on all-green"
+
+
+# ===========================================================================
+# Fix #3 — merge_vulnerability promotes published + last_modified (symmetry
+# with post-PR-N19 merge_cve)
+# ===========================================================================
+
+
+class TestFix3MergeVulnerabilitySymmetry:
+    def test_merge_vulnerability_extra_props_includes_published(self):
+        """AST pin: merge_vulnerability must conditionally add 'published'
+        to extra_props — same shape as PR-N19 Fix #1 on merge_cve."""
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef):
+                for node in cls.body:
+                    if isinstance(node, ast.FunctionDef) and node.name == "merge_vulnerability":
+                        body = ast.unparse(node)
+                        assert 'extra_props["published"]' in body or "extra_props['published']" in body, (
+                            "merge_vulnerability must promote data['published'] to extra_props "
+                            "(PR-N20 follow-up to PR-N19 Fix #1; single-row NVD path was dropping it)"
+                        )
+                        return
+        raise AssertionError("merge_vulnerability not found")
+
+    def test_merge_vulnerability_extra_props_includes_last_modified(self):
+        src = (SRC / "neo4j_client.py").read_text()
+        tree = ast.parse(src)
+        for cls in ast.walk(tree):
+            if isinstance(cls, ast.ClassDef):
+                for node in cls.body:
+                    if isinstance(node, ast.FunctionDef) and node.name == "merge_vulnerability":
+                        body = ast.unparse(node)
+                        assert 'extra_props["last_modified"]' in body or "extra_props['last_modified']" in body, (
+                            "merge_vulnerability must promote data['last_modified'] to extra_props (PR-N20 follow-up to PR-N19 Fix #1)"
+                        )
+                        return
+        raise AssertionError("merge_vulnerability not found")
+
+    def test_merge_vulnerability_behavior_promotes_both_fields(self):
+        """Behavioral pin: invoke merge_vulnerability with data containing
+        published + last_modified; confirm both reach extra_props via the
+        merge_node_with_source mock (same shape as PR-N19 Fix #1's test)."""
+        from neo4j_client import Neo4jClient
+
+        c = Neo4jClient.__new__(Neo4jClient)
+        c.driver = MagicMock()
+        c.merge_node_with_source = MagicMock(return_value=True)
+
+        data = {
+            "cve_id": "CVE-2024-12345",
+            "description": "Symmetry test",
+            "cvss_score": 7.5,
+            "severity": "HIGH",
+            "published": "2024-02-14T12:00:00.000",
+            "last_modified": "2024-03-01T08:30:00.000",
+        }
+        assert c.merge_vulnerability(data) is True
+        call_kwargs = c.merge_node_with_source.call_args.kwargs
+        extra_props = call_kwargs.get("extra_props", {})
+        assert extra_props.get("published") == "2024-02-14T12:00:00.000", (
+            f"merge_vulnerability must pass published to extra_props; got {extra_props.get('published')!r}"
+        )
+        assert extra_props.get("last_modified") == "2024-03-01T08:30:00.000"
+
+
+# ===========================================================================
+# Fix #4 — RUNBOOK documents how to retrieve raw MISP data from a Neo4j node
+# ===========================================================================
+
+
+class TestFix4RunbookMispRetrievalPaths:
+    def _runbook(self) -> str:
+        return (DOCS / "RUNBOOK.md").read_text()
+
+    def test_runbook_documents_misp_retrieval_section(self):
+        rb = self._runbook()
+        assert "Retrieving raw MISP data from a Neo4j node" in rb, (
+            "RUNBOOK must document the three MISP-retrieval paths (attribute UUID, event ID, raw JSON on edge)"
+        )
+
+    def test_runbook_clarifies_node_uuid_is_not_misp_link(self):
+        """The user's audit question conflated n.uuid (deterministic UUIDv5
+        for cross-environment identity) with the MISP back-pointer
+        (misp_attribute_ids[]). Pin the clarifying paragraph."""
+        rb = self._runbook()
+        assert "n.uuid" in rb and "deterministic" in rb.lower() and "NOT" in rb, (
+            "RUNBOOK must clarify that n.uuid is a deterministic UUIDv5 for cross-env identity, "
+            "NOT a foreign key into MISP"
+        )
+
+    def test_runbook_documents_all_three_retrieval_paths(self):
+        rb = self._runbook()
+        assert "misp_attribute_ids" in rb, "Path 1 — MISP attribute UUID"
+        assert "misp_event_ids" in rb, "Path 2 — MISP event ID"
+        assert "SOURCED_FROM" in rb and "raw_data" in rb, "Path 3 — raw JSON on SOURCED_FROM edge"
+
+    def test_runbook_documents_misp_api_fetch_shape(self):
+        rb = self._runbook()
+        # Operator needs to know the HTTP endpoint + header shape.
+        assert "/attributes/" in rb, "RUNBOOK must show the MISP /attributes/<uuid> endpoint"
+        assert "/events/" in rb, "RUNBOOK must show the MISP /events/<id> endpoint"
+        assert "Authorization" in rb, "RUNBOOK must show the Authorization header for MISP API"
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_neo4j_client_imports(self):
+        import neo4j_client  # noqa: F401


### PR DESCRIPTION
## Summary

Post-PR-N19 three-agent readiness audit for the 730-day MISP→Neo4j baseline surfaced three actionable items. All shipped here so the baseline can launch without the 2026-04-19 MISP-PHP-FPM incident shape repeating.

- **Fix #1**: RUNBOOK now documents the baseline launch-path decision (CLI vs DAG+pause) — closes the documentation gap where Issue #57's operator workaround only lived in `docs/flow_audits/`
- **Fix #2**: `scripts/preflight_baseline.sh` — single-command readiness check covering 10 categories (env vars, Neo4j, MISP, DAG pause state, RAM, alerts, sentinel cleanup, kill-switch defaults, test collection)
- **Fix #3**: `merge_vulnerability` symmetry — NVD single-row path now promotes `published` + `last_modified` like `merge_cve` does post-PR-N19
- **Doc**: new RUNBOOK section on retrieving raw MISP data from a Neo4j node (explicitly clarifies `n.uuid` is a deterministic UUIDv5 for cross-env identity, NOT a MISP back-pointer)

## Why this PR

A three-agent audit (date-field integrity, MISP↔Neo4j UUID traceability, general baseline blockers) confirmed **READY** verdicts on everything else, but surfaced these three actionable items:

| Audit finding | Status | Fix |
|---|---|---|
| Launch-path caveat only in `docs/flow_audits/` — RUNBOOK missed it. Risk: operator repeats 2026-04-19 NVD-14.7%-loss incident. | **Baseline-blocking (procedural)** | Fix #1 + Fix #2 |
| `merge_vulnerability` single-row path drops `published`/`last_modified` — same bug shape as pre-PR-N19 `merge_cve` | Non-blocking (batch path is production, but fix is cheap) | Fix #3 |
| User asked "can I use `n.uuid` to retrieve raw MISP data?" — conflates `n.uuid` with `misp_attribute_ids[]` | Documentation gap | Doc update |

## Launch-path section highlights

Three regression xfails in `tests/test_tier1_sequential_robustness.py` are the canonical pins for Issue #57. They stay failing until the DB-backed mutex ships. Meanwhile:

**Option A — CLI (recommended):**
\`\`\`bash
docker compose exec -T airflow-worker python -m edgeguard baseline --days 730
\`\`\`
CLI takes the in-process `baseline_lock` sentinel at `src/run_pipeline.py:1093`; every scheduled DAG's `baseline_skip_reason()` check returns a reason → they self-skip.

**Option B — DAG + pre-pause:**
\`\`\`bash
for dag in edgeguard_daily edgeguard_medium_freq edgeguard_pipeline edgeguard_low_freq; do
  docker compose exec airflow-worker airflow dags pause \$dag
done
docker compose exec airflow-worker airflow dags trigger edgeguard_baseline
# unpause all 4 after baseline_complete task fires
\`\`\`

## Preflight script

10 hard-fail checks; 0 warnings = ready; any ✗ = do NOT launch:

\`\`\`
./scripts/preflight_baseline.sh --launch-path=cli
./scripts/preflight_baseline.sh --launch-path=dag   # adds the pause-state check
EDGEGUARD_PREFLIGHT_STRICT=1 ./scripts/preflight_baseline.sh  # warnings also fail
\`\`\`

## MISP retrieval paths (the user's question)

**Important clarification**: `n.uuid` is a deterministic UUIDv5 for cross-environment identity + STIX parity. It is **NOT** the MISP link.

To fetch raw MISP data from a Neo4j node, use one of three paths (all three exist on every MISP-sourced node):

| Path | Neo4j field | How to use |
|---|---|---|
| Attribute-level | `n.misp_attribute_ids[]` | `GET /attributes/<uuid>` on MISP API |
| Event-level | `n.misp_event_ids[]` | `GET /events/<id>` on MISP API |
| Per-source edge | `(n)-[r:SOURCED_FROM]->(:Source)` with `r.raw_data` | No network call — pickled MISP attribute JSON |

## Test plan

- [x] 20 new regression pins: `tests/test_pr_n20_baseline_launch_procedure.py`
  - 5 RUNBOOK section pins (CLI option, DAG+pause option, Issue #57 cross-ref, preflight-script reference)
  - 7 preflight-script shape pins (env vars, Neo4j, MISP, DAG pause-state, Prometheus, exit codes)
  - 3 `merge_vulnerability` symmetry pins (2 AST + 1 behavioral)
  - 4 MISP-retrieval doc pins (section title, UUID clarification, three paths, API shape)
  - 1 import sanity
- [x] Full suite: **1532 passed, 3 skipped, 3 xfailed** in 219s (20 new tests, all green)
- [x] `ruff format --check src/ tests/` — 159 files clean
- [x] `ruff check src/ tests/` — all checks passed
- [x] `mypy src/` — exit 0
- [x] `bash -n scripts/preflight_baseline.sh` — syntax clean, executable bit set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes Neo4j write behavior for `Vulnerability` nodes (promoting `published`/`last_modified`) and introduces a new operator script that will be relied on for baseline runs; the rest is documentation/tests.
> 
> **Overview**
> **Hardens 730-day baseline operations** by documenting two safe launch paths (CLI lock vs. Airflow DAG + pausing 4 incremental DAGs) in both `README.md` and `docs/RUNBOOK.md`, with explicit preflight/monitoring/post-run validation steps and clearer rationale tied to Issue #57.
> 
> Adds `scripts/preflight_baseline.sh`, a one-shot readiness checker for baseline day (env vars, Neo4j/APOC/indexes, MISP auth, optional DAG pause-state verification, worker RAM, Prometheus rule parsing, stale lock sentinel detection, kill-switch defaults, pytest collection).
> 
> Fixes a data integrity gap in `src/neo4j_client.py` by having `merge_vulnerability` also persist `published` and `last_modified` on the node for single-item NVD/alert paths. Adds a new regression test module `tests/test_pr_n20_baseline_launch_procedure.py` to pin the docs, script behavior, and merge symmetry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 55d574985075f5cf7f2512f38c989d1e421b6252. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->