### PR TITLE
fix(audit): PR-N24 — proactive 7-agent audit BLOCKERs/HIGHs (next 730d baseline)

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -2831,13 +2831,29 @@ baseline_enrichment_task = PythonOperator(
 # operators expect after a successful enrichment run. Without this, a
 # silent ``Campaign = 0`` (the 2026-04-22 incident shape) shows the
 # DAG green and the operator only finds out via manual Cypher days
-# later. STRICT trigger_rule (ALL_SUCCESS): if enrichment failed the
-# postcheck is meaningless, so don't run.
+# later.
+#
+# PR-N24 audit HIGH H2 (proactive 2026-04-22 Prod Readiness): pre-N24
+# this used ``trigger_rule=ALL_SUCCESS`` with the rationale "if
+# enrichment failed the postcheck is meaningless, so don't run." But
+# the postcheck's INV-2 (Indicator > 0) and INV-3 (Source > 0) are
+# UPSTREAM diagnostics — they answer "did sync produce data at all?"
+# which is exactly what an operator needs to triage WHY enrichment
+# failed (e.g. enrichment failed because Source=0 → mark_inactive
+# silent skip → bootstrap_sources never ran). Skipping postcheck on
+# enrichment failure hides the upstream cause.
+#
+# Fix: ``NONE_FAILED_MIN_ONE_SUCCESS`` matches the upstream
+# ``baseline_full_sync_task`` and ``baseline_build_rels_task`` pattern.
+# Postcheck runs whenever AT LEAST ONE upstream succeeded and NO
+# upstream had a true failure → we get the diagnostic signal even
+# when enrichment is the failed task. If everything upstream failed
+# (no successes), the postcheck task is also skipped — correct.
 baseline_postcheck_task = PythonOperator(
     task_id="baseline_postcheck",
     python_callable=assert_baseline_postconditions,
     execution_timeout=timedelta(minutes=10),
-    trigger_rule=TriggerRule.ALL_SUCCESS,
+    trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
     dag=baseline_dag,
 )
 

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -270,7 +270,7 @@ When `EdgeGuardApocBatchPartial` fires:
    - `MemoryLimitExceededException` → Neo4j TX memory cap hit. Lower batch size for that step, OR raise `NEO4J_TX_MEMORY_MAX` (but watch the ceiling — above 4g on 8 GB worker and you're eating worker RSS).
    - `DeadlockDetected` → transient, re-run the step.
    - Schema / constraint error → code bug, file an issue, do NOT re-run blindly.
-3. Option A — re-run just this step: invoke `python -m src.build_relationships --step <N>` (if the CLI supports it) or re-trigger the whole DAG from that step in Airflow UI.
+3. Option A — re-trigger the whole `edgeguard_baseline` DAG from `build_relationships` task in Airflow UI (Graph view → click `build_relationships` → "Clear" → confirm). It re-runs all 12 sub-steps, but the early-step MERGEs are idempotent so only the failed step's edges are re-created. There is currently NO per-step CLI flag — `src/build_relationships.py` runs all 12 steps as a single Python program. (See Issue #58 for the planned `--step N` CLI; until then, full-task re-run is the supported path.)
 4. Option B — if partial data is acceptable for the demo window, leave it. The next incremental sync will fill in most missed edges. Flag for follow-up.
 
 ### Post-run summary grep

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -81,13 +81,26 @@ receivers:
     # Alertmanager loaded it (it's a valid YAML string) and PagerDuty
     # silently 403'd every page — meaning EVERY critical alert during
     # the 26h baseline window WOULD HAVE GONE UNROUTED. The preflight
-    # script (`scripts/preflight_baseline.sh` check [11], also added
-    # in PR-N24) now refuses to launch if this template is still here.
+    # script (`scripts/preflight_baseline.sh` check [7b], also added
+    # in PR-N24) now refuses to launch if either a placeholder OR an
+    # un-rendered ``${ENV_VAR}`` template is still in this YAML.
     #
-    # Operator action: replace ``${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}``
-    # via env-var substitution in your deploy pipeline, OR edit this file
-    # directly to insert your real PagerDuty Events-API v2 integration key
-    # (32-char hex string from the PagerDuty service "Integrations" tab).
+    # ⚠️  IMPORTANT — Alertmanager does NOT perform env-var substitution
+    # in its YAML config files (Bugbot round 1 caught this:
+    # https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/pull/108).
+    # The ``${...}`` template below is intentionally INVALID for
+    # Alertmanager to consume directly — it MUST be rendered before
+    # Alertmanager starts. Two options:
+    #
+    #   1. Treat this file as a TEMPLATE and run ``envsubst`` (or
+    #      helm/kustomize) at deploy time:
+    #
+    #         envsubst < prometheus/alertmanager.yml \
+    #           > /etc/alertmanager/alertmanager.yml
+    #
+    #   2. Edit this file directly and replace the ``${...}`` with the
+    #      real PagerDuty Events-API v2 integration key (32-char hex
+    #      string from the PagerDuty service "Integrations" tab).
     pagerduty_configs:
       - service_key: '${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}'
         description: '{{ .GroupLabels.alertname }}'

--- a/prometheus/alertmanager.yml
+++ b/prometheus/alertmanager.yml
@@ -76,8 +76,20 @@ receivers:
         send_resolved: true
 
   - name: 'on-call'
+    # PR-N24 BLOCKER B2 (proactive audit 2026-04-22): pre-N24 the
+    # service_key was the LITERAL placeholder ``<YOUR_PAGERDUTY_KEY>``.
+    # Alertmanager loaded it (it's a valid YAML string) and PagerDuty
+    # silently 403'd every page — meaning EVERY critical alert during
+    # the 26h baseline window WOULD HAVE GONE UNROUTED. The preflight
+    # script (`scripts/preflight_baseline.sh` check [11], also added
+    # in PR-N24) now refuses to launch if this template is still here.
+    #
+    # Operator action: replace ``${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}``
+    # via env-var substitution in your deploy pipeline, OR edit this file
+    # directly to insert your real PagerDuty Events-API v2 integration key
+    # (32-char hex string from the PagerDuty service "Integrations" tab).
     pagerduty_configs:
-      - service_key: '<YOUR_PAGERDUTY_KEY>'
+      - service_key: '${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}'
         description: '{{ .GroupLabels.alertname }}'
         severity: '{{ .GroupLabels.severity }}'
 

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -613,6 +613,48 @@ groups:
                  for the full rejected list.
               5. See docs/RUNBOOK.md § Top-5 failure mode #5
 
+      - alert: EdgeGuardMispEventAttributesTruncated
+        # PR-N24 audit fix (H3): wires the
+        # ``edgeguard_misp_event_attributes_truncated_total`` counter
+        # added in PR-N23 to an actual alert. Pre-N24 the counter
+        # existed but no alert fired — observability was unwired.
+        #
+        # Each increment = one MISP event whose attribute list exceeded
+        # ``MAX_ATTRIBUTES_PER_EVENT`` and was silently sliced by
+        # ``MISPCollector.collect``. At baseline scale large NVD events
+        # routinely lose 75%+ of their data this way. Non-zero rate
+        # within an hour means active data loss — operator should
+        # either raise the cap (if MISP can handle it) or investigate
+        # why the source is producing over-sized events.
+        #
+        # Use ``increase()`` (absolute count over window) NOT
+        # ``rate()`` — same lesson as PR-N12 follow-ups.
+        expr: sum by (source) (increase(edgeguard_misp_event_attributes_truncated_total[1h])) > 0
+        for: 5m
+        labels:
+          severity: warning
+          component: misp_collector
+        annotations:
+          summary: "EdgeGuard MISP collector truncated over-sized event(s) for {{ $labels.source }} — silent data loss"
+          description: |
+            ``MISPCollector.collect`` truncated one or more events from
+            source ``{{ $labels.source }}`` whose attribute list
+            exceeded ``MAX_ATTRIBUTES_PER_EVENT``. Each occurrence
+            silently drops attributes (typically 75%+ of the event's
+            data on large NVD events).
+
+            Remediation:
+              1. Identify the offending event(s):
+                 ``grep -E 'truncated.*attributes' /opt/airflow/logs/**/misp_collector.log | tail -20``
+              2. Decide: raise ``MAX_ATTRIBUTES_PER_EVENT`` (if MISP
+                 backend can handle larger events — check PHP
+                 ``memory_limit`` and MySQL ``innodb_buffer_pool_size``
+                 first), OR investigate why the upstream source is
+                 producing over-sized events (collector regression /
+                 missing pagination).
+              3. See ``src/collectors/misp_collector.py`` and
+                 ``docs/RUNBOOK.md`` § MISP truncation.
+
       - alert: EdgeGuardBuildRelationshipsSilentDeath
         # PR-N21 Bravo-ops: catches a silent ``build_relationships``
         # subprocess death (exit 137 OOM, SIGKILL from timeout, crash

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -251,12 +251,48 @@ else
   warn "promtool not installed; skipping alerts parse check (install Prometheus tools)"
 fi
 
-# Quick structural pin — expect the edgeguard_pipeline_observability rule group with at least 6 alerts.
+# Quick structural pin — expect the edgeguard_pipeline_observability rule group with at least 9 alerts.
+# PR-N24 audit MED follow-up: bumped from ≥ 6 → ≥ 8 (PR-N21 Bravo-ops adds
+# EdgeGuardBuildRelationshipsSilentDeath + EdgeGuardApocBatchPartial), then
+# bumped again to ≥ 9 for PR-N24 H3 (EdgeGuardMispEventAttributesTruncated).
+# This is a defense-in-depth structural pin — promtool above does the real validation.
 ALERT_COUNT=$(grep -cE '^\s+- alert:' prometheus/alerts.yml 2>/dev/null || echo "0")
-if [[ "$ALERT_COUNT" -ge 6 ]]; then
-  pass "prometheus/alerts.yml has $ALERT_COUNT alert rules (≥ 6 required)"
+if [[ "$ALERT_COUNT" -ge 9 ]]; then
+  pass "prometheus/alerts.yml has $ALERT_COUNT alert rules (≥ 9 required)"
 else
-  fail "prometheus/alerts.yml has only $ALERT_COUNT alerts — expected ≥ 6 per PR-N11/N12/N18"
+  fail "prometheus/alerts.yml has only $ALERT_COUNT alerts — expected ≥ 9 (PR-N11/N12/N18/N21/N24)"
+fi
+
+# -----------------------------------------------------------------------------
+# [7b] PR-N24 BLOCKER B2: alertmanager pager wiring not still placeholder
+# -----------------------------------------------------------------------------
+# Pre-N24, ``prometheus/alertmanager.yml`` shipped with literal
+# ``service_key: '<YOUR_PAGERDUTY_KEY>'``. PagerDuty silently 403s on
+# every page. During the 26h baseline window, EVERY critical alert
+# (BatchPermanentFailure, IneffectiveBatch, BuildRelationshipsSilentDeath,
+# etc.) would have been emitted-but-unrouted — the on-call would never know.
+# This check refuses to launch the baseline if the placeholder template
+# is still in place.
+hdr "[7b] alertmanager pager wiring (PR-N24 B2)"
+if [ -f prometheus/alertmanager.yml ]; then
+  # Only fail when the placeholder appears as a YAML *value* (quoted
+  # scalar), NOT when it appears in an explanatory ``#`` comment. The
+  # comment block in alertmanager.yml documents the placeholder's
+  # history; matching that would fail-close unnecessarily. The actual
+  # failure mode is Alertmanager loading the placeholder as the
+  # ``service_key:`` value — that only happens when it's in quotes.
+  #
+  # sed strips the trailing ``#...`` portion of each line before grep;
+  # the placeholder patterns are then only matched against uncommented
+  # YAML content.
+  if sed 's/#.*$//' prometheus/alertmanager.yml | \
+     grep -qE "'<YOUR_PAGERDUTY_KEY>'|\"<YOUR_PAGERDUTY_KEY>\"|'<YOUR_API_KEY>'|\"<YOUR_API_KEY>\"|'<PLACEHOLDER>'|\"<PLACEHOLDER>\"|'XXXXXXXX-XXXX'|\"XXXXXXXX-XXXX\""; then
+    fail "prometheus/alertmanager.yml still contains a placeholder pager key as a YAML value — PagerDuty will silently 403 every alert. Replace with EDGEGUARD_PAGERDUTY_INTEGRATION_KEY env-var substitution OR a real PagerDuty integration key."
+  else
+    pass "alertmanager.yml has no placeholder pager key values"
+  fi
+else
+  warn "prometheus/alertmanager.yml not found — pager routing not configured"
 fi
 
 # -----------------------------------------------------------------------------

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -271,8 +271,19 @@ fi
 # every page. During the 26h baseline window, EVERY critical alert
 # (BatchPermanentFailure, IneffectiveBatch, BuildRelationshipsSilentDeath,
 # etc.) would have been emitted-but-unrouted — the on-call would never know.
-# This check refuses to launch the baseline if the placeholder template
-# is still in place.
+#
+# This check refuses to launch the baseline if a placeholder OR an
+# un-rendered ``${ENV_VAR}`` template is still in place.
+#
+# Bugbot round 1 (2026-04-23): the original PR-N24 fix replaced the
+# literal ``<YOUR_PAGERDUTY_KEY>`` with ``'${EDGEGUARD_PAGERDUTY_
+# INTEGRATION_KEY}'`` thinking Alertmanager would substitute the
+# env var. It does NOT — Alertmanager loads the YAML literally and
+# would send ``${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}`` as the
+# service key → same silent 403 as the original placeholder.
+# Operators must render alertmanager.yml from a template (envsubst,
+# helm, kustomize, etc.) BEFORE Alertmanager starts. This preflight
+# now refuses both shapes (literal placeholder + un-rendered env var).
 hdr "[7b] alertmanager pager wiring (PR-N24 B2)"
 if [ -f prometheus/alertmanager.yml ]; then
   # Only fail when the placeholder appears as a YAML *value* (quoted
@@ -283,13 +294,13 @@ if [ -f prometheus/alertmanager.yml ]; then
   # ``service_key:`` value — that only happens when it's in quotes.
   #
   # sed strips the trailing ``#...`` portion of each line before grep;
-  # the placeholder patterns are then only matched against uncommented
-  # YAML content.
+  # the placeholder / env-template patterns are then only matched
+  # against uncommented YAML content.
   if sed 's/#.*$//' prometheus/alertmanager.yml | \
-     grep -qE "'<YOUR_PAGERDUTY_KEY>'|\"<YOUR_PAGERDUTY_KEY>\"|'<YOUR_API_KEY>'|\"<YOUR_API_KEY>\"|'<PLACEHOLDER>'|\"<PLACEHOLDER>\"|'XXXXXXXX-XXXX'|\"XXXXXXXX-XXXX\""; then
-    fail "prometheus/alertmanager.yml still contains a placeholder pager key as a YAML value — PagerDuty will silently 403 every alert. Replace with EDGEGUARD_PAGERDUTY_INTEGRATION_KEY env-var substitution OR a real PagerDuty integration key."
+     grep -qE "'<YOUR_PAGERDUTY_KEY>'|\"<YOUR_PAGERDUTY_KEY>\"|'<YOUR_API_KEY>'|\"<YOUR_API_KEY>\"|'<PLACEHOLDER>'|\"<PLACEHOLDER>\"|'XXXXXXXX-XXXX'|\"XXXXXXXX-XXXX\"|'\\\$\\{[A-Z_][A-Z0-9_]*\\}'|\"\\\$\\{[A-Z_][A-Z0-9_]*\\}\""; then
+    fail "prometheus/alertmanager.yml still contains a placeholder OR un-rendered \${...} env-var template as a YAML value — PagerDuty will silently 403 every alert (Alertmanager does NOT expand env vars in YAML). Render alertmanager.yml via envsubst/helm/kustomize before Alertmanager starts, OR insert a real PagerDuty integration key directly."
   else
-    pass "alertmanager.yml has no placeholder pager key values"
+    pass "alertmanager.yml has no placeholder or un-rendered env-template pager key values"
   fi
 else
   warn "prometheus/alertmanager.yml not found — pager routing not configured"

--- a/src/collectors/mitre_collector.py
+++ b/src/collectors/mitre_collector.py
@@ -537,7 +537,17 @@ class MITRECollector:
                 )
             logger.error(f"MITRE ATT&CK collection error: {e}")
             MITRE_CIRCUIT_BREAKER.record_failure()
-            return self._return_status(False, 0, str(e)) if push_to_misp else []
+            # PR-N24 BLOCKER B3 (proactive audit 2026-04-22): same shape as
+            # PR-N17 NVD silent-window-drop + PR-N23 CISA fix. Pre-N24
+            # ``return self._return_status(False, 0, str(e)) if push_to_misp
+            # else []`` returned an EMPTY LIST when push_to_misp=False
+            # (alert-preview / baseline-drain / test-harness flows) —
+            # indistinguishable from "MITRE has no updates today".
+            # Fix: when push_to_misp=True still return status dict (Airflow
+            # contract); when False, re-raise so caller sees the actual error.
+            if push_to_misp:
+                return self._return_status(False, 0, str(e))
+            raise
 
     def _return_status(self, success: bool, count: int, error: str = None, failed: int = 0):
         """Return standardized status dict (delegates to shared make_status)."""

--- a/src/collectors/nvd_collector.py
+++ b/src/collectors/nvd_collector.py
@@ -1221,7 +1221,17 @@ class NVDCollector:
             logger.error(f"NVD collection error: {type(e).__name__}: {e}")
             self.circuit_breaker.record_failure()
             record_collection_failure(self.source_name, error_msg)
-            return self._return_status(False, 0, error_msg)
+            # PR-N24 BLOCKER B3 (proactive audit 2026-04-22): PR-N17 closed
+            # the NvdBatchFetchError internal path but left this outer
+            # ``except Exception`` as a silent swallower for the
+            # ``push_to_misp=False`` branch — caller (baseline-drain /
+            # alert-preview) got a status dict indistinguishable from
+            # "NVD has no new CVEs today". NVD is the canonical CVE source
+            # for the 730-day baseline; a silent outage here is
+            # unacceptable. Same fix shape as OTX/MITRE/CISA.
+            if push_to_misp:
+                return self._return_status(False, 0, error_msg)
+            raise
 
     def _return_status(self, success: bool, count: int, error: str = None, failed: int = 0) -> Dict[str, Any]:
         """Return standardized status dict."""

--- a/src/collectors/otx_collector.py
+++ b/src/collectors/otx_collector.py
@@ -671,18 +671,31 @@ class OTXCollector:
                 _advance_otx_incremental_cursor()
                 return unique
 
+        # PR-N24 BLOCKER B3 (proactive audit 2026-04-22): on push_to_misp=False,
+        # the docstring says "return list of processed items" — but pre-N24
+        # all 4 exception handlers returned a status DICT regardless,
+        # which the alert-preview / test-harness / baseline-drain caller
+        # could not distinguish from a successful empty-list result.
+        # Same shape as the PR-N17 NVD bug + PR-N23 CISA fix. Mirroring
+        # CISA's resolution (cisa_collector.py:312-355): when
+        # push_to_misp=True still return status dict (Airflow contract);
+        # when False, re-raise so the caller sees the actual error.
         except requests.exceptions.Timeout as e:
             error_msg = f"Timeout: {e}"
             logger.error(f"OTX timeout: {e}")
             self.circuit_breaker.record_failure()
             record_collection_failure(self.source_name, error_msg)
-            return self._return_status(False, 0, error_msg)
+            if push_to_misp:
+                return self._return_status(False, 0, error_msg)
+            raise
         except requests.exceptions.ConnectionError as e:
             error_msg = f"Connection error: {e}"
             logger.error(f"OTX connection error: {e}")
             self.circuit_breaker.record_failure()
             record_collection_failure(self.source_name, error_msg)
-            return self._return_status(False, 0, error_msg)
+            if push_to_misp:
+                return self._return_status(False, 0, error_msg)
+            raise
         except requests.exceptions.HTTPError as e:
             if push_to_misp and is_auth_or_access_denied(e):
                 logger.warning(f"OTX: auth/access denied — skipping (optional): {e}")
@@ -699,13 +712,17 @@ class OTXCollector:
             logger.error(f"OTX HTTP error: {e}")
             self.circuit_breaker.record_failure()
             record_collection_failure(self.source_name, error_msg)
-            return self._return_status(False, 0, error_msg)
+            if push_to_misp:
+                return self._return_status(False, 0, error_msg)
+            raise
         except Exception as e:
             error_msg = f"{type(e).__name__}: {e}"
             logger.error(f"OTX collection error: {type(e).__name__}: {e}")
             self.circuit_breaker.record_failure()
             record_collection_failure(self.source_name, error_msg)
-            return self._return_status(False, 0, error_msg)
+            if push_to_misp:
+                return self._return_status(False, 0, error_msg)
+            raise
 
     def _return_status(self, success: bool, count: int, error: str = None, failed: int = 0) -> Dict[str, Any]:
         """Return standardized status dict."""

--- a/src/config.py
+++ b/src/config.py
@@ -447,6 +447,45 @@ def edgeguard_ssl_verify_from_env() -> bool:
 SSL_VERIFY = edgeguard_ssl_verify_from_env()
 
 
+# PR-N24 audit HIGH (proactive 2026-04-22): single source of truth for
+# "is this a production env?". Originally added in PR-N23 BLOCKER #5
+# inside ``src/graphql_api.py`` (as ``_is_prod_env``), but ``src/query_api.py``
+# was NOT updated and still used the pre-N23 fails-open ``_ENV == "prod"``
+# pattern — splitting prod/dev security state across the two API surfaces
+# (Maintainer Dev + Integration agents both flagged this; Devil's Advocate
+# called it out as a scope-gap of the N23 "single source of truth" claim).
+#
+# Lifting the canonical check here so BOTH ``graphql_api.py`` and
+# ``query_api.py`` import the SAME function and can never disagree on
+# the prod/non-prod classification. Any future API surface that needs
+# the same gate must import from here.
+#
+# Contract (matches ``src/graphql_api.py:_is_prod_env`` exactly):
+#   - Both env vars unset / empty → True (secure default)
+#   - EDGEGUARD_ENV in {dev, development, local, staging, test} → False
+#   - Anything else (prod, production, prd, typos, unrecognized) → True
+def is_production_env() -> bool:
+    """Canonical project-wide "is this a production env?" check.
+
+    Fail-closed default: unset / empty / typo → prod.
+
+    The non-prod allowlist is explicit and exhaustive. Anything not in
+    the allowlist is treated as prod. This means an operator typo like
+    ``EDGEGUARD_ENV=production`` or ``EDGEGUARD_ENV=Dev`` correctly
+    treats the deployment as prod (introspection blocked, API key
+    required, etc.) instead of silently falling open.
+    """
+    raw = (os.getenv("EDGEGUARD_ENV") or "").strip().lower()
+    _NON_PROD_ENVS = frozenset({"dev", "development", "local", "staging", "test"})
+    return raw not in _NON_PROD_ENVS
+
+
+# Module-level convenience constant — read once at import time.
+# Callers that need to re-evaluate after env mutation (e.g. tests
+# using monkeypatch.setenv) should call ``is_production_env()`` directly.
+IS_PROD = is_production_env()
+
+
 def _env_bool(name: str, default: str = "true") -> bool:
     raw = os.getenv(name, default)
     return str(raw).strip().lower() in ("1", "true", "yes", "on")

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -67,46 +67,22 @@ MISP_URL = os.getenv("MISP_URL", "").rstrip("/")
 # ---------------------------------------------------------------------------
 EDGEGUARD_API_KEY = os.getenv("EDGEGUARD_API_KEY", "")
 
+# PR-N24 audit HIGH: import the canonical "is production env?" check
+# from src/config.py so graphql_api and query_api can never disagree on
+# the prod/non-prod classification. Pre-N24 each module defined its own
+# check (graphql_api.py had _is_prod_env, query_api.py had _ENV ==
+# "prod") — split state. See ``config.is_production_env`` for full
+# rationale + allowlist.
+from config import is_production_env  # noqa: E402
 
-def _is_prod_env() -> bool:
-    """Single source of truth for "is this a production env?".
-
-    PR-N23 BLOCKER #5 (proactive audit 2026-04-22): the pre-N23
-    ``_IS_PROD`` check used ``os.getenv("EDGEGUARD_ENV", "dev").strip().
-    lower() == "prod"`` — fails-open on:
-      - Typos: ``EDGEGUARD_ENV=production`` → "production" != "prod" →
-        introspection stays ENABLED in prod.
-      - Unset: ``EDGEGUARD_ENV`` missing → introspection ENABLED by default.
-
-    PR-N23 Bugbot round 1 (PR #107, MEDIUM follow-up): the original PR-N23
-    fix only patched ``_IS_PROD`` (line 718) but the ``_ENV`` variable at
-    line 69 — used to gate the API-key requirement at line 96 — still
-    used the OLD fails-open ``"dev"`` default. That created a split
-    state: introspection blocked when EDGEGUARD_ENV unset (good), but
-    API-key enforcement skipped (bad). Fix: define ``_is_prod_env()``
-    ONCE at the top of the module and use it for both gates.
-
-    Contract:
-      - Both env vars unset / empty → ``True`` (secure default)
-      - ``EDGEGUARD_ENV`` in {"dev","development","local","staging","test"}
-        → ``False`` (non-prod allowlist)
-      - Anything else (prod, production, prd, typos, unrecognized values)
-        → ``True``
-    """
-    raw = (os.getenv("EDGEGUARD_ENV") or "").strip().lower()
-    _NON_PROD_ENVS = frozenset({"dev", "development", "local", "staging", "test"})
-    return raw not in _NON_PROD_ENVS
-
-
-# Module-level prod flag — single source of truth for both the API-key
-# enforcement gate (below) AND the GraphQL introspection extension
-# (further down). Pre-N23-Bugbot-round-1 these used different checks
-# and could disagree (introspection blocked + API-key skipped).
-_IS_PROD = _is_prod_env()
+# Module-level prod flag — used by both the API-key enforcement gate
+# (below) AND the GraphQL introspection extension (further down).
+# Always agrees with src/query_api.py via the shared helper.
+_IS_PROD = is_production_env()
 # Backwards-compat: the legacy ``_ENV`` literal is still used by some
 # downstream readers / tests. Keep it for surface compatibility but
-# DON'T use it for security-relevant gating — _is_prod_env() is the
-# canonical check.
+# DON'T use it for security-relevant gating — is_production_env() is
+# the canonical check.
 _ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()
 
 # PR (security A6) — Red Team Tier A: previously the API-key requirement

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -78,11 +78,25 @@ limiter = Limiter(key_func=get_remote_address)
 # API key for the public read endpoints.  Set EDGEGUARD_API_KEY to a non-empty
 # value to require authentication.  Leave unset only in local dev.
 _API_KEY = os.getenv("EDGEGUARD_API_KEY")
-_ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()
 
-if _ENV == "prod" and not _API_KEY:
+# PR-N24 audit HIGH (proactive 2026-04-22): pre-N24 this module used
+# ``_ENV = os.getenv("EDGEGUARD_ENV", "dev").lower()`` then ``if _ENV
+# == "prod"`` — the fails-open pattern PR-N23 BLOCKER #5 fixed for
+# graphql_api but missed for query_api. Asymmetry: typo
+# ``EDGEGUARD_ENV=production`` would treat graphql_api as prod
+# (introspection blocked) but query_api as non-prod (API-key
+# enforcement skipped at startup). Maintainer Dev + Integration audit
+# agents both flagged this; lifting the canonical check to
+# ``src/config.py:is_production_env`` so both APIs share the same
+# fail-closed allowlist semantics.
+from config import is_production_env  # noqa: E402
+
+_IS_PROD = is_production_env()
+
+if _IS_PROD and not _API_KEY:
     raise RuntimeError(
-        "EDGEGUARD_API_KEY must be set when EDGEGUARD_ENV=prod. "
+        "EDGEGUARD_API_KEY must be set when EDGEGUARD_ENV is prod (or unset/typo'd "
+        "since PR-N24 secure defaults treat unrecognized values as prod). "
         "Set a strong random value before starting the API in production."
     )
 
@@ -399,7 +413,12 @@ async def query_threats(request: Request, q: ThreatQuery):
                 zone=q.zone.value if q.zone else None,
                 execution_time_ms=round(execution_time, 2),
                 # Only expose the generated Cypher in non-production builds.
-                cypher=cypher_query if (q.return_cypher and _ENV != "prod") else None,
+                # PR-N24 H1: use _IS_PROD (fail-closed allowlist from
+                # config.is_production_env()) instead of the pre-N24
+                # ``_ENV != "prod"`` strict-equality check, which would
+                # leak Cypher when EDGEGUARD_ENV='production' (typo) or
+                # any other non-allowlisted value.
+                cypher=cypher_query if (q.return_cypher and not _IS_PROD) else None,
             )
 
         except Exception as e:

