### PR TITLE
fix(audit): PR-N22 — historical CVE date backfill script

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -523,6 +523,80 @@ RETURN r.raw_data LIMIT 1;
 
 ---
 
+## PR-N22: backfill historical CVE `published` / `last_modified`
+
+### When to run
+
+PR-N19 Fix #1 closed the MISP-sourced `merge_cve` path that was silently
+dropping `published` / `last_modified` before 2026-04-22. The write path
+is fixed in code, but any CVE ingested before PR-N19 deployed has NULL
+date fields in Neo4j. Run this script when:
+
+- You want to demo/export graph data with proper CVE timelines
+- You don't have 26h for a fresh full baseline
+- You want to preserve existing edge counts / confidence scores (a
+  backfill is non-destructive; a re-baseline would rebuild everything)
+
+### How to run
+
+Safe + idempotent. Dry-run first, then execute:
+
+```bash
+# 1. Dry-run — logs what WOULD change, writes nothing
+./scripts/backfill_cve_dates_from_nvd_meta.py --dry-run
+
+# 2. Real run against cloud Neo4j (env vars set)
+export NEO4J_URI="bolt+s://neo4j-bolt.edgeguard.org:443"
+export NEO4J_PASSWORD="<cloud-password>"
+export MISP_URL="https://misp.edgeguard.org"
+export MISP_API_KEY="<key>"
+export EDGEGUARD_SSL_VERIFY=true
+./scripts/backfill_cve_dates_from_nvd_meta.py --batch-size 100 --rate-limit 10
+```
+
+Expected duration: ~1-2 hours for a ~100K-CVE graph at 10 MISP req/s.
+Lower `--rate-limit 5` during business hours if MISP is user-facing.
+
+### Verify success
+
+After the script completes:
+
+```cypher
+// Expect: very small number (maybe 0) — only CVEs with no NVD_META in MISP
+MATCH (c:CVE)
+WHERE c.published IS NULL AND size(coalesce(c.misp_attribute_ids,[])) > 0
+RETURN count(c) AS still_null;
+
+// Spot-check: top 5 most-connected CVEs should now have dates
+MATCH (c:CVE)
+WHERE c.published IS NOT NULL
+RETURN c.cve_id, c.published, c.last_modified
+ORDER BY c.cvss_score DESC LIMIT 5;
+```
+
+### Idempotency guarantee
+
+The script's `SET c.published = coalesce(c.published, $pub)` pattern
+means re-runs are safe:
+
+- If a baseline ran between script invocations and populated the field,
+  the script respects the baseline value (coalesce prefers the existing
+  non-NULL).
+- If the script crashes mid-run, just re-invoke — it picks up where it
+  left off (the `WHERE c.published IS NULL` filter skips already-done).
+- Running dry-run → real-run → re-run all produce the same final state.
+
+### Known edge cases
+
+- **CVEs without NVD_META in MISP**: ~0.1-0.5% of CVEs (older events
+  with corrupted comment fields). These stay NULL; no data corruption.
+- **Rate-limit too aggressive**: if MISP returns 429, lower
+  `--rate-limit`. Default 10 req/s is conservative.
+- **Neo4j transient errors mid-write**: script logs + increments the
+  `errors` counter but continues. Exit code 1 if any error occurred.
+
+---
+
 ## See also
 
 - `docs/MISP_TUNING.md` — backend tuning for failure modes 1-2
@@ -535,3 +609,4 @@ RETURN r.raw_data LIMIT 1;
 - `src/neo4j_client.py:_is_retryable_neo4j_error` — exception classifier (PR-N15)
 - `src/collectors/nvd_collector.py:NvdBatchFetchError` — NVD silent-window-drop guard (PR-N17)
 - `src/node_identity.py:_REJECTED_PLACEHOLDER_NAMES` — placeholder blocklist (PR-N10 + PR-N10-followup)
+- `scripts/backfill_cve_dates_from_nvd_meta.py` — historical CVE date backfill migration (PR-N22)

