### PR TITLE
fix(audit): PR-N31 — post-PR-N29 baseline-followup bundle (5 deferred items)

### DIFF
--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -67,7 +67,7 @@ promtool check rules prometheus/alerts.yml
 
 ---
 
-## Top 6 failure modes
+## Top 8 failure modes
 
 Each entry: symptom → detection signal → remediation.
 
@@ -246,6 +246,75 @@ Each entry: symptom → detection signal → remediation.
 - **No alert needed.** The DAG-level FAILED state is already alerted
   via `EdgeGuardDAGRunFailures`; `[BASELINE-POSTCHECK-SKIPPED]` is
   documentation, not a separate-page-worthy event.
+
+### 8. MISP fetch fallback (`_MispFallbackHardError`) — PR-N29 / PR-N31
+
+- **Symptom (alert path).** `EdgeGuardMispFetchFallbackHardError`
+  fires (severity=critical), OR `EdgeGuardMispFetchFallbackActive`
+  fires for >10 minutes (severity=warning), OR
+  `MISPToNeo4jSync.run()` traceback shows
+  `_MispFallbackHardError: MISP fallback ... on page N`.
+- **Symptom (log path).** Grep `[MISP-FETCH-FALLBACK-ACTIVE]` —
+  emitted when the primary `/events/index` path errors and the
+  PyMISP / requests-restSearch fallback engages. Grep
+  `[MISP-FETCH-FALLBACK]` for per-page activity / per-failure
+  detail (the sentinel raise's log line is here).
+- **What it means.** EdgeGuard's primary MISP `/events/index` path
+  failed (auth, 5xx, schema drift, broken sync user). The fallback
+  paginated through PyMISP / `restSearch` BUT hit one of four
+  hard-failure modes:
+  1. **errors-payload mid-pagination** — MISP returned HTTP 200 with
+     `{"errors": ...}` (typical: ACL filter matched zero, broken
+     sync user, malformed query).
+  2. **unexpected payload type** — MISP returned a non-list, non-
+     dict-with-response payload (typical: server-side schema bug or
+     proxy injecting an HTML error page).
+  3. **non-200 mid-pagination** — `response.status_code != 200` on
+     a page after the first (typical: MISP-PHP-FPM exhaustion partway
+     through a 50-page walk).
+  4. **safety-cap hit** — fallback paginated through
+     `_FALLBACK_MAX_PAGES = 200` (~100K events) without hitting a
+     short-read terminator. MISP legitimately has more events than
+     the cap allows.
+- **What it does NOT mean.** It does NOT mean the data was silently
+  truncated — that's exactly the failure mode the sentinel exists
+  to prevent. The Airflow task is FAILED (PR-N29 H1: critical-chain
+  tasks have `retries=0`), no partial baseline was committed.
+- **Triage.**
+  1. Identify which branch raised — the alert label `branch` is
+     `pymisp` or `rest_search`. Pipeline log line will reference the
+     same. PyMISP-only failures often indicate library/version
+     incompatibility; `rest_search` failures are pure HTTP/payload.
+  2. Pull the surrounding `[MISP-FETCH-FALLBACK]` log lines for
+     the page number + good-pages count + raw error payload.
+  3. **For mode (1) errors-payload:** check MISP user permissions,
+     ACL config, `EDGEGUARD_MISP_EVENT_SEARCH` env var (defaults to
+     "EdgeGuard" — empty string would match nothing).
+  4. **For mode (2) unexpected payload:** check upstream proxy
+     (Cloudflare / nginx) is not interposing an HTML error page on
+     5xx. Test directly: `curl -s -H "Authorization: $MISP_API_KEY"
+     "$MISP_URL/events/restSearch" -d '{"limit":1}' -H "Content-Type:
+     application/json" | head`.
+  5. **For mode (3) non-200 mid-pagination:** investigate MISP
+     backend health (PHP-FPM workers, MariaDB connection pool,
+     OOM). The 2026-04-19 incident was MISP-PHP-FPM exhaustion;
+     scale workers + reduce `EDGEGUARD_MISP_PAGE_SIZE` (default 500
+     → try 250).
+  6. **For mode (4) safety-cap hit:** if MISP legitimately has >100K
+     EdgeGuard events, raise `_FALLBACK_MAX_PAGES` in
+     `src/run_misp_to_neo4j.py` and redeploy. Otherwise (probably a
+     loop bug or a misconfigured `EDGEGUARD_MISP_EVENT_SEARCH`),
+     fix the root cause.
+- **Re-run.** After remediation, re-trigger the failed DAG run.
+  PR-N29 H1 set `retries=0` on the critical chain — there is no
+  auto-retry. The dagrun MUST be manually re-triggered to run.
+- **Why the sentinel exists.** Pre-PR-N29 the fallback silently
+  truncated at `limit=1000` with no pagination; the
+  `EdgeGuardSyncCoverageGap` alert compared a truncated processed-
+  count to a truncated index-total and saw "no gap." PR-N29 added
+  pagination + the sentinel; PR-N31 added the operator-visible
+  Prometheus counter. See PR #110 (PR-N29) and PR-N31 (this PR) for
+  the audit history.
 
 ---
 

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -319,6 +319,61 @@ groups:
             means events were SILENTLY SKIPPED — the exact failure pattern
             of the 2026-04-14 NVD regression. Investigate immediately.
 
+      # PR-N31 (post-PR-N29 follow-up, 2026-04-25): MISP fetch fallback
+      # alerts. The PyMISP / requests-restSearch fallback in
+      # ``fetch_edgeguard_events`` is engaged only when the primary
+      # ``/events/index`` path errors. PR-N29 made the fallback paginate
+      # + raise ``_MispFallbackHardError`` on hard failures (errors-payload,
+      # unexpected-shape, non-200 mid-pagination, cap-hit). PR-N31 adds the
+      # Prometheus counter + this alert pair so the operator gets paged
+      # rather than learning about it from a missed baseline window.
+      - alert: EdgeGuardMispFetchFallbackActive
+        # Fires when ANY fallback engagement happens at all. Severity warning
+        # because the fallback itself is functional — but sustained activity
+        # signals the primary index path is broken (auth, 5xx, schema drift).
+        # 10m window is the smallest that doesn't fire on a one-off retry.
+        expr: |
+          sum(rate(edgeguard_misp_fetch_fallback_active_total{outcome="engaged"}[10m])) > 0
+        for: 10m
+        labels:
+          severity: warning
+          component: sync
+        annotations:
+          summary: "MISP fetch fallback active for >10m — primary /events/index path is broken"
+          description: |
+            EdgeGuard's MISP fetcher has fallen back to the slower
+            PyMISP / requests-restSearch path for >10 minutes. The
+            primary ``/events/index`` path is returning errors. This is
+            functional but slower; sustained activity is operator-visible
+            evidence of upstream MISP problems. Grep
+            ``[MISP-FETCH-FALLBACK-ACTIVE]`` in pipeline logs to correlate
+            with the underlying failure mode (HTTP status, auth, payload
+            shape). See docs/RUNBOOK.md § "MISP fetch fallback".
+
+      - alert: EdgeGuardMispFetchFallbackHardError
+        # Fires the moment a sentinel raise lands. CRITICAL because
+        # _MispFallbackHardError is the "I refuse to silently truncate"
+        # signal — it means a baseline run just failed in a way that
+        # would otherwise have been invisible (silent data loss). 1m
+        # window because we want this paged immediately, not 10m later.
+        expr: |
+          sum(rate(edgeguard_misp_fetch_fallback_active_total{outcome="hard_error"}[5m])) > 0
+        for: 1m
+        labels:
+          severity: critical
+          component: sync
+        annotations:
+          summary: "MISP fetch fallback raised _MispFallbackHardError ({{ $labels.branch }})"
+          description: |
+            EdgeGuard's MISP fetch fallback raised a hard error in the
+            ``{{ $labels.branch }}`` branch. The sentinel exception means
+            the fallback REFUSED to silently truncate — the baseline /
+            sync run failed visibly rather than producing partial data
+            that would have looked like a successful "no events" sync.
+            See docs/RUNBOOK.md § "_MispFallbackHardError" for the
+            diagnosis tree. The dagrun has already failed (PR-N29 H1 set
+            retries=0 on the critical chain).
+
       - alert: EdgeGuardNeo4jLabelDropBig
         # Per-label 1-day drop > 50% of yesterday's value. Uses offset so
         # the comparison is against the same time yesterday — robust to

--- a/prometheus/alerts.yml
+++ b/prometheus/alerts.yml
@@ -332,23 +332,32 @@ groups:
         # because the fallback itself is functional — but sustained activity
         # signals the primary index path is broken (auth, 5xx, schema drift).
         # 10m window is the smallest that doesn't fire on a one-off retry.
+        #
+        # PR-N31 Bugbot round 1 (2026-04-25, MED): use ``sum by (branch)``
+        # rather than bare ``sum`` so the ``branch`` label survives
+        # aggregation. Symmetric with the HardError alert below (which
+        # NEEDS the label for its annotation template) — matching shape
+        # makes operator queries / Grafana panels uniform and future-
+        # proofs the annotation if we ever want to reference ``branch``
+        # in this alert too.
         expr: |
-          sum(rate(edgeguard_misp_fetch_fallback_active_total{outcome="engaged"}[10m])) > 0
+          sum by (branch) (rate(edgeguard_misp_fetch_fallback_active_total{outcome="engaged"}[10m])) > 0
         for: 10m
         labels:
           severity: warning
           component: sync
         annotations:
-          summary: "MISP fetch fallback active for >10m — primary /events/index path is broken"
+          summary: "MISP fetch fallback active for >10m on {{ $labels.branch }} branch — primary /events/index path is broken"
           description: |
             EdgeGuard's MISP fetcher has fallen back to the slower
-            PyMISP / requests-restSearch path for >10 minutes. The
-            primary ``/events/index`` path is returning errors. This is
-            functional but slower; sustained activity is operator-visible
-            evidence of upstream MISP problems. Grep
-            ``[MISP-FETCH-FALLBACK-ACTIVE]`` in pipeline logs to correlate
-            with the underlying failure mode (HTTP status, auth, payload
-            shape). See docs/RUNBOOK.md § "MISP fetch fallback".
+            PyMISP / requests-restSearch path ({{ $labels.branch }}
+            branch) for >10 minutes. The primary ``/events/index`` path
+            is returning errors. This is functional but slower; sustained
+            activity is operator-visible evidence of upstream MISP
+            problems. Grep ``[MISP-FETCH-FALLBACK-ACTIVE]`` in pipeline
+            logs to correlate with the underlying failure mode (HTTP
+            status, auth, payload shape). See docs/RUNBOOK.md §
+            "MISP fetch fallback".
 
       - alert: EdgeGuardMispFetchFallbackHardError
         # Fires the moment a sentinel raise lands. CRITICAL because
@@ -356,8 +365,16 @@ groups:
         # signal — it means a baseline run just failed in a way that
         # would otherwise have been invisible (silent data loss). 1m
         # window because we want this paged immediately, not 10m later.
+        #
+        # PR-N31 Bugbot round 1 (2026-04-25, MED): the ``$labels.branch``
+        # template references in the annotations REQUIRE the ``branch``
+        # label to survive aggregation. Pre-fix the bare ``sum(rate(...))``
+        # collapsed all labels — the annotation would have rendered as
+        # ``raised _MispFallbackHardError ()`` (empty parens) and the
+        # RUNBOOK § 8 triage step ("identify which branch raised") would
+        # have nothing to read. Use ``sum by (branch)``.
         expr: |
-          sum(rate(edgeguard_misp_fetch_fallback_active_total{outcome="hard_error"}[5m])) > 0
+          sum by (branch) (rate(edgeguard_misp_fetch_fallback_active_total{outcome="hard_error"}[5m])) > 0
         for: 1m
         labels:
           severity: critical

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "edgeguard"
 # CalVer: release date YYYY.M.D (PEP 440). Bump when you tag/publish a release — not on every commit.
-version = "2026.4.24"
+version = "2026.4.25"
 description = "Threat Intelligence Pipeline - Sources to MISP to Neo4j"
 authors = [
     {name = "EdgeGuard Team"}

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -251,16 +251,19 @@ else
   warn "promtool not installed; skipping alerts parse check (install Prometheus tools)"
 fi
 
-# Quick structural pin — expect the edgeguard_pipeline_observability rule group with at least 9 alerts.
+# Quick structural pin — expect the edgeguard_pipeline_observability rule group with at least 11 alerts.
 # PR-N24 audit MED follow-up: bumped from ≥ 6 → ≥ 8 (PR-N21 Bravo-ops adds
 # EdgeGuardBuildRelationshipsSilentDeath + EdgeGuardApocBatchPartial), then
 # bumped again to ≥ 9 for PR-N24 H3 (EdgeGuardMispEventAttributesTruncated).
+# PR-N31 (2026-04-25): bumped to ≥ 11 — added EdgeGuardMispFetchFallbackActive +
+# EdgeGuardMispFetchFallbackHardError (operator visibility for the PR-N29
+# fallback hardening; see prometheus/alerts.yml).
 # This is a defense-in-depth structural pin — promtool above does the real validation.
 ALERT_COUNT=$(grep -cE '^\s+- alert:' prometheus/alerts.yml 2>/dev/null || echo "0")
-if [[ "$ALERT_COUNT" -ge 9 ]]; then
-  pass "prometheus/alerts.yml has $ALERT_COUNT alert rules (≥ 9 required)"
+if [[ "$ALERT_COUNT" -ge 11 ]]; then
+  pass "prometheus/alerts.yml has $ALERT_COUNT alert rules (≥ 11 required)"
 else
-  fail "prometheus/alerts.yml has only $ALERT_COUNT alerts — expected ≥ 9 (PR-N11/N12/N18/N21/N24)"
+  fail "prometheus/alerts.yml has only $ALERT_COUNT alerts — expected ≥ 11 (PR-N11/N12/N18/N21/N24/N31)"
 fi
 
 # -----------------------------------------------------------------------------
@@ -352,6 +355,68 @@ if [[ -x ".venv/bin/pytest" ]]; then
   fi
 else
   warn ".venv/bin/pytest not found; skipping collection check"
+fi
+
+# -----------------------------------------------------------------------------
+# [11] PR-N29 invariants — DAG retries=0, sentinel class, lock max-age
+# -----------------------------------------------------------------------------
+# Defense-in-depth source-pin: PR-N29 hardened the baseline against three
+# silent-failure modes (retries-budget overrun, MISP-fetch-fallback silent
+# truncation, cross-host lock TTL). PR-N31 (2026-04-25) adds this preflight
+# check so an inadvertent revert (rebase mishap, misguided "cleanup",
+# manual edit) is caught BEFORE the baseline launches — not by an
+# operator at hour 26 of a 32h dagrun.
+#
+# Fast-fail (grep, no Python). The full-fat invariant tests live in
+# tests/test_pr_n29_pre_baseline_hardening.py and are part of the [10]
+# pytest collection above.
+hdr "[11] PR-N29 invariants (retries=0, sentinel, lock max-age)"
+
+# (a) _MispFallbackHardError sentinel class is still defined
+if grep -q "^class _MispFallbackHardError(Exception):" src/run_misp_to_neo4j.py 2>/dev/null; then
+  pass "_MispFallbackHardError sentinel class present in src/run_misp_to_neo4j.py"
+else
+  fail "_MispFallbackHardError sentinel class missing — PR-N29 fallback hard-error surfacing reverted? (src/run_misp_to_neo4j.py)"
+fi
+
+# (b) baseline_lock max-age is at least 48h (cross-host buffer above 32h dagrun_timeout)
+if grep -q "_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 48 \* 3600" src/baseline_lock.py 2>/dev/null; then
+  pass "baseline_lock max-age = 48h (PR-N29 M3)"
+else
+  fail "baseline_lock max-age != 48h — cross-host deployments may reap the sentinel mid-baseline (src/baseline_lock.py)"
+fi
+
+# (c) all three critical-chain tasks have retries=0 in the baseline DAG
+RETRIES_ZERO_COUNT=0
+for task in full_neo4j_sync build_relationships run_enrichment_jobs; do
+  # Find the PythonOperator block whose task_id matches; allow ~3000 chars of
+  # surrounding context (kwargs are spread out on multi-line definitions).
+  if .venv/bin/python -c "
+import re, sys
+text = open('dags/edgeguard_pipeline.py').read()
+anchor = 'task_id=\"$task\"'
+idx = text.find(anchor)
+if idx == -1:
+    sys.exit(2)  # task_id missing → DAG structurally broken
+start = text.rfind('PythonOperator(', 0, idx)
+block = text[start:idx + 3000]
+sys.exit(0 if 'retries=0' in block else 1)
+" 2>/dev/null; then
+    RETRIES_ZERO_COUNT=$((RETRIES_ZERO_COUNT+1))
+  else
+    fail "$task is missing retries=0 — a single retry on this 5-6h task would blow through the 32h dagrun_timeout (PR-N29 H1)"
+  fi
+done
+if [[ $RETRIES_ZERO_COUNT -eq 3 ]]; then
+  pass "all 3 critical-chain tasks have retries=0 (PR-N29 H1)"
+fi
+
+# (d) sentinel class is wired into the metric counter (PR-N31 follow-up)
+if grep -q 'record_misp_fetch_fallback("pymisp", "hard_error")' src/run_misp_to_neo4j.py 2>/dev/null \
+   && grep -q 'record_misp_fetch_fallback("rest_search", "hard_error")' src/run_misp_to_neo4j.py 2>/dev/null; then
+  pass "_MispFallbackHardError raises increment edgeguard_misp_fetch_fallback_active_total{outcome=hard_error} (PR-N31)"
+else
+  warn "PR-N31 fallback metric not wired in both branches — operator alerts may be silent on hard-error path"
 fi
 
 # -----------------------------------------------------------------------------

--- a/src/metrics_server.py
+++ b/src/metrics_server.py
@@ -277,6 +277,65 @@ SYNC_EVENTS_INDEX_TOTAL = Gauge(
     "Total events returned by MISP events index for the most recent sync run",
 )
 
+# PR-N31 (post-PR-N29 follow-up, 2026-04-25): MISP fetch fallback activity.
+# The PyMISP / requests-restSearch fallback is engaged ONLY when the
+# primary ``/events/index`` path errors out (auth, 5xx, malformed
+# payload). Pre-PR-N29 the fallback silently truncated at 1000 events;
+# PR-N29 added pagination + the ``_MispFallbackHardError`` sentinel that
+# raises on errors-payload, unexpected-shape, non-200 mid-pagination,
+# and cap-hit. We now want operator-visible signal for BOTH events:
+#
+#   * fallback ENGAGED at all (signals primary index path is degraded)
+#   * fallback raised the sentinel (signals real upstream MISP problem)
+#
+# Without these counters, the only signal was the
+# ``[MISP-FETCH-FALLBACK-ACTIVE]`` log token — invisible to Prometheus,
+# easy to miss in noisy logs. Pairing with the
+# ``EdgeGuardMispFetchFallbackActive`` alert in prometheus/alerts.yml
+# means any sustained fallback usage pages the operator within 10 min.
+#
+# Why Counter not Gauge: fallback-engaged is a discrete event, not a
+# state. ``rate()`` over the counter answers "how often are we falling
+# back" — which is the question that drives the alert and a future
+# Grafana panel. A Gauge would only reflect the most-recent run.
+#
+# Labels:
+#   branch — ``pymisp`` or ``rest_search``. Both branches paginate
+#            independently and can fail independently; per-branch counts
+#            help diagnose whether the issue is PyMISP-version-specific
+#            or HTTP-layer.
+#   outcome — ``engaged`` (fallback ran at all), ``hard_error`` (the
+#             sentinel was raised — i.e. genuine truncation refusal).
+#             Allows the alert to distinguish "fallback works fine, just
+#             active" from "fallback also failing."
+MISP_FETCH_FALLBACK_ACTIVE = Counter(
+    "edgeguard_misp_fetch_fallback_active_total",
+    "MISP fetch fallback engaged (primary /events/index path failed). "
+    "Labels: branch={pymisp,rest_search}, outcome={engaged,hard_error}. "
+    "engaged = fallback path ran; hard_error = _MispFallbackHardError raised "
+    "(errors payload, unexpected shape, non-200 mid-pagination, or cap-hit). "
+    "See PR-N29 + PR-N31 + docs/RUNBOOK.md § 'MISP fetch fallback'.",
+    ["branch", "outcome"],
+)
+
+
+def record_misp_fetch_fallback(branch: str, outcome: str) -> None:
+    """Record one MISP fetch fallback event.
+
+    Defensive wrapper so call-sites in run_misp_to_neo4j don't have to
+    care whether prometheus_client is installed (the
+    ``_METRICS_AVAILABLE`` flag in run_misp_to_neo4j gates this; this
+    function's existence here lets the caller import-once at module
+    load and call without conditionals later).
+
+    branch: 'pymisp' or 'rest_search'
+    outcome: 'engaged' or 'hard_error'
+    """
+    if not PROMETHEUS_AVAILABLE:  # pragma: no cover — Prometheus is required in CI
+        return
+    MISP_FETCH_FALLBACK_ACTIVE.labels(branch=branch, outcome=outcome).inc()
+
+
 # PR-I (2026-04-20 multi-agent audit Red Team #4): MISP tag-impersonation
 # defense can be configured OFF (both allowlists empty). Prior to PR-I,
 # that state was signalled only by a startup log line that fired ONLY in

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -554,6 +554,26 @@ _ZERO_WIDTH_AND_BIDI_CHARS = (
     "\u2067"  # RIGHT-TO-LEFT ISOLATE
     "\u2068"  # FIRST STRONG ISOLATE
     "\u2069"  # POP DIRECTIONAL ISOLATE
+    # PR-N31 (post-PR-N29 follow-up, 2026-04-25): defense-in-depth additions
+    # for invisible / variation-modifying characters that NFKC does NOT
+    # fold and ``str.strip()`` does NOT remove. Each is a documented
+    # confusable-class bypass vector that doesn't yet have a real exploit
+    # but follows the same shape as the U+200E/U+200F gap Bugbot caught
+    # in PR-N29 round 1 — closing them now is cheaper than waiting for
+    # an in-the-wild bypass.
+    "\u034f"  # COMBINING GRAPHEME JOINER (CGJ): zero-width grapheme glue.
+    # Variation Selectors VS1–VS16 (U+FE00..U+FE0F): not folded by NFKC
+    # (they're meaningful for emoji + CJK variants, but harmless on Latin
+    # — and an attacker can stack them onto "unknown" to bypass equality).
+    "\ufe00\ufe01\ufe02\ufe03\ufe04\ufe05\ufe06\ufe07"
+    "\ufe08\ufe09\ufe0a\ufe0b\ufe0c\ufe0d\ufe0e\ufe0f"
+    # NOTE: Variation Selectors Supplement (U+E0100..U+E01EF, 240 chars)
+    # is NOT included here — they're outside the BMP and rare in practice;
+    # adding them would balloon the translate table 16× for marginal gain.
+    # If a real bypass shows up, switch to the Cf-category strip approach
+    # Bugbot autofix #2 suggested in round 2 (universal Unicode format-
+    # control filter via ``unicodedata.category(c) == "Cf"``).
+    "\u061c"  # ARABIC LETTER MARK (bidi-influencer; siblings of LRM/RLM)
 )
 _ZERO_WIDTH_AND_BIDI_TRANSLATE = {ord(c): None for c in _ZERO_WIDTH_AND_BIDI_CHARS}
 

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -57,11 +57,22 @@ from source_truthful_timestamps import coerce_iso as _coerce_to_iso
 from source_truthful_timestamps import extract_source_truthful_timestamps
 
 try:
-    from metrics_server import record_pipeline_duration, record_sync_event_accounting
+    from metrics_server import (
+        record_misp_fetch_fallback,
+        record_pipeline_duration,
+        record_sync_event_accounting,
+    )
 
     _METRICS_AVAILABLE = True
 except ImportError:
     _METRICS_AVAILABLE = False
+
+    # PR-N31: defensive no-op so call-sites can call unconditionally.
+    # Mirrors the pattern used elsewhere when prometheus_client isn't
+    # installed (e.g. local pure-unit-test runs without the metrics dep).
+    def record_misp_fetch_fallback(branch: str, outcome: str) -> None:  # type: ignore[no-redef]
+        return None
+
 
 # Suppress InsecureRequestWarning only when SSL verification is explicitly
 # disabled in config — never globally for the whole process.
@@ -1058,6 +1069,13 @@ class MISPToNeo4jSync:
             _FALLBACK_PAGE_SIZE = 500  # matches the primary index path cadence
             _FALLBACK_MAX_PAGES = 200  # 100K-event safety cap; raise if needed
 
+            # PR-N31: record fallback-engaged metric. Paired with
+            # EdgeGuardMispFetchFallbackActive alert in prometheus/alerts.yml.
+            # Counter (not Gauge) so rate() over time answers the operator's
+            # question "how often are we falling back?" — not just the most
+            # recent run's status.
+            record_misp_fetch_fallback("pymisp", "engaged")
+
             # Fallback: PyMISP restSearch (can be expensive on very large instances).
             try:
                 from pymisp import PyMISP
@@ -1163,119 +1181,143 @@ class MISPToNeo4jSync:
                 # Re-raising hands control to the outer try/except, which has
                 # its own sentinel re-raise that lets the failure surface to
                 # the calling DAG (retries=0 on critical chain — see PR-N29 H1).
+                # PR-N31: record before re-raising so the operator alert fires
+                # on the actual hard-failure event.
+                record_misp_fetch_fallback("pymisp", "hard_error")
                 raise
             except Exception as e:
                 logger.error(f"PyMISP error: {e}, falling back to requests restSearch")
+                # PR-N31: PyMISP failed with a non-sentinel exception — counts
+                # as fallback-engaged on the requests path now. Pre-fix this
+                # path silently fell through; the metric makes the cascade
+                # operator-visible.
+                record_misp_fetch_fallback("rest_search", "engaged")
                 # PR-N29 H3: same pagination for the requests-restSearch path.
-                events = []
-                for page in range(1, _FALLBACK_MAX_PAGES + 1):
-                    rest_body: dict = {
-                        "returnFormat": "json",
-                        "limit": _FALLBACK_PAGE_SIZE,
-                        "page": page,
-                        "search": MISP_EDGEGUARD_DISCOVERY_SEARCH,
-                    }
-                    if since:
-                        rest_body["timestamp"] = int(since.timestamp())
+                # PR-N31: nested try/except around the loop so a sentinel
+                # raised from any of the 4 hard-failure sites below
+                # (non-200, errors-payload, unexpected-shape, cap-hit) is
+                # attributed to "rest_search/hard_error" before propagating
+                # to the outer ``except _MispFallbackHardError`` re-raise.
+                # Symmetric with the PyMISP branch's recording above.
+                try:
+                    events = []
+                    for page in range(1, _FALLBACK_MAX_PAGES + 1):
+                        rest_body = {
+                            "returnFormat": "json",
+                            "limit": _FALLBACK_PAGE_SIZE,
+                            "page": page,
+                            "search": MISP_EDGEGUARD_DISCOVERY_SEARCH,
+                        }
+                        if since:
+                            rest_body["timestamp"] = int(since.timestamp())
 
-                    response = self.session.post(
-                        f"{self.misp_url.rstrip('/')}/events/restSearch",
-                        json=rest_body,
-                        verify=SSL_VERIFY,
-                        timeout=(MISP_CONNECT_TIMEOUT, MISP_REQUEST_TIMEOUT),
-                    )
+                        response = self.session.post(
+                            f"{self.misp_url.rstrip('/')}/events/restSearch",
+                            json=rest_body,
+                            verify=SSL_VERIFY,
+                            timeout=(MISP_CONNECT_TIMEOUT, MISP_REQUEST_TIMEOUT),
+                        )
 
-                    if response.status_code != 200:
-                        # PR-N29 Bugbot round 2 (2026-04-24, MED): pre-fix
-                        # this was a silent ``break`` that kept the partial
-                        # events list and downstream logged "collected N
-                        # rows across M pages" as if successful. A non-200
-                        # mid-pagination is a REAL error (3 good pages + a
-                        # 500 on page 4 silently dropped 25% of the
-                        # baseline). The ``EdgeGuardSyncCoverageGap`` alert
-                        # doesn't catch this either because the index path
-                        # isn't in play in fallback. Raise so the operator
-                        # SEES the failure, can investigate WHY MISP 5xx'd
-                        # mid-pagination, and the partial data isn't taken
-                        # as ground truth.
-                        logger.error(
-                            "[MISP-FETCH-FALLBACK] restSearch HTTP %d on page %d "
-                            "after %d good pages (%d events collected). NOT silently "
-                            "truncating — re-raising so this surfaces as a sync error.",
-                            response.status_code,
-                            page,
-                            page - 1,
-                            len(events),
-                        )
-                        raise _MispFallbackHardError(
-                            f"MISP fallback restSearch HTTP {response.status_code} on "
-                            f"page {page} after {page - 1} good pages "
-                            f"({len(events)} events collected). Investigate MISP backend; "
-                            f"do NOT treat partial fallback as complete."
-                        )
-                    page_data = response.json()
-                    # PR-N29 (multi-agent audit, 2026-04-24, HIGH-3 / Cross-Checker):
-                    # MISP can return HTTP 200 with an ``{"errors": ...}`` body
-                    # (e.g. ACL filter matched zero, broken sync user, malformed
-                    # query). Pre-fix this silently became ``[]`` via
-                    # ``.get("response") or []`` and the loop happily logged
-                    # "0 row(s)" → ``break`` → "successful pagination" with
-                    # zero events. Mirror the PyMISP branch above: errors is a
-                    # hard failure, unexpected payload type is a hard failure,
-                    # only list / wrapped-list payloads are accepted.
-                    if isinstance(page_data, dict):
-                        if "errors" in page_data:
+                        if response.status_code != 200:
+                            # PR-N29 Bugbot round 2 (2026-04-24, MED): pre-fix
+                            # this was a silent ``break`` that kept the partial
+                            # events list and downstream logged "collected N
+                            # rows across M pages" as if successful. A non-200
+                            # mid-pagination is a REAL error (3 good pages + a
+                            # 500 on page 4 silently dropped 25% of the
+                            # baseline). The ``EdgeGuardSyncCoverageGap`` alert
+                            # doesn't catch this either because the index path
+                            # isn't in play in fallback. Raise so the operator
+                            # SEES the failure, can investigate WHY MISP 5xx'd
+                            # mid-pagination, and the partial data isn't taken
+                            # as ground truth.
                             logger.error(
-                                "[MISP-FETCH-FALLBACK] restSearch page %d returned "
-                                "errors payload: %s — aborting fallback (%d good "
-                                "pages already collected).",
+                                "[MISP-FETCH-FALLBACK] restSearch HTTP %d on page %d "
+                                "after %d good pages (%d events collected). NOT silently "
+                                "truncating — re-raising so this surfaces as a sync error.",
+                                response.status_code,
                                 page,
-                                page_data.get("errors"),
                                 page - 1,
+                                len(events),
                             )
                             raise _MispFallbackHardError(
-                                f"MISP fallback restSearch errors on page {page}: {page_data.get('errors')}"
+                                f"MISP fallback restSearch HTTP {response.status_code} on "
+                                f"page {page} after {page - 1} good pages "
+                                f"({len(events)} events collected). Investigate MISP backend; "
+                                f"do NOT treat partial fallback as complete."
                             )
-                        page_rows = page_data.get("response") or []
-                    elif isinstance(page_data, list):
-                        page_rows = page_data
-                    else:
-                        logger.error(
-                            "[MISP-FETCH-FALLBACK] restSearch page %d returned "
-                            "unexpected payload type %s — aborting fallback.",
+                        page_data = response.json()
+                        # PR-N29 (multi-agent audit, 2026-04-24, HIGH-3 / Cross-Checker):
+                        # MISP can return HTTP 200 with an ``{"errors": ...}`` body
+                        # (e.g. ACL filter matched zero, broken sync user, malformed
+                        # query). Pre-fix this silently became ``[]`` via
+                        # ``.get("response") or []`` and the loop happily logged
+                        # "0 row(s)" → ``break`` → "successful pagination" with
+                        # zero events. Mirror the PyMISP branch above: errors is a
+                        # hard failure, unexpected payload type is a hard failure,
+                        # only list / wrapped-list payloads are accepted.
+                        if isinstance(page_data, dict):
+                            if "errors" in page_data:
+                                logger.error(
+                                    "[MISP-FETCH-FALLBACK] restSearch page %d returned "
+                                    "errors payload: %s — aborting fallback (%d good "
+                                    "pages already collected).",
+                                    page,
+                                    page_data.get("errors"),
+                                    page - 1,
+                                )
+                                raise _MispFallbackHardError(
+                                    f"MISP fallback restSearch errors on page {page}: {page_data.get('errors')}"
+                                )
+                            page_rows = page_data.get("response") or []
+                        elif isinstance(page_data, list):
+                            page_rows = page_data
+                        else:
+                            logger.error(
+                                "[MISP-FETCH-FALLBACK] restSearch page %d returned "
+                                "unexpected payload type %s — aborting fallback.",
+                                page,
+                                type(page_data).__name__,
+                            )
+                            raise _MispFallbackHardError(
+                                f"MISP fallback restSearch unexpected payload type on page {page}: {type(page_data).__name__}"
+                            )
+                        if not page_rows:
+                            break
+                        events.extend(page_rows)
+                        logger.info(
+                            "[MISP-FETCH-FALLBACK] restSearch page %d returned %d row(s)",
                             page,
-                            type(page_data).__name__,
+                            len(page_rows),
+                        )
+                        if len(page_rows) < _FALLBACK_PAGE_SIZE:
+                            break
+                    else:
+                        # PR-N29 (multi-agent audit, 2026-04-24, HIGH-2): symmetric
+                        # with the PyMISP cap-hit raise above. Hitting the safety
+                        # cap means truncated coverage; refuse to treat it as
+                        # complete.
+                        logger.error(
+                            "[MISP-FETCH-FALLBACK] restSearch hit _FALLBACK_MAX_PAGES=%d cap "
+                            "(~%d events). If MISP legitimately has more events, "
+                            "raise the cap in src/run_misp_to_neo4j.py.",
+                            _FALLBACK_MAX_PAGES,
+                            _FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE,
                         )
                         raise _MispFallbackHardError(
-                            f"MISP fallback restSearch unexpected payload type on page {page}: {type(page_data).__name__}"
+                            f"MISP fallback restSearch hit _FALLBACK_MAX_PAGES={_FALLBACK_MAX_PAGES} cap "
+                            f"(~{_FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE} events collected). "
+                            f"Refusing to treat truncated fallback as complete."
                         )
-                    if not page_rows:
-                        break
-                    events.extend(page_rows)
-                    logger.info(
-                        "[MISP-FETCH-FALLBACK] restSearch page %d returned %d row(s)",
-                        page,
-                        len(page_rows),
-                    )
-                    if len(page_rows) < _FALLBACK_PAGE_SIZE:
-                        break
-                else:
-                    # PR-N29 (multi-agent audit, 2026-04-24, HIGH-2): symmetric
-                    # with the PyMISP cap-hit raise above. Hitting the safety
-                    # cap means truncated coverage; refuse to treat it as
-                    # complete.
-                    logger.error(
-                        "[MISP-FETCH-FALLBACK] restSearch hit _FALLBACK_MAX_PAGES=%d cap "
-                        "(~%d events). If MISP legitimately has more events, "
-                        "raise the cap in src/run_misp_to_neo4j.py.",
-                        _FALLBACK_MAX_PAGES,
-                        _FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE,
-                    )
-                    raise _MispFallbackHardError(
-                        f"MISP fallback restSearch hit _FALLBACK_MAX_PAGES={_FALLBACK_MAX_PAGES} cap "
-                        f"(~{_FALLBACK_MAX_PAGES * _FALLBACK_PAGE_SIZE} events collected). "
-                        f"Refusing to treat truncated fallback as complete."
-                    )
+                except _MispFallbackHardError:
+                    # PR-N31: symmetric with the PyMISP branch — record before
+                    # propagating to the outer ``except _MispFallbackHardError``
+                    # re-raise. Without this, restSearch hard errors would be
+                    # invisible to Prometheus (only the engaged metric would
+                    # increment) and the operator alert couldn't distinguish
+                    # "fallback running fine" from "fallback also failing."
+                    record_misp_fetch_fallback("rest_search", "hard_error")
+                    raise
 
                 # PR-N29: pagination already collected all events; downstream
                 # normalization runs on the ``events`` variable. Pre-N29 this

--- a/tests/test_pr_n24_audit_blockers.py
+++ b/tests/test_pr_n24_audit_blockers.py
@@ -288,12 +288,22 @@ class TestB2AlertmanagerNoPlaceholderPagerKey:
         assert "PLACEHOLDER_DETECTED" in result.stdout
 
     def test_preflight_alert_count_floor_bumped(self):
-        """PR-N24 H3 added EdgeGuardMispEventAttributesTruncated, so the
-        preflight defense-in-depth alert-count floor must be ≥ 9."""
+        """PR-N24 H3 added EdgeGuardMispEventAttributesTruncated; PR-N31
+        added EdgeGuardMispFetchFallbackActive + EdgeGuardMispFetchFallback
+        HardError. The preflight defense-in-depth alert-count floor
+        bumps with each PR that adds alerts so a future regression that
+        deletes alerts is caught.
+
+        The literal floor value is checked here (not just "≥ N for some N")
+        because PR-N31's TestPRN31FallbackAlerts.test_alert_count_floor_
+        pinned_in_preflight pins the symmetric direction — both must agree
+        on the current floor."""
         text = (SCRIPTS / "preflight_baseline.sh").read_text()
-        # Pre-N24 H3 the floor was 8; post-N24 H3 it must be 9+.
-        assert "ALERT_COUNT" in text and "-ge 9" in text, (
-            "preflight ALERT_COUNT floor must be ``-ge 9`` after PR-N24 H3 added EdgeGuardMispEventAttributesTruncated"
+        # Pre-N24 H3 the floor was 8; PR-N24 H3 → 9; PR-N31 → 11.
+        assert "ALERT_COUNT" in text and "-ge 11" in text, (
+            "preflight ALERT_COUNT floor must be ``-ge 11`` after PR-N31 added "
+            "EdgeGuardMispFetchFallbackActive + EdgeGuardMispFetchFallbackHardError. "
+            "If a future PR adds alerts, bump BOTH this test AND scripts/preflight_baseline.sh."
         )
 
 

--- a/tests/test_pr_n31_baseline_followups.py
+++ b/tests/test_pr_n31_baseline_followups.py
@@ -1,0 +1,682 @@
+"""
+PR-N31 — post-PR-N29 baseline-followup bundle.
+
+PR-N29 hardened the baseline against three silent-failure modes (DAG
+retries-budget overrun, MISP-fetch-fallback silent truncation, cross-
+host lock TTL). The multi-agent audit then surfaced 3 corroborated
+HIGH correctness bugs in the round-2 fix (sentinel exception + sibling
+drift in the requests-restSearch branch) — all merged in PR #110.
+
+PR-N31 closes the deferred items called out in the PR #110 merge body:
+
+* **Observability** — `edgeguard_misp_fetch_fallback_active_total`
+  Counter (labels: branch, outcome) wired into both fallback branches
+  + 2 Prometheus alert rules (warning on sustained engagement,
+  critical on hard_error). Pre-N31 the only signal was the
+  `[MISP-FETCH-FALLBACK-ACTIVE]` log token — invisible to operators
+  unless they were grepping logs.
+* **Defense-in-depth Unicode hardening** — extends the placeholder
+  filter's zero-width / bidi strip table with CGJ (U+034F),
+  variation selectors VS1–VS16 (U+FE00..U+FE0F), and ALM (U+061C).
+  None have a known in-the-wild bypass yet but they're the same
+  shape as the U+200E/U+200F gap Bugbot caught in PR-N29 round 1 —
+  closing them now is cheaper than waiting for an exploit.
+* **Preflight invariant pin** — `scripts/preflight_baseline.sh` now
+  has a `[11] PR-N29 invariants` section that fast-fails if a
+  rebase/cleanup inadvertently reverted the sentinel class, the
+  retries=0 setting on the critical chain, the 48h lock max-age,
+  or the PR-N31 metric wiring.
+* **RUNBOOK section 8** — operator triage tree for
+  `_MispFallbackHardError` covering all four hard-failure modes
+  (errors-payload, unexpected-shape, non-200, cap-hit) with a
+  remediation step for each.
+* **build_campaign_nodes happy-path test** — Holistic H2 from the
+  PR-N29 audit. Pre-N31 the only behavioural test on this function
+  exercised the backfill log line; this PR adds an end-to-end
+  happy-path pin that all 9 Cypher queries are issued in the right
+  order and the `results` dict is populated correctly.
+
+This module pins the contract for all 5 areas.
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+DAGS = REPO_ROOT / "dags"
+SCRIPTS = REPO_ROOT / "scripts"
+PROM = REPO_ROOT / "prometheus"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n31")
+os.environ.setdefault("MISP_API_KEY", "test-key-pr-n31")
+
+
+# ===========================================================================
+# Fix N31-A — Prometheus counter for MISP fetch fallback activity
+# ===========================================================================
+
+
+class TestPRN31FallbackCounter:
+    """The `edgeguard_misp_fetch_fallback_active_total` counter is the
+    Prometheus-visible signal for MISP fetch fallback activity. Pre-N31
+    operators had to grep the `[MISP-FETCH-FALLBACK-ACTIVE]` log token —
+    the metric makes the fallback paths first-class for alerting and
+    Grafana dashboards.
+
+    Two outcomes (`engaged` for fallback ran, `hard_error` for the
+    `_MispFallbackHardError` sentinel raised); two branches (`pymisp`,
+    `rest_search`). Tests pin the counter exists, is correctly
+    labeled, has the right helper, and is wired into both fallback
+    branches at all 4 expected sites (engaged + hard_error per branch).
+    """
+
+    METRICS_FILE = SRC / "metrics_server.py"
+    SYNC_FILE = SRC / "run_misp_to_neo4j.py"
+
+    def test_counter_declared_with_correct_labels(self):
+        """Source pin: the counter exists, is named correctly, and has
+        the right (branch, outcome) labelset. Bare counter without
+        labels would force the alert to differentiate via separate
+        counters — making the alert rule brittle."""
+        text = self.METRICS_FILE.read_text()
+        assert "MISP_FETCH_FALLBACK_ACTIVE = Counter(" in text, (
+            "PR-N31: MISP_FETCH_FALLBACK_ACTIVE Counter must be declared at module level"
+        )
+        assert '"edgeguard_misp_fetch_fallback_active_total"' in text, (
+            "PR-N31: counter name must match the alert rule's expr (edgeguard_misp_fetch_fallback_active_total)"
+        )
+        assert '["branch", "outcome"]' in text, (
+            "PR-N31: labels must be exactly ['branch', 'outcome'] — alert rules + RUNBOOK key on these"
+        )
+
+    def test_counter_helper_function_exists(self):
+        """Behavioural: the `record_misp_fetch_fallback(branch, outcome)`
+        helper exists and can be called without prometheus_client present
+        (no-op fallback in run_misp_to_neo4j when import fails)."""
+        from metrics_server import record_misp_fetch_fallback
+
+        # Call shouldn't raise (smoke). Re-import freshness handled by Python.
+        record_misp_fetch_fallback("pymisp", "engaged")
+        record_misp_fetch_fallback("rest_search", "hard_error")
+
+    def test_helper_no_op_fallback_when_metrics_unavailable(self):
+        """Pre-N31 the counter import would have crashed run_misp_to_neo4j
+        on systems without prometheus_client. The defensive try/except
+        block in run_misp_to_neo4j defines a no-op replacement so all
+        call-sites can call unconditionally."""
+        text = self.SYNC_FILE.read_text()
+        assert "def record_misp_fetch_fallback(branch: str, outcome: str)" in text, (
+            "PR-N31: run_misp_to_neo4j must define a no-op fallback for "
+            "record_misp_fetch_fallback so call-sites can call unconditionally"
+        )
+        # The no-op must be defined inside the ImportError except branch.
+        idx = text.find("except ImportError:")
+        assert idx != -1
+        # Within ~600 chars of ImportError (the except block body) — the
+        # fallback def MUST appear.
+        block = text[idx : idx + 600]
+        assert "def record_misp_fetch_fallback" in block, (
+            "PR-N31: no-op fallback must be defined inside the ImportError except, "
+            "not at module level (would shadow the real import)"
+        )
+
+    def test_pymisp_branch_records_engaged(self):
+        """Source pin: the engaged metric must fire the moment the
+        fallback path is entered — not after the first successful
+        page. Operators want to know "fallback active" instantly,
+        not after a 60-second pagination loop succeeds."""
+        text = self.SYNC_FILE.read_text()
+        # The engaged record must appear BEFORE the PyMISP try block
+        record_idx = text.find('record_misp_fetch_fallback("pymisp", "engaged")')
+        try_idx = text.find("# Fallback: PyMISP restSearch")
+        assert record_idx != -1 and try_idx != -1, (
+            "PR-N31: pymisp/engaged record + PyMISP fallback try block must both exist"
+        )
+        assert record_idx < try_idx, (
+            "PR-N31: pymisp/engaged record must fire BEFORE entering the PyMISP loop "
+            "so operators see 'fallback active' immediately, not after first successful page"
+        )
+
+    def test_pymisp_branch_records_hard_error_on_sentinel(self):
+        """Source pin: the inner `except _MispFallbackHardError:` clause
+        in the PyMISP branch must record `pymisp/hard_error` BEFORE
+        re-raising. Without this, hard errors would only show as
+        engaged — operators couldn't distinguish "fallback running fine"
+        from "fallback also failing."""
+        text = self.SYNC_FILE.read_text()
+        # Locate the inner PyMISP sentinel-catch. The first
+        # `except _MispFallbackHardError:` substring in the file is
+        # inside the sentinel class's own docstring (audit history);
+        # the actual code catch is the SECOND occurrence, inside
+        # ``fetch_edgeguard_events``.
+        fn_start = text.find("def fetch_edgeguard_events(")
+        assert fn_start != -1, "fetch_edgeguard_events function must exist"
+        idx = text.find("except _MispFallbackHardError:", fn_start)
+        assert idx != -1, "PyMISP inner sentinel-catch must exist inside fetch_edgeguard_events"
+        block = text[idx : idx + 1500]
+        assert 'record_misp_fetch_fallback("pymisp", "hard_error")' in block, (
+            "PR-N31: PyMISP inner sentinel-catch must record pymisp/hard_error before re-raising"
+        )
+        # And it MUST be followed by a bare `raise` — recording without
+        # re-raising would silently downgrade the failure.
+        record_pos = block.find('record_misp_fetch_fallback("pymisp", "hard_error")')
+        assert "raise" in block[record_pos : record_pos + 200], (
+            "PR-N31: pymisp/hard_error record must be followed by `raise` to propagate sentinel"
+        )
+
+    def test_restsearch_branch_records_engaged_and_hard_error(self):
+        """Source pin: symmetric with PyMISP — restSearch branch
+        records engaged on entry AND hard_error on sentinel via a
+        dedicated try/except wrapper around the loop."""
+        text = self.SYNC_FILE.read_text()
+        assert 'record_misp_fetch_fallback("rest_search", "engaged")' in text, (
+            "PR-N31: rest_search/engaged record must exist (fires when PyMISP fails "
+            "with non-sentinel exception and the requests-restSearch path engages)"
+        )
+        assert 'record_misp_fetch_fallback("rest_search", "hard_error")' in text, (
+            "PR-N31: rest_search/hard_error record must exist (fires when the "
+            "rest_search loop raises _MispFallbackHardError)"
+        )
+
+    def test_engaged_outcome_value_matches_alert_rule(self):
+        """Cross-file pin: the alert expr in prometheus/alerts.yml
+        filters on `outcome="engaged"`. The Python record call must
+        use the exact same string ("engaged"); a typo would silently
+        break the alert."""
+        sync_text = self.SYNC_FILE.read_text()
+        alerts_text = (PROM / "alerts.yml").read_text()
+        assert 'outcome="engaged"' in alerts_text, "PR-N31: alert rule must filter on outcome='engaged'"
+        assert '"engaged"' in sync_text, "PR-N31: Python record call must use outcome='engaged' (must match alert rule)"
+
+    def test_hard_error_outcome_value_matches_alert_rule(self):
+        """Same cross-file pin for hard_error."""
+        sync_text = self.SYNC_FILE.read_text()
+        alerts_text = (PROM / "alerts.yml").read_text()
+        assert 'outcome="hard_error"' in alerts_text
+        assert '"hard_error"' in sync_text
+
+
+# ===========================================================================
+# Fix N31-B — Prometheus alert rules for fallback activity
+# ===========================================================================
+
+
+class TestPRN31FallbackAlerts:
+    """The two alert rules (warning on sustained engagement, critical on
+    hard_error) translate the counter into operator pages. Pre-N31 the
+    fallback could be running for hours with the only signal being
+    log noise."""
+
+    ALERTS_FILE = PROM / "alerts.yml"
+
+    def test_active_alert_present(self):
+        text = self.ALERTS_FILE.read_text()
+        assert "EdgeGuardMispFetchFallbackActive" in text, (
+            "PR-N31: warning-severity alert for sustained fallback engagement"
+        )
+        # Severity must be warning (not critical) — fallback engaged is
+        # functional, just slower.
+        idx = text.find("EdgeGuardMispFetchFallbackActive")
+        block = text[idx : idx + 1500]
+        assert "severity: warning" in block, (
+            "PR-N31: EdgeGuardMispFetchFallbackActive must be severity=warning "
+            "(fallback engaged is functional, not critical — only sustained=problem)"
+        )
+        # Must reference the counter
+        assert "edgeguard_misp_fetch_fallback_active_total" in block
+
+    def test_hard_error_alert_present(self):
+        text = self.ALERTS_FILE.read_text()
+        assert "EdgeGuardMispFetchFallbackHardError" in text, (
+            "PR-N31: critical-severity alert for _MispFallbackHardError raises"
+        )
+        idx = text.find("EdgeGuardMispFetchFallbackHardError")
+        block = text[idx : idx + 1500]
+        assert "severity: critical" in block, (
+            "PR-N31: EdgeGuardMispFetchFallbackHardError must be severity=critical "
+            "(sentinel raised = baseline failed in a way that would have been silent pre-PR-N29)"
+        )
+        # Short `for: 1m` so the page fires immediately
+        assert "for: 1m" in block, (
+            "PR-N31: hard_error alert must page within 1m — operator needs to know now, not 10m later"
+        )
+
+    def test_alerts_yml_parses(self):
+        """YAML must remain valid after our additions."""
+        import yaml
+
+        with self.ALERTS_FILE.open() as f:
+            doc = yaml.safe_load(f)
+        assert doc and "groups" in doc
+
+    def test_alert_count_floor_pinned_in_preflight(self):
+        """Cross-file pin: the preflight script's structural alert-count
+        check must require ≥ 11 alerts (PR-N31 added 2 to the pre-N31
+        floor of 9). If a future PR adds alerts WITHOUT bumping the
+        preflight floor, the pin catches it."""
+        preflight = (SCRIPTS / "preflight_baseline.sh").read_text()
+        assert 'ALERT_COUNT" -ge 11' in preflight, "PR-N31: preflight alert-count floor must be ≥ 11 (was 9 pre-N31)"
+
+
+# ===========================================================================
+# Fix N31-C — extended Unicode chars in placeholder filter
+# ===========================================================================
+
+
+class TestPRN31ExtendedUnicodeChars:
+    """PR-N29 L1 closed the LRM/RLM gap that Bugbot caught. PR-N31 adds
+    defense-in-depth coverage for invisible chars in the same vector
+    class:
+      * COMBINING GRAPHEME JOINER (U+034F)
+      * Variation Selectors VS1–VS16 (U+FE00..U+FE0F)
+      * ARABIC LETTER MARK (U+061C, sibling of LRM/RLM)
+    None have a documented in-the-wild bypass — these are pre-emptive."""
+
+    def test_cgj_bypass_blocked(self):
+        """COMBINING GRAPHEME JOINER (U+034F): zero-width grapheme glue,
+        not folded by NFKC."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u034f"), "CGJ appended bypass"
+        assert is_placeholder_name("\u034funknown"), "CGJ prepended bypass"
+        assert is_placeholder_name("un\u034fknown"), "CGJ inline bypass"
+
+    def test_variation_selector_1_blocked(self):
+        """VS1 (U+FE00): variation selector for emoji/CJK; harmless on
+        Latin but stackable as a bypass character."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\ufe00"), "VS-1 appended bypass"
+
+    def test_variation_selector_16_blocked(self):
+        """VS-16 (U+FE0F): emoji-presentation selector. Same vector class."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\ufe0f"), "VS-16 appended bypass"
+
+    def test_variation_selectors_full_range_blocked(self):
+        """All 16 variation selectors VS1..VS16 must be stripped — pin
+        the full range to catch off-by-one errors in the translate table."""
+        from node_identity import is_placeholder_name
+
+        for cp in range(0xFE00, 0xFE10):  # VS1..VS16 inclusive
+            ch = chr(cp)
+            assert is_placeholder_name(f"unknown{ch}"), f"variation selector U+{cp:04X} must be stripped"
+
+    def test_arabic_letter_mark_blocked(self):
+        """ARABIC LETTER MARK (U+061C): bidi-influencer in the same
+        family as LRM/RLM."""
+        from node_identity import is_placeholder_name
+
+        assert is_placeholder_name("unknown\u061c"), "ALM appended bypass"
+        assert is_placeholder_name("\u061cunknown"), "ALM prepended bypass"
+
+    def test_pr_n29_chars_still_blocked(self):
+        """Regression pin: PR-N31 additions must NOT remove any of the
+        PR-N29 chars from the translate table."""
+        from node_identity import is_placeholder_name
+
+        # PR-N29 Bugbot round 1
+        assert is_placeholder_name("unknown\u200e"), "LRM still blocked"
+        assert is_placeholder_name("unknown\u200f"), "RLM still blocked"
+        # PR-N29 round 2
+        assert is_placeholder_name("unknown\u180e"), "MVS still blocked"
+        # Original PR-N29
+        assert is_placeholder_name("unknown\u200b"), "ZWSP still blocked"
+
+    def test_genuine_names_still_pass(self):
+        """Negative pin: extended chars must not cause false-positive
+        rejection of real malware/actor names."""
+        from node_identity import is_placeholder_name
+
+        assert not is_placeholder_name("Conti")
+        assert not is_placeholder_name("LockBit")
+        assert not is_placeholder_name("APT29")
+        # Even with VS-16 (which sometimes appears in legitimately-named
+        # Unicode artifacts), if the canonical form is not a placeholder
+        # the name is allowed through.
+        assert not is_placeholder_name("Conti\ufe0f")
+
+
+# ===========================================================================
+# Fix N31-D — preflight script invariant checks for PR-N29
+# ===========================================================================
+
+
+class TestPRN31PreflightInvariants:
+    """The preflight `[11]` section fast-fails if PR-N29 invariants are
+    inadvertently reverted (rebase mishap, misguided "cleanup", manual
+    edit). Catches problems BEFORE the baseline launches — not at hour
+    26 of a 32h dagrun."""
+
+    PREFLIGHT_FILE = SCRIPTS / "preflight_baseline.sh"
+
+    def test_section_11_present(self):
+        text = self.PREFLIGHT_FILE.read_text()
+        assert "[11] PR-N29 invariants" in text, (
+            "PR-N31: preflight must include a [11] section pinning PR-N29 invariants"
+        )
+
+    def test_checks_for_sentinel_class(self):
+        text = self.PREFLIGHT_FILE.read_text()
+        assert "class _MispFallbackHardError(Exception):" in text, (
+            "PR-N31: preflight must grep for the sentinel class definition"
+        )
+
+    def test_checks_for_lock_max_age_48h(self):
+        text = self.PREFLIGHT_FILE.read_text()
+        assert "_BASELINE_LOCK_MAX_AGE_SEC_DEFAULT = 48" in text, (
+            "PR-N31: preflight must verify lock max-age is 48h (PR-N29 M3)"
+        )
+
+    def test_checks_for_critical_chain_retries_zero(self):
+        text = self.PREFLIGHT_FILE.read_text()
+        # Must check ALL THREE critical-chain tasks
+        for task in ("full_neo4j_sync", "build_relationships", "run_enrichment_jobs"):
+            assert task in text, f"PR-N31: preflight must check retries=0 for critical-chain task {task}"
+
+    def test_checks_for_pr_n31_metric_wiring(self):
+        text = self.PREFLIGHT_FILE.read_text()
+        # Looks for the record call signatures in BOTH branches
+        assert 'record_misp_fetch_fallback("pymisp", "hard_error")' in text
+        assert 'record_misp_fetch_fallback("rest_search", "hard_error")' in text
+
+
+# ===========================================================================
+# Fix N31-E — RUNBOOK section for _MispFallbackHardError
+# ===========================================================================
+
+
+class TestPRN31RunbookSection:
+    """The RUNBOOK is the operator's first read on a sentinel raise.
+    Pin the section's existence + completeness so a doc-cleanup PR
+    can't accidentally delete the operator triage tree."""
+
+    RUNBOOK_FILE = REPO_ROOT / "docs" / "RUNBOOK.md"
+
+    def test_section_8_exists(self):
+        text = self.RUNBOOK_FILE.read_text()
+        assert "### 8. MISP fetch fallback" in text, (
+            "PR-N31: RUNBOOK must have a § 8 dedicated to _MispFallbackHardError triage"
+        )
+
+    def test_top_n_header_bumped(self):
+        """The top-of-section header was 'Top 6' before PR-N27 added §7
+        and PR-N31 added §8. Must read 'Top 8' now."""
+        text = self.RUNBOOK_FILE.read_text()
+        assert "## Top 8 failure modes" in text, (
+            "PR-N31: section header must say 'Top 8 failure modes' (was 'Top 6' pre-N27)"
+        )
+
+    def test_section_covers_all_four_failure_modes(self):
+        """The four hard-failure modes the sentinel handles MUST each be
+        documented in the triage tree — otherwise an operator hitting
+        mode (4) cap-hit won't know to bump _FALLBACK_MAX_PAGES."""
+        text = self.RUNBOOK_FILE.read_text()
+        idx = text.find("### 8. MISP fetch fallback")
+        assert idx != -1
+        block = text[idx : idx + 6000]
+        # Each failure mode + its diagnosis hint
+        assert "errors-payload mid-pagination" in block
+        assert "unexpected payload type" in block
+        assert "non-200 mid-pagination" in block
+        assert "safety-cap hit" in block
+        # Each remediation step must appear
+        assert "EDGEGUARD_MISP_EVENT_SEARCH" in block, (
+            "RUNBOOK must mention the search-substring env var (mode 1 remediation)"
+        )
+        assert "_FALLBACK_MAX_PAGES" in block, "RUNBOOK must mention the cap (mode 4 remediation)"
+
+    def test_section_links_to_alert_names(self):
+        """The RUNBOOK must reference the exact alert names so
+        on-call operators can grep from the alert email/page."""
+        text = self.RUNBOOK_FILE.read_text()
+        idx = text.find("### 8. MISP fetch fallback")
+        block = text[idx : idx + 6000]
+        assert "EdgeGuardMispFetchFallbackHardError" in block
+        assert "EdgeGuardMispFetchFallbackActive" in block
+
+    def test_section_explains_no_auto_retry(self):
+        """Critical operator detail: PR-N29 H1 set retries=0 on the
+        critical chain. The RUNBOOK MUST say this explicitly so
+        operators don't wait for an auto-retry that won't come."""
+        text = self.RUNBOOK_FILE.read_text()
+        idx = text.find("### 8. MISP fetch fallback")
+        block = text[idx : idx + 6000]
+        assert "retries=0" in block
+        # And explicit instruction to manually re-trigger
+        assert "manually re-triggered" in block or "manually re-run" in block.lower()
+
+
+# ===========================================================================
+# Fix N31-F — build_campaign_nodes happy-path behavioural test (Holistic H2)
+# ===========================================================================
+
+
+class TestPRN31BuildCampaignNodesHappyPath:
+    """Holistic H2 from the PR-N29 multi-agent audit: pre-PR-N31 the
+    only behavioural test on build_campaign_nodes was the backfill-log
+    pin (test_pr33_bugbot_fixes.py::test_build_campaign_nodes_backfill_
+    heals_null_uuids_runtime). The HAPPY-PATH was untested.
+
+    This test pins the end-to-end happy path:
+      * 1 qualifying ThreatActor (has malware + indicators)
+      * Step 1 creates 1 Campaign
+      * Steps 2/3a/4/5 link malware/indicators, prune stale, cleanup, reactivate
+      * The returned `results` dict reflects the per-step counts
+      * All 9 expected session.run() calls fire in the right order
+      * Campaign uuid is computed deterministically from the actor name
+
+    Without this test, a refactor that re-orders / silently swallows
+    one of the queries would only be caught by the integration test
+    (which requires a live Neo4j). Bug Hunter HIGH-2 from the audit
+    flagged this as the gap.
+    """
+
+    def _build_fake_session(self, actor_name: str = "APT-N31-Test"):
+        """Construct a MagicMock session that returns happy-path values
+        for each of the 9 session.run() calls build_campaign_nodes
+        makes. Returns ``(client, sess, captured_queries)`` so the test
+        can inspect what queries were issued + in what order.
+
+        Mirrors the fixture in test_pr33_bugbot_fixes.py but with
+        positive (non-zero) values to exercise the SUCCESS path that
+        backfill-log test does not.
+        """
+        from unittest.mock import MagicMock
+
+        client = MagicMock()
+        sess = MagicMock()
+        sess.__enter__ = lambda s: s
+        sess.__exit__ = lambda *a: False
+
+        # (1) qualifying_actors_query — one qualifying actor
+        actors_iter = iter([{"name": actor_name}])
+        actors_result = MagicMock()
+        actors_result.__iter__ = lambda self: actors_iter
+
+        # (2) Step 1 create_cypher — 1 Campaign created
+        create_result = MagicMock()
+        create_result.single.return_value = {"campaigns": 1}
+
+        # (3) backfill_cypher — happy path: nothing to backfill
+        backfill_result = MagicMock()
+        backfill_result.single.return_value = {"backfilled": 0}
+
+        # (4) Step 2 link_malware — 3 malware linked
+        link_m_result = MagicMock()
+        link_m_result.single.return_value = {"links": 3}
+
+        # (5) Step 3a link_indicators_batched — apoc.periodic.iterate shape
+        link_i_result = MagicMock()
+        link_i_result.single.return_value = {
+            "committedOperations": 47,
+            "errorMessages": {},
+            "batches": 5,
+            "total": 47,
+        }
+
+        # (6) Step 3a' links_count — TRUE PART_OF edge count after batch
+        links_count_result = MagicMock()
+        links_count_result.single.return_value = {"links": 47}
+
+        # (7) Step 3b prune_query — 0 stale edges to prune (clean run)
+        prune_result = MagicMock()
+        prune_result.single.return_value = {"pruned": 0}
+
+        # (8) Step 4 cleanup_query
+        cleanup_result = MagicMock()
+        cleanup_result.single.return_value = {"count": 0}
+
+        # (9) Step 5 reactivated_query
+        reactivated_result = MagicMock()
+        reactivated_result.single.return_value = {"count": 0}
+
+        captured_queries = []
+        original_side_effect = [
+            actors_result,
+            create_result,
+            backfill_result,
+            link_m_result,
+            link_i_result,
+            links_count_result,
+            prune_result,
+            cleanup_result,
+            reactivated_result,
+        ]
+        idx_holder = {"i": 0}
+
+        def _side_effect(*args, **kwargs):
+            captured_queries.append(args[0] if args else "")
+            ret = original_side_effect[idx_holder["i"]]
+            idx_holder["i"] += 1
+            return ret
+
+        sess.run.side_effect = _side_effect
+        client.driver.session.return_value = sess
+        return client, sess, captured_queries
+
+    def _import_fresh_enrichment_jobs(self):
+        if "enrichment_jobs" in sys.modules:
+            del sys.modules["enrichment_jobs"]
+        return importlib.import_module("enrichment_jobs")
+
+    def test_happy_path_returns_populated_results(self):
+        """The function must return a non-empty `results` dict reflecting
+        what was actually done. Pre-N21 a swallower silently returned
+        {} on errors; this test pins the happy-path counterexample."""
+        ej = self._import_fresh_enrichment_jobs()
+        client, sess, _captured = self._build_fake_session()
+
+        # Speed up time.sleep(3) calls between steps
+        original_sleep = ej.time.sleep
+        ej.time.sleep = lambda *_a: None
+        try:
+            results = ej.build_campaign_nodes(client)
+        finally:
+            ej.time.sleep = original_sleep
+
+        assert isinstance(results, dict)
+        assert results, "happy-path build_campaign_nodes must return non-empty results"
+        # The contract pins: campaigns_created + links_created at minimum
+        assert "campaigns_created" in results or "campaigns_updated" in results, (
+            f"results dict must include campaign accounting; got keys: {sorted(results.keys())}"
+        )
+
+    def test_happy_path_issues_all_9_queries(self):
+        """The function must issue all 9 expected session.run() calls.
+        Fewer calls means a step was silently skipped (the swallower
+        pattern PR-N21 fixed); more means a step duplicated or a new
+        step was added without updating this pin (intentional break-
+        the-build for review)."""
+        ej = self._import_fresh_enrichment_jobs()
+        client, sess, captured = self._build_fake_session()
+
+        original_sleep = ej.time.sleep
+        ej.time.sleep = lambda *_a: None
+        try:
+            ej.build_campaign_nodes(client)
+        finally:
+            ej.time.sleep = original_sleep
+
+        assert sess.run.call_count == 9, (
+            f"build_campaign_nodes must issue exactly 9 session.run() calls "
+            f"(1 pre-fetch + 5 step queries + 3 follow-ups); got {sess.run.call_count}. "
+            f"If you added a step, update this pin AND the fake-session fixture."
+        )
+
+    def test_happy_path_query_order(self):
+        """The 9 queries must fire in a specific order (pre-fetch FIRST,
+        Campaign create SECOND, etc). A reorder could break the
+        backfill-after-create invariant the post-PR-#33 audit caught."""
+        ej = self._import_fresh_enrichment_jobs()
+        client, sess, captured = self._build_fake_session()
+
+        original_sleep = ej.time.sleep
+        ej.time.sleep = lambda *_a: None
+        try:
+            ej.build_campaign_nodes(client)
+        finally:
+            ej.time.sleep = original_sleep
+
+        # Expected query identifiers (substrings unique to each query)
+        # in the order they MUST fire.
+        expected_substrings_in_order = [
+            # (1) qualifying_actors_query — looks for ThreatActor + WHERE EXISTS
+            "MATCH (a:ThreatActor)",
+            # (2) Step 1 create_cypher — has the Campaign MERGE
+            "MERGE (c:Campaign",
+            # (3) backfill_cypher — heals NULL uuids on existing campaigns
+            "backfilled",
+            # (4) Step 2 link_malware — Malware -> Campaign PART_OF
+            ":Malware",
+            # (5) Step 3a — apoc.periodic.iterate signature
+            "apoc.periodic.iterate",
+        ]
+        for i, substr in enumerate(expected_substrings_in_order):
+            assert substr in captured[i], (
+                f"query #{i + 1} must contain '{substr}'; got query starting with: {captured[i][:200]}..."
+            )
+
+    def test_happy_path_passes_campaign_uuids_dict(self):
+        """The post-PR-#33 audit (round 21) caught that the create_cypher
+        MERGE relies on a precomputed `$campaign_uuids` dict to set
+        c.uuid deterministically. The fake session must verify this
+        param is passed; otherwise a refactor could regress the
+        cross-environment traceability contract silently."""
+        ej = self._import_fresh_enrichment_jobs()
+        client, sess, _captured = self._build_fake_session(actor_name="APT-Trace")
+
+        original_sleep = ej.time.sleep
+        ej.time.sleep = lambda *_a: None
+        try:
+            ej.build_campaign_nodes(client)
+        finally:
+            ej.time.sleep = original_sleep
+
+        # The 2nd session.run call (create_cypher) must receive
+        # campaign_uuids as a kwarg with the qualifying actor's name.
+        call_args_list = sess.run.call_args_list
+        # call 0 = pre-fetch (no kwargs); call 1 = create_cypher (kwargs)
+        create_call = call_args_list[1]
+        assert "campaign_uuids" in create_call.kwargs, (
+            "create_cypher must be called with campaign_uuids=... so c.uuid is set"
+        )
+        uuids_dict = create_call.kwargs["campaign_uuids"]
+        assert "APT-Trace" in uuids_dict, "campaign_uuids must include every qualifying actor by name"
+        # Determinism: same actor name → same uuid (cross-environment contract)
+        from node_identity import compute_node_uuid
+
+        expected_uuid = compute_node_uuid("Campaign", {"name": "APT-Trace Campaign"})
+        assert uuids_dict["APT-Trace"] == expected_uuid, (
+            "PR #33 cross-environment contract: Campaign.uuid must be deterministic "
+            "from compute_node_uuid('Campaign', {'name': '<actor> Campaign'})"
+        )

--- a/tests/test_pr_n31_baseline_followups.py
+++ b/tests/test_pr_n31_baseline_followups.py
@@ -265,6 +265,42 @@ class TestPRN31FallbackAlerts:
         preflight = (SCRIPTS / "preflight_baseline.sh").read_text()
         assert 'ALERT_COUNT" -ge 11' in preflight, "PR-N31: preflight alert-count floor must be ≥ 11 (was 9 pre-N31)"
 
+    def test_both_alerts_preserve_branch_label_via_sum_by(self):
+        """PR-N31 Bugbot round 1 (2026-04-25, MED): the alert annotations
+        reference ``{{ $labels.branch }}`` — but bare ``sum(rate(...))``
+        collapses ALL labels, so the template would render as empty
+        parens. Both alerts must use ``sum by (branch) (rate(...))``
+        to preserve the label.
+
+        Pinning BOTH alerts (not just HardError which is the one Bugbot
+        flagged) because PR-N31 fixed both for shape consistency — a
+        future maintainer dropping the by-clause from either one would
+        regress the operator UX.
+        """
+        import re
+
+        text = self.ALERTS_FILE.read_text()
+        for alert_name in ("EdgeGuardMispFetchFallbackActive", "EdgeGuardMispFetchFallbackHardError"):
+            idx = text.find(alert_name)
+            assert idx != -1, f"alert {alert_name} must exist"
+            block = text[idx : idx + 1500]
+            # Positive pin: the expr line must use ``sum by (branch) (rate(``.
+            # Anchored with the leading whitespace (YAML expr block scalar
+            # indentation) so the in-comment narrative reference doesn't
+            # accidentally satisfy the assertion.
+            assert re.search(r"^ {8,}sum by \(branch\) \(rate\(", block, re.MULTILINE), (
+                f"PR-N31 Bugbot round 1: {alert_name} expr must use ``sum by (branch) (rate(...))`` "
+                f"to preserve the branch label for the annotation template. Bare ``sum(rate(...))`` "
+                f"collapses all labels and the annotation would render with empty branch interpolation."
+            )
+            # Negative pin: the expr line must NOT use bare ``sum(rate(`` (regex
+            # again anchored on YAML indentation so the comment narrative is
+            # excluded from the match).
+            assert not re.search(r"^ {8,}sum\(rate\(", block, re.MULTILINE), (
+                f"PR-N31 Bugbot round 1: {alert_name} expr must not be bare "
+                f"``sum(rate(...))`` — that drops the branch label."
+            )
+
 
 # ===========================================================================
 # Fix N31-C — extended Unicode chars in placeholder filter


### PR DESCRIPTION
## Summary

Closes the 5 deferred items called out in the PR #110 (PR-N29) merge body. None are bug-fixes — PR-N29 was correct — these are the "make the silent-failure-defense **observable**" follow-ups punted to a separate PR. Bumps version to **2026.4.25**.

## What this PR does

### 1. Observability — counter + 2 Prometheus alerts

- New `edgeguard_misp_fetch_fallback_active_total` Counter
  (labels: `branch={pymisp,rest_search}`, `outcome={engaged,hard_error}`)
  wired into both fallback branches at all 4 expected sites.
- Two new alert rules:
  - `EdgeGuardMispFetchFallbackActive` (warning, 10m) — sustained
    fallback engagement signals primary `/events/index` is broken.
  - `EdgeGuardMispFetchFallbackHardError` (critical, 1m) — fires
    immediately when the sentinel raises; dagrun has already failed
    (PR-N29 H1: retries=0).
- New `record_misp_fetch_fallback(branch, outcome)` helper with no-op
  fallback for systems without `prometheus_client`.

### 2. Defense-in-depth Unicode hardening

Extends `_ZERO_WIDTH_AND_BIDI_CHARS` with 18 more chars: CGJ (U+034F),
Variation Selectors VS1–VS16 (U+FE00..U+FE0F), and ALM (U+061C). None
have a known in-the-wild bypass — same vector class as the LRM/RLM
gap Bugbot caught in PR-N29 round 1.

### 3. Preflight invariant pin

New `[11] PR-N29 invariants` section in `scripts/preflight_baseline.sh`
that fast-fails if a rebase/cleanup reverts the sentinel class,
`retries=0`, the 48h lock max-age, or the new metric wiring.

Bumps the structural alert-count floor `≥ 9 → ≥ 11`.

### 4. RUNBOOK section 8

Operator triage tree for `_MispFallbackHardError` covering all four
hard-failure modes (errors-payload, unexpected-shape, non-200,
cap-hit) with a remediation step for each. Section header bumped
"Top 6" → "Top 8".

### 5. `build_campaign_nodes` happy-path test (Holistic H2)

4 new behavioural tests pinning the END-TO-END happy path with a
fake-driver fixture — all 9 session.run() calls in correct order,
populated results dict, deterministic Campaign uuid passed via
`campaign_uuids` kwarg.

## Test plan

- [x] 33 new PR-N31 tests pass (8 counter + 4 alerts + 7 unicode + 5 preflight + 5 runbook + 4 build_campaign_nodes)
- [x] Full suite: 1792 passed, 3 skipped, 3 xfailed (3m40s)
- [x] Live-fire smoke test of preflight `[11]`: FAIL=0 WARN=0
- [x] ruff format / ruff check / mypy: green
- [x] alerts.yml parses
- [x] Updated stale PR-N24 pin (`-ge 9` → `-ge 11`)

## What this PR does NOT address

Deferred to PR-N32 (separate one-shot data work):

- Cypher cleanup query for legacy unicode-bypass nodes (Malware /
  ThreatActor / Tool entries created BEFORE PR-N29 L1 with
  ZWSP-class characters in their names). Needs validation against
  production data before shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new Prometheus metrics/alerting and preflight gating around the MISP fetch fallback and baseline invariants; while mostly additive, it touches sync error paths and alert logic that could affect paging/noise and operational behavior.
> 
> **Overview**
> Improves operator visibility into the MISP fetch fallback by adding a new Prometheus counter `edgeguard_misp_fetch_fallback_active_total` (labeled by `branch` and `outcome`), wiring it into both PyMISP and `restSearch` fallback paths in `run_misp_to_neo4j`, and introducing two new alerts (`EdgeGuardMispFetchFallbackActive` warning, `EdgeGuardMispFetchFallbackHardError` critical) with `sum by (branch)` aggregation.
> 
> Adds defense-in-depth hardening and operational pins: expands placeholder-name Unicode stripping in `node_identity`, adds a new `[11]` preflight section that fails fast if key PR-N29 invariants regress (sentinel class, lock TTL, `retries=0`, metric wiring) and bumps the preflight alert-count floor to ≥11; updates the RUNBOOK with a new failure-mode section documenting `_MispFallbackHardError` triage and bumps the header to “Top 8 failure modes”.
> 
> Bumps CalVer version to `2026.4.25` and adds a comprehensive new test module `test_pr_n31_baseline_followups.py` covering the new metric/alerts, Unicode additions, preflight/runbook pins, and a new happy-path behavioral pin for `build_campaign_nodes` query ordering/results.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 837c19b72cb049ff2ee91397d33e225696aa693b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->