--- a/tests/test_pr_n21_enrichment_robustness.py
+++ b/tests/test_pr_n21_enrichment_robustness.py
@@ -234,16 +234,25 @@ class TestFix6BaselinePostcheck:
         assert "AirflowException" in post_body, "violations must raise AirflowException so DAG marks FAILED"
 
     def test_postcheck_strict_trigger_rule(self):
-        """The postcheck task must have ALL_SUCCESS trigger_rule — running
-        it when enrichment failed would just produce a misleading second
-        error."""
+        """The postcheck task's trigger_rule must let the diagnostics run
+        when at least one upstream succeeded.
+
+        PR-N21 originally pinned ``ALL_SUCCESS`` ("don't run on partial
+        failure"), but the proactive PR-N24 audit (Cross-Checker H2) flipped
+        this to ``NONE_FAILED_MIN_ONE_SUCCESS``: INV-2 (Indicator > 0) and
+        INV-3 (Source > 0) are UPSTREAM diagnostics — operators NEED them
+        to triage *why* an enrichment task failed. ``ALL_SUCCESS`` skipped
+        them in exactly the case they were most useful."""
         src = self._dag_src()
         # Find the baseline_postcheck_task PythonOperator block
         anchor = src.find('task_id="baseline_postcheck"')
         assert anchor != -1
         # Search forward for trigger_rule within the next ~500 chars (block size)
         block = src[anchor : anchor + 600]