--- a/scripts/backfill_cve_dates_from_nvd_meta.py
+++ b/scripts/backfill_cve_dates_from_nvd_meta.py
@@ -1,0 +1,471 @@
+#!/usr/bin/env python3
+"""
+PR-N22 — Backfill historical CVE ``published`` / ``last_modified`` from MISP NVD_META.
+
+## Why this script exists
+
+Before PR-N19 Fix #1 (merged 2026-04-22), ``merge_cve`` silently dropped the
+``published`` and ``last_modified`` fields from the MISP-sourced CVE path.
+The ResilMesh-native ``merge_resilmesh_cve`` wrote them correctly, but 99.7%
+of CVEs in a typical baseline come from the MISP path. Bravo Vanko caught
+this in the 2026-04-22 baseline audit — 99,664/99,664 cloud CVEs had NULL
+dates despite NVD having them upstream.
+
+The fix (PR-N19) updated the write path but does nothing about existing
+data. Two options to repair: (a) run a fresh 730-day baseline (takes ~26h
+and re-ingests everything), or (b) run this script, which reads NVD_META
+from MISP attribute comments and backfills the node-level dates WITHOUT
+re-ingesting. Takes ~1-2 hours for a 99K-CVE graph.
+
+## What it does
+
+For each CVE with ``c.published IS NULL`` or ``c.last_modified IS NULL``:
+  1. Reads ``c.misp_attribute_ids[]`` — the real MISP attribute UUIDs.
+  2. Fetches the MISP attribute via ``GET /attributes/<uuid>``.
+  3. Parses the ``comment`` field — it's prefixed with ``"NVD_META:"``
+     followed by JSON (written by ``MISPWriter`` for NVD-sourced CVEs).
+  4. Extracts ``published`` + ``last_modified`` from the JSON.
+  5. Writes them back to Neo4j with ``SET c.published = $pub`` (only if
+     currently NULL — idempotent).
+
+## Idempotency
+
+Safe to re-run. Only writes when the target field is currently NULL — if
+a baseline ran between script invocations and populated the field, the
+script respects that value and skips. No race with concurrent baselines.
+
+## Usage
+
+```bash
+# Dry-run first — prints what WOULD be updated, writes nothing
+./scripts/backfill_cve_dates_from_nvd_meta.py --dry-run
+
+# Execute against cloud Neo4j
+export NEO4J_URI="bolt+s://neo4j-bolt.edgeguard.org:443"
+export NEO4J_PASSWORD="<cloud-password>"
+export MISP_URL="https://misp.edgeguard.org"
+export MISP_API_KEY="<key>"
+./scripts/backfill_cve_dates_from_nvd_meta.py
+
+# Resume from partial run (script is idempotent, just re-run)
+./scripts/backfill_cve_dates_from_nvd_meta.py --batch-size 50
+
+# Limit impact during business hours
+./scripts/backfill_cve_dates_from_nvd_meta.py --rate-limit 5  # 5 req/sec max
+```
+
+## Env vars required
+
+| Var | Purpose |
+|---|---|
+| ``NEO4J_URI`` | Bolt URI (e.g. ``bolt+s://neo4j-bolt.edgeguard.org:443``) |
+| ``NEO4J_PASSWORD`` | Neo4j password |
+| ``MISP_URL`` | MISP base URL (e.g. ``https://misp.edgeguard.org``) |
+| ``MISP_API_KEY`` | MISP API key with attribute read access |
+| ``EDGEGUARD_SSL_VERIFY`` | (optional) ``true`` for strict TLS (default strict) |
+
+## Exit codes
+
+- 0 — all CVEs with MISP attributes backfilled cleanly
+- 1 — any fatal error (connection, auth, unrecoverable exception)
+- 2 — invalid CLI arguments
+
+## See also
+
+- ``src/neo4j_client.py::merge_cve`` — the write path (PR-N19 Fix #1)
+- ``src/run_misp_to_neo4j.py:2385+`` — the NVD_META parse reference
+- ``src/collectors/misp_writer.py`` — where NVD_META is written at ingest
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+import requests
+import urllib3
+
+from neo4j import GraphDatabase
+
+# Suppress urllib3 warnings for self-signed cert setups — operator chose it.
+urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+
+# Log format matches the rest of the EdgeGuard operator surface.
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s %(levelname)s [backfill-cve-dates] %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+
+def _env(name: str, required: bool = True, default: Optional[str] = None) -> Optional[str]:
+    """Read an env var; raise if required and missing."""
+    v = os.environ.get(name, default)
+    if required and not v:
+        raise SystemExit(f"Missing required env var: {name}")
+    return v
+
+
+def _ssl_verify_enabled() -> bool:
+    """Match src/config.py strict-allow-list semantics: only the literal
+    string "true" (case-insensitive, stripped) enables verification."""
+    raw = os.environ.get("EDGEGUARD_SSL_VERIFY") or os.environ.get("SSL_VERIFY") or ""
+    return raw.strip().lower() == "true"
+
+
+# ---------------------------------------------------------------------------
+# NVD_META parser (mirrors src/run_misp_to_neo4j.py:2385+)
+# ---------------------------------------------------------------------------
+
+
+NVD_META_PREFIX = "NVD_META:"
+
+
+def parse_nvd_meta(comment: str) -> Dict:
+    """Parse NVD_META blob from a MISP attribute comment field.
+
+    Returns an empty dict if the prefix is absent OR the JSON is malformed.
+    Exposed as a module-level function so tests can pin the behavior.
+    """
+    if not comment or not isinstance(comment, str):
+        return {}
+    if not comment.startswith(NVD_META_PREFIX):
+        return {}
+    try:
+        return json.loads(comment[len(NVD_META_PREFIX) :])
+    except (json.JSONDecodeError, ValueError):
+        # Operator-visible but not fatal — some older events may have
+        # corrupted comment fields; skip and move on.
+        return {}
+
+
+def extract_dates(nvd_meta: Dict) -> Tuple[Optional[str], Optional[str]]:
+    """Return ``(published, last_modified)`` from an NVD_META blob.
+
+    Empty strings and missing keys both normalize to None so the caller
+    can use a simple ``if value is not None`` check before writing.
+    """
+    pub = nvd_meta.get("published") or None
+    mod = nvd_meta.get("last_modified") or None
+    return pub, mod
+
+
+# ---------------------------------------------------------------------------
+# MISP client
+# ---------------------------------------------------------------------------
+
+
+class MispClient:
+    """Minimal MISP REST client — only the ``GET /attributes/<uuid>`` shape
+    this script needs. No PyMISP dependency to keep this script portable.
+    """
+
+    def __init__(self, base_url: str, api_key: str, ssl_verify: bool):
+        self.base_url = base_url.rstrip("/")
+        self.api_key = api_key
+        self.ssl_verify = ssl_verify
+        self.session = requests.Session()
+        self.session.headers.update(
+            {
+                "Authorization": api_key,
+                "Accept": "application/json",
+                "Content-Type": "application/json",
+            }
+        )
+
+    def get_attribute(self, uuid: str, timeout: float = 10.0) -> Optional[Dict]:
+        """Return the attribute JSON, or None on 404/transient error.
+
+        Structure (MISP 2.4.x): ``{"Attribute": {"uuid": "...", "comment": "NVD_META:{...}", ...}}``.
+        """
+        url = f"{self.base_url}/attributes/{uuid}"
+        try:
+            r = self.session.get(url, timeout=timeout, verify=self.ssl_verify)
+        except requests.RequestException as e:
+            logger.warning("MISP fetch failed for %s: %s", uuid, e)
+            return None
+        if r.status_code == 404:
+            logger.debug("Attribute %s not found in MISP (404)", uuid)
+            return None
+        if r.status_code >= 400:
+            logger.warning("MISP GET /attributes/%s returned HTTP %s", uuid, r.status_code)
+            return None
+        try:
+            body = r.json()
+        except ValueError:
+            logger.warning("MISP returned non-JSON for %s", uuid)
+            return None
+        return body.get("Attribute") or body.get("attribute")
+
+
+# ---------------------------------------------------------------------------
+# Neo4j access
+# ---------------------------------------------------------------------------
+
+
+FETCH_CANDIDATES_CYPHER = """
+MATCH (c:CVE)
+WHERE (c.published IS NULL OR c.last_modified IS NULL)
+  AND size(coalesce(c.misp_attribute_ids, [])) > 0
+RETURN c.cve_id AS cve_id,
+       c.misp_attribute_ids AS attr_ids,
+       c.published AS published,
+       c.last_modified AS last_modified
+LIMIT $batch_size
+"""
+
+UPDATE_CVE_CYPHER = """
+MATCH (c:CVE {cve_id: $cve_id})
+// Idempotency guard: only write when currently NULL. If a baseline
+// populated the field between script invocations, keep the baseline
+// value — it's authoritative.
+SET c.published = coalesce(c.published, $published),
+    c.last_modified = coalesce(c.last_modified, $last_modified)
+RETURN c.published IS NOT NULL AS has_pub, c.last_modified IS NOT NULL AS has_mod
+"""
+
+
+def fetch_candidates(session, batch_size: int) -> List[Dict]:
+    """Fetch a batch of CVEs missing either date field."""
+    rows = session.run(FETCH_CANDIDATES_CYPHER, batch_size=batch_size)
+    return [dict(row) for row in rows]
+
+
+def write_dates(session, cve_id: str, published: Optional[str], last_modified: Optional[str]) -> None:
+    """Write the two date fields, idempotent per CVE."""
+    session.run(
+        UPDATE_CVE_CYPHER,
+        cve_id=cve_id,
+        published=published,
+        last_modified=last_modified,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Backfill driver
+# ---------------------------------------------------------------------------
+
+
+def backfill(
+    neo4j_driver,
+    misp: MispClient,
+    batch_size: int = 100,
+    rate_limit: float = 10.0,
+    dry_run: bool = False,
+    max_cves: Optional[int] = None,
+) -> Dict[str, int]:
+    """Backfill driver loop. Iterates over CVE candidates in batches until
+    no more candidates remain OR ``max_cves`` is hit.
+
+    Returns a summary dict with counts per outcome:
+      - processed: CVEs we looked at
+      - backfilled: CVEs where we wrote at least one field
+      - no_misp_attr: CVEs whose misp_attribute_ids[0] returned no attribute
+      - no_nvd_meta: CVEs where the comment had no NVD_META prefix
+      - no_dates_in_meta: CVEs where NVD_META had neither published nor last_modified
+    """
+    summary = {
+        "processed": 0,
+        "backfilled": 0,
+        "no_misp_attr": 0,
+        "no_nvd_meta": 0,
+        "no_dates_in_meta": 0,
+        "errors": 0,
+    }
+
+    # Rate limiter: enforce at least ``1/rate_limit`` seconds between MISP fetches
+    min_interval = 1.0 / rate_limit if rate_limit > 0 else 0.0
+    last_fetch_at = 0.0
+
+    while True:
+        if max_cves is not None and summary["processed"] >= max_cves:
+            logger.info("Hit --max-cves=%d; stopping.", max_cves)
+            break
+
+        with neo4j_driver.session() as session:
+            candidates = fetch_candidates(session, batch_size)
+
+        if not candidates:
+            logger.info("No more candidates — backfill complete.")
+            break
+
+        logger.info(
+            "[BATCH] %d candidates fetched (summary so far: %s)",
+            len(candidates),
+            summary,
+        )
+
+        for row in candidates:
+            cve_id = row["cve_id"]
+            attr_ids = row.get("attr_ids") or []
+            summary["processed"] += 1
+
+            if not attr_ids:
+                summary["no_misp_attr"] += 1
+                continue
+
+            # Rate-limit the MISP fetch
+            now = time.monotonic()
+            elapsed = now - last_fetch_at
+            if elapsed < min_interval:
+                time.sleep(min_interval - elapsed)
+            last_fetch_at = time.monotonic()
+
+            # Fetch the first attribute (NVD CVE events are single-attribute
+            # in EdgeGuard's MISP layout; first UUID is the one we want).
+            attr = misp.get_attribute(attr_ids[0])
+            if attr is None:
+                summary["no_misp_attr"] += 1
+                continue
+
+            nvd_meta = parse_nvd_meta(attr.get("comment", ""))
+            if not nvd_meta:
+                summary["no_nvd_meta"] += 1
+                continue
+
+            published, last_modified = extract_dates(nvd_meta)
+            if not published and not last_modified:
+                summary["no_dates_in_meta"] += 1
+                continue
+
+            if dry_run:
+                logger.info(
+                    "[DRY-RUN] would write %s: published=%s last_modified=%s",
+                    cve_id,
+                    published,
+                    last_modified,
+                )
+                summary["backfilled"] += 1
+                continue
+
+            try:
+                with neo4j_driver.session() as session:
+                    write_dates(session, cve_id, published, last_modified)
+                summary["backfilled"] += 1
+            except Exception as e:
+                logger.error("Failed to write %s: %s", cve_id, e)
+                summary["errors"] += 1
+
+        # Progress summary after each batch
+        logger.info(
+            "[PROGRESS] processed=%d backfilled=%d errors=%d rate=%.1f/s",
+            summary["processed"],
+            summary["backfilled"],
+            summary["errors"],
+            summary["processed"] / max(time.monotonic() - last_fetch_at + 0.001, 0.001),
+        )
+
+        # If we got fewer than batch_size candidates, we're done (no more
+        # eligible CVEs match the WHERE clause).
+        if len(candidates) < batch_size:
+            logger.info("Last batch was partial (%d < %d); backfill complete.", len(candidates), batch_size)
+            break
+
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill CVE published/last_modified dates from MISP NVD_META (PR-N22).",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print planned updates, write nothing to Neo4j.",
+    )
+    parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=100,
+        help="Candidates to fetch per Neo4j batch (default 100).",
+    )
+    parser.add_argument(
+        "--rate-limit",
+        type=float,
+        default=10.0,
+        help="Max MISP requests per second (default 10). Lower for production-impact-sensitive windows.",
+    )
+    parser.add_argument(
+        "--max-cves",
+        type=int,
+        default=None,
+        help="Cap on total CVEs processed (default: unlimited). Useful for smoke tests.",
+    )
+    args = parser.parse_args(argv)
+
+    if args.batch_size <= 0 or args.rate_limit <= 0:
+        parser.error("--batch-size and --rate-limit must be positive")
+        return 2
+
+    # Read env early so missing creds fail fast
+    neo4j_uri = _env("NEO4J_URI", default="bolt://localhost:7687")
+    neo4j_password = _env("NEO4J_PASSWORD")
+    misp_url = _env("MISP_URL")
+    misp_api_key = _env("MISP_API_KEY")
+    ssl_verify = _ssl_verify_enabled()
+
+    if not ssl_verify:
+        logger.warning(
+            "TLS verification DISABLED (EDGEGUARD_SSL_VERIFY!=true). "
+            "MISP_API_KEY will be sent over unverified TLS. For production, "
+            "set EDGEGUARD_SSL_VERIFY=true."
+        )
+
+    logger.info("Starting CVE date backfill (dry_run=%s)", args.dry_run)
+    logger.info("  Neo4j URI: %s", neo4j_uri)
+    logger.info("  MISP URL:  %s", misp_url)
+    logger.info("  Batch:     %d candidates / rate-limit %s req/s", args.batch_size, args.rate_limit)
+
+    # Connect to Neo4j
+    try:
+        driver = GraphDatabase.driver(neo4j_uri, auth=("neo4j", neo4j_password))
+        driver.verify_connectivity()
+    except Exception as e:
+        logger.error("Neo4j connection failed: %s", e)
+        return 1
+
+    misp = MispClient(misp_url, misp_api_key, ssl_verify=ssl_verify)
+
+    try:
+        summary = backfill(
+            driver,
+            misp,
+            batch_size=args.batch_size,
+            rate_limit=args.rate_limit,
+            dry_run=args.dry_run,
+            max_cves=args.max_cves,
+        )
+    finally:
+        driver.close()
+
+    logger.info("=" * 55)
+    logger.info("BACKFILL SUMMARY")
+    logger.info("=" * 55)
+    for k, v in summary.items():
+        logger.info("  %-20s %d", k, v)
+
+    # Exit 1 if any unrecoverable errors happened (not counting no_*)
+    return 1 if summary.get("errors", 0) > 0 else 0
+
+
+if __name__ == "__main__":
+    # Ensure the src/ module path is available for any downstream imports.
+    repo_root = Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(repo_root / "src"))
+    sys.exit(main())

--- a/scripts/backfill_cve_dates_from_nvd_meta.py
+++ b/scripts/backfill_cve_dates_from_nvd_meta.py
@@ -93,9 +93,6 @@ import urllib3
 
 from neo4j import GraphDatabase
 
-# Suppress urllib3 warnings for self-signed cert setups — operator chose it.
-urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-
 # Log format matches the rest of the EdgeGuard operator surface.
 logging.basicConfig(
     level=logging.INFO,
@@ -129,10 +126,40 @@ def _env_optional(name: str, default: Optional[str] = None) -> Optional[str]:
 
 
 def _ssl_verify_enabled() -> bool:
-    """Match src/config.py strict-allow-list semantics: only the literal
-    string "true" (case-insensitive, stripped) enables verification."""
-    raw = os.environ.get("EDGEGUARD_SSL_VERIFY") or os.environ.get("SSL_VERIFY") or ""
-    return raw.strip().lower() == "true"
+    """Mirror ``src/config.py:edgeguard_ssl_verify_from_env`` exactly.
+
+    Bugbot round 1 (PR #106, HIGH): pre-fix returned ``False`` when
+    neither env var was set — that's the OPPOSITE of the project's
+    secure-by-default convention, and would silently send MISP_API_KEY
+    over unverified TLS in dev environments where operators "didn't
+    set anything."
+
+    Contract (matches src/config.py:434):
+      - Both env vars unset / empty   → ``True``  (secure default)
+      - ``EDGEGUARD_SSL_VERIFY=true`` → ``True``
+      - ``EDGEGUARD_SSL_VERIFY=<other>`` (false, FALSE, 0, ...) → ``False``
+      - SSL_VERIFY checked only if EDGEGUARD_SSL_VERIFY is unset/empty
+    """
+    for key in ("EDGEGUARD_SSL_VERIFY", "SSL_VERIFY"):
+        raw = os.environ.get(key)
+        if raw is None:
+            continue
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        return stripped.lower() == "true"
+    return True
+
+
+# Bugbot round 1 (PR #106, MEDIUM): the unconditional
+# ``urllib3.disable_warnings(InsecureRequestWarning)`` at module load
+# was the wrong shape — every other EdgeGuard file (misp_writer.py,
+# run_misp_to_neo4j.py, health_check.py) gates this behind
+# ``if not SSL_VERIFY:`` so operators KEEP the urllib3 warning when
+# they're verifying TLS (the warning is then a noisy false-positive).
+# Suppress only when SSL verification is explicitly disabled.
+if not _ssl_verify_enabled():
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
 
 
 # ---------------------------------------------------------------------------
@@ -229,10 +256,24 @@ FETCH_CANDIDATES_CYPHER = """
 MATCH (c:CVE)
 WHERE (c.published IS NULL OR c.last_modified IS NULL)
   AND size(coalesce(c.misp_attribute_ids, [])) > 0
+  // Bugbot round 1 (PR #106, HIGH × 2): cursor-based pagination eliminates
+  // TWO distinct infinite-loop modes the pre-fix script had:
+  //   (a) --dry-run: no writes → candidates stay in the WHERE filter
+  //       forever → same batch re-fetched every iteration → no exit.
+  //   (b) normal mode: CVEs that can't be resolved (MISP 404, no NVD_META,
+  //       partial dates) never update → same filter-match → same loop.
+  // Fix: sort by cve_id and advance a cursor (``c.cve_id > $last_cve_id``)
+  // in Python. Every call returns the NEXT batch regardless of whether
+  // writes happened. Loop terminates when the fetch returns < batch_size
+  // rows (exhausted the NULL-candidate set). Deterministic + safe under
+  // concurrent writers (the WHERE filter drops already-backfilled rows
+  // even if the cursor position is pre-written).
+  AND c.cve_id > $last_cve_id
 RETURN c.cve_id AS cve_id,
        c.misp_attribute_ids AS attr_ids,
        c.published AS published,
        c.last_modified AS last_modified
+ORDER BY c.cve_id
 LIMIT $batch_size
 """
 
@@ -247,9 +288,17 @@ RETURN c.published IS NOT NULL AS has_pub, c.last_modified IS NOT NULL AS has_mo
 """
 
 
-def fetch_candidates(session, batch_size: int) -> List[Dict]:
-    """Fetch a batch of CVEs missing either date field."""
-    rows = session.run(FETCH_CANDIDATES_CYPHER, batch_size=batch_size)
+def fetch_candidates(session, batch_size: int, last_cve_id: str = "") -> List[Dict]:
+    """Fetch a batch of CVEs missing either date field, cursor-paginated.
+
+    Args:
+        session: Neo4j session.
+        batch_size: max rows per fetch.
+        last_cve_id: cursor — fetch CVEs with cve_id > this value.
+            Start with ``""`` (empty string) for the first batch;
+            every subsequent call passes the last returned cve_id.
+    """
+    rows = session.run(FETCH_CANDIDATES_CYPHER, batch_size=batch_size, last_cve_id=last_cve_id)
     return [dict(row) for row in rows]
 
 
@@ -299,21 +348,37 @@ def backfill(
     min_interval = 1.0 / rate_limit if rate_limit > 0 else 0.0
     last_fetch_at = 0.0
 
+    # PR-N22 Bugbot round 1 (HIGH × 2): cursor-based pagination. Start
+    # with empty string (every real CVE ID sorts after "") and advance
+    # by the highest cve_id we saw in the previous batch. This eliminates
+    # the infinite-loop failure modes in both --dry-run and normal mode
+    # when CVEs can't be resolved (no writes → no change to WHERE match →
+    # same batch forever).
+    last_cve_id = ""
+
     while True:
         if max_cves is not None and summary["processed"] >= max_cves:
             logger.info("Hit --max-cves=%d; stopping.", max_cves)
             break
 
         with neo4j_driver.session() as session:
-            candidates = fetch_candidates(session, batch_size)
+            candidates = fetch_candidates(session, batch_size, last_cve_id=last_cve_id)
 
         if not candidates:
             logger.info("No more candidates — backfill complete.")
             break
 
+        # Advance cursor to the LAST cve_id in the returned batch.
+        # Because the query ORDER BYs cve_id, this is monotonically
+        # increasing. Safe under concurrent writers: a CVE backfilled
+        # by another process just drops out of the NULL-filter — the
+        # cursor still advances past it.
+        last_cve_id = candidates[-1]["cve_id"]
+
         logger.info(
-            "[BATCH] %d candidates fetched (summary so far: %s)",
+            "[BATCH] %d candidates fetched, cursor → %s (summary: %s)",
             len(candidates),
+            last_cve_id,
             summary,
         )
 

--- a/scripts/backfill_cve_dates_from_nvd_meta.py
+++ b/scripts/backfill_cve_dates_from_nvd_meta.py
@@ -429,39 +429,52 @@ def backfill(
                 time.sleep(min_interval - elapsed)
             last_fetch_at = time.monotonic()
 
-            # Fetch the first attribute (NVD CVE events are single-attribute
-            # in EdgeGuard's MISP layout; first UUID is the one we want).
-            attr = misp.get_attribute(attr_ids[0])
-            if attr is None:
-                summary["no_misp_attr"] += 1
-                continue
-
-            nvd_meta = parse_nvd_meta(attr.get("comment", ""))
-            if not nvd_meta:
-                summary["no_nvd_meta"] += 1
-                continue
-
-            published, last_modified = extract_dates(nvd_meta)
-            if not published and not last_modified:
-                summary["no_dates_in_meta"] += 1
-                continue
-
-            if dry_run:
-                logger.info(
-                    "[DRY-RUN] would write %s: published=%s last_modified=%s",
-                    cve_id,
-                    published,
-                    last_modified,
-                )
-                summary["backfilled"] += 1
-                continue
-
+            # Bugbot round 3 (PR #106, Medium): wrap the ENTIRE per-CVE
+            # processing path (MISP fetch + parse + extract + write) in
+            # a single try/except so an unexpected exception on ONE CVE
+            # (e.g., MISP returning a non-dict ``attr`` object that
+            # ``.get()`` chokes on, or any other AttributeError /
+            # KeyError mid-processing) skips that CVE and continues
+            # with the next one — instead of crashing the whole ~100K-
+            # CVE backfill. Pre-N23-Bugbot-round-3 only the ``write_dates``
+            # call was protected; everything between MISP fetch and
+            # write was unprotected.
             try:
+                # Fetch the first attribute (NVD CVE events are single-attribute
+                # in EdgeGuard's MISP layout; first UUID is the one we want).
+                attr = misp.get_attribute(attr_ids[0])
+                if attr is None:
+                    summary["no_misp_attr"] += 1
+                    continue
+
+                nvd_meta = parse_nvd_meta(attr.get("comment", ""))
+                if not nvd_meta:
+                    summary["no_nvd_meta"] += 1
+                    continue
+
+                published, last_modified = extract_dates(nvd_meta)
+                if not published and not last_modified:
+                    summary["no_dates_in_meta"] += 1
+                    continue
+
+                if dry_run:
+                    logger.info(
+                        "[DRY-RUN] would write %s: published=%s last_modified=%s",
+                        cve_id,
+                        published,
+                        last_modified,
+                    )
+                    summary["backfilled"] += 1
+                    continue
+
                 with neo4j_driver.session() as session:
                     write_dates(session, cve_id, published, last_modified)
                 summary["backfilled"] += 1
             except Exception as e:
-                logger.error("Failed to write %s: %s", cve_id, e)
+                # Per-CVE error containment. Logs with cve_id so
+                # operator can spot-check the offending node + decide
+                # whether to investigate or accept the skip.
+                logger.error("Failed to process %s: %s: %s", cve_id, type(e).__name__, e)
                 summary["errors"] += 1
 
         # Progress summary after each batch.
@@ -523,8 +536,10 @@ def main(argv: Optional[List[str]] = None) -> int:
     args = parser.parse_args(argv)
 
     if args.batch_size <= 0 or args.rate_limit <= 0:
+        # ``parser.error`` internally calls ``sys.exit(2)`` and never
+        # returns — so a ``return 2`` after it would be dead code.
+        # Bugbot round 3 (PR #106, Low) flagged the dead-code shape.
         parser.error("--batch-size and --rate-limit must be positive")
-        return 2
 
     # Read env early so missing creds fail fast
     # NEO4J_URI defaults to localhost; NEO4J_USER defaults to "neo4j"
@@ -553,12 +568,25 @@ def main(argv: Optional[List[str]] = None) -> int:
     logger.info("  MISP URL:  %s", misp_url)
     logger.info("  Batch:     %d candidates / rate-limit %s req/s", args.batch_size, args.rate_limit)
 
-    # Connect to Neo4j
+    # Connect to Neo4j.
+    #
+    # Bugbot round 3 (PR #106, Low): pre-fix the ``except`` returned 1
+    # without closing the driver if ``GraphDatabase.driver(...)``
+    # SUCCEEDED but ``verify_connectivity()`` then raised. The driver
+    # holds a connection pool — leaking it accumulates sockets across
+    # repeated retries. Fix: split into two stages so a failure on
+    # connectivity-check correctly closes the half-initialized driver
+    # before returning.
     try:
         driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
+    except Exception as e:
+        logger.error("Neo4j driver init failed: %s", e)
+        return 1
+    try:
         driver.verify_connectivity()
     except Exception as e:
-        logger.error("Neo4j connection failed: %s", e)
+        logger.error("Neo4j connectivity check failed: %s", e)
+        driver.close()
         return 1
 
     misp = MispClient(misp_url, misp_api_key, ssl_verify=ssl_verify)

--- a/scripts/backfill_cve_dates_from_nvd_meta.py
+++ b/scripts/backfill_cve_dates_from_nvd_meta.py
@@ -109,12 +109,23 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _env(name: str, required: bool = True, default: Optional[str] = None) -> Optional[str]:
-    """Read an env var; raise if required and missing."""
-    v = os.environ.get(name, default)
-    if required and not v:
+def _env_required(name: str) -> str:
+    """Read a REQUIRED env var; ``SystemExit`` if missing.
+
+    Returning ``str`` (not ``Optional[str]``) so callers don't need
+    ``# type: ignore`` or assert-not-None patterns at every use site.
+    Mypy: the ``raise`` exits the function on the missing-var path,
+    so the return value is provably non-None when control reaches it.
+    """
+    v = os.environ.get(name)
+    if not v:
         raise SystemExit(f"Missing required env var: {name}")
     return v
+
+
+def _env_optional(name: str, default: Optional[str] = None) -> Optional[str]:
+    """Read an OPTIONAL env var; ``None`` if unset and no default."""
+    return os.environ.get(name, default)
 
 
 def _ssl_verify_enabled() -> bool:
@@ -414,10 +425,12 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
 
     # Read env early so missing creds fail fast
-    neo4j_uri = _env("NEO4J_URI", default="bolt://localhost:7687")
-    neo4j_password = _env("NEO4J_PASSWORD")
-    misp_url = _env("MISP_URL")
-    misp_api_key = _env("MISP_API_KEY")
+    # NEO4J_URI defaults to localhost; the others are mandatory (script can't
+    # do anything useful without MISP credentials + Neo4j password).
+    neo4j_uri = _env_optional("NEO4J_URI", default="bolt://localhost:7687") or "bolt://localhost:7687"
+    neo4j_password = _env_required("NEO4J_PASSWORD")
+    misp_url = _env_required("MISP_URL")
+    misp_api_key = _env_required("MISP_API_KEY")
     ssl_verify = _ssl_verify_enabled()
 
     if not ssl_verify:

--- a/scripts/backfill_cve_dates_from_nvd_meta.py
+++ b/scripts/backfill_cve_dates_from_nvd_meta.py
@@ -181,11 +181,24 @@ def parse_nvd_meta(comment: str) -> Dict:
     if not comment.startswith(NVD_META_PREFIX):
         return {}
     try:
-        return json.loads(comment[len(NVD_META_PREFIX) :])
+        parsed = json.loads(comment[len(NVD_META_PREFIX) :])
     except (json.JSONDecodeError, ValueError):
         # Operator-visible but not fatal — some older events may have
         # corrupted comment fields; skip and move on.
         return {}
+    # Bugbot round 2 (PR #106, Medium): ``json.loads`` returns any JSON
+    # type (list / string / int / bool), not just a dict. A truthy
+    # non-dict value (e.g., ``NVD_META:[1,2]``) would pass the
+    # ``if not nvd_meta:`` guard at the call site, then ``extract_dates``
+    # would call ``.get()`` on it and raise ``AttributeError`` OUTSIDE
+    # the per-CVE try/except — crashing the entire backfill. On re-run
+    # the same corrupted CVE reappears at the cursor position, blocking
+    # all progress. Fix: narrow return type to dict; anything else
+    # (list, string, int, etc.) is equivalent to "no NVD_META" for our
+    # purposes.
+    if not isinstance(parsed, dict):
+        return {}
+    return parsed
 
 
 def extract_dates(nvd_meta: Dict) -> Tuple[Optional[str], Optional[str]]:
@@ -348,6 +361,15 @@ def backfill(
     min_interval = 1.0 / rate_limit if rate_limit > 0 else 0.0
     last_fetch_at = 0.0
 
+    # Bugbot round 2 (PR #106, Low): track the REAL run-start so the
+    # ``[PROGRESS]`` rate calculation uses a meaningful denominator.
+    # Pre-fix used ``time.monotonic() - last_fetch_at`` where
+    # ``last_fetch_at`` is the timestamp of the LAST MISP fetch (a few
+    # ms ago), producing garbage values like "40000 CVE/s". Using
+    # ``run_started_at`` gives the average throughput across the full
+    # run — the actionable operator signal.
+    run_started_at = time.monotonic()
+
     # PR-N22 Bugbot round 1 (HIGH × 2): cursor-based pagination. Start
     # with empty string (every real CVE ID sorts after "") and advance
     # by the highest cve_id we saw in the previous batch. This eliminates
@@ -383,6 +405,15 @@ def backfill(
         )
 
         for row in candidates:
+            # Bugbot round 2 (PR #106, Medium): the max-cves cap used to
+            # only fire at the TOP of the while-loop, meaning a first
+            # batch of 100 candidates would process ALL 100 even when
+            # ``--max-cves=10`` was set — defeating the smoke-test use
+            # case. Fix: check at every iteration of the inner for-loop.
+            if max_cves is not None and summary["processed"] >= max_cves:
+                logger.info("Hit --max-cves=%d mid-batch; stopping.", max_cves)
+                break
+
             cve_id = row["cve_id"]
             attr_ids = row.get("attr_ids") or []
             summary["processed"] += 1
@@ -433,13 +464,19 @@ def backfill(
                 logger.error("Failed to write %s: %s", cve_id, e)
                 summary["errors"] += 1
 
-        # Progress summary after each batch
+        # Progress summary after each batch.
+        # Bugbot round 2 (PR #106, Low): use ``run_started_at`` instead
+        # of ``last_fetch_at`` as the rate-denominator. Pre-fix divided
+        # by "time since the last fetch (~ms)" producing absurd rates
+        # like "40000/s".
+        elapsed_total = max(time.monotonic() - run_started_at, 0.001)
         logger.info(
-            "[PROGRESS] processed=%d backfilled=%d errors=%d rate=%.1f/s",
+            "[PROGRESS] processed=%d backfilled=%d errors=%d elapsed=%.1fs avg_rate=%.2f/s",
             summary["processed"],
             summary["backfilled"],
             summary["errors"],
-            summary["processed"] / max(time.monotonic() - last_fetch_at + 0.001, 0.001),
+            elapsed_total,
+            summary["processed"] / elapsed_total,
         )
 
         # If we got fewer than batch_size candidates, we're done (no more
@@ -490,9 +527,15 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
 
     # Read env early so missing creds fail fast
-    # NEO4J_URI defaults to localhost; the others are mandatory (script can't
-    # do anything useful without MISP credentials + Neo4j password).
+    # NEO4J_URI defaults to localhost; NEO4J_USER defaults to "neo4j"
+    # (matches src/config.py convention). Password + MISP creds are
+    # mandatory (script can't do anything useful without them).
     neo4j_uri = _env_optional("NEO4J_URI", default="bolt://localhost:7687") or "bolt://localhost:7687"
+    # Bugbot round 2 (PR #106, Medium): pre-fix hardcoded ``"neo4j"``
+    # as the username. Rest of the project reads ``NEO4J_USER`` via
+    # src/config.py (default "neo4j"); deployments using a different
+    # user would fail to authenticate when running this script.
+    neo4j_user = _env_optional("NEO4J_USER", default="neo4j") or "neo4j"
     neo4j_password = _env_required("NEO4J_PASSWORD")
     misp_url = _env_required("MISP_URL")
     misp_api_key = _env_required("MISP_API_KEY")
@@ -506,13 +549,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         )
 
     logger.info("Starting CVE date backfill (dry_run=%s)", args.dry_run)
-    logger.info("  Neo4j URI: %s", neo4j_uri)
+    logger.info("  Neo4j URI: %s (user: %s)", neo4j_uri, neo4j_user)
     logger.info("  MISP URL:  %s", misp_url)
     logger.info("  Batch:     %d candidates / rate-limit %s req/s", args.batch_size, args.rate_limit)
 
     # Connect to Neo4j
     try:
-        driver = GraphDatabase.driver(neo4j_uri, auth=("neo4j", neo4j_password))
+        driver = GraphDatabase.driver(neo4j_uri, auth=(neo4j_user, neo4j_password))
         driver.verify_connectivity()
     except Exception as e:
         logger.error("Neo4j connection failed: %s", e)

--- a/tests/test_pr_n22_cve_date_backfill.py
+++ b/tests/test_pr_n22_cve_date_backfill.py
@@ -375,3 +375,99 @@ class TestRunbookDocumentsBackfill:
         assert "still_null" in rb or "Verify success" in rb, (
             "RUNBOOK must include a verification Cypher block (e.g. count of still-NULL CVEs)"
         )
+
+
+# ===========================================================================
+# Bugbot round 2 (PR #106) — 4 new findings addressed
+# ===========================================================================
+
+
+class TestBugbotRound2Fixes:
+    """Bugbot's re-review of the round-1 fix commit flagged 4 new real bugs:
+    - MEDIUM: --max-cves cap not enforced within a batch
+    - LOW: progress rate uses wrong time reference
+    - MEDIUM: Neo4j username hardcoded, ignores NEO4J_USER
+    - MEDIUM: parse_nvd_meta can return non-dict, crashing extract_dates
+    """
+
+    def _src(self) -> str:
+        return BACKFILL_SCRIPT.read_text()
+
+    def test_max_cves_enforced_within_batch(self):
+        """MEDIUM: pre-fix the max_cves check only fired at the TOP of the
+        while-loop. With ``--max-cves=10`` and ``--batch-size=100`` the
+        first batch would process all 100 before the check — defeating
+        the smoke-test cap."""
+        src = self._src()
+        # The fix adds a second max_cves check inside the for-loop.
+        # Count ``max_cves is not None`` occurrences in backfill() — must
+        # be at least 2 (outer while + inner for).
+        body = src[src.find("def backfill") : src.find("\ndef ", src.find("def backfill") + 5)]
+        check_count = body.count("max_cves is not None and summary[")
+        assert check_count >= 2, (
+            f"max_cves must be checked BOTH at the while-loop top AND inside the for-loop; "
+            f"found only {check_count} checks (need >= 2 for per-iteration enforcement)"
+        )
+
+    def test_progress_rate_uses_run_started_at(self):
+        """LOW: the pre-fix progress log divided by ``time.monotonic() -
+        last_fetch_at`` where last_fetch_at was ~ms ago, producing absurd
+        rates like "40000 CVE/s". Fix uses ``run_started_at`` (captured
+        once before the loop)."""
+        src = self._src()
+        assert "run_started_at = time.monotonic()" in src, (
+            "backfill() must capture run_started_at before the loop for accurate rate calculation"
+        )
+        # Negative: the pre-fix denominator pattern must NOT appear.
+        assert 'summary["processed"] / max(time.monotonic() - last_fetch_at' not in src, (
+            "pre-fix rate calculation (time since last_fetch_at) is the Bugbot round 2 regression shape"
+        )
+        # Positive: the progress log must use run_started_at-based denominator.
+        assert "time.monotonic() - run_started_at" in src, (
+            "progress log must compute elapsed from run_started_at, not last_fetch_at"
+        )
+
+    def test_neo4j_user_from_env_not_hardcoded(self):
+        """MEDIUM: pre-fix used ``auth=("neo4j", neo4j_password)`` — hardcoded
+        the username. Must read ``NEO4J_USER`` env var (default "neo4j")
+        matching src/config.py convention."""
+        src = self._src()
+        # Negative: hardcoded literal must NOT appear.
+        assert 'auth=("neo4j", neo4j_password)' not in src, (
+            'hardcoded ``auth=("neo4j", neo4j_password)`` ignores NEO4J_USER env var. '
+            "Bugbot round 2, PR #106, Medium severity."
+        )
+        # Positive: must read NEO4J_USER env + use it in auth.
+        assert '"NEO4J_USER"' in src or "'NEO4J_USER'" in src, (
+            "script must read NEO4J_USER env var (default 'neo4j') like src/config.py"
+        )
+        assert "auth=(neo4j_user, neo4j_password)" in src, (
+            "Neo4j driver must be constructed with (neo4j_user, neo4j_password)"
+        )
+
+    def test_parse_nvd_meta_rejects_non_dict(self):
+        """MEDIUM: pre-fix ``parse_nvd_meta`` returned ``json.loads(...)``
+        directly — could yield list/string/int/bool. A truthy non-dict
+        would pass the ``if not nvd_meta:`` guard, then extract_dates
+        would call ``.get()`` on it and raise AttributeError OUTSIDE
+        the per-CVE try/except, crashing the entire backfill."""
+        src = self._src()
+        # Positive: the fix must narrow to dict with an isinstance check.
+        assert "isinstance(parsed, dict)" in src or "isinstance(nvd_meta, dict)" in src, (
+            "parse_nvd_meta must narrow return type to dict — json.loads can yield any JSON type"
+        )
+
+    def test_parse_nvd_meta_behavior_non_dict_inputs(self):
+        """Behavioral pin for Bugbot round 2 parse_nvd_meta fix."""
+        backfill_module = _load_backfill_module()
+        # List payload → {} (not [1,2,3])
+        assert backfill_module.parse_nvd_meta("NVD_META:[1,2,3]") == {}
+        # String payload → {}
+        assert backfill_module.parse_nvd_meta('NVD_META:"just a string"') == {}
+        # Integer payload → {}
+        assert backfill_module.parse_nvd_meta("NVD_META:42") == {}
+        # Boolean payload → {}
+        assert backfill_module.parse_nvd_meta("NVD_META:true") == {}
+        # Dict payload → passes through
+        result = backfill_module.parse_nvd_meta('NVD_META:{"published":"2021-01-01"}')
+        assert result == {"published": "2021-01-01"}

--- a/tests/test_pr_n22_cve_date_backfill.py
+++ b/tests/test_pr_n22_cve_date_backfill.py
@@ -234,8 +234,12 @@ class TestBugbotRound1Fixes:
         past it. Regression pin against someone "simplifying" the driver
         back to the no-cursor loop."""
         src = self._src()
-        # The assignment pattern we need to see inside backfill()
-        assert 'last_cve_id = candidates[-1]["cve_id"]' in src or 'last_cve_id = candidates[-1]["cve_id"]' in src, (
+        # The assignment pattern we need to see inside backfill().
+        # Bugbot round 2 (PR #106, Low): the pre-fix ``or`` had two
+        # IDENTICAL string literals (copy-paste bug — both branches
+        # were double-quoted instead of one double + one single). Fix:
+        # accept either single-quoted or double-quoted dict-key form.
+        assert "last_cve_id = candidates[-1]['cve_id']" in src or 'last_cve_id = candidates[-1]["cve_id"]' in src, (
             "backfill driver must advance last_cve_id to candidates[-1]['cve_id'] after each batch"
         )
 

--- a/tests/test_pr_n22_cve_date_backfill.py
+++ b/tests/test_pr_n22_cve_date_backfill.py
@@ -200,6 +200,108 @@ class TestIdempotencyCypher:
 
 
 # ===========================================================================
+# Bugbot round 1 (PR #106) — 4 legit findings must stay closed
+# ===========================================================================
+
+
+class TestBugbotRound1Fixes:
+    """Bugbot caught 4 real bugs on the first-pass PR-N22 commit:
+    - HIGH:   dry-run infinite loop (no writes → same batch re-fetched)
+    - HIGH:   normal-mode infinite loop on unresolvable CVEs
+    - HIGH:   SSL verify defaulted to INSECURE when env unset
+    - MEDIUM: urllib3 disable_warnings unconditional
+    """
+
+    def _src(self) -> str:
+        return BACKFILL_SCRIPT.read_text()
+
+    def test_fetch_uses_cursor_pagination(self):
+        """HIGH × 2: both infinite-loop modes (--dry-run + unresolvable
+        CVEs) are caused by the WHERE filter never changing for failed
+        attempts. Fix: cursor-based pagination via
+        ``c.cve_id > $last_cve_id ORDER BY c.cve_id LIMIT $batch_size``.
+        Every fetch returns the NEXT batch regardless of write success."""
+        src = self._src()
+        assert "c.cve_id > $last_cve_id" in src, (
+            "fetch query must use cursor pagination (c.cve_id > $last_cve_id) — "
+            "without this, dry-run AND unresolvable-CVE normal-mode runs infinite-loop"
+        )
+        assert "ORDER BY c.cve_id" in src, "cursor pagination requires deterministic ordering by cve_id"
+
+    def test_backfill_driver_advances_cursor(self):
+        """The Python-side driver must advance ``last_cve_id`` to the
+        LAST cve_id in the returned batch so the next iteration fetches
+        past it. Regression pin against someone "simplifying" the driver
+        back to the no-cursor loop."""
+        src = self._src()
+        # The assignment pattern we need to see inside backfill()
+        assert 'last_cve_id = candidates[-1]["cve_id"]' in src or 'last_cve_id = candidates[-1]["cve_id"]' in src, (
+            "backfill driver must advance last_cve_id to candidates[-1]['cve_id'] after each batch"
+        )
+
+    def test_ssl_verify_defaults_to_secure(self):
+        """HIGH: pre-fix ``_ssl_verify_enabled`` returned False when env
+        var was unset. Project convention (src/config.py:434) defaults
+        to True (secure). Mirror the config.py function exactly."""
+        src = self._src()
+        # The implementation must have an explicit ``return True`` fall-through
+        # (the "neither env set" case). Anchor on the function body.
+        start = src.find("def _ssl_verify_enabled")
+        end = src.find("\ndef ", start + 1)
+        body = src[start:end]
+        assert "return True" in body, (
+            "_ssl_verify_enabled must default to True (secure) when env vars unset — "
+            "matching src/config.py:edgeguard_ssl_verify_from_env"
+        )
+        # Must iterate both env var names (canonical + fallback), matching
+        # the config.py precedence.
+        assert '"EDGEGUARD_SSL_VERIFY"' in body and '"SSL_VERIFY"' in body, (
+            "_ssl_verify_enabled must check both EDGEGUARD_SSL_VERIFY (canonical) "
+            "and SSL_VERIFY (fallback) in that order"
+        )
+
+    def test_urllib3_disable_warnings_guarded_by_ssl_verify(self):
+        """MEDIUM: urllib3.disable_warnings was called UNCONDITIONALLY at
+        module load. Other EdgeGuard files gate this behind
+        ``if not SSL_VERIFY:`` so the warning stays visible when TLS IS
+        being verified (then it's a real signal). Pin via AST — only
+        look at actual ``Expr(Call(urllib3.disable_warnings))`` nodes
+        at module top-level, not at docstring/comment mentions."""
+        import ast
+
+        tree = ast.parse(self._src())
+        # Find top-level ``Expr`` statements whose value is a Call to
+        # ``urllib3.disable_warnings``. If any exists at module level
+        # (NOT inside an ``If``), the guard is missing.
+        for node in tree.body:
+            if isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+                func = node.value.func
+                if isinstance(func, ast.Attribute) and func.attr == "disable_warnings":
+                    raise AssertionError(
+                        "urllib3.disable_warnings called at module top-level without an ``if not "
+                        "_ssl_verify_enabled()`` guard. This was Bugbot round 1 MEDIUM — "
+                        "unconditional suppression hides real TLS-misconfig warnings."
+                    )
+        # Positive: the guarded call must exist somewhere. Walk all Ifs
+        # at module level and confirm at least one has a disable_warnings
+        # call in its body.
+        found_guarded = False
+        for node in tree.body:
+            if isinstance(node, ast.If):
+                # The test condition should reference _ssl_verify_enabled
+                test_src = ast.unparse(node.test)
+                if "_ssl_verify_enabled" not in test_src:
+                    continue
+                for stmt in node.body:
+                    if isinstance(stmt, ast.Expr) and isinstance(stmt.value, ast.Call):
+                        fn = stmt.value.func
+                        if isinstance(fn, ast.Attribute) and fn.attr == "disable_warnings":
+                            found_guarded = True
+                            break
+        assert found_guarded, "urllib3.disable_warnings must be inside an ``if not _ssl_verify_enabled():`` block"
+
+
+# ===========================================================================
 # Fix #4 — CLI contract
 # ===========================================================================
 

--- a/tests/test_pr_n22_cve_date_backfill.py
+++ b/tests/test_pr_n22_cve_date_backfill.py
@@ -475,3 +475,68 @@ class TestBugbotRound2Fixes:
         # Dict payload → passes through
         result = backfill_module.parse_nvd_meta('NVD_META:{"published":"2021-01-01"}')
         assert result == {"published": "2021-01-01"}
+
+
+# ===========================================================================
+# Bugbot round 3 (PR #106) — 3 NEW findings addressed
+# ===========================================================================
+
+
+class TestBugbotRound3Fixes:
+    """Bugbot's review of round 2 fix commit flagged 3 new real bugs:
+    - LOW: unreachable dead code after parser.error()
+    - LOW: Neo4j driver not closed on connectivity check failure
+    - MEDIUM: per-CVE MISP parsing errors crash entire backfill
+    """
+
+    def _src(self) -> str:
+        return BACKFILL_SCRIPT.read_text()
+
+    def test_no_dead_return_after_parser_error(self):
+        """LOW: ``parser.error()`` calls ``sys.exit(2)`` and never
+        returns, so a ``return 2`` after it is unreachable dead code."""
+        src = self._src()
+        # The pre-fix shape: parser.error followed immediately by return 2
+        bad_pattern = 'parser.error("--batch-size and --rate-limit must be positive")\n        return 2'
+        assert bad_pattern not in src, (
+            "dead ``return 2`` after parser.error() — parser.error internally "
+            "calls sys.exit(2); the return statement is unreachable. "
+            "Bugbot round 3, PR #106, Low severity."
+        )
+
+    def test_driver_closed_on_connectivity_check_failure(self):
+        """LOW: pre-fix had ``try { driver=...; verify_connectivity() }
+        except: return 1`` — if driver init succeeded but verify
+        FAILED, the half-initialized driver leaked its connection pool."""
+        src = self._src()
+        # The fix splits driver init and verify_connectivity into
+        # two separate try blocks; the second (verify) closes the
+        # driver before returning 1.
+        verify_pos = src.find("driver.verify_connectivity()")
+        assert verify_pos != -1, "must call verify_connectivity"
+        block = src[verify_pos : verify_pos + 1000]
+        assert "driver.close()" in block, (
+            "verify_connectivity exception handler must call driver.close() "
+            "to release the connection pool before returning. "
+            "Bugbot round 3, PR #106, Low severity."
+        )
+
+    def test_per_cve_errors_dont_crash_run(self):
+        """MEDIUM: pre-fix only wrapped the ``write_dates`` call in
+        try/except. An exception during ``misp.get_attribute``,
+        ``parse_nvd_meta``, or ``extract_dates`` would crash the whole
+        ~100K-CVE backfill run instead of skipping that CVE."""
+        src = self._src()
+        # The misp.get_attribute call MUST be inside a try block.
+        loop_anchor = "for row in candidates:"
+        loop_pos = src.find(loop_anchor)
+        assert loop_pos != -1
+        loop_body = src[loop_pos : loop_pos + 4000]
+        try_pos = loop_body.find("            try:")
+        misp_pos = loop_body.find("misp.get_attribute(")
+        assert try_pos != -1 and misp_pos != -1, "loop must contain try + misp.get_attribute"
+        assert try_pos < misp_pos, (
+            "the per-CVE try/except must wrap misp.get_attribute (and the rest of "
+            "the per-CVE processing path), not just write_dates. "
+            "Bugbot round 3, PR #106, Medium severity."
+        )

--- a/tests/test_pr_n22_cve_date_backfill.py
+++ b/tests/test_pr_n22_cve_date_backfill.py
@@ -1,0 +1,275 @@
+"""
+PR-N22 — historical CVE date backfill regression pins.
+
+Covers ``scripts/backfill_cve_dates_from_nvd_meta.py``, which reads MISP
+NVD_META (written at ingest by MISPWriter for NVD-sourced CVEs) and
+backfills ``c.published`` / ``c.last_modified`` on Neo4j CVE nodes that
+were ingested before PR-N19 Fix #1 (when the write path silently dropped
+those fields).
+
+The script is:
+  - Idempotent — safe to re-run without double-writes
+  - Non-destructive — uses ``coalesce`` so an existing non-NULL value
+    from a post-PR-N19 baseline is preserved (not overwritten)
+  - Bounded — batch_size + rate_limit flags
+  - Operator-friendly — dry-run mode, progress logs, exit-code distinction
+
+These tests pin:
+  1. The script exists + is executable
+  2. The NVD_META parser is correct + safe against malformed input
+  3. The date extractor normalizes empty/missing to None
+  4. The Cypher write uses ``coalesce`` (idempotency guard)
+  5. RUNBOOK documents the migration (when/how/verify/idempotency)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO_ROOT / "scripts"
+DOCS = REPO_ROOT / "docs"
+
+# The script lives in scripts/ and imports neo4j/requests at module load;
+# tests that exercise parser functions bypass the driver import by
+# reading the module source directly.
+BACKFILL_SCRIPT = SCRIPTS / "backfill_cve_dates_from_nvd_meta.py"
+
+
+# ===========================================================================
+# Fix #1 — script exists + is executable
+# ===========================================================================
+
+
+class TestBackfillScriptExistsAndIsExecutable:
+    def test_script_exists(self):
+        assert BACKFILL_SCRIPT.exists(), "scripts/backfill_cve_dates_from_nvd_meta.py must exist"
+
+    def test_script_is_executable(self):
+        """Operators run it directly — chmod +x is part of the
+        deliverable, not 'python3 script.py'."""
+        assert os.access(BACKFILL_SCRIPT, os.X_OK), "backfill script must be chmod +x"
+
+    def test_script_has_shebang(self):
+        content = BACKFILL_SCRIPT.read_text()
+        assert content.startswith("#!/usr/bin/env python3"), "script must start with ``#!/usr/bin/env python3`` shebang"
+
+
+# ===========================================================================
+# Fix #2 — NVD_META parser contract
+# ===========================================================================
+
+
+# Dynamically load the script module so we can exercise ``parse_nvd_meta``
+# + ``extract_dates`` without requiring neo4j/requests to be importable
+# at test time. The ``neo4j`` + ``requests`` imports happen at module
+# load; if they fail, tests still pin the source shape.
+def _load_backfill_module():
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("backfill_cve_dates", BACKFILL_SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    # Make sure the ``src/`` sibling is on the path so any downstream
+    # imports (if the script grows) work.
+    src_path = str(REPO_ROOT / "src")
+    if src_path not in sys.path:
+        sys.path.insert(0, src_path)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def backfill_module():
+    """Load the script as a module. Skips tests if neo4j/requests aren't
+    installed (which is unusual in this repo — both are hard deps — but
+    keeps CI from failing on a minimal env)."""
+    try:
+        return _load_backfill_module()
+    except ImportError as e:
+        pytest.skip(f"backfill module imports not available: {e}")
+
+
+class TestNvdMetaParser:
+    """``parse_nvd_meta`` must handle:
+    - Happy path (prefix + valid JSON)
+    - Missing prefix (not NVD_META-tagged comment)
+    - Empty / None input
+    - Malformed JSON (soft-fail to empty dict, not crash)
+    """
+
+    def test_parses_valid_nvd_meta(self, backfill_module):
+        meta = backfill_module.parse_nvd_meta(
+            'NVD_META:{"published": "2021-12-10T10:15:09.143", "last_modified": "2024-04-03T17:02:49.887"}'
+        )
+        assert meta.get("published") == "2021-12-10T10:15:09.143"
+        assert meta.get("last_modified") == "2024-04-03T17:02:49.887"
+
+    def test_missing_prefix_returns_empty(self, backfill_module):
+        # Old-style comments without the NVD_META prefix: not an error,
+        # just no data to backfill.
+        assert backfill_module.parse_nvd_meta("Log4Shell description") == {}
+        assert backfill_module.parse_nvd_meta("") == {}
+
+    def test_none_input_returns_empty(self, backfill_module):
+        """Defensive: MISP comment can be None on some attribute shapes."""
+        assert backfill_module.parse_nvd_meta(None) == {}
+
+    def test_non_string_returns_empty(self, backfill_module):
+        """Defensive: if MISP ever returns a structured comment, don't crash."""
+        assert backfill_module.parse_nvd_meta({"some": "dict"}) == {}
+        assert backfill_module.parse_nvd_meta(12345) == {}
+
+    def test_malformed_json_returns_empty(self, backfill_module):
+        """JSON corruption in the comment → skip the CVE, don't crash."""
+        assert backfill_module.parse_nvd_meta("NVD_META:{not valid json") == {}
+        assert backfill_module.parse_nvd_meta("NVD_META:not-json-at-all") == {}
+
+
+class TestDateExtractor:
+    """``extract_dates`` must normalize empty strings / missing keys to
+    None so callers can use a simple ``if v is not None`` guard."""
+
+    def test_both_fields_present(self, backfill_module):
+        pub, mod = backfill_module.extract_dates({"published": "2021-12-10T10:15:09", "last_modified": "2024-04-03"})
+        assert pub == "2021-12-10T10:15:09"
+        assert mod == "2024-04-03"
+
+    def test_empty_strings_normalize_to_none(self, backfill_module):
+        # Empty string is what MISP stores when the field is missing
+        # upstream — we must not pass "" into the Cypher SET (would
+        # set the node to an empty string, not NULL).
+        pub, mod = backfill_module.extract_dates({"published": "", "last_modified": ""})
+        assert pub is None
+        assert mod is None
+
+    def test_missing_keys_return_none(self, backfill_module):
+        pub, mod = backfill_module.extract_dates({"other_field": "value"})
+        assert pub is None
+        assert mod is None
+
+    def test_one_field_present_one_missing(self, backfill_module):
+        pub, mod = backfill_module.extract_dates({"published": "2021-12-10"})
+        assert pub == "2021-12-10"
+        assert mod is None
+
+
+# ===========================================================================
+# Fix #3 — Idempotency: the Cypher write uses coalesce
+# ===========================================================================
+
+
+class TestIdempotencyCypher:
+    """The UPDATE Cypher must use ``coalesce(c.published, $published)`` so
+    an already-populated value (from a post-PR-N19 baseline) is never
+    overwritten by the script."""
+
+    def test_update_cypher_uses_coalesce_for_published(self):
+        src = BACKFILL_SCRIPT.read_text()
+        assert "c.published = coalesce(c.published, $published)" in src, (
+            "UPDATE Cypher must use ``coalesce`` on ``published`` to preserve any "
+            "value already written by a post-PR-N19 baseline"
+        )
+
+    def test_update_cypher_uses_coalesce_for_last_modified(self):
+        src = BACKFILL_SCRIPT.read_text()
+        assert "c.last_modified = coalesce(c.last_modified, $last_modified)" in src, (
+            "UPDATE Cypher must use ``coalesce`` on ``last_modified`` to preserve any "
+            "value already written by a post-PR-N19 baseline"
+        )
+
+    def test_fetch_cypher_filters_to_null_candidates_only(self):
+        """The fetch step must only return CVEs with at least one NULL
+        date field — otherwise re-runs would reprocess everything."""
+        src = BACKFILL_SCRIPT.read_text()
+        assert "c.published IS NULL OR c.last_modified IS NULL" in src, (
+            "fetch step must filter to candidates missing at least one date"
+        )
+
+    def test_fetch_cypher_requires_misp_attr_id(self):
+        """CVEs without ``misp_attribute_ids`` can't be backfilled (no
+        upstream source to read from). Must be filtered out of the
+        candidate set — otherwise the script spins on them every run."""
+        src = BACKFILL_SCRIPT.read_text()
+        assert "size(coalesce(c.misp_attribute_ids, [])) > 0" in src, (
+            "fetch step must require at least one misp_attribute_ids entry"
+        )
+
+
+# ===========================================================================
+# Fix #4 — CLI contract
+# ===========================================================================
+
+
+class TestCliContract:
+    """The script's CLI must expose the flags the operator runbook
+    describes (``--dry-run``, ``--batch-size``, ``--rate-limit``,
+    ``--max-cves``) and its exit codes must distinguish error-free
+    completion from partial failure."""
+
+    def test_dry_run_flag_exists(self):
+        src = BACKFILL_SCRIPT.read_text()
+        assert '"--dry-run"' in src, "script must accept --dry-run flag"
+
+    def test_batch_size_flag_exists(self):
+        src = BACKFILL_SCRIPT.read_text()
+        assert '"--batch-size"' in src, "script must accept --batch-size flag"
+
+    def test_rate_limit_flag_exists(self):
+        src = BACKFILL_SCRIPT.read_text()
+        assert '"--rate-limit"' in src, "script must accept --rate-limit flag"
+
+    def test_max_cves_flag_exists(self):
+        """Smoke-test convenience: cap processed count so an operator
+        can verify behavior on 10 CVEs before committing to the full run."""
+        src = BACKFILL_SCRIPT.read_text()
+        assert '"--max-cves"' in src, "script must accept --max-cves flag"
+
+    def test_exit_code_1_on_errors(self):
+        src = BACKFILL_SCRIPT.read_text()
+        # Must return 1 if any unrecoverable error; 0 on clean run.
+        assert "return 1 if summary.get(" in src, "script must return exit 1 when errors > 0"
+
+
+# ===========================================================================
+# Fix #5 — RUNBOOK documents the migration
+# ===========================================================================
+
+
+class TestRunbookDocumentsBackfill:
+    def _runbook(self) -> str:
+        return (DOCS / "RUNBOOK.md").read_text()
+
+    def test_runbook_has_backfill_section(self):
+        rb = self._runbook()
+        assert "PR-N22" in rb and "backfill" in rb.lower(), (
+            "RUNBOOK must have a PR-N22 backfill section so operators can find it"
+        )
+
+    def test_runbook_shows_dry_run_first(self):
+        """The operator protocol must emphasize dry-run first — a 100K-CVE
+        real-run with a misconfigured env var would be painful."""
+        rb = self._runbook()
+        assert "--dry-run" in rb, "RUNBOOK must show --dry-run as the first step"
+        dry_run_pos = rb.find("--dry-run")
+        real_run_pos = rb.find("./scripts/backfill_cve_dates_from_nvd_meta.py --batch-size")
+        # Dry-run must appear BEFORE the real-run command in the RUNBOOK order.
+        if real_run_pos != -1:
+            assert dry_run_pos < real_run_pos, "RUNBOOK must document dry-run BEFORE the real-run command"
+
+    def test_runbook_documents_idempotency(self):
+        rb = self._runbook()
+        assert "idempotent" in rb.lower() or "idempotenc" in rb.lower(), (
+            "RUNBOOK must explicitly state the script is idempotent so operators feel safe re-running"
+        )
+
+    def test_runbook_shows_verify_cypher(self):
+        """Operators need post-migration verification queries — paste-ready
+        Cypher for 'did this actually work?'"""
+        rb = self._runbook()
+        assert "still_null" in rb or "Verify success" in rb, (
+            "RUNBOOK must include a verification Cypher block (e.g. count of still-NULL CVEs)"
+        )


### PR DESCRIPTION
## Summary

Closes the operational gap left by PR-N19 Fix #1: that PR repaired the `merge_cve` write path so the **next** baseline populates `c.published` + `c.last_modified` correctly, but did NOTHING about the **existing 99,664 cloud CVEs** (all NULL on both fields per Bravo Vanko's 2026-04-22 audit).

This PR adds a one-shot migration script that reads MISP NVD_META and backfills the dates **without a re-baseline**. ~1-2 hours for a 99K-CVE graph; safe to re-run; non-destructive.

## What ships

### `scripts/backfill_cve_dates_from_nvd_meta.py`

Per CVE with NULL `published` or `last_modified`:
1. Read `c.misp_attribute_ids[0]` — real MISP attribute UUID (PR #32 traceability lineage)
2. Fetch via `GET /attributes/<uuid>`
3. Parse the `comment` field (prefix `"NVD_META:"` + JSON — same parser shape as `src/run_misp_to_neo4j.py:2385+`)
4. Extract `published` + `last_modified`, normalize empty strings to None
5. Write with `SET c.published = coalesce(c.published, $pub)` so any value already set by a post-PR-N19 baseline is preserved

**Operator surface**:
- `--dry-run` — print planned writes, change nothing
- `--batch-size` (default 100)
- `--rate-limit` (default 10 req/s; lower for production windows)
- `--max-cves` — smoke-test cap
- Honors `EDGEGUARD_SSL_VERIFY` with project-matching strict-allow-list semantics
- Exit 0 on clean run; exit 1 on any unrecoverable error
- Per-batch progress logs + grand summary with per-outcome counts

### `docs/RUNBOOK.md`

New "PR-N22: backfill historical CVE published / last_modified" section:
- When to run (pre-evaluator-demo unblock vs full re-baseline)
- Dry-run-first protocol with copy-paste env var setup
- Verify success queries
- Idempotency guarantee (no race with concurrent baselines)
- Known edge cases

## Idempotency

Re-runs are safe — three layers of protection:
1. `WHERE c.published IS NULL OR c.last_modified IS NULL` filter skips already-done CVEs
2. `coalesce` SET clause preserves any value written between invocations
3. No deletes, no overwrites of non-NULL fields

If a baseline ran between script invocations and populated the field, the script respects the baseline value (authoritative). Crash mid-run? Just re-run.

## Test plan

- [x] **25 regression pins** in `tests/test_pr_n22_cve_date_backfill.py`:
  - 3× script-exists-and-is-executable
  - 5× NVD_META parser (happy path, missing prefix, None, non-string, malformed JSON)
  - 4× date extractor (both, empty-strings-to-None, missing keys, partial)
  - 4× idempotency Cypher (coalesce on both fields, NULL-only filter, requires misp_attribute_ids)
  - 5× CLI contract (4 flags + exit code 1 on errors)
  - 4× RUNBOOK documentation pins
- [x] Full pytest: **1537 passed**, 3 skipped, 3 xfailed
- [x] `ruff format` / `ruff check` / `mypy` all clean
- [x] Script syntax-checks + is executable (chmod +x)

## How to use post-merge

```bash
# 1. Dry-run first
./scripts/backfill_cve_dates_from_nvd_meta.py --dry-run

# 2. Real run against cloud Neo4j
export NEO4J_URI="bolt+s://neo4j-bolt.edgeguard.org:443"
export NEO4J_PASSWORD="<cloud-password>"
export MISP_URL="https://misp.edgeguard.org"
export MISP_API_KEY="<key>"
export EDGEGUARD_SSL_VERIFY=true
./scripts/backfill_cve_dates_from_nvd_meta.py --batch-size 100 --rate-limit 10
```

After completion, the cloud Neo4j will have `c.published` and `c.last_modified` populated on every CVE with an upstream NVD_META — no waiting for a 26h re-baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new operational script that reads from MISP and writes to Neo4j CVE nodes; while idempotent via `coalesce`, it touches production data and relies on external services/rate limiting.
> 
> **Overview**
> Introduces `scripts/backfill_cve_dates_from_nvd_meta.py` to backfill missing CVE `published`/`last_modified` properties by fetching MISP attributes and parsing `NVD_META:` JSON, then updating Neo4j with `coalesce`-guarded writes plus `--dry-run`, batching, rate limiting, and safer cursor-based pagination.
> 
> Updates the RUNBOOK with a new PR-N22 procedure (when to run, commands, verification Cypher, idempotency/edge cases) and adds a comprehensive `tests/test_pr_n22_cve_date_backfill.py` suite to pin parser behavior, CLI contract, TLS-verify defaults, pagination/loop termination, and documentation presence.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c210bab18772dfc074fc267a867296c25b2afd70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->