### PR TITLE
fix(audit): PR-N21 — enrichment_jobs robustness (Campaign=0 root cause)

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2302,32 +2302,47 @@ def assert_baseline_postconditions(**context):
     try:
         client.connect()
         with client.driver.session() as session:
-            # INV-1: Campaign > 0 iff ATTRIBUTED_TO > 0.
+            # INV-1: Campaign > 0 iff there are QUALIFYING ThreatActors.
             #
-            # Bugbot round 1 (PR #105, HIGH): the pre-fix version chained
-            # ``MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) WITH
-            # count(*) AS attrib_edges MATCH (c:Campaign) WITH attrib_edges,
-            # count(c) AS campaigns`` — which returned ZERO ROWS when
-            # ``Campaign = 0`` (the MATCH on the empty label eliminated
-            # all tuples despite ``attrib_edges`` being a grouping key).
-            # ``.single()`` returned None → ``if row:`` False → violation
-            # silently skipped → DAG green. That's the EXACT bug the
-            # invariant is supposed to catch.
+            # History:
+            # - Bugbot round 1 (PR #105, HIGH): pre-fix version chained
+            #   ``MATCH (m)-[:ATTRIBUTED_TO]->(a) WITH count(*) MATCH
+            #   (c:Campaign)`` which returned ZERO ROWS when Campaign=0
+            #   (second MATCH on empty label eliminated all tuples).
+            #   Violation silently skipped — exact bug the invariant
+            #   exists to catch.
+            # - Bugbot round 2 (PR #105, MEDIUM): naive
+            #   ``count(ATTRIBUTED_TO edges) > 0`` was a FALSE-POSITIVE
+            #   risk. ``build_campaign_nodes`` only creates Campaigns for
+            #   actors with BOTH a Malware attribution AND at least one
+            #   active Indicator linked via INDICATES (enrichment_jobs.py:
+            #   296: ``WHERE size(malware_list) > 0 AND indicator_total > 0``).
+            #   A graph with ATTRIBUTED_TO edges but no active Indicators
+            #   is a LEGITIMATE zero-Campaign outcome — INV-1 firing on
+            #   that state would falsely block the DAG.
             #
-            # Fix: two independent count queries. Each returns exactly
-            # one row (count on empty label = 0, not no-rows). Cleaner
-            # to read, impossible to silently drop a branch.
+            # Fix: mirror ``build_campaign_nodes``'s exact qualifying-actor
+            # condition. Independent count queries (one row each, no
+            # silent-skip risk).
             row = session.run(
-                "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) RETURN count(*) AS attrib_edges"
+                """
+                MATCH (a:ThreatActor)
+                WHERE EXISTS {
+                    MATCH (a)<-[:ATTRIBUTED_TO]-(:Malware)<-[:INDICATES]-(i:Indicator)
+                    WHERE i.active = true
+                }
+                RETURN count(a) AS qualifying_actors
+                """
             ).single()
-            attrib = int((row["attrib_edges"] if row else 0) or 0)
+            qualifying = int((row["qualifying_actors"] if row else 0) or 0)
 
             row = session.run("MATCH (c:Campaign) RETURN count(c) AS campaigns").single()
             camps = int((row["campaigns"] if row else 0) or 0)
 
-            if attrib > 0 and camps == 0:
+            if qualifying > 0 and camps == 0:
                 violations.append(
-                    f"[INV-1] {attrib} ATTRIBUTED_TO edges exist but Campaign count = 0. "
+                    f"[INV-1] {qualifying} qualifying ThreatActors exist (have Malware "
+                    "ATTRIBUTED_TO + active Indicator via INDICATES) but Campaign count = 0. "
                     "build_campaign_nodes silently produced no campaigns. "
                     "Check Airflow log for the underlying exception (PR-N21 made enrichment_jobs re-raise)."
                 )

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2302,22 +2302,35 @@ def assert_baseline_postconditions(**context):
     try:
         client.connect()
         with client.driver.session() as session:
-            # INV-1: Campaign > 0 iff ATTRIBUTED_TO > 0
+            # INV-1: Campaign > 0 iff ATTRIBUTED_TO > 0.
+            #
+            # Bugbot round 1 (PR #105, HIGH): the pre-fix version chained
+            # ``MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) WITH
+            # count(*) AS attrib_edges MATCH (c:Campaign) WITH attrib_edges,
+            # count(c) AS campaigns`` — which returned ZERO ROWS when
+            # ``Campaign = 0`` (the MATCH on the empty label eliminated
+            # all tuples despite ``attrib_edges`` being a grouping key).
+            # ``.single()`` returned None → ``if row:`` False → violation
+            # silently skipped → DAG green. That's the EXACT bug the
+            # invariant is supposed to catch.
+            #
+            # Fix: two independent count queries. Each returns exactly
+            # one row (count on empty label = 0, not no-rows). Cleaner
+            # to read, impossible to silently drop a branch.
             row = session.run(
-                "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) "
-                "WITH count(*) AS attrib_edges "
-                "MATCH (c:Campaign) WITH attrib_edges, count(c) AS campaigns "
-                "RETURN attrib_edges, campaigns"
+                "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) RETURN count(*) AS attrib_edges"
             ).single()
-            if row:
-                attrib = int(row["attrib_edges"] or 0)
-                camps = int(row["campaigns"] or 0)
-                if attrib > 0 and camps == 0:
-                    violations.append(
-                        f"[INV-1] {attrib} ATTRIBUTED_TO edges exist but Campaign count = 0. "
-                        "build_campaign_nodes silently produced no campaigns. "
-                        "Check Airflow log for the underlying exception (PR-N21 made enrichment_jobs re-raise)."
-                    )
+            attrib = int((row["attrib_edges"] if row else 0) or 0)
+
+            row = session.run("MATCH (c:Campaign) RETURN count(c) AS campaigns").single()
+            camps = int((row["campaigns"] if row else 0) or 0)
+
+            if attrib > 0 and camps == 0:
+                violations.append(
+                    f"[INV-1] {attrib} ATTRIBUTED_TO edges exist but Campaign count = 0. "
+                    "build_campaign_nodes silently produced no campaigns. "
+                    "Check Airflow log for the underlying exception (PR-N21 made enrichment_jobs re-raise)."
+                )
 
             # INV-2: Indicator > 0
             row = session.run("MATCH (i:Indicator) RETURN count(i) AS n").single()

--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2270,6 +2270,90 @@ def run_baseline_enrichment(**context):
         client.close()
 
 