-        assert "TriggerRule.ALL_SUCCESS" in block, "baseline_postcheck must use ALL_SUCCESS trigger_rule"
+        assert "TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS" in block, (
+            "baseline_postcheck must use NONE_FAILED_MIN_ONE_SUCCESS trigger_rule "
+            "(PR-N24 H2: diagnostics must run after partial-failure to help triage)"
+        )
 
 
 # ===========================================================================

--- a/tests/test_pr_n23_proactive_audit_blockers.py
+++ b/tests/test_pr_n23_proactive_audit_blockers.py
@@ -277,21 +277,37 @@ class TestFix5IsProdFailsClosed:
     False, leaving introspection ENABLED in prod for any env typo."""
 
     def test_is_prod_uses_non_prod_allowlist(self):
-        src = (SRC / "graphql_api.py").read_text()
-        # The fix switches from ``== "prod"`` to a non-prod allowlist
-        # (dev/development/local/staging/test) with prod as the default.
-        assert "_NON_PROD_ENVS" in src or "non_prod" in src.lower(), (
-            "graphql_api must use a non-prod allowlist (fail-closed) rather than ``== 'prod'`` strict-equality"
+        # PR-N24 H1: the canonical helper now lives in src/config.py
+        # (single source of truth). Both src/graphql_api.py and
+        # src/query_api.py import ``is_production_env`` from there.
+        # The non-prod allowlist therefore lives in src/config.py — assert
+        # against the canonical implementation rather than the import site.
+        cfg_src = (SRC / "config.py").read_text()
+        assert "_NON_PROD_ENVS" in cfg_src or "non_prod" in cfg_src.lower(), (
+            "src/config.py must use a non-prod allowlist (fail-closed) rather than ``== 'prod'`` strict-equality"
+        )
+        # And graphql_api must consume the canonical helper, not redefine.
+        gql_src = (SRC / "graphql_api.py").read_text()
+        assert "from config import is_production_env" in gql_src, (
+            "graphql_api.py must import is_production_env from src.config (PR-N24 H1)"
         )
 
     def test_is_prod_not_equal_prod_only(self):
-        """The strict-equality regression pattern must NOT return directly."""
-        src = (SRC / "graphql_api.py").read_text()
-        # The pre-N23 shape was ``_IS_PROD = ... == "prod"`` at top level.
-        # Post-N23 it's a function call. Anchor on the presence of a
-        # ``def _is_prod_env`` function (structural change indicator).
-        assert "def _is_prod_env" in src, (
-            "graphql_api must define a _is_prod_env() function (not a one-liner strict-equality check)"
+        """The strict-equality regression pattern must NOT return directly.
+
+        PR-N24 H1 update: the structural anchor is no longer
+        ``def _is_prod_env`` inside graphql_api.py (it was moved to
+        ``src.config.is_production_env``). Anchor instead on the canonical
+        function in src/config.py."""
+        cfg_src = (SRC / "config.py").read_text()
+        assert "def is_production_env" in cfg_src, (
+            "src/config.py must define is_production_env() (PR-N24 H1 canonical helper)"
+        )
+        # Negative pin: the broken ``== 'prod'`` shape must not have come
+        # back at module load time.
+        gql_src = (SRC / "graphql_api.py").read_text()
+        assert '_IS_PROD = (os.getenv("EDGEGUARD_ENV") or "").strip().lower() == "prod"' not in gql_src, (
+            "graphql_api.py must not return to the strict-equality fails-open shape"
         )
 
     def test_api_key_gate_uses_is_prod_env(self):
@@ -317,52 +333,51 @@ class TestFix5IsProdFailsClosed:
         )
 
     def test_is_prod_behavior(self):
-        """Behavioral pin: call _is_prod_env() with various EDGEGUARD_ENV
-        values and assert the expected prod/non-prod classification."""
-        # Import fresh to pick up env-var changes
+        """Behavioral pin: call is_production_env() with various EDGEGUARD_ENV
+        values and assert the expected prod/non-prod classification.
+
+        PR-N24 H1 update: the function moved from graphql_api.py to
+        src/config.py (single source of truth). Same semantics, new
+        location."""
         import importlib
 
-        if "graphql_api" in sys.modules:
-            # Can't re-import easily due to FastAPI registration side-effects,
-            # so exec the _is_prod_env function in isolation.
-            pass
-
-        # We import the source and exec just the function definition to
-        # test it in isolation without triggering GraphQL/FastAPI imports.
-        src = (SRC / "graphql_api.py").read_text()
-        fn_start = src.find("def _is_prod_env")
-        fn_end = src.find("\n_IS_PROD = _is_prod_env()")
-        assert fn_start != -1 and fn_end != -1, "_is_prod_env function not found"
+        # Exec only the function definition from src/config.py in isolation
+        # so we can manipulate EDGEGUARD_ENV per case without re-importing
+        # the full config module (which triggers downstream side effects).
+        src = (SRC / "config.py").read_text()
+        fn_start = src.find("def is_production_env")
+        fn_end = src.find("IS_PROD = is_production_env()", fn_start)
+        assert fn_start != -1 and fn_end != -1, "is_production_env() not found in src/config.py"
         fn_src = src[fn_start:fn_end]
 
         ns: dict = {"os": importlib.import_module("os")}
         exec(fn_src, ns)
-        _is_prod_env = ns["_is_prod_env"]
+        is_production_env = ns["is_production_env"]
 
         # Test matrix
         try:
             saved = os.environ.get("EDGEGUARD_ENV")
             # Case 1: unset → prod (fail-closed)
             os.environ.pop("EDGEGUARD_ENV", None)
-            assert _is_prod_env() is True, "unset EDGEGUARD_ENV → prod (fail-closed)"
+            assert is_production_env() is True, "unset EDGEGUARD_ENV → prod (fail-closed)"
             # Case 2: "dev" → non-prod
             os.environ["EDGEGUARD_ENV"] = "dev"
-            assert _is_prod_env() is False, '"dev" → non-prod'
+            assert is_production_env() is False, '"dev" → non-prod'
             # Case 3: "production" (typo-ish) → prod
             os.environ["EDGEGUARD_ENV"] = "production"
-            assert _is_prod_env() is True, '"production" → prod (not in non-prod allowlist)'
+            assert is_production_env() is True, '"production" → prod (not in non-prod allowlist)'
             # Case 4: "prod" → prod
             os.environ["EDGEGUARD_ENV"] = "prod"
-            assert _is_prod_env() is True
+            assert is_production_env() is True
             # Case 5: empty string → prod
             os.environ["EDGEGUARD_ENV"] = ""
-            assert _is_prod_env() is True, "empty → prod (fail-closed)"
+            assert is_production_env() is True, "empty → prod (fail-closed)"
             # Case 6: random garbage → prod
             os.environ["EDGEGUARD_ENV"] = "asdfasdf"
-            assert _is_prod_env() is True
+            assert is_production_env() is True
             # Case 7: "staging" → non-prod (explicitly allowlisted)
             os.environ["EDGEGUARD_ENV"] = "staging"
-            assert _is_prod_env() is False
+            assert is_production_env() is False
         finally:
             if saved is None:
                 os.environ.pop("EDGEGUARD_ENV", None)

--- a/tests/test_pr_n24_audit_blockers.py
+++ b/tests/test_pr_n24_audit_blockers.py
@@ -178,11 +178,35 @@ class TestB2AlertmanagerNoPlaceholderPagerKey:
             "Replace with EDGEGUARD_PAGERDUTY_INTEGRATION_KEY env-var substitution."
         )
 
-    def test_alertmanager_uses_env_var_substitution(self):
+    def test_alertmanager_documents_template_rendering_requirement(self):
+        """The committed alertmanager.yml uses ``${EDGEGUARD_PAGERDUTY_
+        INTEGRATION_KEY}`` as a TEMPLATE PLACEHOLDER that operators must
+        render via envsubst (or replace inline) before Alertmanager
+        starts. Bugbot round 1 (PR #108) caught the original PR-N24
+        misunderstanding that Alertmanager would expand the template
+        itself — it does not. The ``${...}`` shape is intentional but
+        REQUIRES rendering; without rendering, PagerDuty 403s same as
+        the original ``<YOUR_PAGERDUTY_KEY>`` placeholder.
+
+        This test pins the dual contract: (a) the template marker is
+        present so operators know what to render, and (b) the comment
+        explains the rendering requirement so they don't assume
+        Alertmanager will do it for them."""
         text = (PROMETHEUS / "alertmanager.yml").read_text()
+        # (a) Template marker present (so envsubst has something to substitute).
         assert "${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}" in text, (
-            "alertmanager.yml service_key must use ``${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}`` "
-            "env-var template so operators can wire a real key without editing the file"
+            "alertmanager.yml must include the ``${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}`` "
+            "template marker so operators can render via envsubst at deploy time"
+        )
+        # (b) Comment must explicitly warn about Alertmanager's lack of
+        # env-var substitution, so a future maintainer doesn't assume
+        # the template will be magically expanded.
+        assert "envsubst" in text or "does NOT" in text, (
+            "alertmanager.yml comment must explain that Alertmanager does NOT "
+            "expand ${...} env-var templates in YAML; operators MUST render "
+            "the file (envsubst/helm/kustomize) before Alertmanager loads it. "
+            "This was the Bugbot round 1 finding on PR #108 — without the "
+            "warning, future maintainers will trip on the same bug."
         )
 
     def test_preflight_check_7b_present(self):
@@ -193,6 +217,75 @@ class TestB2AlertmanagerNoPlaceholderPagerKey:
         )
         # The fail message must reference the placeholder shapes.
         assert "<YOUR_PAGERDUTY_KEY>" in text, "preflight check [7b] must scan for the <YOUR_PAGERDUTY_KEY> placeholder"
+
+    def test_preflight_check_7b_rejects_unrendered_env_template(self):
+        """Bugbot round 1 (PR #108): Alertmanager does NOT perform env-var
+        substitution in its YAML config. If alertmanager.yml ships with
+        ``service_key: '${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}'``, the
+        literal string ``${EDGEGUARD_...}`` is sent to PagerDuty as the
+        key → silent 403, identical to the original ``<YOUR_PAGERDUTY_KEY>``
+        bug. Preflight must refuse both shapes."""
+        text = (SCRIPTS / "preflight_baseline.sh").read_text()
+        # The check must include the un-rendered env-var template pattern.
+        # Match either the regex token shape used in [7b] or an explicit
+        # mention in the comment block.
+        assert "[A-Z_][A-Z0-9_]*" in text, (
+            "preflight [7b] must include an ``\\$\\{[A-Z_][A-Z0-9_]*\\}`` "
+            "regex token rejecting un-rendered env-var templates "
+            "(Bugbot round 1, PR #108)"
+        )
+        # The fail message / comment must explain Alertmanager doesn't
+        # expand env vars (so future maintainers don't 'simplify' the
+        # check away thinking the env-var pattern is safe).
+        assert "Alertmanager does NOT" in text or "envsubst" in text, (
+            "preflight [7b] comment / failure message must clarify why "
+            "the env-var template is unsafe (Alertmanager doesn't expand "
+            "${...} in YAML)"
+        )
+
+    def test_preflight_check_7b_rejects_unrendered_template_at_runtime(self):
+        """End-to-end pin: actually run the preflight script's [7b] check
+        against the current ``alertmanager.yml`` and assert it fails.
+        This catches shell-escaping bugs in the regex (which the static
+        text scan above can't detect)."""
+        import subprocess
+
+        # Extract just the [7b] check stanza and run it standalone in a
+        # subshell against the real alertmanager.yml. Use a quick wrapper
+        # that emits an exit code we can introspect.
+        script = r"""
+        set -uo pipefail
+        cd "$1"
+        if [ ! -f prometheus/alertmanager.yml ]; then
+            echo "alertmanager.yml missing"; exit 99
+        fi
+        if sed 's/#.*$//' prometheus/alertmanager.yml | \
+           grep -qE "'<YOUR_PAGERDUTY_KEY>'|\"<YOUR_PAGERDUTY_KEY>\"|'<YOUR_API_KEY>'|\"<YOUR_API_KEY>\"|'<PLACEHOLDER>'|\"<PLACEHOLDER>\"|'XXXXXXXX-XXXX'|\"XXXXXXXX-XXXX\"|'\\\$\\{[A-Z_][A-Z0-9_]*\\}'|\"\\\$\\{[A-Z_][A-Z0-9_]*\\}\""; then
+            echo "PLACEHOLDER_DETECTED"
+            exit 1
+        else
+            echo "CLEAN"
+            exit 0
+        fi
+        """
+        result = subprocess.run(
+            ["bash", "-c", script, "_", str(REPO_ROOT)],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        # While alertmanager.yml ships with the un-rendered ``${...}``
+        # template, the check must EXIT 1 (PLACEHOLDER_DETECTED).
+        # Once an operator renders the file via envsubst (or inserts a
+        # real key), the check exits 0 — and this test will need to be
+        # updated to point at a fixture file with the un-rendered shape.
+        assert result.returncode == 1, (
+            f"preflight [7b] regex must reject the un-rendered "
+            f"``${{EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}}`` template currently "
+            f"in alertmanager.yml. Got exit={result.returncode}, "
+            f"stdout={result.stdout!r}, stderr={result.stderr!r}"
+        )
+        assert "PLACEHOLDER_DETECTED" in result.stdout
 
     def test_preflight_alert_count_floor_bumped(self):
         """PR-N24 H3 added EdgeGuardMispEventAttributesTruncated, so the

--- a/tests/test_pr_n24_audit_blockers.py
+++ b/tests/test_pr_n24_audit_blockers.py
@@ -1,0 +1,600 @@
+"""
+PR-N24 — proactive 7-agent audit BLOCKERs/HIGHs.
+
+After PR-N20/N21/N22/N23 (15 rounds of reactive Bugbot fixes), a 7-agent
+proactive audit on 2026-04-22 surfaced 6 additional blockers / highs that
+the reactive loop missed. PR-N24 closes them before the next 730-day
+baseline run.
+
+Fixes tracked here:
+
+* **B1** — ``docs/RUNBOOK.md`` referenced ``python -m src.build_relationships
+  --step <N>`` for APOC partial-batch recovery, but no such CLI flag
+  exists. Operator on 3am pager call would chase a phantom flag for
+  20 minutes. Fix: replace the line with the real Airflow-UI re-trigger
+  path + an Issue #58 cross-ref.
+
+* **B2** — ``prometheus/alertmanager.yml`` shipped with
+  ``service_key: '<YOUR_PAGERDUTY_KEY>'``. PagerDuty silently 403s on
+  every page during the 26h baseline window. Fix: env-var template
+  + a NEW preflight check ([7b]) that refuses to launch when any
+  placeholder shape is still in the file.
+
+* **B3.1 / B3.2** — OTX + MITRE collectors had the same silent-swallower
+  shape PR-N17 fixed in NVD and PR-N23 fixed in CISA: their broad
+  exception handlers returned a status dict (or empty list) on
+  ``push_to_misp=False`` instead of re-raising. Fix: ``if push_to_misp:
+  return self._return_status(...); raise``.
+
+* **B3.3** — AST-scan CI test forbidding the silent-swallower shape across
+  ``src/collectors/`` so the next collector added doesn't reintroduce
+  the bug class. Defensive — the explicit per-collector pins above
+  will fail before this scan does, but the scan catches future
+  regressions in collectors not pinned by name.
+
+* **H1** — ``_is_prod_env`` was duplicated in ``src/graphql_api.py`` and
+  inverted (fails-open) in ``src/query_api.py``: a typo'd
+  ``EDGEGUARD_ENV`` would lock GraphQL but skip the API-key gate. PR-N24
+  centralizes the helper as ``src/config.is_production_env()`` and
+  rewires both API modules to import it. Single source of truth →
+  no split state.
+
+* **H2** — ``baseline_postcheck_task`` had ``trigger_rule=ALL_SUCCESS``,
+  meaning the post-baseline INV-2 / INV-3 invariant probes did NOT run
+  if any upstream enrichment task failed — exactly when operators most
+  need diagnostic counts. Fix: flip to ``NONE_FAILED_MIN_ONE_SUCCESS``
+  so the diagnostics always run when at least one upstream succeeded.
+
+* **H3** — ``edgeguard_misp_event_attributes_truncated_total`` counter
+  was added in PR-N23 but no alert wired it. Counter without alert =
+  unobservable counter. Fix: add ``EdgeGuardMispEventAttributesTruncated``
+  to ``prometheus/alerts.yml`` and bump the preflight ``ALERT_COUNT``
+  floor from ≥ 8 to ≥ 9.
+"""
+
+from __future__ import annotations
+
+import ast
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+DOCS = REPO_ROOT / "docs"
+SCRIPTS = REPO_ROOT / "scripts"
+PROMETHEUS = REPO_ROOT / "prometheus"
+DAGS = REPO_ROOT / "dags"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n24")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n24")
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+def _function_node(src_path: Path, fn_name: str, class_name: str | None = None) -> ast.FunctionDef:
+    """Locate a function/method node by name + optional class."""
+    tree = ast.parse(src_path.read_text())
+    for node in ast.walk(tree):
+        if class_name is not None:
+            if isinstance(node, ast.ClassDef) and node.name == class_name:
+                for inner in node.body:
+                    if isinstance(inner, ast.FunctionDef) and inner.name == fn_name:
+                        return inner
+        elif isinstance(node, ast.FunctionDef) and node.name == fn_name:
+            return node
+    raise AssertionError(f"function {fn_name} not found in {src_path}")
+
+
+def _is_broad_handler(node: ast.ExceptHandler) -> bool:
+    """``except Exception``, ``except`` (bare), or ``except BaseException``."""
+    if node.type is None:
+        return True
+    if isinstance(node.type, ast.Name):
+        return node.type.id in {"Exception", "BaseException"}
+    return False
+
+
+def _has_bare_raise(node: ast.ExceptHandler) -> bool:
+    """At least one ``raise`` (bare or non-bare) anywhere in the handler body."""
+    for stmt in ast.walk(ast.Module(body=node.body, type_ignores=[])):
+        if isinstance(stmt, ast.Raise):
+            return True
+    return False
+
+
+# ===========================================================================
+# Fix B1 — RUNBOOK no longer references the phantom --step N CLI flag
+# ===========================================================================
+
+
+class TestB1RunbookNoPhantomStepFlag:
+    """``docs/RUNBOOK.md`` must not promise a ``--step <N>`` CLI flag for
+    ``build_relationships`` because no such flag exists."""
+
+    def test_runbook_does_not_reference_step_n_cli_flag(self):
+        text = (DOCS / "RUNBOOK.md").read_text()
+        # Pre-N24: "invoke ``python -m src.build_relationships --step <N>``"
+        # was the operator instruction. No such CLI exists.
+        assert "build_relationships --step" not in text, (
+            "RUNBOOK must not reference ``build_relationships --step <N>`` — "
+            "the CLI flag does not exist (Issue #58). At 3am the operator "
+            "would chase a phantom flag for 20 minutes."
+        )
+
+    def test_runbook_points_to_airflow_ui_recovery(self):
+        text = (DOCS / "RUNBOOK.md").read_text()
+        # The fix replaces the phantom flag with the real Airflow-UI path.
+        assert "Airflow UI" in text, (
+            "RUNBOOK must reference ``Airflow UI`` for the APOC partial-batch "
+            "recovery path (the actual operator action)"
+        )
+
+    def test_runbook_cross_refs_step_n_issue(self):
+        text = (DOCS / "RUNBOOK.md").read_text()
+        # The fix should reference the tracking issue for adding the flag.
+        assert "Issue #58" in text or "issue #58" in text, (
+            "RUNBOOK should cross-ref Issue #58 (tracking the missing --step N flag)"
+        )
+
+
+# ===========================================================================
+# Fix B2 — alertmanager pager wiring not still placeholder + preflight gate
+# ===========================================================================
+
+
+class TestB2AlertmanagerNoPlaceholderPagerKey:
+    """``prometheus/alertmanager.yml`` must not ship with a literal pager
+    placeholder, and the preflight script must refuse to launch when one
+    is found."""
+
+    def test_alertmanager_has_no_placeholder_pager_key(self):
+        """Scan uncommented YAML content only. The explanatory comment in
+        the file documents the placeholder's history — matching the
+        placeholder inside a ``#`` comment would fail-close on docs,
+        not on real config."""
+        path = PROMETHEUS / "alertmanager.yml"
+        lines = path.read_text().splitlines()
+        # Strip each line's trailing ``#...`` portion before scanning.
+        uncommented = "\n".join(line.split("#", 1)[0] for line in lines)
+        # The placeholder is dangerous only when it's a YAML scalar value
+        # (single- or double-quoted). Match only those shapes.
+        forbidden = re.compile(
+            r"""['"]<YOUR_PAGERDUTY_KEY>['"]|"""
+            r"""['"]<YOUR_API_KEY>['"]|"""
+            r"""['"]<PLACEHOLDER>['"]|"""
+            r"""['"]XXXXXXXX-XXXX['"]"""
+        )
+        assert not forbidden.search(uncommented), (
+            "alertmanager.yml still ships with a placeholder pager key as a YAML value — "
+            "PagerDuty will silently 403 every alert during the 26h baseline. "
+            "Replace with EDGEGUARD_PAGERDUTY_INTEGRATION_KEY env-var substitution."
+        )
+
+    def test_alertmanager_uses_env_var_substitution(self):
+        text = (PROMETHEUS / "alertmanager.yml").read_text()
+        assert "${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}" in text, (
+            "alertmanager.yml service_key must use ``${EDGEGUARD_PAGERDUTY_INTEGRATION_KEY}`` "
+            "env-var template so operators can wire a real key without editing the file"
+        )
+
+    def test_preflight_check_7b_present(self):
+        text = (SCRIPTS / "preflight_baseline.sh").read_text()
+        assert "PR-N24 BLOCKER B2" in text, (
+            "preflight_baseline.sh must contain the [7b] PR-N24 B2 alertmanager "
+            "placeholder check that refuses to launch with placeholders in place"
+        )
+        # The fail message must reference the placeholder shapes.
+        assert "<YOUR_PAGERDUTY_KEY>" in text, "preflight check [7b] must scan for the <YOUR_PAGERDUTY_KEY> placeholder"
+
+    def test_preflight_alert_count_floor_bumped(self):
+        """PR-N24 H3 added EdgeGuardMispEventAttributesTruncated, so the
+        preflight defense-in-depth alert-count floor must be ≥ 9."""
+        text = (SCRIPTS / "preflight_baseline.sh").read_text()
+        # Pre-N24 H3 the floor was 8; post-N24 H3 it must be 9+.
+        assert "ALERT_COUNT" in text and "-ge 9" in text, (
+            "preflight ALERT_COUNT floor must be ``-ge 9`` after PR-N24 H3 added EdgeGuardMispEventAttributesTruncated"
+        )
+
+
+# ===========================================================================
+# Fix B3.1 — OTX collector re-raises on push_to_misp=False
+# ===========================================================================
+
+
+class TestB3OtxCollectorReraises:
+    """All 4 transient-error handlers in ``OTXCollector.collect`` must
+    re-raise when ``push_to_misp=False`` instead of returning a status
+    dict that the caller can't distinguish from an empty success."""
+
+    def test_otx_collect_handlers_have_bare_raise(self):
+        src = (SRC / "collectors" / "otx_collector.py").read_text()
+        # Anchor on the PR-N24 BLOCKER B3 comment so we scan only the
+        # collect() handlers, not the unrelated health-check ones.
+        anchor = "PR-N24 BLOCKER B3"
+        start = src.find(anchor)
+        assert start != -1, (
+            "otx_collector.py must contain the PR-N24 BLOCKER B3 comment "
+            "block above the collect-path exception handlers"
+        )
+        block = src[start : start + 4000]
+        bare_raise_count = sum(1 for line in block.splitlines() if line.strip() == "raise")
+        assert bare_raise_count >= 4, (
+            "OTX collector must contain a bare ``raise`` in each of the 4 "
+            "collect-path handlers (Timeout/ConnectionError/HTTPError/Exception); "
+            f"found only {bare_raise_count}."
+        )
+        assert "if push_to_misp:" in block, "fix shape is ``if push_to_misp: return self._return_status(...); raise``"
+
+
+# ===========================================================================
+# Fix B3.2 — MITRE collector re-raises on push_to_misp=False
+# ===========================================================================
+
+
+class TestB3MitreCollectorReraises:
+    """``MitreCollector.collect``'s broad ``except Exception`` must re-raise
+    when ``push_to_misp=False`` instead of returning ``[]`` (which the
+    caller can't tell apart from "MITRE has no updates today")."""
+
+    def test_mitre_collect_handler_reraises(self):
+        src = (SRC / "collectors" / "mitre_collector.py").read_text()
+        anchor = "PR-N24 BLOCKER B3"
+        start = src.find(anchor)
+        assert start != -1, (
+            "mitre_collector.py must contain the PR-N24 BLOCKER B3 comment "
+            "block above the collect-path exception handler"
+        )
+        block = src[start : start + 1500]
+
+        # Strip comment content so ``# ... else []`` documentation doesn't
+        # trigger the negative pin — we want to match real code only.
+        code_only = "\n".join(line.split("#", 1)[0] for line in block.splitlines())
+
+        # The pre-N24 silent-list pattern must NOT remain in actual code.
+        assert "else []" not in code_only, (
+            "mitre_collector must not return ``[]`` on the push_to_misp=False "
+            "branch — that's the silent-swallower shape PR-N24 closes."
+        )
+        # Must explicitly re-raise after the push_to_misp=True branch.
+        after_gate = code_only.split("if push_to_misp:")[-1]
+        assert "raise" in after_gate, "mitre_collector must ``raise`` after the ``if push_to_misp: return ...`` branch"
+
+
+# ===========================================================================
+# Fix B3.3 — AST scan: forbid the silent-swallower pattern across collectors
+# ===========================================================================
+
+
+class TestB3AstScanNoSilentSwallowers:
+    """Cross-collector AST scan: any ``collect`` method (or any function
+    that takes a ``push_to_misp`` parameter) with a broad exception
+    handler MUST re-raise inside that handler — no silent fallback.
+
+    Defensive scan to prevent the bug class returning when a NEW collector
+    is added without remembering the per-collector pin."""
+
+    # Some collectors are wrappers / utility modules; collect-method scans
+    # don't apply.
+    _COLLECTOR_FILES = sorted(
+        p
+        for p in (SRC / "collectors").glob("*.py")
+        if p.name not in {"__init__.py", "collector_utils.py", "misp_writer.py"}
+    )
+
+    # PR-N24 scope decision: the AST scan found the same silent-swallower
+    # bug class in several collectors beyond the four PR-N24 closes
+    # (MISP/CISA/OTX/MITRE/NVD). Rather than balloon PR-N24 into a
+    # full bug-class sweep across every collector, these are tracked as
+    # follow-up in Issue #68 and will ship in PR-N25.
+    #
+    # The AST scan still enforces the invariant going forward — any NEW
+    # collector added with this pattern will fail the scan. The set below
+    # is a temporary MAX — it must shrink, never grow. PR-N25 removes
+    # entries as each collector is fixed. When empty, the allowlist
+    # short-circuit can be deleted entirely.
+    _KNOWN_OFFENDERS_BACKLOG = frozenset(
+        {
+            "finance_feed_collector.py",
+            "global_feed_collector.py",
+            "vt_collector.py",
+        }
+    )
+
+    def _broad_handlers_in_function(self, fn: ast.FunctionDef) -> list[ast.ExceptHandler]:
+        broad: list[ast.ExceptHandler] = []
+        for node in ast.walk(fn):
+            if isinstance(node, ast.ExceptHandler) and _is_broad_handler(node):
+                broad.append(node)
+        return broad
+
+    def _functions_with_push_to_misp_param(self, tree: ast.Module) -> list[ast.FunctionDef]:
+        out: list[ast.FunctionDef] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.FunctionDef):
+                arg_names = {a.arg for a in node.args.args} | {a.arg for a in node.args.kwonlyargs}
+                if "push_to_misp" in arg_names:
+                    out.append(node)
+        return out
+
+    def test_no_collector_collect_method_silently_swallows(self):
+        """Every function in ``src/collectors/`` that takes ``push_to_misp``
+        must, in any broad ``except Exception`` handler, contain at least
+        one ``raise`` — not silently fall back to a status dict / list.
+
+        Collectors in ``_KNOWN_OFFENDERS_BACKLOG`` are exempt (tracked in
+        Issue #68, PR-N25 follow-up). The allowlist must shrink, never grow."""
+        offenders: list[str] = []
+        for path in self._COLLECTOR_FILES:
+            if path.name in self._KNOWN_OFFENDERS_BACKLOG:
+                continue
+            tree = ast.parse(path.read_text())
+            for fn in self._functions_with_push_to_misp_param(tree):
+                for handler in self._broad_handlers_in_function(fn):
+                    if not _has_bare_raise(handler):
+                        offenders.append(
+                            f"{path.relative_to(REPO_ROOT)}:{handler.lineno} "
+                            f"in function ``{fn.name}`` — broad except has no ``raise``"
+                        )
+        assert not offenders, (
+            "the following collector exception handlers silently swallow errors "
+            "(no ``raise`` in any broad ``except`` body of a ``push_to_misp``-aware "
+            "function) — this is the PR-N17 / PR-N23 / PR-N24 bug class:\n  "
+            + "\n  ".join(offenders)
+            + "\n\nFix: ``if push_to_misp: return self._return_status(...); raise``"
+        )
+
+    def test_known_offenders_allowlist_shrinks_over_time(self):
+        """Meta-pin: the PR-N25 follow-up allowlist must match only files
+        that still have the bug. Once a collector is fixed in PR-N25,
+        its entry must come out of ``_KNOWN_OFFENDERS_BACKLOG`` — the
+        scan re-enables on fixed files. Prevents the allowlist from
+        becoming a forever-silent escape hatch."""
+        for collector_name in self._KNOWN_OFFENDERS_BACKLOG:
+            path = SRC / "collectors" / collector_name
+            assert path.exists(), (
+                f"allowlist entry ``{collector_name}`` refers to a nonexistent file. "
+                "Either remove the entry or point it at the correct path."
+            )
+            tree = ast.parse(path.read_text())
+            still_broken = False
+            for fn in self._functions_with_push_to_misp_param(tree):
+                for handler in self._broad_handlers_in_function(fn):
+                    if not _has_bare_raise(handler):
+                        still_broken = True
+                        break
+                if still_broken:
+                    break
+            assert still_broken, (
+                f"allowlist entry ``{collector_name}`` no longer has the "
+                "silent-swallower bug — REMOVE it from _KNOWN_OFFENDERS_BACKLOG "
+                "so the AST scan can enforce the invariant on this file going forward."
+            )
+
+    def test_no_return_empty_tuple_pattern(self):
+        """The exact PR-N23 NVD-shape regression — ``return [], set()`` from
+        a broad exception handler — must not appear in any collector."""
+        offenders: list[str] = []
+        for path in self._COLLECTOR_FILES:
+            tree = ast.parse(path.read_text())
+            for handler in (node for node in ast.walk(tree) if isinstance(node, ast.ExceptHandler)):
+                if not _is_broad_handler(handler):
+                    continue
+                for stmt in ast.walk(ast.Module(body=handler.body, type_ignores=[])):
+                    if not isinstance(stmt, ast.Return):
+                        continue
+                    val = stmt.value
+                    # ``return [], set()`` parses as Return(Tuple([List([]), Call(Name('set'))]))
+                    if isinstance(val, ast.Tuple) and len(val.elts) == 2:
+                        first, second = val.elts
+                        if (
+                            isinstance(first, ast.List)
+                            and not first.elts
+                            and isinstance(second, ast.Call)
+                            and isinstance(second.func, ast.Name)
+                            and second.func.id == "set"
+                            and not second.args
+                        ):
+                            offenders.append(
+                                f"{path.relative_to(REPO_ROOT)}:{stmt.lineno} — "
+                                "``return [], set()`` from broad-except handler"
+                            )
+        assert not offenders, (
+            "found the exact PR-N23 silent-swallower regression pattern "
+            "(``return [], set()`` from ``except Exception``):\n  " + "\n  ".join(offenders)
+        )
+
+
+# ===========================================================================
+# Fix H1 — is_production_env() centralized in src/config.py
+# ===========================================================================
+
+
+class TestH1IsProductionEnvCentralized:
+    """``is_production_env()`` must live in ``src/config.py`` (single source
+    of truth), and both API modules must import it instead of defining
+    their own copy."""
+
+    def test_config_defines_is_production_env(self):
+        src = (SRC / "config.py").read_text()
+        assert "def is_production_env" in src, (
+            "src/config.py must define ``is_production_env()`` as the canonical project-wide prod-detection helper"
+        )
+        # Must include the fail-closed allowlist semantics.
+        assert "_NON_PROD_ENVS" in src or "non_prod" in src.lower(), (
+            "is_production_env() must use a non-prod allowlist (fail-closed)"
+        )
+        assert "IS_PROD" in src, "src/config.py should also expose the eagerly-evaluated ``IS_PROD`` constant"
+
+    def test_graphql_api_imports_from_config(self):
+        src = (SRC / "graphql_api.py").read_text()
+        assert "from config import is_production_env" in src, (
+            "graphql_api.py must import is_production_env from src.config (canonical helper). "
+            "Pre-N24 it defined its own copy → split prod-detection state."
+        )
+        # The local function definition must be GONE.
+        assert "def _is_prod_env" not in src, (
+            "graphql_api.py must NOT redefine _is_prod_env — import from config instead"
+        )
+
+    def test_query_api_imports_from_config(self):
+        src = (SRC / "query_api.py").read_text()
+        assert "from config import is_production_env" in src, (
+            "query_api.py must import is_production_env from src.config (canonical helper)"
+        )
+        # Strip comment lines so the PR-N24 audit-explanation block (which
+        # quotes the pre-fix pattern verbatim in a ``#`` comment) doesn't
+        # trigger the negative pin.
+        code_only = "\n".join(line.split("#", 1)[0] for line in src.splitlines())
+        # The pre-N24 fails-open shape must be gone from actual code.
+        assert '_ENV = os.getenv("EDGEGUARD_ENV", "dev")' not in code_only, (
+            "query_api.py must NOT use the fails-open ``EDGEGUARD_ENV, 'dev'`` default — "
+            "use is_production_env() (fail-closed allowlist)"
+        )
+
+    def test_is_production_env_behavior(self):
+        """Behavioural pin on the canonical helper: matrix of EDGEGUARD_ENV
+        values → expected prod/non-prod classification. Fail-closed default."""
+        # Exec the function definition in isolation to avoid full src/config.py
+        # import side effects.
+        src = (SRC / "config.py").read_text()
+        fn_start = src.find("def is_production_env")
+        assert fn_start != -1
+        # Find the end: next top-level statement (line starting in column 0
+        # that isn't part of the function or its decorators/blank lines).
+        # Cheap heuristic: stop at the next ``IS_PROD = `` line.
+        fn_end = src.find("IS_PROD = is_production_env()", fn_start)
+        assert fn_end != -1, "expected ``IS_PROD = is_production_env()`` constant after the function"
+        fn_src = src[fn_start:fn_end]
+
+        ns: dict = {"os": __import__("os")}
+        exec(fn_src, ns)
+        is_prod = ns["is_production_env"]
+
+        saved = os.environ.get("EDGEGUARD_ENV")
+        try:
+            os.environ.pop("EDGEGUARD_ENV", None)
+            assert is_prod() is True, "unset → prod (fail-closed)"
+            os.environ["EDGEGUARD_ENV"] = ""
+            assert is_prod() is True, "empty → prod (fail-closed)"
+            os.environ["EDGEGUARD_ENV"] = "dev"
+            assert is_prod() is False
+            os.environ["EDGEGUARD_ENV"] = "development"
+            assert is_prod() is False
+            os.environ["EDGEGUARD_ENV"] = "local"
+            assert is_prod() is False
+            os.environ["EDGEGUARD_ENV"] = "staging"
+            assert is_prod() is False
+            os.environ["EDGEGUARD_ENV"] = "test"
+            assert is_prod() is False
+            os.environ["EDGEGUARD_ENV"] = "prod"
+            assert is_prod() is True
+            os.environ["EDGEGUARD_ENV"] = "production"
+            assert is_prod() is True, "production typo → prod (not in non-prod allowlist)"
+            os.environ["EDGEGUARD_ENV"] = "asdfasdf"
+            assert is_prod() is True, "garbage → prod (fail-closed)"
+            # Whitespace + case insensitivity
+            os.environ["EDGEGUARD_ENV"] = "  DEV  "
+            assert is_prod() is False, "whitespace-padded ``DEV`` should normalize to dev"
+        finally:
+            if saved is None:
+                os.environ.pop("EDGEGUARD_ENV", None)
+            else:
+                os.environ["EDGEGUARD_ENV"] = saved
+
+    def test_query_api_gate_uses_is_prod(self):
+        """The API-key requirement gate in query_api.py must consult the
+        canonical helper, not the old ``_ENV == 'prod'`` strict-equality check."""
+        src = (SRC / "query_api.py").read_text()
+        # Negative: the broken gate must NOT remain.
+        assert '_ENV == "prod"' not in src, (
+            "query_api.py must not retain the ``_ENV == 'prod'`` gate (fails-open on typos)"
+        )
+        # Positive: gate must reference _IS_PROD (or call is_production_env()).
+        assert "_IS_PROD" in src, "query_api.py must store + use _IS_PROD for the API-key gate"
+
+
+# ===========================================================================
+# Fix H2 — baseline_postcheck trigger_rule allows partial-failure diagnostics
+# ===========================================================================
+
+
+class TestH2BaselinePostcheckTriggerRule:
+    """``baseline_postcheck_task`` must use ``NONE_FAILED_MIN_ONE_SUCCESS``
+    (not ``ALL_SUCCESS``) so the INV-2 / INV-3 invariant probes still
+    run after partial enrichment failure — exactly when operators most
+    need them to triage."""
+
+    def test_postcheck_uses_none_failed_min_one_success(self):
+        text = (DAGS / "edgeguard_pipeline.py").read_text()
+        # Find the baseline_postcheck_task definition + check trigger_rule.
+        idx = text.find("baseline_postcheck_task")
+        assert idx != -1, "baseline_postcheck_task not found in edgeguard_pipeline.py"
+        # Scan forward ~3000 chars to find its trigger_rule kwarg.
+        block = text[idx : idx + 3000]
+        assert "NONE_FAILED_MIN_ONE_SUCCESS" in block, (
+            "baseline_postcheck_task must use trigger_rule=NONE_FAILED_MIN_ONE_SUCCESS "
+            "(post-N24 H2). Pre-N24 ALL_SUCCESS skipped the diagnostics on partial failure."
+        )
+
+    def test_postcheck_no_longer_uses_all_success(self):
+        text = (DAGS / "edgeguard_pipeline.py").read_text()
+        idx = text.find("baseline_postcheck_task")
+        block = text[idx : idx + 3000]
+        # The pre-N24 shape must NOT remain on the postcheck task.
+        # (ALL_SUCCESS may still be the default for OTHER tasks — only
+        # check inside the baseline_postcheck_task definition window.)
+        assert "trigger_rule=TriggerRule.ALL_SUCCESS" not in block, (
+            "baseline_postcheck_task must not use ALL_SUCCESS trigger_rule"
+        )
+
+
+# ===========================================================================
+# Fix H3 — EdgeGuardMispEventAttributesTruncated alert wired in alerts.yml
+# ===========================================================================
+
+
+class TestH3MispEventAttributesTruncatedAlert:
+    """The PR-N23 ``edgeguard_misp_event_attributes_truncated_total`` counter
+    must have a paired alert that fires on non-zero rate."""
+
+    def test_alert_present_in_alerts_yml(self):
+        text = (PROMETHEUS / "alerts.yml").read_text()
+        assert "EdgeGuardMispEventAttributesTruncated" in text, (
+            "prometheus/alerts.yml must define the EdgeGuardMispEventAttributesTruncated "
+            "alert that wires the PR-N23 counter to actionable observability"
+        )
+
+    def test_alert_uses_increase_not_rate(self):
+        """Same lesson as PR-N12: ``rate(...) > 0`` is per-second; use
+        ``increase()`` for absolute count over window."""
+        text = (PROMETHEUS / "alerts.yml").read_text()
+        idx = text.find("EdgeGuardMispEventAttributesTruncated")
+        block = text[idx : idx + 1500]
+        assert "increase(edgeguard_misp_event_attributes_truncated_total" in block, (
+            "alert expr must use ``increase(edgeguard_misp_event_attributes_truncated_total[...])`` "
+            "(absolute count) — NOT ``rate(...)`` which is per-second"
+        )
+
+    def test_alert_labelled_by_source(self):
+        text = (PROMETHEUS / "alerts.yml").read_text()
+        idx = text.find("EdgeGuardMispEventAttributesTruncated")
+        block = text[idx : idx + 1500]
+        assert "by (source)" in block, "alert must aggregate ``by (source)`` so operators see which feed is over-sized"
+
+    def test_alert_severity_warning(self):
+        text = (PROMETHEUS / "alerts.yml").read_text()
+        idx = text.find("EdgeGuardMispEventAttributesTruncated")
+        block = text[idx : idx + 1500]
+        assert "severity: warning" in block, (
+            "truncation is data-loss but recoverable (raise the cap or fix the source) — "
+            "severity should be ``warning``, not ``critical`` (consistent with similar"
+            " observability alerts)"
+        )


### PR DESCRIPTION
## Summary

After PR-N20/N21/N22/N23 (15 rounds of reactive Bugbot fixes across 4 PRs), a 7-agent proactive audit on 2026-04-22 surfaced **7 additional blockers/highs** the reactive loop missed. PR-N24 closes them before the next 730-day baseline run.

The audit's framing: per-line bot review catches line-level bugs; multi-agent audit catches *architecture-level* issues no per-line scan can see (claimed-but-absent SSoTs, destructive code paths with low coverage, observability counters wired without alerts, split prod/dev gating state, etc.).

## What's in this PR

| Fix | Severity | What it closes |
|---|---|---|
| **B1** | BLOCKER | RUNBOOK referenced phantom ``build_relationships --step <N>`` flag → operator chases nothing at 3am. Replaced with real Airflow-UI re-trigger path + Issue #58 cross-ref. |
| **B2** | BLOCKER | ``alertmanager.yml`` shipped with literal ``<YOUR_PAGERDUTY_KEY>`` → PagerDuty silently 403'd every page → 26h baseline window had ZERO routed critical alerts. Env-var template + new preflight check [7b]. |
| **B3.1/B3.2** | BLOCKER | OTX + MITRE collectors had the silent-swallower shape PR-N17 fixed for NVD and PR-N23 fixed for CISA. Same bug class, different collectors. ``if push_to_misp: return self._return_status(...); raise`` |
| **B3.3** | BLOCKER | New AST-scan CI test (``TestB3AstScanNoSilentSwallowers``) forbids the bug class going forward. Discovered 3 additional offenders → ``_KNOWN_OFFENDERS_BACKLOG`` allowlist + companion test that enforces "must shrink, never grow." |
| **B3.bonus** | BLOCKER | Fixed NVD's outer ``except Exception`` swallower as bonus — NVD is the canonical CVE source for the 730d baseline. |
| **H1** | HIGH (security) | ``_is_prod_env`` was duplicated in graphql_api.py + inverted (fails-open) in query_api.py → typo'd ``EDGEGUARD_ENV`` → split state (GraphQL locked, API-key gate skipped). Centralized as ``src/config.is_production_env()`` (fail-closed allowlist). Also fixed secondary leak in ``query_api.py:419`` (Cypher exposed in prod on env typos). |
| **H2** | HIGH | ``baseline_postcheck_task`` had ``ALL_SUCCESS`` trigger_rule. INV-2/INV-3 are upstream diagnostics — they need to run when enrichment fails (the case operators most need them). Flipped to ``NONE_FAILED_MIN_ONE_SUCCESS``. |
| **H3** | HIGH | ``edgeguard_misp_event_attributes_truncated_total`` shipped in PR-N23 but no alert wired it (counter without alert = unobservable). Added ``EdgeGuardMispEventAttributesTruncated`` + bumped preflight floor ≥ 9. |

## Why this PR exists (lessons-learned)

The Devil's Advocate audit agent honestly critiqued the proactive-audit approach: "the audit caught 6 real blockers; Bugbot round 1 then caught 2 MORE the audit missed — 25% miss rate." Both modalities matter — per-line bots catch line-level bugs in a diff; multi-agent audits catch architectural issues. PR-N24 is the **architecture-level** sweep; future rounds may surface line-level issues per-PR-bot didn't see in this diff.

## Out of scope (filed as follow-ups)

- **PR-N25**: shrink the AST-scan allowlist (3 remaining collectors: ``finance_feed_collector.py``, ``global_feed_collector.py``, ``vt_collector.py``). Each fix removes one allowlist entry until empty.
- **Pre-existing OTX test bug**: ``test_otx_collector_collect_returns_items`` patches a method parameter as if it were an instance attribute. Pre-existing on main, not caused by this PR.

## Test plan

- [x] ``ruff format --check src/ tests/ dags/`` — clean (165 files)
- [x] ``ruff check src/ tests/ dags/`` — clean
- [x] ``mypy src/`` — clean
- [x] ``pytest tests/test_pr_n24_audit_blockers.py`` — **23/23 pass**
- [x] ``pytest tests/test_pr_n23_proactive_audit_blockers.py`` — 25/25 pass (with H1 pin updates)
- [x] ``pytest tests/test_pr_n21_enrichment_robustness.py`` — full pass (with H2 pin update)
- [x] **Full suite**: 1659 passed, 3 skipped, 3 xfailed (excluding 1 unrelated pre-existing failure)
- [x] ``bash -n scripts/preflight_baseline.sh`` — clean syntax
- [ ] Verify ``./scripts/preflight_baseline.sh --launch-path=cli`` rejects placeholder `<YOUR_PAGERDUTY_KEY>` in alertmanager.yml (manual)
- [ ] Verify the new ``EdgeGuardMispEventAttributesTruncated`` alert fires in a Prometheus dry-run (``promtool check rules``)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> High because it changes production/security gating in `graphql_api.py`/`query_api.py`, alters baseline DAG execution semantics, and modifies alerting/paging configuration and preflight enforcement that can block launches if misconfigured.
> 
> **Overview**
> Closes several baseline and prod-readiness gaps: the baseline post-run invariant task now runs after *partial* upstream success (`NONE_FAILED_MIN_ONE_SUCCESS`) so operators still get diagnostic counts when enrichment fails.
> 
> Hardens paging/observability by replacing the Alertmanager PagerDuty placeholder key with an env-templated value, adding a new preflight guard that fails if placeholders or un-rendered `${...}` remain, and wiring the previously-unalerted `edgeguard_misp_event_attributes_truncated_total` counter into a new `EdgeGuardMispEventAttributesTruncated` alert (with the preflight alert-count floor bumped accordingly).
> 
> Fixes silent failure modes by making `otx`, `mitre`, and `nvd` collectors re-raise exceptions when `push_to_misp=False` (instead of returning empty/ambiguous results), and centralizes prod detection as `config.is_production_env()` so both `graphql_api.py` and `query_api.py` consistently enforce API-key requirements and avoid leaking debug Cypher on env typos.
> 
> Updates the RUNBOOK recovery instructions for `build_relationships` (removes nonexistent `--step` guidance) and adds a dedicated `tests/test_pr_n24_audit_blockers.py` suite to pin these behaviors and an AST scan to prevent reintroducing the “silent swallower” collector pattern.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e41d4a7e7340dbb7e9a60bef247e4e7d0a965847. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->