### PR TITLE
fix(audit): PR-N29 — pre-baseline hardening (4 audit findings)

### DIFF
--- a/dags/edgeguard_pipeline.py
+++ b/dags/edgeguard_pipeline.py
@@ -1820,10 +1820,17 @@ baseline_dag = DAG(
     max_active_runs=1,  # Only one baseline at a time
     # Worst-case wall time: tier1 sequential (cisa 14s + mitre 28s + otx ~3h
     # + nvd ~5h ≈ 8h) + tier2 parallel (~2h) + full_sync (~6h) +
-    # build_rels (~5h) + enrich (~5h) = ~26h realistic, ~31h with a single
-    # retry on the longest task. 32h cap leaves ~1-6h of headroom; if real
-    # runs trend longer post-PR-F4 (sequential tier1 added ~3h), bump this
-    # via a follow-up rather than letting Airflow hard-kill at the cap.
+    # build_rels (~5h) + enrich (~5h) = ~26h realistic.
+    #
+    # PR-N29 (Holistic H1, pre-baseline audit 2026-04-23): each of the
+    # critical-chain tasks (full_neo4j_sync, build_relationships,
+    # run_enrichment_jobs) now has retries=0 — see their task definitions
+    # for the rationale. Pre-N29 a single retry on ANY of those tasks
+    # would have blown through the 32h dagrun_timeout mid-enrichment,
+    # leaving the graph in a partially-mutated state. With retries=0,
+    # 26h realistic + ~6h headroom = 32h is safe. Collectors still have
+    # retries=1 (inherited from default_args) — they're short and
+    # transient-flake-prone, so a single retry is cheap and well-justified.
     dagrun_timeout=timedelta(hours=32),
     is_paused_upon_creation=False,  # Must be unpaused so manual triggers execute immediately
     tags=["threat-intel", "edgeguard", "baseline", "manual"],
@@ -2784,6 +2791,17 @@ baseline_full_sync_task = PythonOperator(
     task_id="full_neo4j_sync",
     python_callable=run_baseline_full_sync,
     execution_timeout=timedelta(hours=6),
+    # PR-N29 (Holistic H1, pre-baseline audit 2026-04-23): inherit
+    # baseline_dag's ``retries: 1`` → override to 0 on the long, slow,
+    # idempotent critical-chain tasks. A 6h task retrying once eats
+    # 12h of the 32h dagrun_timeout — leaving insufficient headroom
+    # for build_rels (5h) + enrich (5h) + the rest of the chain. The
+    # sync task is idempotent (MERGEs with composite keys), so a
+    # retry doesn't meaningfully raise the chance of eventual success
+    # — it just doubles the wall-time cost. Better to fail cleanly
+    # and have the operator investigate than to silently re-run and
+    # crash the dagrun cap mid-enrichment.
+    retries=0,
     trigger_rule=TriggerRule.ALL_DONE,
     dag=baseline_dag,
 )
@@ -2807,6 +2825,9 @@ baseline_build_rels_task = PythonOperator(
     # bump in this same PR — without both, build_relationships
     # would still stall on transaction-memory exhaustion.
     execution_timeout=timedelta(hours=5),
+    # PR-N29 (Holistic H1): retries=0 on the critical chain. See
+    # full_neo4j_sync's retries=0 comment above for rationale.
+    retries=0,
     # PR #35: NONE_FAILED_MIN_ONE_SUCCESS — run if the upstream
     # full_neo4j_sync didn't crash (success OR skipped, but not failed).
     # Default ALL_SUCCESS would block this task even when the sync
@@ -2822,6 +2843,9 @@ baseline_enrichment_task = PythonOperator(
     task_id="run_enrichment_jobs",
     python_callable=run_baseline_enrichment,
     execution_timeout=timedelta(hours=5),
+    # PR-N29 (Holistic H1): retries=0 — same rationale as the two
+    # upstream critical-chain tasks.
+    retries=0,
     # PR #35: same rationale as build_relationships above.
     trigger_rule=TriggerRule.NONE_FAILED_MIN_ONE_SUCCESS,
     dag=baseline_dag,

--- a/docs/VERSIONING.md
+++ b/docs/VERSIONING.md
@@ -30,4 +30,4 @@ For ad-hoc identification of an arbitrary checkout, use **`edgeguard version`** 
 
 ---
 
-_Last updated: 2026-03-20_
+_Last updated: 2026-04-24_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "edgeguard"
 # CalVer: release date YYYY.M.D (PEP 440). Bump when you tag/publish a release — not on every commit.
-version = "2026.4.18"
+version = "2026.4.24"
 description = "Threat Intelligence Pipeline - Sources to MISP to Neo4j"
 authors = [
     {name = "EdgeGuard Team"}

--- a/src/baseline_lock.py
+++ b/src/baseline_lock.py
@@ -56,7 +56,17 @@ logger = logging.getLogger(__name__)
 # Max age before a sentinel is considered stale on cross-host setups.
 # PID-check covers local same-host stale detection; this catches the case
 # where the process holding the lock crashed on a different host.
-_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 24 * 3600
+#
+# PR-N29 (Holistic M3, pre-baseline audit 2026-04-23): bumped 24h → 48h.
+# Rationale: the baseline DAG's ``dagrun_timeout`` is 32h (see
+# ``dags/edgeguard_pipeline.py:baseline_dag`` — ~26h realistic + 6h
+# headroom). Cross-host deployments (k8s / multi-host docker-compose)
+# where a different host writes the sentinel than reads it would have
+# the lock reaped 8h before the baseline finishes under the old 24h
+# default. Same-host deployments (the recommended CLI launch path per
+# preflight script) are unaffected — PID liveness check bypasses this
+# age cap. 48h gives 16h buffer above the dagrun_timeout ceiling.
+_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 48 * 3600
 
 
 def _repo_root() -> str:

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -535,6 +535,16 @@ _ZERO_WIDTH_AND_BIDI_CHARS = (
     "\u200f"  # RIGHT-TO-LEFT MARK (RLM)
     "\u2060"  # WORD JOINER
     "\ufeff"  # ZERO WIDTH NO-BREAK SPACE / BOM
+    # PR-N29 Bugbot round 2 (2026-04-24, LOW): non-standard whitespace/
+    # separator chars that ``str.strip()`` does NOT remove and that NFKC
+    # does NOT fold to a regular space. Without these in the translate
+    # table, an attacker can bypass the filter with e.g.
+    # ``"unknown\u180e"`` or ``"unknown\u2028"``. (NBSP U+00A0 is already
+    # handled because NFKC folds it to a regular space, then strip()
+    # removes it — but ONLY thanks to the translate→NFKC→strip ordering.)
+    "\u180e"  # MONGOLIAN VOWEL SEPARATOR (zero-width; not folded by NFKC)
+    "\u2028"  # LINE SEPARATOR (not stripped by str.strip on all platforms)
+    "\u2029"  # PARAGRAPH SEPARATOR (same)
     "\u202a"  # LEFT-TO-RIGHT EMBEDDING
     "\u202b"  # RIGHT-TO-LEFT EMBEDDING
     "\u202c"  # POP DIRECTIONAL FORMATTING

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -525,6 +525,14 @@ _ZERO_WIDTH_AND_BIDI_CHARS = (
     "\u200b"  # ZERO WIDTH SPACE
     "\u200c"  # ZERO WIDTH NON-JOINER
     "\u200d"  # ZERO WIDTH JOINER
+    # PR-N29 Bugbot round 1 (2026-04-24, MED): U+200E + U+200F are
+    # zero-width directional marks in the same Unicode block as
+    # U+200B–U+200D. NFKC + str.strip() do NOT remove them, so an
+    # attacker could bypass ``is_placeholder_name`` with
+    # ``"unknown\u200e"`` (LRM) or ``"unknown\u200f"`` (RLM). GitHub
+    # patched a similar @-mention bypass against the same vector.
+    "\u200e"  # LEFT-TO-RIGHT MARK (LRM)
+    "\u200f"  # RIGHT-TO-LEFT MARK (RLM)
     "\u2060"  # WORD JOINER
     "\ufeff"  # ZERO WIDTH NO-BREAK SPACE / BOM
     "\u202a"  # LEFT-TO-RIGHT EMBEDDING

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -521,20 +521,61 @@ _REJECTED_PLACEHOLDER_NAMES: frozenset = frozenset(
 )
 
 
+_ZERO_WIDTH_AND_BIDI_CHARS = (
+    "\u200b"  # ZERO WIDTH SPACE
+    "\u200c"  # ZERO WIDTH NON-JOINER
+    "\u200d"  # ZERO WIDTH JOINER
+    "\u2060"  # WORD JOINER
+    "\ufeff"  # ZERO WIDTH NO-BREAK SPACE / BOM
+    "\u202a"  # LEFT-TO-RIGHT EMBEDDING
+    "\u202b"  # RIGHT-TO-LEFT EMBEDDING
+    "\u202c"  # POP DIRECTIONAL FORMATTING
+    "\u202d"  # LEFT-TO-RIGHT OVERRIDE
+    "\u202e"  # RIGHT-TO-LEFT OVERRIDE
+    "\u2066"  # LEFT-TO-RIGHT ISOLATE
+    "\u2067"  # RIGHT-TO-LEFT ISOLATE
+    "\u2068"  # FIRST STRONG ISOLATE
+    "\u2069"  # POP DIRECTIONAL ISOLATE
+)
+_ZERO_WIDTH_AND_BIDI_TRANSLATE = {ord(c): None for c in _ZERO_WIDTH_AND_BIDI_CHARS}
+
+
 def is_placeholder_name(value: Any) -> bool:
     """Return True if ``value`` canonicalizes to a known placeholder
     string. Used by merge_malware / merge_actor / merge_tool to reject
     MERGE on placeholder natural keys (PR-N10).
 
-    Canonicalization mirrors ``canonicalize_merge_key``'s name handling:
-    NFC-normalize, strip, lowercase. Non-string inputs (None, int, etc.)
-    return True (a non-string is definitionally not a meaningful name,
-    and returning True means "reject the MERGE" — the caller then treats
-    the item as having no valid identity).
+    Canonicalization steps (in order):
+      1. Strip zero-width + bidirectional-control characters (PR-N29 L1).
+         These are invisible but distinct under NFC — e.g.
+         ``"unknown\\u200b"`` would pass the pre-N29 check even though
+         it's visually identical to the rejected ``"unknown"``.
+      2. NFKC normalize (PR-N29 L1, upgrade from NFC). NFKC folds
+         compatibility characters (full-width Latin → half-width, ligatures,
+         etc.). Does NOT fold cross-script confusables (Cyrillic 'а' stays
+         distinct from Latin 'a') — those require a confusables library
+         and we accept the residual risk as LOW (no in-the-wild exploit).
+      3. Strip whitespace.
+      4. Lowercase.
+      5. Exact match against ``_REJECTED_PLACEHOLDER_NAMES``.
+
+    Non-string inputs (None, int, etc.) return True — a non-string is
+    definitionally not a meaningful name, and returning True means
+    "reject the MERGE" — the caller treats the item as having no valid
+    identity.
+
+    PR-N29 (Holistic L1, pre-baseline audit 2026-04-23): upgraded from
+    bare NFC to NFKC + zero-width/bidi strip. Pre-N29 an attacker with
+    MISP write access could craft ``Malware{name:"unknown\\u200b"}`` or
+    ``Malware{name:"unknоwn"}`` (Cyrillic 'о') to bypass the filter.
+    Cyrillic confusables still bypass — tracked but not exploited today.
     """
     if not isinstance(value, str):
         return True
-    canonical = unicodedata.normalize("NFC", value).strip().lower()
+    # Step 1: strip zero-width and bidi-control characters.
+    stripped_controls = value.translate(_ZERO_WIDTH_AND_BIDI_TRANSLATE)
+    # Steps 2-4: NFKC normalize, whitespace-strip, lowercase.
+    canonical = unicodedata.normalize("NFKC", stripped_controls).strip().lower()
     return canonical in _REJECTED_PLACEHOLDER_NAMES
 
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1041,7 +1041,43 @@ class MISPToNeo4jSync:
                     page_result = misp.search(controller="events", **search_kwargs)
                     if not page_result:
                         break
-                    page_rows = list(page_result)
+                    # PR-N29 Bugbot round 2 (2026-04-24, MED): PyMISP can
+                    # return a list, ``{"response": [...]}``, or
+                    # ``{"errors": ...}`` depending on version + error path.
+                    # ``list(dict)`` would yield the dict's KEYS as bare
+                    # strings ("response", "errors") — those then go into
+                    # ``events`` and downstream normalize drops them all
+                    # to zero, with the loop logging "successful pagination."
+                    # Mirror the requests-restSearch branch's explicit
+                    # unwrap below.
+                    if isinstance(page_result, dict):
+                        if "errors" in page_result:
+                            logger.error(
+                                "[MISP-FETCH-FALLBACK] PyMISP page %d returned "
+                                "errors payload: %s — aborting fallback (%d good "
+                                "pages already collected).",
+                                page,
+                                page_result.get("errors"),
+                                page - 1,
+                            )
+                            raise RuntimeError(
+                                f"MISP fallback PyMISP errors on page {page}: {page_result.get('errors')}"
+                            )
+                        page_rows = page_result.get("response") or []
+                    elif isinstance(page_result, list):
+                        page_rows = page_result
+                    else:
+                        logger.error(
+                            "[MISP-FETCH-FALLBACK] PyMISP page %d returned "
+                            "unexpected payload type %s — aborting fallback.",
+                            page,
+                            type(page_result).__name__,
+                        )
+                        raise RuntimeError(
+                            f"MISP fallback PyMISP unexpected payload type on page {page}: {type(page_result).__name__}"
+                        )
+                    if not page_rows:
+                        break
                     events.extend(page_rows)
                     logger.info(
                         "[MISP-FETCH-FALLBACK] PyMISP page %d returned %d row(s)",
@@ -1092,10 +1128,33 @@ class MISPToNeo4jSync:
                     )
 
                     if response.status_code != 200:
-                        # Propagate to the existing error path below by
-                        # breaking out here with the partial ``events`` and
-                        # letting the downstream handler run.
-                        break
+                        # PR-N29 Bugbot round 2 (2026-04-24, MED): pre-fix
+                        # this was a silent ``break`` that kept the partial
+                        # events list and downstream logged "collected N
+                        # rows across M pages" as if successful. A non-200
+                        # mid-pagination is a REAL error (3 good pages + a
+                        # 500 on page 4 silently dropped 25% of the
+                        # baseline). The ``EdgeGuardSyncCoverageGap`` alert
+                        # doesn't catch this either because the index path
+                        # isn't in play in fallback. Raise so the operator
+                        # SEES the failure, can investigate WHY MISP 5xx'd
+                        # mid-pagination, and the partial data isn't taken
+                        # as ground truth.
+                        logger.error(
+                            "[MISP-FETCH-FALLBACK] restSearch HTTP %d on page %d "
+                            "after %d good pages (%d events collected). NOT silently "
+                            "truncating — re-raising so this surfaces as a sync error.",
+                            response.status_code,
+                            page,
+                            page - 1,
+                            len(events),
+                        )
+                        raise RuntimeError(
+                            f"MISP fallback restSearch HTTP {response.status_code} on "
+                            f"page {page} after {page - 1} good pages "
+                            f"({len(events)} events collected). Investigate MISP backend; "
+                            f"do NOT treat partial fallback as complete."
+                        )
                     page_data = response.json()
                     # ``events`` may be a raw list OR wrapped in {"response": [...]}
                     if isinstance(page_data, dict):

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -1002,7 +1002,25 @@ class MISPToNeo4jSync:
                     logger.warning("[FETCH] Index returned rows but normalized to 0 events — check payload shape")
                 return normalized
 
-            logger.warning("[FETCH] Event index unavailable — falling back to PyMISP / restSearch (may be slow)")
+            # PR-N29 (Holistic H3, pre-baseline audit 2026-04-23): pre-N29
+            # this fallback used ``limit: 1000`` with NO pagination. For
+            # a 730d baseline against a populated MISP (empirically >1000
+            # events in the 2026-04-19 incident), the fallback silently
+            # truncated. ``EdgeGuardSyncCoverageGap`` alert compares
+            # processed vs ``edgeguard_sync_events_index_total`` which IS
+            # the truncated count — so no gap was visible. Fix: paginate
+            # both the PyMISP and requests-restSearch branches, matching
+            # the 500-per-page cadence of the primary index path.
+            logger.warning(
+                "[MISP-FETCH-FALLBACK-ACTIVE] Event index unavailable — falling "
+                "back to PyMISP / restSearch with pagination. This path is slower "
+                "than the index; investigate WHY the index failed. Grep this "
+                "token in logs to correlate with other failure modes."
+            )
+
+            # Pagination bounds (PR-N29 H3):
+            _FALLBACK_PAGE_SIZE = 500  # matches the primary index path cadence
+            _FALLBACK_MAX_PAGES = 200  # 100K-event safety cap; raise if needed
 
             # Fallback: PyMISP restSearch (can be expensive on very large instances).
             try:
@@ -1010,42 +1028,108 @@ class MISPToNeo4jSync:
 
                 misp = PyMISP(self.misp_url, self.misp_api_key, **_pymisp_client_kwargs())
 
-                search_kwargs: dict = {"limit": 1000, "search": MISP_EDGEGUARD_DISCOVERY_SEARCH}
-                if since:
-                    search_kwargs["timestamp"] = int(since.timestamp())
+                events = []
+                for page in range(1, _FALLBACK_MAX_PAGES + 1):
+                    search_kwargs: dict = {
+                        "limit": _FALLBACK_PAGE_SIZE,
+                        "page": page,
+                        "search": MISP_EDGEGUARD_DISCOVERY_SEARCH,
+                    }
+                    if since:
+                        search_kwargs["timestamp"] = int(since.timestamp())
 
-                misp_events = misp.search(controller="events", **search_kwargs)
-
-                if misp_events:
-                    events = list(misp_events)
+                    page_result = misp.search(controller="events", **search_kwargs)
+                    if not page_result:
+                        break
+                    page_rows = list(page_result)
+                    events.extend(page_rows)
                     logger.info(
-                        f"[FETCH] PyMISP returned {len(events)} row(s) (since={since}); normalizing to flat Event dicts"
+                        "[MISP-FETCH-FALLBACK] PyMISP page %d returned %d row(s)",
+                        page,
+                        len(page_rows),
+                    )
+                    if len(page_rows) < _FALLBACK_PAGE_SIZE:
+                        # Short read — we're at the end.
+                        break
+                else:
+                    # Hit the safety cap
+                    logger.error(
+                        "[MISP-FETCH-FALLBACK] Hit _FALLBACK_MAX_PAGES=%d cap "
+                        "(~%d events). If MISP legitimately has more events, "
+                        "raise the cap in src/run_misp_to_neo4j.py. Silent data "
+                        "loss risk until this is addressed.",
+                        _FALLBACK_MAX_PAGES,
+                        _FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE,
+                    )
+
+                if events:
+                    logger.info(
+                        f"[FETCH] PyMISP pagination returned {len(events)} row(s) total "
+                        f"across {page} page(s) (since={since}); normalizing"
                     )
                 else:
                     logger.info("No events found in MISP")
 
             except Exception as e:
                 logger.error(f"PyMISP error: {e}, falling back to requests restSearch")
-                rest_body: dict = {
-                    "returnFormat": "json",
-                    "limit": 1000,
-                    "search": MISP_EDGEGUARD_DISCOVERY_SEARCH,
-                }
-                if since:
-                    rest_body["timestamp"] = int(since.timestamp())
+                # PR-N29 H3: same pagination for the requests-restSearch path.
+                events = []
+                for page in range(1, _FALLBACK_MAX_PAGES + 1):
+                    rest_body: dict = {
+                        "returnFormat": "json",
+                        "limit": _FALLBACK_PAGE_SIZE,
+                        "page": page,
+                        "search": MISP_EDGEGUARD_DISCOVERY_SEARCH,
+                    }
+                    if since:
+                        rest_body["timestamp"] = int(since.timestamp())
 
-                response = self.session.post(
-                    f"{self.misp_url.rstrip('/')}/events/restSearch",
-                    json=rest_body,
-                    verify=SSL_VERIFY,
-                    timeout=(MISP_CONNECT_TIMEOUT, MISP_REQUEST_TIMEOUT),
-                )
+                    response = self.session.post(
+                        f"{self.misp_url.rstrip('/')}/events/restSearch",
+                        json=rest_body,
+                        verify=SSL_VERIFY,
+                        timeout=(MISP_CONNECT_TIMEOUT, MISP_REQUEST_TIMEOUT),
+                    )
 
-                if response.status_code == 200:
-                    events = response.json()
+                    if response.status_code != 200:
+                        # Propagate to the existing error path below by
+                        # breaking out here with the partial ``events`` and
+                        # letting the downstream handler run.
+                        break
+                    page_data = response.json()
+                    # ``events`` may be a raw list OR wrapped in {"response": [...]}
+                    if isinstance(page_data, dict):
+                        page_rows = page_data.get("response") or []
+                    elif isinstance(page_data, list):
+                        page_rows = page_data
+                    else:
+                        page_rows = []
+                    if not page_rows:
+                        break
+                    events.extend(page_rows)
                     logger.info(
-                        "[FETCH] events/restSearch fallback: payload type=%s — will normalize",
-                        type(events).__name__,
+                        "[MISP-FETCH-FALLBACK] restSearch page %d returned %d row(s)",
+                        page,
+                        len(page_rows),
+                    )
+                    if len(page_rows) < _FALLBACK_PAGE_SIZE:
+                        break
+                else:
+                    logger.error(
+                        "[MISP-FETCH-FALLBACK] restSearch hit _FALLBACK_MAX_PAGES=%d cap",
+                        _FALLBACK_MAX_PAGES,
+                    )
+
+                # PR-N29: pagination already collected all events; downstream
+                # normalization runs on the ``events`` variable. Pre-N29 this
+                # block had an ``if response.status_code == 200: events =
+                # response.json()`` re-assign on a single-shot response; now
+                # redundant because pagination loop already handled it.
+                if events:
+                    logger.info(
+                        "[FETCH] events/restSearch fallback (paginated): collected %d row(s) across %d page(s)",
+                        len(events),
+                        page,
                     )
 
         except (

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -73,6 +73,41 @@ MISP_CONNECT_TIMEOUT = 30  # Connection timeout (seconds)
 MISP_REQUEST_TIMEOUT = 300  # Read timeout (seconds) — large events (95K+ attrs) need time
 
 
+class _MispFallbackHardError(Exception):
+    """Sentinel: a non-recoverable failure inside the MISP fetch fallback paths.
+
+    PR-N29 (multi-agent audit, 2026-04-24, HIGH-1/2/3): the PyMISP and
+    requests-restSearch fallback branches in ``fetch_edgeguard_events``
+    discovered three distinct hard-error paths during the audit:
+
+    1. PyMISP returning ``{"errors": ...}`` mid-pagination
+    2. PyMISP returning an unexpected payload type mid-pagination
+    3. requests-restSearch returning HTTP 5xx mid-pagination
+    4. EITHER branch hitting the ``_FALLBACK_MAX_PAGES`` safety cap
+
+    All four MUST surface to the operator. The previous fix (Bugbot
+    round 2) used a bare ``raise RuntimeError(...)`` — but the enclosing
+    ``except Exception as e: logger.error(...)`` blocks at lines ~1109
+    (PyMISP fallback → swallowed back to requests-restSearch path) and
+    ~1201 (outer broad) silently catch ``RuntimeError`` and turn the
+    failure into a partial-success "no events found" state, exactly
+    the silent-truncation failure mode PR-N29 H3 was meant to close.
+
+    A dedicated sentinel + explicit ``except _MispFallbackHardError:
+    raise`` clauses ahead of the broad ``except Exception`` give us a
+    clean fast-path to the calling DAG (which has retries=0 on the
+    critical chain — see PR-N29 H1) without touching the legitimate
+    transient-network catch above.
+
+    The sentinel is intentionally NOT in the ``retry_with_backoff``
+    retry set: a 500 mid-pagination is not a transient network issue
+    and re-trying immediately would only paper over the underlying
+    MISP backend problem.
+    """
+
+    pass
+
+
 def _pymisp_client_kwargs() -> Dict[str, Any]:
     """PyMISP constructor kwargs: SSL verify, HTTP timeouts, optional Host override.
 
@@ -1060,7 +1095,7 @@ class MISPToNeo4jSync:
                                 page_result.get("errors"),
                                 page - 1,
                             )
-                            raise RuntimeError(
+                            raise _MispFallbackHardError(
                                 f"MISP fallback PyMISP errors on page {page}: {page_result.get('errors')}"
                             )
                         page_rows = page_result.get("response") or []
@@ -1073,7 +1108,7 @@ class MISPToNeo4jSync:
                             page,
                             type(page_result).__name__,
                         )
-                        raise RuntimeError(
+                        raise _MispFallbackHardError(
                             f"MISP fallback PyMISP unexpected payload type on page {page}: {type(page_result).__name__}"
                         )
                     if not page_rows:
@@ -1088,14 +1123,24 @@ class MISPToNeo4jSync:
                         # Short read — we're at the end.
                         break
                 else:
-                    # Hit the safety cap
+                    # PR-N29 (multi-agent audit, 2026-04-24, HIGH-2): hitting the
+                    # safety cap means we may have legitimately MORE events in
+                    # MISP than the cap allows. Pre-fix this only logged; the
+                    # outer ``except Exception`` then silently treated the
+                    # truncated list as "all" events. Now raise so the operator
+                    # SEES the cap-hit. To intentionally raise the cap, edit
+                    # ``_FALLBACK_MAX_PAGES`` in this file.
                     logger.error(
-                        "[MISP-FETCH-FALLBACK] Hit _FALLBACK_MAX_PAGES=%d cap "
+                        "[MISP-FETCH-FALLBACK] PyMISP hit _FALLBACK_MAX_PAGES=%d cap "
                         "(~%d events). If MISP legitimately has more events, "
-                        "raise the cap in src/run_misp_to_neo4j.py. Silent data "
-                        "loss risk until this is addressed.",
+                        "raise the cap in src/run_misp_to_neo4j.py.",
                         _FALLBACK_MAX_PAGES,
                         _FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE,
+                    )
+                    raise _MispFallbackHardError(
+                        f"MISP fallback PyMISP hit _FALLBACK_MAX_PAGES={_FALLBACK_MAX_PAGES} cap "
+                        f"(~{_FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE} events collected). "
+                        f"Refusing to treat truncated fallback as complete."
                     )
 
                 if events:
@@ -1106,6 +1151,18 @@ class MISPToNeo4jSync:
                 else:
                     logger.info("No events found in MISP")
 
+            except _MispFallbackHardError:
+                # PR-N29 (multi-agent audit, 2026-04-24, HIGH-1): the sentinel
+                # raised inside the PyMISP loop above (errors payload, unexpected
+                # type, cap-hit) MUST escape this try/except — otherwise the
+                # broad ``except Exception`` below treats the hard failure as a
+                # transient PyMISP issue and falls through to the
+                # requests-restSearch path, masking the real underlying problem
+                # and producing a partial-success "no events found" outcome.
+                # Re-raising hands control to the outer try/except, which has
+                # its own sentinel re-raise that lets the failure surface to
+                # the calling DAG (retries=0 on critical chain — see PR-N29 H1).
+                raise
             except Exception as e:
                 logger.error(f"PyMISP error: {e}, falling back to requests restSearch")
                 # PR-N29 H3: same pagination for the requests-restSearch path.
@@ -1149,20 +1206,48 @@ class MISPToNeo4jSync:
                             page - 1,
                             len(events),
                         )
-                        raise RuntimeError(
+                        raise _MispFallbackHardError(
                             f"MISP fallback restSearch HTTP {response.status_code} on "
                             f"page {page} after {page - 1} good pages "
                             f"({len(events)} events collected). Investigate MISP backend; "
                             f"do NOT treat partial fallback as complete."
                         )
                     page_data = response.json()
-                    # ``events`` may be a raw list OR wrapped in {"response": [...]}
+                    # PR-N29 (multi-agent audit, 2026-04-24, HIGH-3 / Cross-Checker):
+                    # MISP can return HTTP 200 with an ``{"errors": ...}`` body
+                    # (e.g. ACL filter matched zero, broken sync user, malformed
+                    # query). Pre-fix this silently became ``[]`` via
+                    # ``.get("response") or []`` and the loop happily logged
+                    # "0 row(s)" → ``break`` → "successful pagination" with
+                    # zero events. Mirror the PyMISP branch above: errors is a
+                    # hard failure, unexpected payload type is a hard failure,
+                    # only list / wrapped-list payloads are accepted.
                     if isinstance(page_data, dict):
+                        if "errors" in page_data:
+                            logger.error(
+                                "[MISP-FETCH-FALLBACK] restSearch page %d returned "
+                                "errors payload: %s — aborting fallback (%d good "
+                                "pages already collected).",
+                                page,
+                                page_data.get("errors"),
+                                page - 1,
+                            )
+                            raise _MispFallbackHardError(
+                                f"MISP fallback restSearch errors on page {page}: {page_data.get('errors')}"
+                            )
                         page_rows = page_data.get("response") or []
                     elif isinstance(page_data, list):
                         page_rows = page_data
                     else:
-                        page_rows = []
+                        logger.error(
+                            "[MISP-FETCH-FALLBACK] restSearch page %d returned "
+                            "unexpected payload type %s — aborting fallback.",
+                            page,
+                            type(page_data).__name__,
+                        )
+                        raise _MispFallbackHardError(
+                            f"MISP fallback restSearch unexpected payload type on page {page}: {type(page_data).__name__}"
+                        )
                     if not page_rows:
                         break
                     events.extend(page_rows)
@@ -1174,9 +1259,21 @@ class MISPToNeo4jSync:
                     if len(page_rows) < _FALLBACK_PAGE_SIZE:
                         break
                 else:
+                    # PR-N29 (multi-agent audit, 2026-04-24, HIGH-2): symmetric
+                    # with the PyMISP cap-hit raise above. Hitting the safety
+                    # cap means truncated coverage; refuse to treat it as
+                    # complete.
                     logger.error(
-                        "[MISP-FETCH-FALLBACK] restSearch hit _FALLBACK_MAX_PAGES=%d cap",
+                        "[MISP-FETCH-FALLBACK] restSearch hit _FALLBACK_MAX_PAGES=%d cap "
+                        "(~%d events). If MISP legitimately has more events, "
+                        "raise the cap in src/run_misp_to_neo4j.py.",
                         _FALLBACK_MAX_PAGES,
+                        _FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE,
+                    )
+                    raise _MispFallbackHardError(
+                        f"MISP fallback restSearch hit _FALLBACK_MAX_PAGES={_FALLBACK_MAX_PAGES} cap "
+                        f"(~{_FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE} events collected). "
+                        f"Refusing to treat truncated fallback as complete."
                     )
 
                 # PR-N29: pagination already collected all events; downstream
@@ -1198,6 +1295,21 @@ class MISPToNeo4jSync:
             requests.exceptions.ChunkedEncodingError,
         ):
             raise  # let @retry_with_backoff handle transient errors
+        except _MispFallbackHardError:
+            # PR-N29 (multi-agent audit, 2026-04-24, HIGH-1): the sentinel
+            # marks a non-recoverable failure in the fallback paths
+            # (PyMISP errors payload, unexpected payload type, restSearch
+            # HTTP 5xx mid-pagination, OR safety-cap hit). Pre-fix the
+            # broad ``except Exception`` below caught these as a generic
+            # "Error fetching events", logged it, and returned an empty
+            # list — the calling DAG's ``EdgeGuardSyncCoverageGap`` alert
+            # then compared an empty processed-list to an empty
+            # events-index and saw "no gap." Re-raising lets the failure
+            # propagate to the DAG (which has retries=0 on the critical
+            # chain — see PR-N29 H1) so the operator sees the real error.
+            # Intentionally NOT in the @retry_with_backoff retry set:
+            # a 500 mid-pagination is not a transient network issue.
+            raise
         except Exception as e:
             logger.error(f"Error fetching events: {type(e).__name__}: {e}")
 

--- a/tests/test_pr_n29_pre_baseline_hardening.py
+++ b/tests/test_pr_n29_pre_baseline_hardening.py
@@ -54,6 +54,29 @@ Folded into PR-N30 (stacked on PR #109's merge):
 Deferred to a separate follow-up PR:
 * Holistic H2 — ``build_campaign_nodes`` behavioural happy-path test
   (larger scope, needs fake-driver fixture design)
+
+## Multi-agent audit follow-up (2026-04-24)
+
+A 7-agent audit on the PR #109 merge surfaced 3 corroborated HIGH
+correctness bugs all rooted in PR-N29's Bugbot-round-2 fix:
+
+* **HIGH-1 (Bug Hunter / Cross-Checker)** — ``raise RuntimeError`` from
+  the new fallback paths is silently caught by the broader
+  ``except Exception`` blocks at lines ~1109 (PyMISP try/except) and
+  ~1201 (outer broad). Hard errors degrade to "no events found" with
+  no operator surface.
+* **HIGH-2 (Bug Hunter / Devil's Advocate)** — hitting
+  ``_FALLBACK_MAX_PAGES`` only logs; the truncated event list is then
+  treated as ground truth.
+* **HIGH-3 (Cross-Checker sibling drift)** — the requests-restSearch
+  branch is missing the errors-key check + unexpected-payload raise
+  that the PyMISP branch has post-Bugbot-round-2.
+
+Fix pattern: a dedicated ``_MispFallbackHardError`` sentinel +
+explicit ``except _MispFallbackHardError: raise`` clauses ahead of
+every broad ``except Exception``. Cap-hit branches now raise the
+sentinel as well. Tests pinning the contract live in
+``TestPRN29MispFallbackHardErrorSentinel`` below.
 """
 
 from __future__ import annotations
@@ -190,21 +213,29 @@ class TestPRN29H3MispFetchFallbackPaginated:
         )
 
     def test_non200_mid_pagination_raises_not_silent_break(self):
-        """PR-N29 Bugbot round 2 (MED): a non-200 response on any page
-        after the first MUST raise (or otherwise surface as a sync error)
-        rather than silently truncate with the partial events list. Pre-
-        fix the ``break`` on non-200 left a positive log line "collected
-        N row(s) across M pages" while having silently dropped 25%+ of
-        the baseline."""
+        """PR-N29 Bugbot round 2 (MED) → multi-agent audit (HIGH-1): a non-200
+        response on any page after the first MUST raise (or otherwise
+        surface as a sync error) rather than silently truncate with the
+        partial events list. Pre-fix the ``break`` on non-200 left a
+        positive log line "collected N row(s) across M pages" while
+        having silently dropped 25%+ of the baseline.
+
+        The multi-agent audit further surfaced that ``raise RuntimeError``
+        was being swallowed by the broad ``except Exception`` — replaced
+        with the dedicated ``_MispFallbackHardError`` sentinel, which has
+        explicit ``except _MispFallbackHardError: raise`` re-raises ahead
+        of every broad ``except Exception`` clause."""
         text = self.SRC_FILE.read_text()
         # Find the non-200 branch in the requests-restSearch fallback
         idx = text.find("response.status_code != 200")
         assert idx != -1, "non-200 check must exist in the fallback"
         block = text[idx : idx + 2000]
-        # Must explicitly raise (not just break)
-        assert "raise RuntimeError" in block, (
-            "PR-N29 Bugbot round 2: non-200 mid-pagination must raise "
-            "(explicit error surface), NOT silently break with partial events"
+        # Must explicitly raise the sentinel (not just break, not bare RuntimeError)
+        assert "raise _MispFallbackHardError" in block, (
+            "PR-N29 multi-agent audit (HIGH-1): non-200 mid-pagination must "
+            "raise the dedicated _MispFallbackHardError sentinel so the broad "
+            "except Exception below doesn't swallow it. Bare ``raise RuntimeError`` "
+            "is NOT enough — it gets caught by the outer except Exception clause."
         )
         # The error message must be operator-actionable
         assert "good pages" in block, (
@@ -428,4 +459,228 @@ class TestPRN29L1PlaceholderUnicodeHardening:
             "bypass the filter. Fix requires a confusables library (not in scope "
             "for PR-N29). This test pins the RESIDUAL so updating it signals "
             "a real fix."
+        )
+
+
+# ===========================================================================
+# Multi-agent audit (2026-04-24) — _MispFallbackHardError sentinel contract
+# ===========================================================================
+
+
+class TestPRN29MispFallbackHardErrorSentinel:
+    """7-agent audit on PR-N29 (2026-04-24) corroborated 3 HIGH findings:
+
+    * Bug Hunter HIGH-1 / Cross-Checker HIGH-1: ``raise RuntimeError`` is
+      caught by the broad ``except Exception`` blocks at lines ~1109
+      (PyMISP fallback) and ~1201 (outer). Hard errors silently degrade
+      to "no events found".
+    * Bug Hunter HIGH-2 / Devil's Advocate critique: cap-hit on
+      ``_FALLBACK_MAX_PAGES`` only logs — silent truncation if MISP
+      legitimately has more events than the cap.
+    * Cross-Checker HIGH-1/2 (sibling drift): the requests-restSearch
+      branch was missing the errors-key check + unexpected-shape raise
+      that the PyMISP branch had after Bugbot round 2.
+
+    The fix uses a dedicated ``_MispFallbackHardError`` sentinel +
+    explicit ``except _MispFallbackHardError: raise`` clauses ahead of
+    every broad ``except Exception``. These tests pin the contract.
+    """
+
+    SRC_FILE = SRC / "run_misp_to_neo4j.py"
+
+    # ----- shape / source-pin tests (no PyMISP / Airflow needed) -----
+
+    def test_sentinel_class_is_defined_at_module_level(self):
+        """The sentinel must exist as a module-level Exception subclass —
+        importable from tests, picklable across processes, easy to grep."""
+        text = self.SRC_FILE.read_text()
+        assert "class _MispFallbackHardError(Exception):" in text, (
+            "PR-N29 audit HIGH-1: ``_MispFallbackHardError`` must be a "
+            "module-level Exception subclass so the explicit re-raise "
+            "clauses can reference it without import gymnastics."
+        )
+
+    def test_sentinel_class_importable(self):
+        """Behavioural: the sentinel can actually be imported."""
+        from run_misp_to_neo4j import _MispFallbackHardError
+
+        assert issubclass(_MispFallbackHardError, Exception)
+        # Subclass of Exception, NOT BaseException — KeyboardInterrupt /
+        # SystemExit must still propagate normally and not be caught by
+        # the general ``except Exception`` clauses we're using.
+        assert _MispFallbackHardError.__bases__ == (Exception,)
+
+    def test_no_bare_raise_RuntimeError_in_fallback_paths(self):
+        """Negative pin: pre-fix the fallback paths used ``raise RuntimeError``
+        which the broad ``except Exception`` swallowed. After fix, all 5
+        raise sites must use ``_MispFallbackHardError``.
+
+        Scope: only the ``fetch_edgeguard_events`` method body — the
+        sentinel's own docstring documents the audit history and contains
+        the literal string ``raise RuntimeError(...)`` as part of the
+        narrative."""
+        text = self.SRC_FILE.read_text()
+        # Extract the fetch_edgeguard_events method body
+        start = text.find("def fetch_edgeguard_events(")
+        assert start != -1, "fetch_edgeguard_events method must exist"
+        # Find the start of the next top-level method
+        end = text.find("\n    @", start + 1)
+        if end == -1:
+            end = text.find("\n    def ", start + 1)
+        assert end != -1, "must find end of fetch_edgeguard_events"
+        method_body = text[start:end]
+        assert "raise RuntimeError(" not in method_body, (
+            "PR-N29 audit HIGH-1: fetch_edgeguard_events fallback paths must "
+            "not raise bare RuntimeError — those get swallowed by the broad "
+            "except Exception blocks. Use _MispFallbackHardError instead."
+        )
+
+    def test_pymisp_cap_hit_raises_sentinel(self):
+        """Bug Hunter HIGH-2 / Devil's Advocate: hitting
+        ``_FALLBACK_MAX_PAGES`` must surface as a hard error, not just a
+        log line. Pre-fix the cap-hit branch only ``logger.error``ed and
+        the truncated event list was treated as ground truth."""
+        text = self.SRC_FILE.read_text()
+        # PyMISP cap-hit block — find the for/else and the raise
+        idx = text.find("PyMISP hit _FALLBACK_MAX_PAGES")
+        assert idx != -1, "PyMISP cap-hit log line must exist"
+        block = text[idx : idx + 1500]
+        assert "raise _MispFallbackHardError" in block, (
+            "PR-N29 audit HIGH-2: PyMISP cap-hit must raise sentinel. "
+            "logger.error alone leaves the truncated list as ground truth."
+        )
+
+    def test_restsearch_cap_hit_raises_sentinel(self):
+        """Bug Hunter HIGH-2: symmetric — restSearch cap-hit must also raise."""
+        text = self.SRC_FILE.read_text()
+        idx = text.find("restSearch hit _FALLBACK_MAX_PAGES")
+        assert idx != -1, "restSearch cap-hit log line must exist"
+        block = text[idx : idx + 1500]
+        assert "raise _MispFallbackHardError" in block, (
+            "PR-N29 audit HIGH-2: restSearch cap-hit must raise sentinel (symmetric with PyMISP cap-hit branch)."
+        )
+
+    def test_restsearch_branch_handles_errors_payload(self):
+        """Cross-Checker HIGH-1 (sibling drift): the PyMISP branch checks
+        ``"errors" in page_result``; the requests-restSearch branch did
+        NOT have this check before the multi-agent audit. After fix,
+        both branches must surface MISP HTTP-200 errors-payload as a
+        hard error."""
+        text = self.SRC_FILE.read_text()
+        # Anchor on the restSearch page_data block — page_data is the
+        # restSearch variable, distinct from page_result (PyMISP).
+        idx = text.find("page_data = response.json()")
+        assert idx != -1, "restSearch page_data assignment must exist"
+        block = text[idx : idx + 2500]
+        assert '"errors" in page_data' in block, (
+            "PR-N29 audit Cross-Checker HIGH-1: requests-restSearch branch "
+            'must check ``"errors" in page_data`` (mirrors PyMISP branch). '
+            "Pre-fix MISP could return HTTP 200 with errors-payload and the "
+            "loop silently produced 0 events."
+        )
+        assert "raise _MispFallbackHardError" in block, (
+            "PR-N29 audit Cross-Checker HIGH-1: errors-payload in restSearch must raise the sentinel."
+        )
+
+    def test_restsearch_branch_handles_unexpected_payload_type(self):
+        """Cross-Checker HIGH-2: the PyMISP branch raises on unexpected
+        payload type; the restSearch branch silently coerced to ``[]``
+        before the audit. After fix, both branches must raise."""
+        text = self.SRC_FILE.read_text()
+        idx = text.find("page_data = response.json()")
+        assert idx != -1
+        block = text[idx : idx + 2500]
+        assert "restSearch page %d returned" in block and "unexpected payload type" in block, (
+            "PR-N29 audit Cross-Checker HIGH-2: restSearch branch must log "
+            "+ raise on unexpected payload type (mirrors PyMISP branch)."
+        )
+
+    def test_pymisp_inner_except_re_raises_sentinel(self):
+        """HIGH-1: the inner ``except Exception as e`` after the PyMISP try/
+        except (which falls through to the requests-restSearch branch on
+        error) MUST be preceded by ``except _MispFallbackHardError: raise``.
+        Otherwise hard errors raised inside the PyMISP loop fall through
+        to the requests path silently."""
+        text = self.SRC_FILE.read_text()
+        # Anchor on the "PyMISP error" log line — uniquely identifies the
+        # inner except block we care about.
+        idx = text.find('logger.error(f"PyMISP error:')
+        assert idx != -1, "inner PyMISP except must exist"
+        # Look backwards for the preceding except clause
+        preceding = text[max(0, idx - 1500) : idx]
+        assert "except _MispFallbackHardError:" in preceding, (
+            "PR-N29 audit HIGH-1: the ``except Exception as e`` after the "
+            "PyMISP fallback try/except must be preceded by an explicit "
+            "``except _MispFallbackHardError: raise`` clause. Otherwise "
+            "hard errors raised inside the PyMISP loop fall through to "
+            "the requests-restSearch path silently."
+        )
+
+    def test_outer_except_re_raises_sentinel(self):
+        """HIGH-1: the outer broad ``except Exception as e`` at the bottom
+        of ``fetch_edgeguard_events`` MUST be preceded by an explicit
+        sentinel re-raise. Otherwise the function returns ``[]`` (empty
+        normalized list) on hard errors, which the calling DAG treats
+        as "no events to sync today." """
+        text = self.SRC_FILE.read_text()
+        # Anchor on the unique outer log message
+        idx = text.find('logger.error(f"Error fetching events:')
+        assert idx != -1, "outer broad except must exist"
+        preceding = text[max(0, idx - 1500) : idx]
+        assert "except _MispFallbackHardError:" in preceding, (
+            "PR-N29 audit HIGH-1: the outer ``except Exception as e`` must "
+            "be preceded by ``except _MispFallbackHardError: raise``. "
+            "Otherwise the function returns [] on hard errors and the DAG "
+            "silently treats it as 'no events to sync.'"
+        )
+
+    # ----- behavioural tests via direct sentinel exercise -----
+
+    def test_sentinel_is_not_caught_by_except_Exception_in_principle(self):
+        """Behavioural: ``except _MispFallbackHardError: raise`` re-raises
+        the sentinel through any subsequent broad ``except Exception``
+        clause. Verify the Python exception machinery does what we expect
+        when the explicit handler is in place."""
+        from run_misp_to_neo4j import _MispFallbackHardError
+
+        caught_by_specific = False
+        caught_by_generic = False
+        try:
+            try:
+                raise _MispFallbackHardError("test")
+            except _MispFallbackHardError:
+                caught_by_specific = True
+                raise
+            except Exception:
+                caught_by_generic = True
+        except _MispFallbackHardError:
+            pass
+
+        assert caught_by_specific, "specific handler must catch the sentinel"
+        assert not caught_by_generic, (
+            "the broad ``except Exception`` clause must NOT catch the "
+            "sentinel when ``except _MispFallbackHardError: raise`` runs "
+            "first. This pins the Python exception-resolution semantics "
+            "the fallback paths rely on."
+        )
+
+    def test_sentinel_is_caught_by_except_Exception_when_no_specific_handler(self):
+        """Negative pin: WITHOUT the explicit ``except _MispFallbackHardError:
+        raise`` clause, the broad ``except Exception`` DOES catch the
+        sentinel — which is exactly the silent-truncation bug we're
+        fixing. This test documents the failure mode so a future
+        maintainer who deletes the explicit clause sees this test fail."""
+        from run_misp_to_neo4j import _MispFallbackHardError
+
+        caught = False
+        try:
+            raise _MispFallbackHardError("test")
+        except Exception:
+            caught = True
+
+        assert caught, (
+            "PR-N29 audit HIGH-1 documentation: ``except Exception`` DOES "
+            "catch ``_MispFallbackHardError`` (it's an Exception subclass). "
+            "This is exactly why we need the explicit re-raise clause "
+            "ahead of every broad except in the fallback paths."
         )

--- a/tests/test_pr_n29_pre_baseline_hardening.py
+++ b/tests/test_pr_n29_pre_baseline_hardening.py
@@ -1,0 +1,327 @@
+"""
+PR-N29 — pre-baseline hardening.
+
+Comprehensive 7-agent audit on PR #109 surfaced 4 findings OUTSIDE the
+PR #109 diff that affect the 730-day baseline. They're in files PR #109
+doesn't touch, so they split cleanly into this focused follow-up PR.
+
+Fixes:
+
+1. **H1 (Holistic)** — Baseline DAG timeout math was broken.
+   ``dagrun_timeout=32h`` + ``retries: 1`` + 5h critical-chain tasks =
+   a single retry on ANY of sync/build_rels/enrich would blow through
+   the cap mid-enrichment, leaving the graph mid-mutated.
+   Fix: set ``retries=0`` on the three critical-chain tasks.
+
+2. **H3 (Holistic)** — MISP fetch fallback silently truncated at 1000
+   events. If ``_fetch_edgeguard_events_via_requests_index`` errored
+   (which DID happen in 2026-04-19 incident), the PyMISP/restSearch
+   fallback ran with ``limit=1000`` and NO pagination → silent data
+   loss on populated MISP instances (>1K events).
+   Fix: paginate both fallback branches (500/page, 200-page cap = 100K
+   safety ceiling). Add ``[MISP-FETCH-FALLBACK-ACTIVE]`` log token so
+   operators know to grep for fallback-path activity.
+
+3. **M3 (Holistic)** — ``_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 24h`` but
+   baseline ``dagrun_timeout = 32h``. Cross-host deployments would have
+   the sentinel reaped 8h before the baseline finishes. Same-host PID
+   check bypasses this, so the CLI launch path is unaffected, but
+   future k8s / multi-host docker-compose deployments were on a
+   slow-burn clock.
+   Fix: bump default to 48h (16h buffer above dagrun_timeout).
+
+4. **L1 (Red Team)** — ``is_placeholder_name`` did only NFC + strip +
+   lowercase. An attacker with MISP write access could bypass the
+   PR-N10 placeholder filter with:
+     - ``"unknown\\u200b"`` (zero-width space appended)
+     - ``"unknоwn"`` (Cyrillic 'о' instead of Latin 'o')
+   The first is fixable cheaply. The second (cross-script confusables)
+   requires a confusables library — LOW-severity, tracked but not
+   fixed here.
+   Fix: strip zero-width / bidi-control chars; upgrade NFC → NFKC.
+
+## What this PR does NOT address
+
+Folded into PR-N30 (stacked on PR #109's merge):
+* Red Team H1 — `--dry-run` READ session mode (modifies backfill script
+  in PR #109)
+* Cross-Checker H-2 — Q4 [0..200] cap vs backfill-uncapped intersection
+  (modifies build_relationships.py queries + backfill — both in PR #109)
+* Cross-Checker M-1 — Path A vs Path B empty-string drift (same)
+* Test Coverage — proper behavioural sentinel test (needs pytest-airflow
+  fixture)
+
+Deferred to a separate follow-up PR:
+* Holistic H2 — ``build_campaign_nodes`` behavioural happy-path test
+  (larger scope, needs fake-driver fixture design)
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+DAGS = REPO_ROOT / "dags"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n29")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n29")
+
+
+# ===========================================================================
+# Fix H1 — DAG timeout math / retries=0 on critical chain
+# ===========================================================================
+
+
+class TestPRN29H1CriticalChainRetriesZero:
+    """PR-N29 Holistic H1: the three baseline critical-chain tasks
+    (full_neo4j_sync, build_relationships, run_enrichment_jobs) MUST
+    have ``retries=0`` so a single retry on any 5-6h task doesn't blow
+    through the 32h dagrun_timeout mid-enrichment."""
+
+    DAG_FILE = DAGS / "edgeguard_pipeline.py"
+
+    def _find_task_block(self, task_id: str) -> str:
+        """Return the PythonOperator(...) block for ``task_id``, approximately
+        2500 chars of surrounding context."""
+        text = self.DAG_FILE.read_text()
+        anchor = f'task_id="{task_id}"'
+        idx = text.find(anchor)
+        assert idx != -1, f"{task_id!r} not found in DAG file"
+        # Scan back a few lines to find the PythonOperator( opening
+        start = text.rfind("PythonOperator(", 0, idx)
+        return text[start : idx + 2500]
+
+    def test_full_neo4j_sync_has_retries_zero(self):
+        block = self._find_task_block("full_neo4j_sync")
+        assert "retries=0" in block, (
+            "PR-N29 H1: full_neo4j_sync must override retries=0 so a retry "
+            "on this 6h task doesn't burn 12h of the 32h dagrun_timeout cap"
+        )
+
+    def test_build_relationships_has_retries_zero(self):
+        block = self._find_task_block("build_relationships")
+        assert "retries=0" in block, (
+            "PR-N29 H1: build_relationships must override retries=0 (5h task, same reasoning as full_neo4j_sync)"
+        )
+
+    def test_run_enrichment_jobs_has_retries_zero(self):
+        block = self._find_task_block("run_enrichment_jobs")
+        assert "retries=0" in block, "PR-N29 H1: run_enrichment_jobs must override retries=0 (5h task)"
+
+    def test_baseline_dag_comment_explains_n29_change(self):
+        """The baseline_dag declaration comment should explain WHY
+        retries=0 on the critical chain is the right trade-off."""
+        text = self.DAG_FILE.read_text()
+        # Find the baseline_dag DAG(...) declaration
+        anchor = "baseline_dag = DAG("
+        idx = text.find(anchor)
+        assert idx != -1
+        block = text[idx : idx + 2500]
+        assert "PR-N29" in block and "H1" in block, (
+            "PR-N29 H1: the baseline_dag comment block must reference PR-N29 "
+            "so future maintainers can trace the retries-budget rationale"
+        )
+
+
+# ===========================================================================
+# Fix H3 — MISP fetch fallback pagination
+# ===========================================================================
+
+
+class TestPRN29H3MispFetchFallbackPaginated:
+    """PR-N29 Holistic H3: the PyMISP and requests-restSearch fallback
+    branches in ``fetch_edgeguard_events`` MUST paginate. Pre-N29 both
+    used ``limit: 1000`` with NO pagination, silently truncating on
+    populated MISP instances."""
+
+    SRC_FILE = SRC / "run_misp_to_neo4j.py"
+
+    def test_pagination_constants_defined(self):
+        text = self.SRC_FILE.read_text()
+        # The paginator uses these internal constants
+        assert "_FALLBACK_PAGE_SIZE" in text, "PR-N29 H3: fallback must define _FALLBACK_PAGE_SIZE (per-page batch)"
+        assert "_FALLBACK_MAX_PAGES" in text, "PR-N29 H3: fallback must define _FALLBACK_MAX_PAGES (safety cap)"
+
+    def test_pymisp_branch_paginates(self):
+        text = self.SRC_FILE.read_text()
+        # The PyMISP branch must iterate pages via search(... page=N ...)
+        # Anchor on the MISP-FETCH-FALLBACK-ACTIVE log token + PyMISP logging
+        assert "[MISP-FETCH-FALLBACK-ACTIVE]" in text, (
+            "PR-N29 H3: fallback must emit [MISP-FETCH-FALLBACK-ACTIVE] log "
+            "token so operators can grep for fallback-path activity"
+        )
+        assert '"page": page' in text, "PR-N29 H3: fallback search_kwargs must include page=page for pagination"
+
+    def test_restSearch_branch_paginates(self):
+        text = self.SRC_FILE.read_text()
+        # The requests.post body must include "page" for pagination
+        assert "[MISP-FETCH-FALLBACK] restSearch page" in text, (
+            "PR-N29 H3: requests-restSearch branch must log per-page progress"
+        )
+
+    def test_no_singleshot_limit_1000_in_fallback(self):
+        """Negative pin: the pre-N29 single-shot ``limit: 1000`` shape
+        must not remain alongside the pagination loop — that would be a
+        partial fix."""
+        text = self.SRC_FILE.read_text()
+        # Count: pre-N29 had exactly 2 occurrences of ``"limit": 1000`` (PyMISP
+        # + requests-restSearch). After fix: 0 occurrences (both use _FALLBACK_PAGE_SIZE).
+        # Any remaining ``"limit": 1000`` means the fix is incomplete.
+        # Strip comment lines so the audit-history comment doesn't count.
+        code_only = "\n".join(line.split("#", 1)[0] for line in text.splitlines())
+        assert '"limit": 1000' not in code_only, (
+            "PR-N29 H3: no single-shot ``limit: 1000`` should remain in the "
+            "fallback paths; both branches must use the paginated _FALLBACK_PAGE_SIZE"
+        )
+
+
+# ===========================================================================
+# Fix M3 — baseline_lock max-age bumped to 48h
+# ===========================================================================
+
+
+class TestPRN29M3BaselineLockMaxAge:
+    """PR-N29 Holistic M3: ``_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT`` must be
+    at least 48h so cross-host deployments don't reap the sentinel
+    during a 32h-dagrun_timeout baseline."""
+
+    LOCK_FILE = SRC / "baseline_lock.py"
+
+    def test_max_age_at_least_48h(self):
+        text = self.LOCK_FILE.read_text()
+        # Positive pin on the new value
+        assert "_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 48 * 3600" in text, (
+            "PR-N29 M3: _BASELINE_LOCK_MAX_AGE_SEC_DEFAULT must be 48*3600 (48h) "
+            "to give a 16h buffer above the baseline dagrun_timeout of 32h. "
+            "Cross-host deployments would otherwise have the sentinel reaped "
+            "8h before the baseline finishes."
+        )
+
+    def test_max_age_comment_references_dagrun_timeout(self):
+        """The constant's comment must explain WHY 48h — cross-reference
+        the dagrun_timeout so a future maintainer can trace the invariant."""
+        text = self.LOCK_FILE.read_text()
+        # Anchor on PR-N29 M3 marker
+        idx = text.find("PR-N29")
+        assert idx != -1, "PR-N29 M3: comment block must be present"
+        block = text[idx : idx + 1500]
+        assert "dagrun_timeout" in block, (
+            "PR-N29 M3: the comment must reference dagrun_timeout so the lock vs timeout invariant is greppable"
+        )
+
+
+# ===========================================================================
+# Fix L1 — Unicode NFKC + zero-width/bidi strip in placeholder filter
+# ===========================================================================
+
+
+class TestPRN29L1PlaceholderUnicodeHardening:
+    """PR-N29 Red Team L1: ``is_placeholder_name`` must strip zero-width
+    and bidirectional-control characters AND upgrade NFC → NFKC so an
+    attacker can't bypass PR-N10 with ``"unknown\\u200b"`` or similar
+    trivial obfuscations."""
+
+    def test_bare_placeholder_still_rejected(self):
+        """Regression pin: the basic ``"unknown"`` case still rejects."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown")
+        assert is_placeholder_name("UNKNOWN")
+        assert is_placeholder_name("  unknown  ")
+        assert is_placeholder_name("n/a")
+        assert is_placeholder_name(None)
+
+    def test_zero_width_space_bypass_blocked(self):
+        """PR-N29 L1: ``"unknown\\u200b"`` (ZWSP appended) previously
+        passed the filter because NFC + strip + lowercase doesn't fold
+        zero-width chars. After fix, zero-width chars are stripped
+        BEFORE normalization."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u200b"), (
+            "PR-N29 L1: ZWSP (\\u200b) must not let an attacker bypass the filter"
+        )
+        assert is_placeholder_name("\u200bunknown"), "leading ZWSP"
+        assert is_placeholder_name("unk\u200bnown"), "inline ZWSP"
+
+    def test_zwnj_bypass_blocked(self):
+        """ZERO WIDTH NON-JOINER (U+200C) must be stripped."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u200c")
+
+    def test_zwj_bypass_blocked(self):
+        """ZERO WIDTH JOINER (U+200D) must be stripped."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u200d")
+
+    def test_bom_bypass_blocked(self):
+        """ZERO WIDTH NO-BREAK SPACE / BOM (U+FEFF) must be stripped."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\ufeff")
+        assert is_placeholder_name("\ufeffunknown")
+
+    def test_rlo_bypass_blocked(self):
+        """RIGHT-TO-LEFT OVERRIDE (U+202E) must be stripped."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("\u202eunknown")
+
+    def test_word_joiner_bypass_blocked(self):
+        """WORD JOINER (U+2060) must be stripped."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("un\u2060known")
+
+    def test_genuine_malware_name_not_rejected(self):
+        """Negative pin: a real malware name that happens to contain a
+        zero-width char (unlikely but possible) shouldn't be over-rejected.
+        The ONLY way a name becomes a placeholder is if after stripping
+        zero-width chars + NFKC + strip + lowercase, it's in
+        _REJECTED_PLACEHOLDER_NAMES."""
+        from node_identity import is_placeholder_name
+
+        assert not is_placeholder_name("Conti")
+        assert not is_placeholder_name("LockBit")
+        assert not is_placeholder_name("Cobalt Strike")
+        # Even with ZWSP — if the canonical form is not a placeholder, allow.
+        assert not is_placeholder_name("Conti\u200b")
+
+    def test_nfkc_fullwidth_fold(self):
+        """NFKC folds full-width Latin to half-width. Pre-N29 NFC didn't
+        fold this. After fix, full-width "ｕｎｋｎｏｗｎ" is rejected."""
+        from node_identity import is_placeholder_name
+
+        fullwidth_unknown = "\uff55\uff4e\uff4b\uff4e\uff4f\uff57\uff4e"  # ｕｎｋｎｏｗｎ
+        assert is_placeholder_name(fullwidth_unknown), (
+            "PR-N29 L1: NFKC must fold full-width Latin unknown → ASCII unknown"
+        )
+
+    def test_cyrillic_confusable_still_passes_filter_documented_residual(self):
+        """Cross-script confusables (Cyrillic 'о' U+043E ≠ Latin 'o' U+006F)
+        are NOT folded by NFKC — they're semantically different characters
+        in Unicode. Fixing requires a confusables library. This test
+        PINS the residual risk so a future maintainer doesn't think this
+        is covered."""
+        from node_identity import is_placeholder_name
+
+        # Cyrillic 'о' (U+043E) in place of Latin 'o' (U+006F)
+        cyrillic_unknown = "unkn\u043ewn"
+        # Post-N29 this STILL passes the filter — it's a genuine
+        # cross-script bypass not fixable without a confusables lib.
+        # Pin the RESIDUAL so any future work that actually fixes this
+        # updates this test too (documenting the fix).
+        assert not is_placeholder_name(cyrillic_unknown), (
+            "PR-N29 L1 residual risk: cross-script Cyrillic confusables still "
+            "bypass the filter. Fix requires a confusables library (not in scope "
+            "for PR-N29). This test pins the RESIDUAL so updating it signals "
+            "a real fix."
+        )

--- a/tests/test_pr_n29_pre_baseline_hardening.py
+++ b/tests/test_pr_n29_pre_baseline_hardening.py
@@ -165,6 +165,53 @@ class TestPRN29H3MispFetchFallbackPaginated:
             "PR-N29 H3: requests-restSearch branch must log per-page progress"
         )
 
+    def test_pymisp_dict_payload_handled_via_unwrap(self):
+        """PR-N29 Bugbot round 2 (MED): PyMISP can return a list,
+        ``{"response": [...]}``, or ``{"errors": ...}`` depending on
+        version + error path. ``list(dict)`` would yield the dict's KEYS
+        as bare strings — those would then go into ``events`` and
+        downstream normalize would drop them all to zero. Mirror the
+        requests-restSearch branch's explicit unwrap."""
+        text = self.SRC_FILE.read_text()
+        # Must check isinstance(page_result, dict) before list(page_result)
+        assert "isinstance(page_result, dict)" in text, (
+            "PR-N29 Bugbot round 2: PyMISP fallback must check dict shape "
+            "before list() to avoid silently containing dict keys as event rows"
+        )
+        # Must look up "response" key (PyMISP's wrapper convention)
+        assert 'page_result.get("response")' in text, (
+            "PR-N29 Bugbot round 2: PyMISP dict-shape unwrap must use "
+            'page_result.get("response") (mirrors requests-restSearch branch)'
+        )
+        # Must explicitly handle "errors" payload (raise, don't silently truncate)
+        assert '"errors" in page_result' in text, (
+            "PR-N29 Bugbot round 2: PyMISP dict-shape must surface errors payload "
+            "rather than silently producing zero events"
+        )
+
+    def test_non200_mid_pagination_raises_not_silent_break(self):
+        """PR-N29 Bugbot round 2 (MED): a non-200 response on any page
+        after the first MUST raise (or otherwise surface as a sync error)
+        rather than silently truncate with the partial events list. Pre-
+        fix the ``break`` on non-200 left a positive log line "collected
+        N row(s) across M pages" while having silently dropped 25%+ of
+        the baseline."""
+        text = self.SRC_FILE.read_text()
+        # Find the non-200 branch in the requests-restSearch fallback
+        idx = text.find("response.status_code != 200")
+        assert idx != -1, "non-200 check must exist in the fallback"
+        block = text[idx : idx + 2000]
+        # Must explicitly raise (not just break)
+        assert "raise RuntimeError" in block, (
+            "PR-N29 Bugbot round 2: non-200 mid-pagination must raise "
+            "(explicit error surface), NOT silently break with partial events"
+        )
+        # The error message must be operator-actionable
+        assert "good pages" in block, (
+            "PR-N29 Bugbot round 2: error message must report the good-pages "
+            "count so operators can quickly assess scope of partial fetch"
+        )
+
     def test_no_singleshot_limit_1000_in_fallback(self):
         """Negative pin: the pre-N29 single-shot ``limit: 1000`` shape
         must not remain alongside the pagination loop — that would be a
@@ -301,6 +348,42 @@ class TestPRN29L1PlaceholderUnicodeHardening:
         assert is_placeholder_name("unknown\u200f"), "RLM appended bypass"
         assert is_placeholder_name("\u200funknown"), "RLM prepended bypass"
         assert is_placeholder_name("un\u200fknown"), "RLM inline bypass"
+
+    def test_mongolian_vowel_separator_bypass_blocked(self):
+        """PR-N29 Bugbot round 2 (LOW): MONGOLIAN VOWEL SEPARATOR
+        (U+180E) is zero-width but NFKC does not fold it. Pre-fix it
+        bypassed the filter."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u180e"), "U+180E appended bypass"
+        assert is_placeholder_name("\u180eunknown"), "U+180E prepended bypass"
+
+    def test_line_separator_bypass_blocked(self):
+        """PR-N29 Bugbot round 2 (LOW): U+2028 LINE SEPARATOR is not
+        always stripped by ``str.strip()`` and not folded by NFKC."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u2028"), "U+2028 appended bypass"
+        assert is_placeholder_name("un\u2028known"), "U+2028 inline bypass"
+
+    def test_paragraph_separator_bypass_blocked(self):
+        """PR-N29 Bugbot round 2 (LOW): U+2029 PARAGRAPH SEPARATOR —
+        sibling of U+2028, same bypass class."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u2029"), "U+2029 appended bypass"
+        assert is_placeholder_name("\u2029unknown"), "U+2029 prepended bypass"
+
+    def test_nbsp_bypass_blocked_via_nfkc_then_strip(self):
+        """NBSP U+00A0 isn't in the translate table but NFKC folds it
+        to a regular space, then ``str.strip()`` removes it. Verify the
+        ordering (translate → NFKC → strip) actually catches NBSP."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u00a0"), (
+            "NBSP appended must be normalised + stripped (translate→NFKC→strip ordering)"
+        )
+        assert is_placeholder_name("\u00a0unknown"), "NBSP prepended"
 
     def test_genuine_malware_name_not_rejected(self):
         """Negative pin: a real malware name that happens to contain a

--- a/tests/test_pr_n29_pre_baseline_hardening.py
+++ b/tests/test_pr_n29_pre_baseline_hardening.py
@@ -281,6 +281,27 @@ class TestPRN29L1PlaceholderUnicodeHardening:
 
         assert is_placeholder_name("un\u2060known")
 
+    def test_lrm_bypass_blocked(self):
+        """PR-N29 Bugbot round 1 (MED): LEFT-TO-RIGHT MARK (U+200E) is
+        a zero-width directional mark in the same Unicode block as
+        U+200B–U+200D. Original PR-N29 missed it; Bugbot caught the gap.
+        ``"unknown\\u200e"`` must still be rejected."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u200e"), "LRM appended bypass"
+        assert is_placeholder_name("\u200eunknown"), "LRM prepended bypass"
+        assert is_placeholder_name("un\u200eknown"), "LRM inline bypass"
+
+    def test_rlm_bypass_blocked(self):
+        """PR-N29 Bugbot round 1 (MED): RIGHT-TO-LEFT MARK (U+200F) —
+        same finding as LRM, U+200E + U+200F travel as a pair in
+        bidirectional-formatting attacks."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u200f"), "RLM appended bypass"
+        assert is_placeholder_name("\u200funknown"), "RLM prepended bypass"
+        assert is_placeholder_name("un\u200fknown"), "RLM inline bypass"
+
     def test_genuine_malware_name_not_rejected(self):
         """Negative pin: a real malware name that happens to contain a
         zero-width char (unlikely but possible) shouldn't be over-rejected.


### PR DESCRIPTION
## Summary

The 7-agent audit on PR #109 surfaced **4 findings OUTSIDE the PR #109 diff** that affect the 730-day baseline. They're in files PR #109 doesn't touch, so they split cleanly into this focused follow-up PR.

## What's in this PR

| Fix | Severity | Impact |
|---|---|---|
| **H1 Holistic** | HIGH | Baseline DAG timeout math: single retry on any 5h critical-chain task would blow through the 32h dagrun_timeout mid-enrichment. Fixed with `retries=0` on sync/build_rels/enrich. |
| **H3 Holistic** | HIGH | MISP fetch fallback silently truncated at 1000 events (2026-04-19 incident). Fixed with pagination (500/page, 200-page cap) + `[MISP-FETCH-FALLBACK-ACTIVE]` log token. |
| **M3 Holistic** | MED | `_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT` was 24h but `dagrun_timeout` is 32h. Cross-host deployments would reap the sentinel 8h early. Bumped to 48h. |
| **L1 Red Team** | MED | `is_placeholder_name` bypass via zero-width chars (`"unknown\u200b"`) and full-width Latin. Fixed by stripping zero-width/bidi-control chars + upgrading NFC → NFKC. Cross-script Cyrillic confusables remain as documented residual. |

## What this PR does NOT address (deferred to PR-N30 / later)

- **PR-N30** (stacked on PR #109's merge, touches PR #109's new files):
  - Red Team H1 — `--dry-run` READ session mode (backfill script)
  - Cross-Checker H-2 — Q4 `[0..200]` cap vs backfill uncapped intersection
  - Cross-Checker M-1 — Path A vs Path B empty-string drift
  - Test Coverage REC-B1 — proper pytest-airflow behavioural sentinel test
- **Separate follow-up**: Holistic H2 — behavioural happy-path test for `build_campaign_nodes`

## Test plan

- [x] `ruff format --check src/ tests/ dags/ scripts/` — clean
- [x] `ruff check` — clean
- [x] `mypy src/` — clean
- [x] New tests in `tests/test_pr_n29_pre_baseline_hardening.py` — **20/20 pass** (4 + 4 + 2 + 10 across the 4 fixes)
- [x] **Full suite: 1681 passed**, 3 skipped, 3 xfailed
- [ ] Pre-baseline dry-run: `./scripts/preflight_baseline.sh --launch-path=cli` (manual, pre-launch)
- [ ] Verify on the next 730d baseline: no retries fire on the critical chain; fallback log token greppable if MISP index path errors; cross-host lock semantics unchanged

## Notable design decision — L1 Cyrillic confusable residual

NFKC folds full-width Latin to half-width (`"ｕｎｋｎｏｗｎ"` → `"unknown"`) but does NOT fold cross-script confusables (Cyrillic 'о' U+043E ≠ Latin 'o' U+006F). Fixing this requires a `confusable_homoglyphs`-style library, out of scope for this PR. The test `test_cyrillic_confusable_still_passes_filter_documented_residual` pins the residual so a future fix HAS to update the test — document-via-test pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches baseline execution semantics and MISP→Neo4j sync event fetching; mistakes could cause failed/partial baselines or missed data, though changes are mostly guardrails and additional tests.
> 
> **Overview**
> **Improves baseline reliability and fail-fast behavior.** The baseline DAG now forces `retries=0` on the long critical-chain tasks (`full_neo4j_sync`, `build_relationships`, `run_enrichment_jobs`) to avoid exceeding the 32h `dagrun_timeout` and leaving Neo4j partially mutated.
> 
> **Prevents silent data loss when MISP index fetch fails.** `fetch_edgeguard_events` fallback paths (PyMISP and `events/restSearch`) are converted from a single `limit=1000` request to paginated fetching (500/page with a safety cap), add an explicit fallback-activation log token, and introduce a `_MispFallbackHardError` sentinel so mid-pagination errors/cap-hits propagate instead of being swallowed into “no events found”.
> 
> **Tightens baseline mutex + identity checks.** Cross-host baseline lock staleness default is increased from 24h→48h, and `is_placeholder_name` now strips zero-width/bidi control chars and uses NFKC normalization to block trivial placeholder bypasses.
> 
> **Adds regression coverage + bumps release metadata.** New tests pin these contracts, and CalVer is bumped to `2026.4.24` (with matching docs update).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1b39b39f15dec6f5316a44755112b14bfd801b5f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->