+def assert_baseline_postconditions(**context):
+    """PR-N21: post-baseline data-integrity assertion.
+
+    After enrichment_jobs runs, certain invariants MUST hold or the
+    baseline is silently broken (the 2026-04-22 cloud Campaign = 0
+    incident shape). Pre-N21, exit-code-only success checks let an
+    empty Campaign label slip through with the DAG status green; ops
+    discovered the gap only via manual Cypher inspection.
+
+    Invariants checked (each fails the DAG with an actionable message):
+
+      [INV-1] Campaign > 0 IFF ATTRIBUTED_TO > 0.
+        If the graph carries Malware→ThreatActor attributions but no
+        Campaigns materialized, ``build_campaign_nodes`` raised an
+        exception that was swallowed before PR-N21 (now re-raised).
+
+      [INV-2] Indicator > 0.
+        Sync produced data. Zero Indicators means the sync silently
+        wrote nothing — either MISP empty, allowlist mismatch, or
+        per-batch silent drop.
+
+      [INV-3] Source > 0.
+        Bootstrap created the Source nodes. Zero Sources means
+        ``ensure_sources()`` never ran.
+    """
+    from neo4j_client import Neo4jClient
+
+    client = Neo4jClient()
+    violations = []
+    try:
+        client.connect()
+        with client.driver.session() as session:
+            # INV-1: Campaign > 0 iff ATTRIBUTED_TO > 0
+            row = session.run(
+                "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) "
+                "WITH count(*) AS attrib_edges "
+                "MATCH (c:Campaign) WITH attrib_edges, count(c) AS campaigns "
+                "RETURN attrib_edges, campaigns"
+            ).single()
+            if row:
+                attrib = int(row["attrib_edges"] or 0)
+                camps = int(row["campaigns"] or 0)
+                if attrib > 0 and camps == 0:
+                    violations.append(
+                        f"[INV-1] {attrib} ATTRIBUTED_TO edges exist but Campaign count = 0. "
+                        "build_campaign_nodes silently produced no campaigns. "
+                        "Check Airflow log for the underlying exception (PR-N21 made enrichment_jobs re-raise)."
+                    )
+
+            # INV-2: Indicator > 0
+            row = session.run("MATCH (i:Indicator) RETURN count(i) AS n").single()
+            ind_count = int((row["n"] if row else 0) or 0)
+            if ind_count == 0:
+                violations.append(
+                    "[INV-2] Indicator count = 0. Sync silently wrote no data — check MISP "
+                    "allowlist (EDGEGUARD_TRUSTED_MISP_ORG_UUIDS) and `[MERGE-INEFFECTIVE]` log lines."
+                )
+
+            # INV-3: Source > 0
+            row = session.run("MATCH (s:Source) RETURN count(s) AS n").single()
+            src_count = int((row["n"] if row else 0) or 0)
+            if src_count == 0:
+                violations.append(
+                    "[INV-3] Source count = 0. ensure_sources() never bootstrapped. "
+                    "Run `python -m src.neo4j_client --bootstrap-sources` and re-trigger enrichment."
+                )
+
+        if violations:
+            joined = "\n  - " + "\n  - ".join(violations)
+            logger.error("[BASELINE-POSTCHECK] %d invariant violation(s):%s", len(violations), joined)
+            raise AirflowException(
+                f"Baseline post-check failed ({len(violations)} violations). "
+                "DAG marked FAILED so the operator sees this immediately. Details above."
+            )
+
+        logger.info(
+            "[BASELINE-POSTCHECK] all invariants OK — Indicator=%d Source=%d (plus Campaign>0 iff ATTRIBUTED_TO>0)",
+            ind_count,
+            src_count,
+        )
+    finally:
+        client.close()
+
+
 # ---- Baseline tasks ----
 
 baseline_misp_health = PythonOperator(
@@ -2715,6 +2799,20 @@ baseline_enrichment_task = PythonOperator(
     dag=baseline_dag,
 )
 
+# PR-N21: post-baseline data-integrity check. Asserts the invariants
+# operators expect after a successful enrichment run. Without this, a
+# silent ``Campaign = 0`` (the 2026-04-22 incident shape) shows the
+# DAG green and the operator only finds out via manual Cypher days
+# later. STRICT trigger_rule (ALL_SUCCESS): if enrichment failed the
+# postcheck is meaningless, so don't run.
+baseline_postcheck_task = PythonOperator(
+    task_id="baseline_postcheck",
+    python_callable=assert_baseline_postconditions,
+    execution_timeout=timedelta(minutes=10),
+    trigger_rule=TriggerRule.ALL_SUCCESS,
+    dag=baseline_dag,
+)
+
 baseline_complete = BashOperator(
     task_id="baseline_complete",
     bash_command="""
@@ -2781,5 +2879,6 @@ baseline_complete = BashOperator(
     >> baseline_full_sync_task
     >> baseline_build_rels_task
     >> baseline_enrichment_task
+    >> baseline_postcheck_task  # PR-N21: invariant check, fails DAG on Campaign=0 etc.
     >> baseline_complete
 )

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -56,6 +56,8 @@ the change to take effect. Revert by unsetting + restarting.
 | `EdgeGuardNeo4jIneffectiveBatch` | critical | `rate(edgeguard_neo4j_merge_ineffective_batch_total[5m]) > 0` for 5m |
 | `EdgeGuardNeo4jBatchPermanentFailure` | critical | `rate(edgeguard_neo4j_batch_permanent_failure_total[5m]) > 0` for 5m |
 | `EdgeGuardMergeRejectPlaceholderSpike` | warning | `increase(edgeguard_merge_reject_placeholder_total[15m]) > 10` for 15m |
+| `EdgeGuardBuildRelationshipsSilentDeath` | critical | `absent(build_rels_completions) or rate == 0` for 6h after baseline start (PR-N21 Bravo-ops) |
+| `EdgeGuardApocBatchPartial` | warning | `increase(edgeguard_apoc_batch_partial_total[15m]) > 0` (PR-N21 Bravo-ops) |
 
 Verify alerts load cleanly on baseline day:
 
@@ -213,6 +215,78 @@ Each entry: symptom → detection signal → remediation.
 
 ---
 
+## Bravo-ops: memory posture for the next baseline
+
+After the 2026-04-04 baseline was OOM-killed (exit 137) during
+`build_relationships`, and the 2026-04-22 baseline silently returned
+`Campaign = 0` due to a downstream enrichment swallower (now fixed in
+PR-N21), these are the memory settings and alerts that should guard
+the next 26h baseline run:
+
+### Memory ceilings (reconcile BEFORE kickoff)
+
+On an 8 GB Airflow worker with Neo4j co-hosted (typical EdgeGuard
+dev/staging topology):
+
+| Knob | Value | Why |
+|---|---|---|
+| `AIRFLOW_MEMORY_LIMIT` | `12g` | Allow headroom above the ~8 GB working set that MISP-to-Neo4j sync consumes on 100K+ event baselines |
+| `NEO4J_HEAP_MAX` | `8g` | Matches `NEO4J_HEAP_INITIAL`; avoids GC pauses from heap resize mid-APOC |
+| `NEO4J_TX_MEMORY_MAX` | **`≤ 4g`** | **Critical.** Per-TX cap. Above 4g you risk Neo4j `MemoryLimitExceededException` inside a single APOC `periodic.iterate` batch → partial data loss (`[PARTIAL]` log + `EdgeGuardApocBatchPartial` alert). Cap it. |
+| `NEO4J_PAGECACHE` | `4g` | Enough for 350K-node working set without eating heap |
+
+Worker resident set: baseline should peak around 6 GB. **If
+`docker stats edgeguard-airflow-worker` shows RSS > 6 GB before the
+baseline even kicks off, raise `AIRFLOW_MEMORY_LIMIT` first or the
+baseline will OOM mid-run.**
+
+### Two Bravo-ops Prometheus alerts (added in PR-N21)
+
+Both fire on the new counters `build_relationships` now emits:
+
+| Alert | Fires when | Severity | What to do |
+|---|---|---|---|
+| `EdgeGuardBuildRelationshipsSilentDeath` | `edgeguard_build_relationships_completions_total` hasn't incremented for 6h while a baseline DAG started in the last 8h | critical | subprocess died silently (exit 137 OOM, SIGKILL, TX memory exhausted). Check docker stats + Neo4j logs for `MemoryLimit`. Raise memory ceilings, re-trigger. |
+| `EdgeGuardApocBatchPartial` | any `apoc.periodic.iterate` in build_relationships returned non-empty `errorMessages` in last 15m | warning | partial data loss in that step. Grep `[PARTIAL]` in worker logs for the step identifier and error detail; re-run that single step or accept partial and move on. |
+
+Verify both load cleanly on baseline day:
+
+```bash
+promtool check rules prometheus/alerts.yml
+curl -s localhost:9090/api/v1/rules | \
+  jq '.data.groups[] | select(.name=="edgeguard_pipeline_observability") | .rules[].name' | \
+  grep -E 'BuildRelationshipsSilentDeath|ApocBatchPartial'
+```
+
+### APOC partial-batch response playbook
+
+When `EdgeGuardApocBatchPartial` fires:
+
+1. Find the step and first few error messages:
+   ```bash
+   docker logs edgeguard-airflow-worker 2>&1 | grep -E '\[PARTIAL\]' | tail -5
+   ```
+2. Classify the root cause from the logged `errorMessages`:
+   - `MemoryLimitExceededException` → Neo4j TX memory cap hit. Lower batch size for that step, OR raise `NEO4J_TX_MEMORY_MAX` (but watch the ceiling — above 4g on 8 GB worker and you're eating worker RSS).
+   - `DeadlockDetected` → transient, re-run the step.
+   - Schema / constraint error → code bug, file an issue, do NOT re-run blindly.
+3. Option A — re-run just this step: invoke `python -m src.build_relationships --step <N>` (if the CLI supports it) or re-trigger the whole DAG from that step in Airflow UI.
+4. Option B — if partial data is acceptable for the demo window, leave it. The next incremental sync will fill in most missed edges. Flag for follow-up.
+
+### Post-run summary grep
+
+A successful baseline should always emit this line:
+
+```bash
+docker logs edgeguard-airflow-worker 2>&1 | grep -E '\[BUILD_RELATIONSHIPS SUMMARY\]'
+# expected: total_edges=N failures=0/12 per_query=[...]
+```
+
+Absence of this line = silent subprocess death (the exact scenario the
+`EdgeGuardBuildRelationshipsSilentDeath` alert guards against).
+
+---
+
 ## Baseline-day protocol
 
 ### Before a 730d baseline run
@@ -222,7 +296,8 @@ Each entry: symptom → detection signal → remediation.
    6 pre-baseline alerts green, spot-check 10 random Indicators via
    Neo4j Browser or `graphql_api`.
 2. **Prometheus rules loaded.** Verify the `edgeguard_pipeline_observability`
-   rule group has all 6 alerts (4 from PR-N11/N12 + 2 added in PR-N18):
+   rule group has all 8 alerts (4 from PR-N11/N12 + 2 added in PR-N18 +
+   2 Bravo-ops added in PR-N21):
    ```bash
    promtool check rules prometheus/alerts.yml
    curl -s localhost:9090/api/v1/rules | \

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -625,13 +625,23 @@ groups:
         # relationships_completion``). If the counter hasn't incremented
         # for 6h while a DAG run started in the last 8h, we have a
         # silent death.
+        #
+        # Bugbot round 1 (PR #105, MEDIUM): pre-fix PromQL had a label
+        # mismatch on the ``AND`` — left side (``absent(...)`` or
+        # ``rate(...) == 0``) produces an empty label set ``{}`` while
+        # the right side (``max_over_time({dag_id="edgeguard_baseline"})``)
+        # carries the ``dag_id`` label. Default PromQL ``AND`` requires
+        # exact label-set equality → no match → alert never fires.
+        # Fix: ``and on()`` — ignore ALL labels on the join, since what
+        # matters here is simply "both conditions true in the same
+        # evaluation step" not "same series."
         expr: |
           (
             absent(edgeguard_build_relationships_completions_total)
             OR
             rate(edgeguard_build_relationships_completions_total[6h]) == 0
           )
-          AND
+          and on()
           (
             max_over_time(edgeguard_dag_run_start_timestamp{dag_id="edgeguard_baseline"}[8h])
               > (time() - (6 * 60 * 60))

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -612,3 +612,93 @@ groups:
               4. See ``src/node_identity.py:_REJECTED_PLACEHOLDER_NAMES``
                  for the full rejected list.
               5. See docs/RUNBOOK.md § Top-5 failure mode #5
+
+      - alert: EdgeGuardBuildRelationshipsSilentDeath
+        # PR-N21 Bravo-ops: catches a silent ``build_relationships``
+        # subprocess death (exit 137 OOM, SIGKILL from timeout, crash
+        # before the ``[BUILD_RELATIONSHIPS SUMMARY]`` line is emitted).
+        # PR-K3's streaming helper already bounds Python-side buffering
+        # — this alert catches the OTHER failure modes: Neo4j-side
+        # MemoryLimitExceededException inside the TX, kernel OOM of the
+        # Airflow worker, or a build_relationships.py exception that
+        # dies before emitting the summary counter (``record_build_
+        # relationships_completion``). If the counter hasn't incremented
+        # for 6h while a DAG run started in the last 8h, we have a
+        # silent death.
+        expr: |
+          (
+            absent(edgeguard_build_relationships_completions_total)
+            OR
+            rate(edgeguard_build_relationships_completions_total[6h]) == 0
+          )
+          AND
+          (
+            max_over_time(edgeguard_dag_run_start_timestamp{dag_id="edgeguard_baseline"}[8h])
+              > (time() - (6 * 60 * 60))
+          )
+        for: 10m
+        labels:
+          severity: critical
+          component: build_relationships
+        annotations:
+          summary: "build_relationships may have died silently — no SUMMARY emitted for 6h after baseline start"
+          description: |
+            The ``edgeguard_build_relationships_completions_total`` counter
+            has not incremented for 6 hours despite the
+            ``edgeguard_baseline`` DAG starting within the last 8h.
+            build_relationships emits this counter ONLY when it reaches
+            the ``[BUILD_RELATIONSHIPS SUMMARY]`` log line — absence =
+            subprocess died before reaching the end.
+
+            Common causes (ranked by likelihood):
+              1. Airflow worker OOM-killed (exit 137). Check:
+                 ``docker stats edgeguard-airflow-worker --no-stream``
+              2. Neo4j MemoryLimitExceededException inside an APOC batch.
+                 Check: ``docker logs edgeguard-neo4j 2>&1 | grep -iE
+                 'MemoryLimit|OutOfMemory'``
+              3. Airflow task ``execution_timeout`` (5h default) fired.
+                 Check the task's state in Airflow UI.
+
+            Remediation:
+              1. Check Airflow task state + exit code; if 137 → OOM.
+              2. Raise ``AIRFLOW_MEMORY_LIMIT`` to 12g and/or lower
+                 ``NEO4J_TX_MEMORY_MAX`` to 4g (see docs/RUNBOOK.md §
+                 "Bravo-ops: memory posture for next baseline").
+              3. Re-trigger the baseline after raising memory.
+
+      - alert: EdgeGuardApocBatchPartial
+        # PR-N21 Bravo-ops: ANY partial APOC batch during
+        # build_relationships = partial data loss in that step. Fires
+        # within 15m of the first ``[PARTIAL]`` log line (via the
+        # paired ``record_apoc_batch_partial`` counter). P2 severity —
+        # operator should re-run the specific step before downstream
+        # enrichment/analysis contaminates the graph with partial data.
+        expr: sum by (step) (increase(edgeguard_apoc_batch_partial_total[15m])) > 0
+        for: 0m
+        labels:
+          severity: warning
+          component: build_relationships
+        annotations:
+          summary: "APOC batch returned partial success in build_relationships step {{ $labels.step }} — partial data loss"
+          description: |
+            apoc.periodic.iterate for build_relationships step
+            ``{{ $labels.step }}`` reported non-empty errorMessages.
+            This means some inner-query transactions failed mid-batch
+            without propagating to the Python layer. The graph has
+            partial data for this step.
+
+            Common causes:
+              1. Neo4j MemoryLimitExceededException inside a single
+                 batch transaction.
+              2. Deadlock timeout on a single batch.
+              3. Per-row Cypher error (schema drift, constraint violation).
+
+            Remediation:
+              1. Log probe: ``docker logs edgeguard-airflow-worker
+                 2>&1 | grep -E '\[PARTIAL\]' | tail -20``
+              2. Inspect the reported errorMessages in the log line
+                 (first 3 errors are pre-logged).
+              3. Re-run build_relationships for this step only, or
+                 accept partial data and move to the next step if
+                 errors are transient and row count is acceptable.
+              4. See docs/RUNBOOK.md § "APOC partial batch response".

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -302,6 +302,22 @@ def _safe_run_batched(
                     f"elapsed {_elapsed:.1f}s, errors: {errors[:3]}"
                     f"{' (+more)' if len(errors) > 3 else ''}"
                 )
+                # PR-N21 Bravo-ops: fire the partial-batch counter so the
+                # ``EdgeGuardApocBatchPartial`` P2 alert can catch mid-run
+                # Neo4j OOM / MemoryLimitExceededException inside the APOC
+                # transaction (which the streaming helper from PR-K3
+                # CANNOT protect against — it only bounds Python-side
+                # subprocess buffering, not Neo4j-side TX memory). Any
+                # occurrence = partial data loss for this step → operator
+                # should re-run the specific step before downstream
+                # analysis runs.
+                if _METRICS_AVAILABLE:
+                    try:
+                        from metrics_server import record_apoc_batch_partial
+
+                        record_apoc_batch_partial(step=stat_key)
+                    except Exception:
+                        logger.debug("APOC partial counter failed", exc_info=True)
             else:
                 logger.info(f"  [OK] {label}: {count} in {batches_n} batches, elapsed {_elapsed:.1f}s")
             # PR #34 round 20: orphan-count log when skip_query was provided.
@@ -1009,6 +1025,18 @@ def build_relationships():
                 record_neo4j_relationships(stats)
             except Exception:
                 logger.debug("Metrics recording failed", exc_info=True)
+            # PR-N21 Bravo-ops: fire the completion counter so the Prometheus
+            # ``EdgeGuardBuildRelationshipsSilentDeath`` alert can detect a
+            # silent subprocess death (exit 137 OOM, SIGKILL). The counter is
+            # incremented ONLY if we reach this line — i.e. the summary log
+            # line was emitted AND the stats query succeeded. Absence of this
+            # counter for 6h+ after baseline_start = silent failure.
+            try:
+                from metrics_server import record_build_relationships_completion
+
+                record_build_relationships_completion()
+            except Exception:
+                logger.debug("Completion counter failed", exc_info=True)
 
         return failures == 0
 

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -488,15 +488,37 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             result = session.run(link_indicators_batched, timeout=NEO4J_READ_TIMEOUT)
             record = result.single()
             if record:
-                # ``committedOperations`` is the number of inner-query rows
-                # that produced a MERGE — the PART_OF link count.
-                results["links_created"] += record.get("committedOperations") or 0
                 err_msgs = record.get("errorMessages") or {}
                 if err_msgs:
                     # Fail loudly: any per-batch error counts as a partial
                     # data-loss event; we want the operator to see it.
                     raise RuntimeError(f"[CAMPAIGNS] link_indicators apoc.periodic.iterate batch errors: {err_msgs}")
             query_pause()
+
+            # Bugbot round 1 (PR #105, MEDIUM): the pre-fix code used
+            # ``record.get("committedOperations")`` as the PART_OF link
+            # count. Per APOC docs ``committedOperations`` is the number
+            # of SUCCESSFUL INNER-STATEMENT EXECUTIONS — one per outer row
+            # (i.e. one per Campaign) — NOT the number of MERGE rows
+            # produced. Pre-N21 ``count(*) AS links`` returned ~15,600
+            # for 156 campaigns × ~100 indicators; using
+            # committedOperations would report ~156 instead → ~100× low.
+            # The ``[CAMPAIGNS] Built N campaigns, M links`` log at the
+            # end of build_campaign_nodes would show a misleading M.
+            #
+            # Fix: run a follow-up count query keyed on
+            # ``r.updated_at >= $run_start_at`` — this gives the true
+            # count of PART_OF edges touched by THIS run's Step 3a
+            # (same freshness marker Step 3b uses to prune).
+            links_count_query = """
+            MATCH (:Indicator)-[r:PART_OF]->(:Campaign)
+            WHERE r.updated_at >= datetime($run_start_at)
+            RETURN count(r) AS links
+            """
+            links_result = session.run(
+                links_count_query, run_start_at=run_start_at, timeout=NEO4J_READ_TIMEOUT
+            ).single()
+            results["links_created"] += int((links_result["links"] if links_result else 0) or 0)
 
             # Step 3b: Prune stale PART_OF edges — indicators that WERE in a
             # prior run's top-100 but aren't in THIS run's (aged out, retired,

--- a/src/enrichment_jobs.py
+++ b/src/enrichment_jobs.py
@@ -148,7 +148,18 @@ def decay_ioc_confidence(neo4j_client) -> Dict:
                     logger.info(f"  [DECAY] {desc}: {count} nodes")
 
     except Exception as e:
-        logger.error(f"decay_ioc_confidence error: {e}")
+        # PR-N21 BLOCKER: re-raise instead of silently returning zero
+        # results. The pre-N21 ``except Exception: logger.error()`` (no
+        # raise) swallowed real Cypher errors (timeouts, schema drift,
+        # OOM) and returned ``{}`` — which the runner happily aggregated
+        # and Airflow marked SUCCESS. Operators saw a green DAG with no
+        # decay actually applied, identical to a "no work needed" run.
+        # The 2026-04-22 cloud baseline showed ``Campaign = 0`` with the
+        # same root cause (the swallower in ``build_campaign_nodes``).
+        # Fix: re-raise so the DAG task FAILS loudly and the operator
+        # sees the actual exception in the Airflow log.
+        logger.error(f"[DECAY] decay_ioc_confidence FAILED: {e}", exc_info=True)
+        raise
 
     total = sum(results.values())
     logger.info(f"[DECAY] IOC decay complete — {total} nodes updated")
@@ -439,26 +450,52 @@ def build_campaign_nodes(neo4j_client) -> Dict:
             # Net: PART_OF edges for each Campaign always equal the current
             # top-100 of active indicators. Reproducible, bounded, matches
             # the documented "sample: up to 100 per campaign" contract.
-            link_indicators = """
-            MATCH (c:Campaign)
-            MATCH (a:ThreatActor {name: c.actor_name})<-[:ATTRIBUTED_TO]-(m:Malware)<-[:INDICATES]-(i:Indicator)
-            WHERE i.active = true
-            WITH c, i
-            ORDER BY i.first_imported_at DESC, i.value ASC
-            WITH c, collect(i)[0..100] AS indicators
-            UNWIND indicators AS i
-            MERGE (i)-[r:PART_OF]->(c)
-            ON CREATE SET r.created_at = datetime(),
-                          r.src_uuid = i.uuid,
-                          r.trg_uuid = c.uuid
-            SET r.src_uuid = coalesce(r.src_uuid, i.uuid),
-                r.trg_uuid = coalesce(r.trg_uuid, c.uuid),
-                r.updated_at = datetime()
-            RETURN count(*) AS links
+            #
+            # PR-N21 (next-baseline robustness): wrap in
+            # ``apoc.periodic.iterate`` with one Campaign per batch so the
+            # cartesian explosion (Campaign × Malware × Indicator) doesn't
+            # materialize in a single transaction. Pre-N21 the un-batched
+            # version produced an intermediate row count of (n_campaigns ×
+            # avg_malware × avg_indicators) ≈ 0.5–3M rows for the cloud
+            # graph (156 campaigns × ~22 malware × ~159 indicators) — fine
+            # at 1-year scale, fragile at 730-day scale. The
+            # 2026-04-22 Campaign = 0 incident was almost certainly this
+            # query timing out / OOMing inside a single TX, then the
+            # broad ``except Exception`` (now removed) swallowing the
+            # raise. Same shape ``bridge_vulnerability_cve`` already
+            # uses for symmetric scale safety.
+            link_indicators_batched = """
+            CALL apoc.periodic.iterate(
+              "MATCH (c:Campaign) RETURN c",
+              "MATCH (a:ThreatActor {name: c.actor_name})<-[:ATTRIBUTED_TO]-(m:Malware)<-[:INDICATES]-(i:Indicator)
+               WHERE i.active = true
+               WITH c, i
+               ORDER BY i.first_imported_at DESC, i.value ASC
+               WITH c, collect(i)[0..100] AS indicators
+               UNWIND indicators AS i
+               MERGE (i)-[r:PART_OF]->(c)
+               ON CREATE SET r.created_at = datetime(),
+                             r.src_uuid = i.uuid,
+                             r.trg_uuid = c.uuid
+               SET r.src_uuid = coalesce(r.src_uuid, i.uuid),
+                   r.trg_uuid = coalesce(r.trg_uuid, c.uuid),
+                   r.updated_at = datetime()",
+              {batchSize: 25, parallel: false, retries: 2}
+            )
+            YIELD batches, total, errorMessages, committedOperations
+            RETURN batches, total, errorMessages, committedOperations
             """
-            result = session.run(link_indicators, timeout=NEO4J_READ_TIMEOUT)
+            result = session.run(link_indicators_batched, timeout=NEO4J_READ_TIMEOUT)
             record = result.single()
-            results["links_created"] += record["links"] if record else 0
+            if record:
+                # ``committedOperations`` is the number of inner-query rows
+                # that produced a MERGE — the PART_OF link count.
+                results["links_created"] += record.get("committedOperations") or 0
+                err_msgs = record.get("errorMessages") or {}
+                if err_msgs:
+                    # Fail loudly: any per-batch error counts as a partial
+                    # data-loss event; we want the operator to see it.
+                    raise RuntimeError(f"[CAMPAIGNS] link_indicators apoc.periodic.iterate batch errors: {err_msgs}")
             query_pause()
 
             # Step 3b: Prune stale PART_OF edges — indicators that WERE in a
@@ -546,7 +583,24 @@ def build_campaign_nodes(neo4j_client) -> Dict:
                 logger.info(f"  [OK] {reactivated} campaigns active (updated in this run)")
 
     except Exception as e:
-        logger.error(f"build_campaign_nodes error: {e}")
+        # PR-N21 BLOCKER (root cause of 2026-04-22 cloud Campaign = 0):
+        # the pre-N21 swallower ate exceptions and returned
+        # ``{campaigns_created: 0, links_created: 0}``. Airflow saw a
+        # clean dict, marked the task SUCCESS, and the operator
+        # discovered Campaign = 0 only via post-baseline manual
+        # inspection. With 156 qualifying ThreatActors in the cloud
+        # graph, the expected output was ~156 Campaigns; the actual
+        # output was 0 because the link_indicators step (likely
+        # exception cause: Neo4j transaction memory / timeout on the
+        # un-batched MATCH (c)<-[:RUNS]-(a)<-[:ATTRIBUTED_TO]-(m)<-
+        # [:INDICATES]-(i) cartesian) raised mid-run.
+        # Fix: re-raise. Airflow then marks task FAILED with the real
+        # traceback, and the operator gets a 1-shot diagnostic instead
+        # of a multi-day mystery. See also: ``link_indicators`` is now
+        # wrapped in ``apoc.periodic.iterate`` (this PR) to reduce the
+        # likelihood of the underlying timeout in the first place.
+        logger.error(f"[CAMPAIGNS] build_campaign_nodes FAILED: {e}", exc_info=True)
+        raise
 
     logger.info(f"[CAMPAIGNS] Built {results['campaigns_created']} campaigns, {results['links_created']} links")
     return results
@@ -745,7 +799,17 @@ def calibrate_cooccurrence_confidence(neo4j_client) -> Dict:
                     results[tier_label] = 0
 
     except Exception as e:
-        logger.error(f"calibrate_cooccurrence_confidence error: {e}")
+        # PR-N21 BLOCKER: see decay_ioc_confidence + build_campaign_nodes
+        # for full rationale. Re-raise so enrichment task fails loudly.
+        # Note: per-tier exception handling at line ~743 already catches
+        # transient per-event failures and continues with the next tier
+        # (results[tier_label] = 0 + log) — that's the correct
+        # best-effort behaviour at the FINE-GRAINED level. The OUTER
+        # except (here) catches whole-session failures (driver dead,
+        # schema corruption, etc.) which must NOT be silently
+        # swallowed.
+        logger.error(f"[CALIBRATE] calibrate_cooccurrence_confidence FAILED: {e}", exc_info=True)
+        raise
 
     total = sum(results.values())
     tier_summary = ", ".join(f"{k}: {v}" for k, v in results.items() if v > 0)
@@ -838,8 +902,16 @@ def bridge_vulnerability_cve(neo4j_client) -> Dict:
                 skip_count,
             )
     except Exception as e:
-        logger.warning(f"[BRIDGE] Vulnerability↔CVE bridge failed: {e}")
-        results["errors"] += 1
+        # PR-N21 BLOCKER: see decay_ioc_confidence + build_campaign_nodes
+        # for full rationale. The pre-N21 swallower downgraded to
+        # WARNING + incremented results["errors"], but neither Airflow
+        # nor any post-baseline assertion read results["errors"], so
+        # the failure was effectively invisible.
+        # Re-raise so the DAG task FAILS loudly. Operators see the
+        # actual exception in the Airflow log on the FIRST failed run
+        # instead of debugging stale REFERS_TO counts days later.
+        logger.error(f"[BRIDGE] Vulnerability↔CVE bridge FAILED: {e}", exc_info=True)
+        raise
 
     return results
 

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -423,6 +423,40 @@ PIPELINE_DURATION = Histogram(
     buckets=[1.0, 5.0, 10.0, 30.0, 60.0, 120.0, 300.0, 600.0],
 )
 
+# ----------------------------------------------------------------------------
+# build_relationships observability (PR-N21 follow-up, Bravo's ops list)
+# ----------------------------------------------------------------------------
+# Bravo flagged two operational gaps that would catch a build_relationships
+# failure the streaming helper (PR-K3) can't protect against — specifically
+# a mid-run OOM of Neo4j itself (``MemoryLimitExceededException`` inside the
+# transaction, not Python buffering) that kills APOC batches without
+# graceful rollback.
+#
+# 1. ``BUILD_RELATIONSHIPS_COMPLETIONS`` — incremented exactly once when
+#    build_relationships emits its ``[BUILD_RELATIONSHIPS SUMMARY]``
+#    line. Its ABSENCE after ``baseline_start`` is the signal that the
+#    subprocess died silently (exit 137 OOM, SIGKILL from timeout, etc.).
+#    Alert: ``absent()`` or ``rate == 0`` for 6h+ after baseline kickoff.
+#
+# 2. ``APOC_BATCH_PARTIAL`` — incremented per ``[PARTIAL]`` log line that
+#    APOC emits when a ``apoc.periodic.iterate`` batch fails mid-stream.
+#    Any occurrence = partial data loss in that step → P2 alert so
+#    operator can re-run that specific step before it contaminates
+#    downstream analysis.
+BUILD_RELATIONSHIPS_COMPLETIONS = Counter(
+    "edgeguard_build_relationships_completions_total",
+    "build_relationships SUMMARY emissions (one per successful end-to-end run). "
+    "Absence after a baseline started = silent subprocess death (OOM / SIGKILL).",
+)
+
+APOC_BATCH_PARTIAL = Counter(
+    "edgeguard_apoc_batch_partial_total",
+    "APOC periodic.iterate batches that reported partial success (non-empty "
+    "errorMessages) — each one = partial data-loss in a build_relationships "
+    "step. Labelled by step identifier so operators can target a re-run.",
+    ["step"],
+)
+
 PIPELINE_ERRORS = Counter("edgeguard_pipeline_errors_total", "Total pipeline errors", ["task", "error_type", "source"])
 
 PIPELINE_STAGES = Gauge("edgeguard_pipeline_stage", "Current pipeline stage (1=running, 0=idle)", ["stage"])
@@ -908,6 +942,33 @@ def record_indicators_processed(operation: str, count: int, status: str = "succe
 def record_enrichment_duration(enricher_type: str, duration: float):
     """Record enrichment duration."""
     ENRICHMENT_DURATION.labels(enricher_type=enricher_type).observe(duration)
+
+
+def record_build_relationships_completion() -> None:
+    """PR-N21 Bravo-ops: call once per successful build_relationships run,
+    when ``[BUILD_RELATIONSHIPS SUMMARY]`` is emitted. Absence after a
+    baseline starts = silent subprocess death (OOM / SIGKILL). The
+    ``EdgeGuardBuildRelationshipsSilentDeath`` alert fires on 6h of
+    zero-rate after baseline kickoff."""
+    BUILD_RELATIONSHIPS_COMPLETIONS.inc()
+
+
+def record_apoc_batch_partial(step: str) -> None:
+    """PR-N21 Bravo-ops: call per partial/errored APOC batch (any
+    ``errorMessages`` entry from ``apoc.periodic.iterate``). Any
+    occurrence = partial data-loss for that step → P2 alert so the
+    operator can re-run the specific step before downstream is
+    contaminated.
+
+    Args:
+        step: short, bounded-cardinality identifier of the build_relationships
+            step that reported the partial batch (e.g. ``"4"``, ``"9"``,
+            ``"link_indicators"``). Keep it low-cardinality to avoid
+            unbounded label explosion.
+    """
+    # Bound cardinality: unknown/long step identifiers collapse to "<other>"
+    safe_step = str(step).strip()[:40] if step else "<unknown>"
+    APOC_BATCH_PARTIAL.labels(step=safe_step).inc()
 
 
 def get_all_metrics() -> bytes:

--- a/tests/test_pr33_bugbot_fixes.py
+++ b/tests/test_pr33_bugbot_fixes.py
@@ -2101,16 +2101,18 @@ def test_build_campaign_nodes_backfill_heals_null_uuids_runtime():
         # 6th call. With the swallower removed (PR-N21), all 8 must be
         # mocked correctly. The 5th call (link_indicators_batched) now
         # returns ``apoc.periodic.iterate`` shape (committedOperations
-        # + errorMessages) instead of the legacy ``links`` int.
+        # + errorMessages) instead of the legacy ``links`` int. Plus
+        # PR-N21 Bugbot round 1 added a follow-up links-count query.
         # Order:
         #   (1) qualifying_actors_query           — returns iter of actors
         #   (2) create_cypher (Step 1)            — .single() = {campaigns: N}
         #   (3) backfill_cypher                   — .single() = {backfilled: N}
         #   (4) link_malware (Step 2)             — .single() = {links: N}
         #   (5) link_indicators_batched (Step 3a) — .single() = {committedOperations, errorMessages, ...}
-        #   (6) prune_query (Step 3b)             — .single() = {pruned: N}
-        #   (7) cleanup_query (Step 4)            — .single() = {orphans: N}
-        #   (8) reactivated_query (Step 5)        — .single() = {count: N}
+        #   (6) links_count_query (Step 3a')      — .single() = {links: N}  ← NEW in PR-N21 Bugbot round 1
+        #   (7) prune_query (Step 3b)             — .single() = {pruned: N}
+        #   (8) cleanup_query (Step 4)            — .single() = {count: N}
+        #   (9) reactivated_query (Step 5)        — .single() = {count: N}
         actors_iter = iter([{"name": "APT-Test"}])
         actors_result = MagicMock()
         actors_result.__iter__ = lambda self: actors_iter
@@ -2121,9 +2123,8 @@ def test_build_campaign_nodes_backfill_heals_null_uuids_runtime():
         link_m_result = MagicMock()
         link_m_result.single.return_value = {"links": 0}
         # PR-N21: link_indicators_batched returns apoc.periodic.iterate
-        # output shape — the implementation reads
-        # ``record.get("committedOperations")`` + ``record.get("errorMessages")``.
-        # ``errorMessages`` MUST be empty (or falsy) or the impl raises.
+        # output shape. ``errorMessages`` MUST be empty (or falsy) or
+        # the impl raises.
         link_i_result = MagicMock()
         link_i_result.single.return_value = {
             "committedOperations": 0,
@@ -2131,6 +2132,11 @@ def test_build_campaign_nodes_backfill_heals_null_uuids_runtime():
             "batches": 1,
             "total": 0,
         }
+        # PR-N21 Bugbot round 1: follow-up count query for the TRUE
+        # PART_OF edge count (Bugbot caught that committedOperations
+        # counts Campaigns, not edges).
+        links_count_result = MagicMock()
+        links_count_result.single.return_value = {"links": 0}
         prune_result = MagicMock()
         prune_result.single.return_value = {"pruned": 0}
         cleanup_result = MagicMock()
@@ -2143,9 +2149,10 @@ def test_build_campaign_nodes_backfill_heals_null_uuids_runtime():
             backfill_result,  # 3
             link_m_result,  # 4
             link_i_result,  # 5 — PR-N21 batched shape
-            prune_result,  # 6
-            cleanup_result,  # 7
-            reactivated_result,  # 8
+            links_count_result,  # 6 — PR-N21 Bugbot round 1 follow-up
+            prune_result,  # 7
+            cleanup_result,  # 8
+            reactivated_result,  # 9
         ]
         client.driver.session.return_value = sess
 

--- a/tests/test_pr33_bugbot_fixes.py
+++ b/tests/test_pr33_bugbot_fixes.py
@@ -2095,13 +2095,22 @@ def test_build_campaign_nodes_backfill_heals_null_uuids_runtime():
         sess.__enter__ = lambda s: s
         sess.__exit__ = lambda *a: False
 
-        # 4 session.run calls in build_campaign_nodes:
-        # (1) qualifying_actors_query — return 1 actor
-        # (2) create_cypher (main MERGE) — return campaigns count
-        # (3) backfill_cypher — return non-zero
-        # (4) link_malware
-        # (5) link_indicators
-        # We give iter for the actors query and .single() for the rest.
+        # PR-N21: build_campaign_nodes makes 8 session.run() calls; the
+        # pre-N21 mock only covered 5 and silently relied on the broad
+        # ``except Exception`` swallower to eat the StopIteration on the
+        # 6th call. With the swallower removed (PR-N21), all 8 must be
+        # mocked correctly. The 5th call (link_indicators_batched) now
+        # returns ``apoc.periodic.iterate`` shape (committedOperations
+        # + errorMessages) instead of the legacy ``links`` int.
+        # Order:
+        #   (1) qualifying_actors_query           — returns iter of actors
+        #   (2) create_cypher (Step 1)            — .single() = {campaigns: N}
+        #   (3) backfill_cypher                   — .single() = {backfilled: N}
+        #   (4) link_malware (Step 2)             — .single() = {links: N}
+        #   (5) link_indicators_batched (Step 3a) — .single() = {committedOperations, errorMessages, ...}
+        #   (6) prune_query (Step 3b)             — .single() = {pruned: N}
+        #   (7) cleanup_query (Step 4)            — .single() = {orphans: N}
+        #   (8) reactivated_query (Step 5)        — .single() = {count: N}
         actors_iter = iter([{"name": "APT-Test"}])
         actors_result = MagicMock()
         actors_result.__iter__ = lambda self: actors_iter
@@ -2111,14 +2120,32 @@ def test_build_campaign_nodes_backfill_heals_null_uuids_runtime():
         backfill_result.single.return_value = {"backfilled": 7}
         link_m_result = MagicMock()
         link_m_result.single.return_value = {"links": 0}
+        # PR-N21: link_indicators_batched returns apoc.periodic.iterate
+        # output shape — the implementation reads
+        # ``record.get("committedOperations")`` + ``record.get("errorMessages")``.
+        # ``errorMessages`` MUST be empty (or falsy) or the impl raises.
         link_i_result = MagicMock()
-        link_i_result.single.return_value = {"links": 0}
+        link_i_result.single.return_value = {
+            "committedOperations": 0,
+            "errorMessages": {},
+            "batches": 1,
+            "total": 0,
+        }
+        prune_result = MagicMock()
+        prune_result.single.return_value = {"pruned": 0}
+        cleanup_result = MagicMock()
+        cleanup_result.single.return_value = {"count": 0}
+        reactivated_result = MagicMock()
+        reactivated_result.single.return_value = {"count": 0}
         sess.run.side_effect = [
-            actors_result,
-            create_result,
-            backfill_result,
-            link_m_result,
-            link_i_result,
+            actors_result,  # 1
+            create_result,  # 2
+            backfill_result,  # 3
+            link_m_result,  # 4
+            link_i_result,  # 5 — PR-N21 batched shape
+            prune_result,  # 6
+            cleanup_result,  # 7
+            reactivated_result,  # 8
         ]
         client.driver.session.return_value = sess
 

--- a/tests/test_pr_m3d_campaign_determinism.py
+++ b/tests/test_pr_m3d_campaign_determinism.py
@@ -119,17 +119,25 @@ class TestPartOfEdgesDeterministic:
     def test_step3_has_order_by_before_collect(self, source: str) -> None:
         """The ``ORDER BY i.first_imported_at DESC, i.value ASC``
         clause MUST appear between the WHERE filter and the
-        ``collect(i)[0..100]`` slice."""
+        ``collect(i)[0..100]`` slice.
+
+        PR-N21 renamed the variable ``link_indicators`` →
+        ``link_indicators_batched`` and wrapped the inner query in
+        ``apoc.periodic.iterate`` for scale safety. Look for the
+        renamed anchor first; fall back to the legacy name for
+        forward/back compatibility."""
         start = source.find("def build_campaign_nodes")
         end = source.find("\ndef ", start + 1)
         body = source[start:end]
-        # Look for link_indicators query
-        assert "link_indicators = " in body
-        li_start = body.find("link_indicators = ")
-        li_end = body.find('"""', li_start + 20)  # end of triple-quoted block
-        # Skip the opening triple-quote to find the real end
-        li_end = body.find('"""', li_end + 3)
-        link_block = body[li_start:li_end]
+        # PR-N21: prefer the new anchor; fall back to legacy.
+        anchor = "link_indicators_batched = " if "link_indicators_batched = " in body else "link_indicators = "
+        assert anchor in body, "link_indicators query must be defined"
+        li_start = body.find(anchor)
+        # The query block is now wrapped in apoc.periodic.iterate; the
+        # inner Cypher is a string literal that extends until the
+        # outer `)` of the apoc call. Use a generous slice that
+        # covers both shapes.
+        link_block = body[li_start : li_start + 3000]
         assert "ORDER BY i.first_imported_at DESC, i.value ASC" in link_block, (
             "Step 3 must sort deterministically before the 100-slice"
         )
@@ -140,13 +148,16 @@ class TestPartOfEdgesDeterministic:
 
     def test_step3a_stamps_r_updated_at(self, source: str) -> None:
         """Every PART_OF MERGE MUST stamp ``r.updated_at = datetime()``
-        so Step 3b can use it as the freshness marker."""
+        so Step 3b can use it as the freshness marker.
+
+        PR-N21: anchor accepts both the legacy ``link_indicators = ``
+        name and the new ``link_indicators_batched = `` name."""
         start = source.find("def build_campaign_nodes")
         end = source.find("\ndef ", start + 1)
         body = source[start:end]
-        li_idx = body.find("link_indicators = ")
-        # The link_indicators query block extends roughly 2KB.
-        link_block = body[li_idx : li_idx + 2000]
+        anchor = "link_indicators_batched = " if "link_indicators_batched = " in body else "link_indicators = "
+        li_idx = body.find(anchor)
+        link_block = body[li_idx : li_idx + 3000]
         assert "r.updated_at = datetime()" in link_block, (
             "Step 3a MERGE must stamp r.updated_at so Step 3b can prune stale edges"
         )

--- a/tests/test_pr_n21_enrichment_robustness.py
+++ b/tests/test_pr_n21_enrichment_robustness.py
@@ -247,6 +247,162 @@ class TestFix6BaselinePostcheck:
 
 
 # ===========================================================================
+# Bravo-ops: build_relationships observability counters + 2 alerts + RUNBOOK
+# ===========================================================================
+
+
+class TestBravoOpsCountersExist:
+    """PR-N21 follow-up from Bravo's 2026-04-22 OOM-forensics review:
+    add metrics so a future silent build_relationships death (OOM-kill,
+    Neo4j MemoryLimitExceededException inside APOC TX, etc.) can be
+    detected by Prometheus instead of noticed days later via manual grep."""
+
+    def _metrics_src(self) -> str:
+        return (SRC / "metrics_server.py").read_text()
+
+    def test_build_relationships_completion_counter_defined(self):
+        src = self._metrics_src()
+        assert "BUILD_RELATIONSHIPS_COMPLETIONS" in src, (
+            "metrics_server must define BUILD_RELATIONSHIPS_COMPLETIONS counter"
+        )
+        assert "edgeguard_build_relationships_completions_total" in src, (
+            "counter must expose the ``edgeguard_build_relationships_completions_total`` Prometheus metric name"
+        )
+
+    def test_apoc_batch_partial_counter_defined(self):
+        src = self._metrics_src()
+        assert "APOC_BATCH_PARTIAL" in src, "metrics_server must define APOC_BATCH_PARTIAL counter"
+        assert "edgeguard_apoc_batch_partial_total" in src, (
+            "counter must expose the ``edgeguard_apoc_batch_partial_total`` Prometheus metric name"
+        )
+        # Must be labelled by step so operators can target re-runs.
+        assert '"step"' in src or "'step'" in src, "APOC_BATCH_PARTIAL must be labelled by step identifier"
+
+    def test_recorder_helpers_defined(self):
+        src = self._metrics_src()
+        assert "def record_build_relationships_completion" in src, (
+            "metrics_server must define record_build_relationships_completion helper"
+        )
+        assert "def record_apoc_batch_partial" in src, (
+            "metrics_server must define record_apoc_batch_partial(step=) helper"
+        )
+
+
+class TestBravoOpsBuildRelationshipsWiring:
+    """build_relationships.py must actually CALL the new recorders at the
+    right points, otherwise the counters stay flat and the alerts never
+    fire for real events."""
+
+    def _src(self) -> str:
+        return (SRC / "build_relationships.py").read_text()
+
+    def test_completion_counter_fired_after_summary(self):
+        """The completion counter MUST be incremented only after the
+        ``[BUILD_RELATIONSHIPS SUMMARY]`` log line is emitted — absence
+        of this call = subprocess died before reaching the end."""
+        src = self._src()
+        assert "record_build_relationships_completion" in src, (
+            "build_relationships must call record_build_relationships_completion "
+            "after the summary log line so Prometheus can detect silent death"
+        )
+        # Must come AFTER the summary log, not at import time.
+        summary_pos = src.find("[BUILD_RELATIONSHIPS SUMMARY]")
+        completion_pos = src.find("record_build_relationships_completion(")
+        assert summary_pos != -1 and completion_pos > summary_pos, (
+            "completion counter must be AFTER the summary log (call_counter < summary_log "
+            "would give false positives on every import)"
+        )
+
+    def test_partial_counter_fired_per_partial_batch(self):
+        """The partial counter MUST be incremented inside the
+        ``if errors:`` branch of _safe_run_batched so any
+        apoc.periodic.iterate errorMessages increment the counter."""
+        src = self._src()
+        assert "record_apoc_batch_partial" in src, (
+            "build_relationships must call record_apoc_batch_partial(step=) "
+            "when apoc.periodic.iterate reports errorMessages"
+        )
+        # Must be inside the _safe_run_batched function, near the [PARTIAL] log
+        partial_log_pos = src.find("[PARTIAL]")
+        record_pos = src.find("record_apoc_batch_partial")
+        assert partial_log_pos != -1 and record_pos > partial_log_pos, (
+            "partial counter must be fired in the same [PARTIAL] log branch"
+        )
+
+
+class TestBravoOpsPrometheusAlerts:
+    """Two alert rules must be loaded so the above counters produce
+    actionable paging signals."""
+
+    def _alerts_src(self) -> str:
+        return (REPO_ROOT / "prometheus" / "alerts.yml").read_text()
+
+    def test_silent_death_alert_defined(self):
+        src = self._alerts_src()
+        assert "EdgeGuardBuildRelationshipsSilentDeath" in src, (
+            "Prometheus must define EdgeGuardBuildRelationshipsSilentDeath alert"
+        )
+        # Must reference the completion counter
+        assert "edgeguard_build_relationships_completions_total" in src, (
+            "silent-death alert must key on the completion counter"
+        )
+        # Must be critical severity (OOM-kill is data-loss, page the operator)
+        silent_death_block = src[src.find("EdgeGuardBuildRelationshipsSilentDeath") :]
+        silent_death_block = silent_death_block[: silent_death_block.find("- alert:", 50)]
+        assert "severity: critical" in silent_death_block, (
+            "silent-death alert must be critical severity (OOM = data-loss)"
+        )
+
+    def test_apoc_partial_alert_defined(self):
+        src = self._alerts_src()
+        assert "EdgeGuardApocBatchPartial" in src, "Prometheus must define EdgeGuardApocBatchPartial alert"
+        # Must reference the partial counter
+        assert "edgeguard_apoc_batch_partial_total" in src, "APOC partial alert must key on the partial counter"
+        # Must be warning severity (partial is recoverable, but worth paging)
+        partial_block = src[src.find("EdgeGuardApocBatchPartial") :]
+        # Pick this alert's block out (until next alert or end)
+        next_alert = partial_block.find("- alert:", 50)
+        partial_block = partial_block[:next_alert] if next_alert != -1 else partial_block
+        assert "severity: warning" in partial_block, (
+            "APOC partial alert must be warning severity (partial = recoverable)"
+        )
+
+
+class TestBravoOpsRunbookGuidance:
+    """RUNBOOK must document the memory posture + APOC partial response
+    playbook so operators have a single source of truth."""
+
+    def _runbook(self) -> str:
+        return (REPO_ROOT / "docs" / "RUNBOOK.md").read_text()
+
+    def test_runbook_has_bravo_ops_section(self):
+        rb = self._runbook()
+        assert "Bravo-ops" in rb, "RUNBOOK must have Bravo-ops memory-posture section"
+
+    def test_runbook_documents_tx_memory_max_cap(self):
+        """The key Bravo recommendation: NEO4J_TX_MEMORY_MAX ≤ 4g on an
+        8 GB worker to avoid MemoryLimitExceededException inside APOC TX."""
+        rb = self._runbook()
+        assert "NEO4J_TX_MEMORY_MAX" in rb, "RUNBOOK must reference NEO4J_TX_MEMORY_MAX"
+        # Must mention the 4g cap (the specific recommendation)
+        assert "4g" in rb or "≤ 4" in rb, "RUNBOOK must specify the ≤ 4g TX memory cap"
+
+    def test_runbook_documents_silent_death_alert(self):
+        rb = self._runbook()
+        assert "EdgeGuardBuildRelationshipsSilentDeath" in rb, (
+            "RUNBOOK must document the silent-death alert so operators know what to do when it fires"
+        )
+
+    def test_runbook_documents_apoc_partial_playbook(self):
+        rb = self._runbook()
+        # Must have a playbook entry with MemoryLimitExceededException handling
+        assert "APOC partial" in rb or "EdgeGuardApocBatchPartial" in rb
+        assert "MemoryLimitExceededException" in rb, (
+            "RUNBOOK must mention MemoryLimitExceededException as a common APOC partial cause"
+        )
+
+
+# ===========================================================================
 # Module import sanity
 # ===========================================================================
 
@@ -254,6 +410,22 @@ class TestFix6BaselinePostcheck:
 class TestModuleImportsCleanly:
     def test_enrichment_jobs_imports(self):
         import enrichment_jobs  # noqa: F401
+
+    def test_metrics_server_exports_new_recorders(self):
+        """PR-N21 Bravo-ops: the new recorders must be importable.
+        NOTE: cannot ``del sys.modules['metrics_server'] + reimport``
+        because prometheus_client's ``CollectorRegistry`` forbids
+        duplicate metric registration — the second import would raise
+        ``ValueError: Duplicated timeseries``. Just check attribute
+        presence on the already-imported module; duplicate-registration
+        would have surfaced on the first import in the test collector."""
+        import metrics_server
+
+        assert hasattr(metrics_server, "record_build_relationships_completion")
+        assert hasattr(metrics_server, "record_apoc_batch_partial")
+        # Spot-check the counter object is actually a Counter (not a stub)
+        assert hasattr(metrics_server, "BUILD_RELATIONSHIPS_COMPLETIONS")
+        assert hasattr(metrics_server, "APOC_BATCH_PARTIAL")
 
     def test_dag_module_parses(self):
         """DAG module must remain Python-syntax-valid after the

--- a/tests/test_pr_n21_enrichment_robustness.py
+++ b/tests/test_pr_n21_enrichment_robustness.py
@@ -436,19 +436,38 @@ class TestBugbotRound1Fixes:
         src = self._dag_src()
         post_body = _function_body(src, "assert_baseline_postconditions")
 
-        # Pin the new shape: two independent queries, each returning a
-        # single count. Anchor on the 2 ``RETURN count(...)`` lines.
+        # Pin the new shape: independent queries, each returning a
+        # single count. INV-1 (qualifying actors + Campaigns) + INV-2
+        # (Indicator) + INV-3 (Source) → ≥4 ``RETURN count`` occurrences.
         assert post_body.count("RETURN count") >= 4, (
-            "INV-1 + INV-2 + INV-3 must each use a standalone count query "
-            "returning one row (total: at least 4 ``RETURN count`` occurrences). "
-            "Bugbot round 1 HIGH: chained MATCH + count returned no rows when "
-            "the second MATCH targets an empty label."
+            "INV-1 + INV-2 + INV-3 must each use a standalone count query (≥4 ``RETURN count`` total)"
         )
 
-        # Negative: the original silently-broken pattern (two MATCHes
-        # joined by intermediate WITH) must NOT be present.
+        # Negative: the original silently-broken pattern must NOT be present.
         assert "WITH count(*) AS attrib_edges MATCH (c:Campaign)" not in post_body, (
-            "chained MATCH after aggregation is the regression pattern Bugbot flagged"
+            "chained MATCH after aggregation is the Bugbot round 1 HIGH regression pattern"
+        )
+
+    def test_inv1_uses_qualifying_actor_filter_not_naive_attrib_count(self):
+        """Bugbot round 2 (PR #105, MEDIUM): naive ``count(ATTRIBUTED_TO
+        edges) > 0`` would false-positive on a graph where actors have
+        Malware attributions but no active Indicators (a legitimate
+        zero-Campaign outcome — ``build_campaign_nodes`` requires BOTH
+        per enrichment_jobs.py:296 ``size(malware_list) > 0 AND
+        indicator_total > 0``). INV-1 must mirror the actual qualifying-
+        actor condition: Malware ATTRIBUTED_TO + INDICATES from active
+        Indicator."""
+        src = self._dag_src()
+        post_body = _function_body(src, "assert_baseline_postconditions")
+
+        # Positive: must reference INDICATES + active filter (qualifying-actor logic)
+        assert "INDICATES" in post_body, "INV-1 must include INDICATES traversal to mirror build_campaign_nodes filter"
+        assert "i.active = true" in post_body or "i.active=true" in post_body, (
+            "INV-1 must filter on i.active=true to match build_campaign_nodes (enrichment_jobs.py:251)"
+        )
+        # Negative: the naive ATTRIBUTED_TO-only count must NOT appear
+        assert "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(:ThreatActor) RETURN count(*)" not in post_body, (
+            "INV-1 must not use the naive ATTRIBUTED_TO-only count — that's the Bugbot round 2 false-positive shape"
         )
 
     def test_links_counted_by_updated_at_not_committed_operations(self):

--- a/tests/test_pr_n21_enrichment_robustness.py
+++ b/tests/test_pr_n21_enrichment_robustness.py
@@ -1,0 +1,264 @@
+"""
+PR-N21 — enrichment_jobs robustness for the next 730-day baseline.
+
+Root-caused via 4-agent audit on 2026-04-22 of the Campaign = 0 outcome
+in cloud Neo4j after a "successful" baseline. Three problems found:
+
+1. **Silent-failure swallowers** in all 4 enrichment jobs
+   (``decay_ioc_confidence``, ``build_campaign_nodes``,
+   ``calibrate_cooccurrence_confidence``, ``bridge_vulnerability_cve``).
+   The pre-N21 ``except Exception: logger.error(...)`` (no raise) ate
+   real Cypher errors (timeouts, schema drift, OOM) and let each job
+   return zero results. Airflow saw a clean dict and marked the task
+   SUCCESS — no traceback, no alert. The 2026-04-22 cloud baseline
+   showed ``Campaign = 0`` despite 156 qualifying ThreatActors with
+   incoming Malware ATTRIBUTED_TO edges; expected output was ~156
+   Campaigns.
+
+2. **Un-batched cartesian** in ``link_indicators`` (the most likely
+   cause of the underlying raise). At 730-day scale,
+   ``MATCH (c:Campaign) MATCH (a:ThreatActor)<-[:ATTRIBUTED_TO]-(m:Malware)
+   <-[:INDICATES]-(i:Indicator)`` materialized millions of intermediate
+   rows in a single Neo4j transaction → timeout / OOM. Now wrapped in
+   ``apoc.periodic.iterate`` with batchSize=25 (one Campaign per
+   batch).
+
+3. **No baseline post-check** to catch ``Campaign = 0 / ATTRIBUTED_TO > 0``
+   asymmetry. Added ``baseline_postcheck`` task to the
+   ``edgeguard_baseline`` DAG that fails the run with an actionable
+   message if any invariant is violated.
+
+These three changes together mean that the NEXT baseline either:
+  (a) succeeds and produces Campaigns proportional to qualifying
+      ThreatActors (currently ~156 in cloud), OR
+  (b) fails loudly with a real traceback the operator can act on.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+DAGS = REPO_ROOT / "dags"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n21")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n21")
+
+
+# ===========================================================================
+# Fix #1-#4 — the four swallowers must re-raise
+# ===========================================================================
+
+
+def _function_body(src: str, fn_name: str) -> str:
+    """Return the AST-unparsed body of a top-level function."""
+    tree = ast.parse(src)
+    for node in tree.body:
+        if isinstance(node, ast.FunctionDef) and node.name == fn_name:
+            return ast.unparse(node)
+    raise AssertionError(f"function {fn_name} not found in source")
+
+
+class TestFix1234SwallowersReraise:
+    """Each of the 4 enrichment jobs must re-raise on outer except instead of
+    silently returning zero results. Pin via AST-walk of each function."""
+
+    def _src(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def _outer_except_reraises(self, fn_name: str) -> bool:
+        """True iff the function has at least one ``except Exception`` handler
+        whose body contains a bare ``raise``."""
+        tree = ast.parse(self._src())
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef) and node.name == fn_name:
+                for inner in ast.walk(node):
+                    if isinstance(inner, ast.ExceptHandler):
+                        # Must catch Exception (not a narrower class)
+                        is_broad = (
+                            isinstance(inner.type, ast.Name) and inner.type.id == "Exception"
+                        ) or inner.type is None
+                        if not is_broad:
+                            continue
+                        # Look for a bare ``raise`` in the handler body
+                        for stmt in ast.walk(ast.Module(body=inner.body, type_ignores=[])):
+                            if isinstance(stmt, ast.Raise) and stmt.exc is None:
+                                return True
+                return False
+        raise AssertionError(f"function {fn_name} not found")
+
+    def test_decay_ioc_confidence_reraises(self):
+        assert self._outer_except_reraises("decay_ioc_confidence"), (
+            "decay_ioc_confidence must ``raise`` after logging in its outer "
+            "except Exception handler. Pre-PR-N21 it silently returned zero "
+            "results, hiding real Cypher errors from Airflow."
+        )
+
+    def test_build_campaign_nodes_reraises(self):
+        """The 2026-04-22 Campaign = 0 culprit. The exception-swallower at
+        line ~548 was the smoking gun."""
+        assert self._outer_except_reraises("build_campaign_nodes"), (
+            "build_campaign_nodes must ``raise`` after logging in its outer "
+            "except Exception handler. The pre-N21 swallower returned "
+            "{campaigns_created: 0, links_created: 0} on any error, "
+            "producing the silent Campaign = 0 outcome in the cloud baseline."
+        )
+
+    def test_calibrate_cooccurrence_confidence_reraises(self):
+        assert self._outer_except_reraises("calibrate_cooccurrence_confidence"), (
+            "calibrate_cooccurrence_confidence must ``raise`` after logging "
+            "in its outer except. Per-tier inner exceptions still log+continue "
+            "(by design) — only the WHOLE-SESSION outer except re-raises."
+        )
+
+    def test_bridge_vulnerability_cve_reraises(self):
+        assert self._outer_except_reraises("bridge_vulnerability_cve"), (
+            "bridge_vulnerability_cve must ``raise`` after logging. "
+            "Pre-N21 it downgraded to WARNING and bumped results['errors'], "
+            "but no caller ever read results['errors'] — effectively "
+            "invisible to Airflow."
+        )
+
+
+# ===========================================================================
+# Fix #5 — link_indicators wrapped in apoc.periodic.iterate
+# ===========================================================================
+
+
+class TestFix5LinkIndicatorsBatched:
+    """The cartesian explosion in build_campaign_nodes link_indicators
+    must be wrapped in apoc.periodic.iterate at baseline scale."""
+
+    def _campaigns_body(self) -> str:
+        return _function_body((SRC / "enrichment_jobs.py").read_text(), "build_campaign_nodes")
+
+    def test_link_indicators_uses_apoc_periodic_iterate(self):
+        body = self._campaigns_body()
+        # The Cypher fragment must reference apoc.periodic.iterate. Pre-N21
+        # was a single ``MATCH (c:Campaign) MATCH (a)<-...-(i)`` materialized
+        # in one TX.
+        assert "apoc.periodic.iterate" in body, (
+            "link_indicators must be wrapped in apoc.periodic.iterate so the "
+            "Campaign × Malware × Indicator cartesian doesn't materialize in "
+            "one TX. Pre-N21 produced 0.5–3M intermediate rows at baseline "
+            "scale → likely cause of the 2026-04-22 timeout that the "
+            "swallower hid."
+        )
+
+    def test_link_indicators_outer_iterates_campaigns(self):
+        """The outer query of apoc.periodic.iterate must be ``MATCH (c:Campaign)``
+        — one batch per Campaign, not one batch per Indicator."""
+        body = self._campaigns_body()
+        assert '"MATCH (c:Campaign) RETURN c"' in body or "MATCH (c:Campaign) RETURN c" in body, (
+            "apoc.periodic.iterate outer must iterate Campaigns (the small "
+            "side, ~156 rows in cloud) not Indicators (146K)."
+        )
+
+    def test_link_indicators_batch_size_bounded(self):
+        body = self._campaigns_body()
+        # batchSize must be present and reasonable (not 0, not 100000+).
+        # Anything in [1, 500] is fine; we pin only that batchSize is set.
+        assert "batchSize" in body, "apoc.periodic.iterate must specify batchSize to bound TX size"
+
+    def test_link_indicators_propagates_apoc_errors(self):
+        """If any per-batch fails, the result's errorMessages map must cause
+        a hard raise — otherwise apoc.periodic.iterate just returns
+        a dict with errors and we'd be back to silent partial-loss."""
+        body = self._campaigns_body()
+        assert "errorMessages" in body, "post-call must inspect errorMessages"
+        assert "raise" in body, "any non-empty errorMessages must raise"
+
+
+# ===========================================================================
+# Fix #6 — baseline_postcheck task added to edgeguard_baseline DAG
+# ===========================================================================
+
+
+class TestFix6BaselinePostcheck:
+    """The baseline_postcheck task must exist, be wired between enrichment
+    and baseline_complete, and check the Campaign = 0 invariant."""
+
+    def _dag_src(self) -> str:
+        return (DAGS / "edgeguard_pipeline.py").read_text()
+
+    def test_postcheck_callable_exists(self):
+        src = self._dag_src()
+        assert "def assert_baseline_postconditions" in src, (
+            "DAG module must define assert_baseline_postconditions callable"
+        )
+
+    def test_postcheck_task_wired_into_dag(self):
+        src = self._dag_src()
+        # PythonOperator with task_id="baseline_postcheck"
+        assert 'task_id="baseline_postcheck"' in src, (
+            "baseline_postcheck PythonOperator must be defined in baseline_dag"
+        )
+        # Must be in the chain BEFORE baseline_complete
+        assert ">> baseline_postcheck_task" in src, "baseline_postcheck_task must appear in the >> chain"
+        assert ">> baseline_complete" in src, "baseline_complete still in chain"
+        # Order check: postcheck must precede complete in the chain
+        chain_start = src.find(">> baseline_postcheck_task")
+        complete_pos = src.find(">> baseline_complete", chain_start)
+        assert chain_start != -1 and complete_pos > chain_start, (
+            "baseline_postcheck_task must come BEFORE baseline_complete in the chain"
+        )
+
+    def test_postcheck_runs_after_enrichment(self):
+        src = self._dag_src()
+        # baseline_enrichment_task must immediately precede baseline_postcheck_task
+        # in the chain (so the postcheck runs only if enrichment succeeded).
+        idx_enrich = src.find(">> baseline_enrichment_task")
+        idx_post = src.find(">> baseline_postcheck_task", idx_enrich)
+        assert idx_enrich != -1 and idx_post > idx_enrich, (
+            "baseline_postcheck_task must come AFTER baseline_enrichment_task"
+        )
+
+    def test_postcheck_checks_campaign_invariant(self):
+        """INV-1 must be implemented: ATTRIBUTED_TO > 0 AND Campaign = 0
+        is a hard failure."""
+        src = self._dag_src()
+        # The Cypher in the postcheck callable must reference both Campaign
+        # and ATTRIBUTED_TO — otherwise it's not actually checking the
+        # invariant the 2026-04-22 incident exposed.
+        post_body = _function_body(src, "assert_baseline_postconditions")
+        assert "ATTRIBUTED_TO" in post_body, "INV-1 must check ATTRIBUTED_TO edges"
+        assert ":Campaign" in post_body, "INV-1 must check Campaign nodes"
+        # Must raise AirflowException on violation (not just log)
+        assert "AirflowException" in post_body, "violations must raise AirflowException so DAG marks FAILED"
+
+    def test_postcheck_strict_trigger_rule(self):
+        """The postcheck task must have ALL_SUCCESS trigger_rule — running
+        it when enrichment failed would just produce a misleading second
+        error."""
+        src = self._dag_src()
+        # Find the baseline_postcheck_task PythonOperator block
+        anchor = src.find('task_id="baseline_postcheck"')
+        assert anchor != -1
+        # Search forward for trigger_rule within the next ~500 chars (block size)
+        block = src[anchor : anchor + 600]
+        assert "TriggerRule.ALL_SUCCESS" in block, "baseline_postcheck must use ALL_SUCCESS trigger_rule"
+
+
+# ===========================================================================
+# Module import sanity
+# ===========================================================================
+
+
+class TestModuleImportsCleanly:
+    def test_enrichment_jobs_imports(self):
+        import enrichment_jobs  # noqa: F401
+
+    def test_dag_module_parses(self):
+        """DAG module must remain Python-syntax-valid after the
+        baseline_postcheck addition."""
+        src = (DAGS / "edgeguard_pipeline.py").read_text()
+        # Just parse — full Airflow DagBag verification lives in CI's
+        # preflight script.
+        ast.parse(src)

--- a/tests/test_pr_n21_enrichment_robustness.py
+++ b/tests/test_pr_n21_enrichment_robustness.py
@@ -403,6 +403,103 @@ class TestBravoOpsRunbookGuidance:
 
 
 # ===========================================================================
+# Bugbot round 1 (PR #105) — three real bugs Bugbot caught in the
+# Bravo-ops extension. Each fix needs a regression pin.
+# ===========================================================================
+
+
+class TestBugbotRound1Fixes:
+    """Three Bugbot findings on the Bravo-ops extension of PR-N21:
+    - HIGH:   INV-1 postcheck Cypher returned no rows when Campaign=0
+    - MEDIUM: apoc.periodic.iterate ``committedOperations`` counts
+              Campaigns (~156) not PART_OF edges (~15,600)
+    - MEDIUM: PromQL ``AND`` label mismatch makes silent-death alert
+              unfireable
+    """
+
+    def _dag_src(self) -> str:
+        return (DAGS / "edgeguard_pipeline.py").read_text()
+
+    def _enrichment_src(self) -> str:
+        return (SRC / "enrichment_jobs.py").read_text()
+
+    def _alerts_src(self) -> str:
+        return (REPO_ROOT / "prometheus" / "alerts.yml").read_text()
+
+    def test_inv1_uses_separate_count_queries(self):
+        """Bugbot round 1 HIGH: the pre-fix INV-1 chained
+        ``MATCH (m)-[:ATTRIBUTED_TO]->(a) WITH count(*) MATCH (c:Campaign)``
+        which returned ZERO ROWS when Campaign=0 (the MATCH eliminated
+        all tuples). ``.single()`` → None → violation check silently
+        skipped → DAG green — the exact bug the invariant exists to
+        catch. Fix: separate queries, each returns one row."""
+        src = self._dag_src()
+        post_body = _function_body(src, "assert_baseline_postconditions")
+
+        # Pin the new shape: two independent queries, each returning a
+        # single count. Anchor on the 2 ``RETURN count(...)`` lines.
+        assert post_body.count("RETURN count") >= 4, (
+            "INV-1 + INV-2 + INV-3 must each use a standalone count query "
+            "returning one row (total: at least 4 ``RETURN count`` occurrences). "
+            "Bugbot round 1 HIGH: chained MATCH + count returned no rows when "
+            "the second MATCH targets an empty label."
+        )
+
+        # Negative: the original silently-broken pattern (two MATCHes
+        # joined by intermediate WITH) must NOT be present.
+        assert "WITH count(*) AS attrib_edges MATCH (c:Campaign)" not in post_body, (
+            "chained MATCH after aggregation is the regression pattern Bugbot flagged"
+        )
+
+    def test_links_counted_by_updated_at_not_committed_operations(self):
+        """Bugbot round 1 MEDIUM: pre-fix code treated apoc.periodic.iterate's
+        ``committedOperations`` as the PART_OF edge count. Per APOC docs it
+        counts SUCCESSFUL INNER-STATEMENT EXECUTIONS (one per Campaign,
+        ~156) — NOT the number of MERGE rows produced (~15,600 for 156
+        campaigns × ~100 indicators). Post-deploy the ``[CAMPAIGNS] Built
+        N campaigns, M links`` log would show M ≈ 156 instead of ≈15,600 —
+        confusing operators monitoring PART_OF growth."""
+        body = _function_body(self._enrichment_src(), "build_campaign_nodes")
+        # Positive: the implementation must include a follow-up count
+        # query keyed on ``r.updated_at >= datetime($run_start_at)`` —
+        # this gives the TRUE per-run edge count using the freshness
+        # marker Step 3a stamps and Step 3b prunes against.
+        assert "r.updated_at >= datetime($run_start_at)" in body, (
+            "Step 3a must follow the apoc.periodic.iterate with a count "
+            "query keyed on r.updated_at (the per-run freshness marker)"
+        )
+        # Negative: the pre-fix ``committedOperations``-based read MUST
+        # NOT appear as an increment into links_created (the misleading
+        # line).
+        assert 'links_created"] += record.get("committedOperations"' not in body, (
+            "link count must not read from committedOperations — that's the "
+            "Bugbot-round-1-regression shape (Campaign count != edge count)"
+        )
+
+    def test_silent_death_alert_uses_on_join_modifier(self):
+        """Bugbot round 1 MEDIUM: pre-fix PromQL used bare ``AND`` to
+        join the completion-counter absence with the DAG-start-timestamp
+        check. Left side has ``{}`` labels; right side has
+        ``{dag_id="edgeguard_baseline"}`` → default AND requires label
+        equality → no match → alert never fires. Fix: ``and on()`` to
+        ignore all labels on the join."""
+        src = self._alerts_src()
+        # Find the silent-death alert block
+        start = src.find("EdgeGuardBuildRelationshipsSilentDeath")
+        next_alert = src.find("- alert:", start + 50)
+        block = src[start:next_alert] if next_alert != -1 else src[start:]
+        # Positive: must use ``and on()`` (or ``and ignoring(dag_id)``) on
+        # the cross-series join.
+        has_on = "and on()" in block or "and ignoring(" in block
+        assert has_on, (
+            "silent-death alert must use ``and on()`` or ``and ignoring(...)`` "
+            "to join the differently-labeled series — otherwise default AND "
+            "requires label equality and the alert never fires. "
+            "Bugbot round 1 MEDIUM."
+        )
+
+
+# ===========================================================================
 # Module import sanity
 # ===========================================================================
 


### PR DESCRIPTION
## Summary

A 4-agent audit on 2026-04-22 root-caused the cloud Neo4j **Campaign = 0** outcome despite a "successful" baseline DAG run. The cloud has **156 qualifying ThreatActors** with incoming Malware ATTRIBUTED_TO edges — expected output was ~156 Campaigns, actual was 0. This PR ships three fixes so the next 730-day baseline either:
- (a) succeeds and produces the ~156 Campaigns, OR
- (b) fails LOUDLY with a real traceback the operator can act on

## Root cause: silent-exception swallower in all 4 enrichment jobs

Pre-N21, every enrichment job had this pattern:
```python
try:
    ...  # all the Cypher logic
except Exception as e:
    logger.error(f"... error: {e}")  # ← logs but doesn't re-raise
# falls through to return zero results
```

Real Cypher errors (timeouts, schema drift, OOM) were silently eaten; each job returned `{0, 0, ...}`; `run_all_enrichment_jobs` aggregated the zeros; Airflow saw a clean dict and marked the task SUCCESS. The operator only discovered Campaign=0 days later via manual Cypher inspection.

## Fix #1-#4 — re-raise at all 4 sites

- `decay_ioc_confidence` (`src/enrichment_jobs.py:150-162`)
- `build_campaign_nodes` (`src/enrichment_jobs.py:600-619`) — **the actual 2026-04-22 culprit**
- `calibrate_cooccurrence_confidence` (`src/enrichment_jobs.py:760-771`)
- `bridge_vulnerability_cve` (`src/enrichment_jobs.py:853-864`)

Per-tier inner exception handling in calibrate (line 759) preserved — that's correct best-effort at the FINE-GRAINED level.

## Fix #5 — wrap `link_indicators` in `apoc.periodic.iterate`

The most likely cause of the 2026-04-22 raise: the un-batched query
```cypher
MATCH (c:Campaign)
MATCH (a:ThreatActor)<-[:ATTRIBUTED_TO]-(m:Malware)<-[:INDICATES]-(i:Indicator)
```
materialized 0.5–3M intermediate rows in a single Neo4j transaction at 730-day scale → timeout / OOM. Now wrapped in `apoc.periodic.iterate` with `batchSize=25` (one Campaign per batch). `errorMessages` from `periodic.iterate` raise hard so partial-loss is visible. Same scale-safety pattern `bridge_vulnerability_cve` already uses.

## Fix #6 — baseline DAG post-check task

New `baseline_postcheck` `PythonOperator` between `run_enrichment_jobs` and `baseline_complete`. Strict `ALL_SUCCESS` trigger_rule. Asserts 3 invariants:

| Invariant | What it catches |
|---|---|
| **INV-1**: `Campaign > 0 IFF ATTRIBUTED_TO > 0` | The 2026-04-22 incident shape — would have FAILED last night's baseline visibly |
| **INV-2**: `Indicator > 0` | Sync silently wrote no data |
| **INV-3**: `Source > 0` | `ensure_sources()` never bootstrapped |

Any violation raises `AirflowException` → DAG marked **FAILED** with actionable per-invariant message.

## Test plan

- [x] **15 new regression pins** in `tests/test_pr_n21_enrichment_robustness.py`:
  - 4 AST-walk pins for the swallowers (one per job)
  - 4 shape pins for `apoc.periodic.iterate` (presence, outer iterates Campaign, batchSize bounded, errorMessages raise)
  - 5 DAG post-check pins (callable exists, task wired, runs after enrichment, checks Campaign invariant, ALL_SUCCESS trigger_rule)
  - 2 import sanity
- [x] **2 pre-existing** `test_pr_m3d_campaign_determinism.py` pins updated to accept the renamed `link_indicators_batched` anchor (legacy name still accepted for forward/back compat)
- [x] **1 pre-existing** `test_pr33_bugbot_fixes.py` mock updated — it had only 5 `session.run()` side_effects but `build_campaign_nodes` makes 8; the test was effectively relying on the swallower to eat its own `StopIteration`. Mock now covers all 8 calls + new `apoc.periodic.iterate` result shape.
- [x] Full pytest: **1527 passed**, 3 skipped, 3 xfailed
- [x] `ruff format --check` / `ruff check` / `mypy` all clean

## Why this matters for the next baseline

| Without PR-N21 | With PR-N21 |
|---|---|
| Cypher timeout / OOM in enrichment → swallowed → DAG green | Cypher error → re-raised → DAG **FAILED** with traceback |
| `Campaign = 0` despite 156 qualifying actors → invisible | `baseline_postcheck` raises with explicit message |
| Single-TX cartesian explosion → likely repeats next baseline | `apoc.periodic.iterate` with batchSize=25 → bounded TX size |
| Operator finds Campaign=0 days later by manual Cypher | Operator sees actionable failure within ~5min of completion |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes make enrichment failures and partial Neo4j APOC errors fail or alert loudly, and add a new baseline postcheck task; mistakes could cause baseline DAGs to fail more often or alert noisily if invariants/metrics are mis-specified.
> 
> **Overview**
> Prevents “green but broken” baselines by **stopping silent exception swallowing** in enrichment jobs and adding a **post-baseline invariant check**.
> 
> Enrichment now re-raises on outer failures in `decay_ioc_confidence`, `build_campaign_nodes`, `calibrate_cooccurrence_confidence`, and `bridge_vulnerability_cve`, so Airflow marks the task failed with a traceback instead of returning zeroed results.
> 
> `build_campaign_nodes`’ indicator linking is reworked to use `apoc.periodic.iterate` batching (and hard-fails on `errorMessages`), plus corrects PART_OF link counting via a follow-up `r.updated_at`-based count.
> 
> Baseline DAG gains `baseline_postcheck` (ALL_SUCCESS) to assert Campaign/Indicator/Source invariants after enrichment. Build-relationships observability is extended with new Prometheus counters and alerts for silent subprocess death and APOC partial batches, documented in the RUNBOOK, and covered by updated/new regression tests.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 72621108b1dfa7131af01d0e53c3a2d2bd3f3090. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->