### PR TITLE
fix(audit): PR-N32 — read-only legacy-unicode audit + 730d launch checklist

### DIFF
--- a/docs/BASELINE_LAUNCH_CHECKLIST.md
+++ b/docs/BASELINE_LAUNCH_CHECKLIST.md
@@ -1,0 +1,292 @@
+# 730-day baseline — launch-day checklist
+
+**Purpose:** the single doc the operator walks through immediately
+before triggering a 730-day MISP→Neo4j baseline. Every item maps to a
+concrete failure mode that has either bitten us in a prior run or that
+the audit cycle (PR-N26 / N29 / N30 / N31) explicitly built defenses
+against.
+
+**This is not a substitute for** [`docs/RUNBOOK.md`](RUNBOOK.md) — that
+remains the comprehensive operator reference. This file is a **pre-flight
+checklist**: 30 minutes of structured verification before pulling the
+trigger on a 32-hour irreversible-mid-run process.
+
+**Pass/fail interpretation:** every item either ✅ passes or 🛑 blocks
+the launch. There is no soft-warn tier here — soft warns belong in
+`scripts/preflight_baseline.sh` (they fire there, you decide whether to
+override). When this file says "block", it means stop and escalate.
+
+---
+
+## How to use this doc
+
+Run the items **in order**. Each section has:
+
+* **What** — the one-line action
+* **Command** — exactly what to run
+* **Pass criteria** — what success looks like
+* **If it fails** — the specific remediation pointer (RUNBOOK section,
+  follow-up PR, or "stop and ask")
+
+The whole thing should take 30 minutes if you've launched a baseline
+before, 60 minutes the first time. Budget 2 hours total so you don't
+short-cut on a discovery.
+
+---
+
+## Pre-launch checklist
+
+### [1] Live preflight run — `scripts/preflight_baseline.sh`
+
+**What:** run the 11-check preflight in strict mode against the actual
+prod environment. This is the single most important check — it
+exercises every PR-N29 invariant (sentinel class, retries=0, lock
+max-age, alert wiring) in addition to the original 8 sanity checks.
+
+**Command:**
+
+```bash
+EDGEGUARD_PREFLIGHT_STRICT=1 ./scripts/preflight_baseline.sh
+```
+
+**Pass criteria:** exit code 0, all 11 checks green. Specifically:
+
+* `[1] required env vars present` — NEO4J_PASSWORD, MISP_API_KEY, MISP_URL
+* `[2] Neo4j reachable + APOC + indexes`
+* `[3] MISP API reachable + auth valid`
+* `[4] launch-path decision confirmed` (CLI vs DAG+pause)
+* `[5] IF DAG path: 4 incremental DAGs PAUSED` (Issue #57)
+* `[6] Airflow worker RAM ≥ 4 GB`
+* `[7] Prometheus alerts.yml parses + ≥ 11 rules loaded`
+* `[8] no stale baseline_lock sentinel`
+* `[9..10]` (existing checks)
+* `[11] PR-N29 invariants` — sentinel class, retries=0, 48h lock
+  max-age, fallback metric wiring
+
+**If it fails:** the failing check tells you the exact remediation. Do
+**NOT** override `STRICT=1` to skip a fail — every fail in this script
+is a real risk that has either bitten us in production or was
+explicitly designed to catch a bypass attempt.
+
+---
+
+### [2] 7-day smoke baseline on the post-PR-N31 codebase
+
+**What:** confirm the new `_MispFallbackHardError` sentinel + counter +
+alert wiring work end-to-end against a live MISP. The unit tests pin
+the contract, but only a live run proves the fallback metric actually
+emits and Alertmanager actually routes the alert.
+
+**Command:** see [`docs/BASELINE_SMOKE_TEST.md`](BASELINE_SMOKE_TEST.md)
+for the full procedure. Short form:
+
+```bash
+# .env additions
+EDGEGUARD_BASELINE_DAYS=7
+EDGEGUARD_BASELINE_COLLECTION_LIMIT=1000
+
+# trigger via Airflow
+airflow dags trigger edgeguard_baseline
+```
+
+**Pass criteria:**
+
+* Smoke baseline completes without raising `_MispFallbackHardError`
+* Prometheus shows `edgeguard_misp_fetch_fallback_active_total` exists
+  as a series (even if value=0 — proves the counter is registered)
+* Post-run, the 7-day graph has the expected node + relationship counts
+  for the smoke window
+
+**If the smoke ran AT LEAST 7 days ago against a different commit:**
+re-run it. PR-N31's metric wiring is too new to trust without a fresh
+smoke against the post-PR-N31 codebase.
+
+**If it fails:** the smoke run failure mode itself is the diagnostic.
+Map to RUNBOOK § "Top 8 failure modes":
+
+| Smoke failure | RUNBOOK section |
+|---|---|
+| MISP 5xx exhaustion | § 1 |
+| Neo4j ineffective batch | § 4 |
+| `_MispFallbackHardError` raised | § 8 (newly added in PR-N29/N31) |
+| Placeholder MERGE spike | § 6 |
+
+---
+
+### [3] Alertmanager receiver wired for `severity=critical, component=sync`
+
+**What:** confirm the new
+`EdgeGuardMispFetchFallbackHardError` (critical severity, component=sync)
+actually reaches a human pager / Slack / email channel. The alert rule
+is wired in `prometheus/alerts.yml` — but if Alertmanager routing has
+no receiver matching those labels, the alert fires into the void.
+
+**Command:**
+
+```bash
+# Replace <amtool-config> with your Alertmanager config path or URL
+amtool config routes test --tree --config.file=<amtool-config> \
+    severity=critical component=sync
+```
+
+**Pass criteria:** the output names a receiver (Slack channel, PagerDuty
+service, email address — whatever your routing tree resolves to). NOT
+just `default-receiver` if your default is "/dev/null" — verify the
+specific matcher landed.
+
+**If it fails:** Alertmanager routing config needs a receiver block for
+`{severity=critical, component=sync}`. This is operator-side config;
+no code change. Mirror whatever pattern you use for the existing
+`EdgeGuardCircuitBreakerOpen` alert (same severity / component=circuit-breaker).
+
+---
+
+### [4] MISP event count vs `_FALLBACK_MAX_PAGES = 200` cap
+
+**What:** check whether the populated MISP has more EdgeGuard events
+than the fallback safety cap can paginate. The cap is 200 pages × 500
+events = 100,000 events. If MISP legitimately has more, the fallback
+will raise `_MispFallbackHardError` mid-baseline (PR-N29 made this
+visible — but it still needs the cap raised in advance, not at
+hour 18 of a 32-hour run).
+
+**Command:**
+
+```bash
+curl -s -H "Authorization: $MISP_API_KEY" \
+     -H "Accept: application/json" \
+     "$MISP_URL/events/index" \
+  | jq 'if type=="array" then length else (.response | length) end'
+```
+
+(rough scale; the actual fallback walks `/events/restSearch` with
+``search=EdgeGuard``, so the number above is an upper bound)
+
+**Pass criteria:** event count < 100,000.
+
+**If event count ≥ 100,000:**
+
+1. Edit `src/run_misp_to_neo4j.py` — bump `_FALLBACK_MAX_PAGES`
+   to a value ≥ `ceil(actual_count / 500) * 1.2` (20% headroom).
+2. **Important:** this only matters if the primary `/events/index`
+   path is broken (PR-N29 made the index path the default). The
+   fallback only engages if the index errors. So this is
+   defense-in-depth — consider also fixing why the index errors.
+3. Re-run preflight (`[1]` above) to confirm nothing else regressed.
+
+---
+
+### [5] Disk + RAM headroom for projected scale
+
+**What:** confirm the host has enough Neo4j data-disk space + heap RAM
+for the expected end state. Pre-2-year historical: documented at
+~350,000 nodes / ~700,000 relationships. OOM at hour 26 of a 32-hour
+dagrun is the worst failure mode — recovery requires the procedure
+in [`docs/BACKUP.md`](BACKUP.md) § "Restore procedure" and 6+ hours of
+operator time.
+
+**Command (Docker Compose):**
+
+```bash
+# Disk: where the Neo4j volume lives
+docker volume inspect edgeguard-knowledge-graph_neo4j_data \
+  | jq -r '.[0].Mountpoint' | xargs df -h
+
+# RAM: Neo4j heap config
+docker compose exec neo4j neo4j-admin server memory-recommendation
+```
+
+**Pass criteria:**
+
+* Free disk ≥ 50 GB on the Neo4j data volume (current footprint ×4 for
+  WAL + index rebuilds during heavy MERGE)
+* `dbms.memory.heap.max_size` ≥ 8 GB (4 GB minimum, 8 GB recommended
+  for 350k-node baseline; 16 GB if you can spare)
+* `dbms.memory.pagecache.size` ≥ 4 GB
+
+**If it fails:** stop. There is no graceful recovery from mid-baseline
+OOM. Either:
+
+* Add disk / increase heap, then re-run this check
+* Reduce baseline scope (`EDGEGUARD_BASELINE_DAYS=365` for a 1-year
+  baseline as a fallback), and run that one first while procurement
+  catches up
+
+---
+
+### [6] PR-N32 unicode-bypass audit
+
+**What:** check whether legacy `Malware`/`ThreatActor`/`Tool` nodes
+exist with zero-width / bidi-control chars in their names — created
+BEFORE the PR-N29 L1 placeholder filter landed. Read-only audit; no
+mutation.
+
+**Command:**
+
+```bash
+./scripts/audit_legacy_unicode_bypass_nodes.py
+```
+
+**Pass criteria:** total suspicious count = 0 OR ≤ 10 with operator
+spot-check OK.
+
+**If audit returns ≥ 1 suspicious node:**
+
+| Count    | Action                                                                 |
+|----------|------------------------------------------------------------------------|
+| 0        | ✅ pass — close PR-N32 as a no-op                                      |
+| 1–10     | One-shot Cypher per node (rename / re-merge / delete); no PR needed   |
+| > 10     | 🛑 build a proper PR-N32 migration BEFORE the baseline. The baseline doesn't fix legacy data. |
+
+The audit script's recommendation block tells you which bucket you're
+in and what to do.
+
+---
+
+## Launch decision
+
+If all 6 items pass, you are cleared to run `edgeguard_baseline`. Pick
+your launch path per RUNBOOK § "Baseline launch path":
+
+* **Option A (recommended):** CLI invocation — see RUNBOOK § "Option A"
+* **Option B:** DAG + pre-pause the 4 incremental schedulers — see
+  RUNBOOK § "Option B"
+
+**Do not pick both.** The DAG and CLI paths share the `baseline_lock`
+sentinel; concurrent invocation will (correctly) fail-fast with
+`BaselineAlreadyRunning`, but it's a confusing state to debug.
+
+---
+
+## During the run
+
+* Watch the `EdgeGuardMispFetchFallbackActive` (warning) and
+  `EdgeGuardMispFetchFallbackHardError` (critical) alerts. Both are
+  PR-N31; both should be SILENT for the entire run if everything is
+  healthy.
+* Watch `edgeguard_pipeline_duration_seconds` for the 3 critical-chain
+  tasks (`full_neo4j_sync`, `build_relationships`, `run_enrichment_jobs`).
+  Each should complete within its expected envelope (RUNBOOK has the
+  envelopes).
+* The `EdgeGuardSyncCoverageGap` alert is what catches silent
+  truncation between MISP attribute count and processed count.
+
+## After the run
+
+Follow [`docs/RUNBOOK.md`](RUNBOOK.md) § "After the run" — postcheck
+queries, sector-stats reconciliation, alert mute window cleanup.
+
+---
+
+## Cross-references
+
+* [`docs/RUNBOOK.md`](RUNBOOK.md) — comprehensive operator reference
+* [`docs/BACKUP.md`](BACKUP.md) — backup + restore procedure
+* [`docs/BASELINE_SMOKE_TEST.md`](BASELINE_SMOKE_TEST.md) — 7-day smoke
+* [`scripts/preflight_baseline.sh`](../scripts/preflight_baseline.sh) — automated readiness check
+* [`scripts/audit_legacy_unicode_bypass_nodes.py`](../scripts/audit_legacy_unicode_bypass_nodes.py) — PR-N32 audit
+* [`prometheus/alerts.yml`](../prometheus/alerts.yml) — alert rule definitions
+
+---
+
+_Last updated: 2026-04-25 — added in PR-N32 alongside the legacy unicode-bypass audit script._

--- a/scripts/audit_legacy_unicode_bypass_nodes.py
+++ b/scripts/audit_legacy_unicode_bypass_nodes.py
@@ -1,0 +1,284 @@
+#!/usr/bin/env python3
+"""
+PR-N32 — Read-only audit: legacy unicode-bypass nodes in Neo4j.
+
+## Why this script exists
+
+PR-N29 L1 + PR-N31 closed 35 zero-width / bidi-control / variation-
+selector chars in ``is_placeholder_name`` so an attacker (or buggy
+upstream feed) can no longer create ``Malware``/``ThreatActor``/``Tool``
+nodes whose ``name`` is a placeholder ("unknown", "n/a", …) padded with
+invisible chars. **However**: nodes that were MERGEd BEFORE PR-N29 L1
+(i.e., older than 2026-04-24) bypassed the filter and may still exist
+in production Neo4j with names like ``"unknown​"``,
+``"unknown‎"``, etc.
+
+This script answers a single question: **how many such nodes exist
+right now in the connected Neo4j**, so the operator can decide whether
+PR-N32 (a destructive cleanup PR) is needed at all.
+
+| Audit result          | Implication                                                |
+|-----------------------|------------------------------------------------------------|
+| 0 suspicious nodes    | PR-N32 cleanup not needed; close as a no-op                |
+| 1–10 suspicious       | Manual rename / re-merge in a one-shot Cypher; no PR needed |
+| > 10 suspicious       | Build a proper migration: rename / re-merge / hard delete  |
+
+The script is **strictly read-only** — opens a Neo4j session in
+``READ_ACCESS`` mode so a future-maintainer drift (e.g. someone adding
+a stray MERGE) fails with a loud ``neo4j.exceptions.ClientError``
+instead of silently mutating production.
+
+## Single source of truth
+
+The list of "suspicious" characters is imported directly from
+``src/node_identity._ZERO_WIDTH_AND_BIDI_CHARS`` — the same canonical
+list ``is_placeholder_name`` strips. If a future PR adds chars to that
+list, this audit picks them up automatically without a separate update.
+
+## Usage
+
+    export NEO4J_URI="bolt://localhost:7687"
+    export NEO4J_PASSWORD="<password>"
+    export NEO4J_USER="neo4j"  # optional, defaults to neo4j
+
+    # Default: count + sample 5 names per label.
+    ./scripts/audit_legacy_unicode_bypass_nodes.py
+
+    # More samples for triage.
+    ./scripts/audit_legacy_unicode_bypass_nodes.py --sample-limit 20
+
+    # Quiet mode — just the JSON summary on stdout for piping.
+    ./scripts/audit_legacy_unicode_bypass_nodes.py --json
+
+Exit codes:
+    0 — audit ran successfully (regardless of finding count)
+    1 — connection / config error (operator-actionable)
+
+The audit NEVER exits non-zero on "found N suspicious nodes" — that's
+informational, not a CI failure. If you want a CI gate based on the
+count, parse the JSON output: ``--json | jq '.total_suspicious'``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+# Make src/ importable so we can pull the canonical char list from
+# node_identity (single source of truth — see module docstring).
+SRC = Path(__file__).resolve().parent.parent / "src"
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+
+from neo4j import READ_ACCESS, Driver, GraphDatabase  # noqa: E402
+from node_identity import _ZERO_WIDTH_AND_BIDI_CHARS  # noqa: E402
+
+logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+logger = logging.getLogger(__name__)
+
+
+# Labels that use ``name`` as natural key + are subject to placeholder
+# filtering via ``is_placeholder_name`` (see neo4j_client.merge_malware /
+# merge_actor / merge_tool). Sectors are excluded — Sector names are
+# operator-controlled (config), not feed-derived.
+_AUDITED_LABELS = ("Malware", "ThreatActor", "Tool")
+
+
+def _build_suspicious_regex() -> str:
+    """Return a Cypher-compatible regex matching any of the canonical
+    zero-width / bidi-control / variation-selector chars.
+
+    Cypher uses Java regex syntax. We use the inline ``\\uXXXX`` escapes
+    rather than a literal char class so the regex is greppable and
+    doesn't depend on the source file's encoding.
+
+    Single source of truth: pulls from
+    ``node_identity._ZERO_WIDTH_AND_BIDI_CHARS`` — if a future PR adds
+    chars there, this audit picks them up automatically."""
+    escapes = "".join(f"\\u{ord(c):04x}" for c in _ZERO_WIDTH_AND_BIDI_CHARS)
+    return f".*[{escapes}].*"
+
+
+_SUSPICIOUS_REGEX = _build_suspicious_regex()
+
+
+def _count_query(label: str) -> str:
+    """Cypher to count + sample suspicious nodes for one label.
+
+    Returns three things:
+    * ``total`` — total nodes of this label (for context — what % is suspicious)
+    * ``suspicious`` — count of nodes whose ``name`` matches the regex
+    * ``samples`` — first N suspicious node names (for operator triage)
+
+    The label is interpolated server-side because Cypher doesn't support
+    parameterised label names — we control the input via ``_AUDITED_LABELS``
+    so injection is not a vector."""
+    return f"""
+    MATCH (n:{label})
+    WITH count(n) AS total,
+         collect(CASE WHEN n.name =~ $regex THEN n.name END) AS all_names
+    UNWIND all_names AS name
+    WITH total, name
+    WHERE name IS NOT NULL
+    WITH total, collect(name) AS suspicious_names
+    RETURN total,
+           size(suspicious_names) AS suspicious,
+           suspicious_names[0..$sample_limit] AS samples
+    """
+
+
+def _annotate_codepoints(name: str) -> str:
+    """Render a name with its non-ASCII codepoints visible.
+
+    A raw ``"unknown​"`` printed to terminal looks identical to
+    ``"unknown"`` — operator can't visually identify the problem. This
+    helper renders each non-printable as ``<U+200B>`` so the bypass is
+    obvious in the audit output."""
+    out_parts = []
+    for c in name:
+        if ord(c) < 128 and c.isprintable():
+            out_parts.append(c)
+        else:
+            out_parts.append(f"<U+{ord(c):04X}>")
+    return "".join(out_parts)
+
+
+def get_driver() -> Driver:
+    """Connect using NEO4J_URI / NEO4J_PASSWORD / NEO4J_USER from env.
+    Mirrors ``scripts/backfill_edge_misp_event_ids.py`` for consistency."""
+    uri = os.environ.get("NEO4J_URI")
+    password = os.environ.get("NEO4J_PASSWORD")
+    if not uri:
+        logger.error("NEO4J_URI not set — required (e.g. bolt://localhost:7687)")
+        sys.exit(1)
+    if not password:
+        logger.error("NEO4J_PASSWORD not set — required")
+        sys.exit(1)
+    user = os.environ.get("NEO4J_USER", "neo4j")
+    return GraphDatabase.driver(uri, auth=(user, password))
+
+
+def audit_label(driver: Driver, label: str, sample_limit: int) -> Dict[str, Any]:
+    """Run the count + sample query for one label.
+
+    READ_ACCESS at session level — guarantees no write can sneak in even
+    if the query string is later modified (e.g. by a future maintainer
+    adding a stray MERGE). Server rejects writes with
+    ``neo4j.exceptions.ClientError`` — loud failure beats silent
+    corruption."""
+    with driver.session(default_access_mode=READ_ACCESS) as session:
+        result = session.run(
+            _count_query(label),
+            regex=_SUSPICIOUS_REGEX,
+            sample_limit=sample_limit,
+        )
+        record = result.single()
+        if record is None:
+            return {"label": label, "total": 0, "suspicious": 0, "samples": []}
+        return {
+            "label": label,
+            "total": int(record["total"]),
+            "suspicious": int(record["suspicious"]),
+            "samples": list(record["samples"] or []),
+        }
+
+
+def render_human(per_label: List[Dict[str, Any]]) -> str:
+    """Operator-facing summary — column-aligned + codepoint-annotated."""
+    lines = ["", "=== Audit: Legacy unicode-bypass nodes ===", ""]
+    total_suspicious = 0
+    for row in per_label:
+        lines.append(
+            f"[{row['label']:<14}] total_nodes={row['total']:>10,}   "
+            f"suspicious={row['suspicious']:>4}" + ("   (all clean)" if row["suspicious"] == 0 else "")
+        )
+        if row["samples"]:
+            lines.append("  Samples (codepoints expanded):")
+            for s in row["samples"]:
+                lines.append(f"    - {_annotate_codepoints(s)!r}")
+        total_suspicious += row["suspicious"]
+
+    lines.append("")
+    lines.append(f"Total suspicious: {total_suspicious}")
+    lines.append("")
+
+    if total_suspicious == 0:
+        lines.append("RECOMMENDATION: PR-N32 cleanup is NOT needed — close it as a no-op.")
+        lines.append("")
+        lines.append("All node names are clean of the canonical zero-width / bidi-")
+        lines.append("control / variation-selector char set. The PR-N29 L1 + PR-N31")
+        lines.append("filter is doing its job for new MERGEs, and there is no legacy")
+        lines.append("backlog to clean up.")
+    elif total_suspicious <= 10:
+        lines.append(f"RECOMMENDATION: {total_suspicious} suspicious nodes — manual one-shot Cypher.")
+        lines.append("")
+        lines.append("Small enough to fix by hand. For each sample above, decide:")
+        lines.append("  * RENAME — operator-canonical name is obvious; ``SET n.name = ...``")
+        lines.append("  * RE-MERGE — find the canonical node + ``CALL apoc.refactor.mergeNodes(...)``")
+        lines.append("  * DELETE — node has no real edges; ``MATCH (n) WHERE elementId(n)=... DETACH DELETE n``")
+        lines.append("")
+        lines.append("No need for a migration PR — keep it as a one-shot in")
+        lines.append("docs/MIGRATIONS.md with a date stamp + the count above.")
+    else:
+        lines.append(f"RECOMMENDATION: {total_suspicious} suspicious nodes — full PR-N32 migration warranted.")
+        lines.append("")
+        lines.append("Open PR-N32 with:")
+        lines.append("  1. A reusable cleanup script under scripts/ (mirrors")
+        lines.append("     backfill_edge_misp_event_ids.py — --dry-run + --commit modes,")
+        lines.append("     READ_ACCESS in dry-run, idempotency guard).")
+        lines.append("  2. Policy decision tree (rename / re-merge / delete) per pattern.")
+        lines.append("  3. Docs/MIGRATIONS.md entry + RUNBOOK pointer.")
+        lines.append("  4. Behavioural test on a fake driver (no live Neo4j needed in CI).")
+    lines.append("")
+    return "\n".join(lines)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="PR-N32 — read-only audit of legacy unicode-bypass nodes in Neo4j.")
+    parser.add_argument(
+        "--sample-limit",
+        type=int,
+        default=5,
+        help="How many suspicious node names to sample per label (default: 5).",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Emit machine-readable JSON on stdout instead of human summary.",
+    )
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    driver = get_driver()
+    try:
+        per_label = [audit_label(driver, label, args.sample_limit) for label in _AUDITED_LABELS]
+    finally:
+        # finally before the broad rendering: no NameError-mask risk because
+        # ``driver`` is already bound by this point (get_driver sys.exit's on failure).
+        driver.close()
+
+    if args.json:
+        # Machine-readable for CI / piping. Schema is stable: any change
+        # here MUST update the test in tests/test_pr_n32_unicode_audit.py.
+        payload = {
+            "schema_version": 1,
+            "per_label": per_label,
+            "total_suspicious": sum(r["suspicious"] for r in per_label),
+            "audited_labels": list(_AUDITED_LABELS),
+            "char_count_in_filter": len(_ZERO_WIDTH_AND_BIDI_CHARS),
+        }
+        print(json.dumps(payload, indent=2, ensure_ascii=False))
+    else:
+        print(render_human(per_label))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/audit_legacy_unicode_bypass_nodes.py
+++ b/scripts/audit_legacy_unicode_bypass_nodes.py
@@ -117,15 +117,22 @@ def _count_query(label: str) -> str:
 
     The label is interpolated server-side because Cypher doesn't support
     parameterised label names — we control the input via ``_AUDITED_LABELS``
-    so injection is not a vector."""
+    so injection is not a vector.
+
+    PR-N32 Bugbot round 1 (2026-04-25, MED): the prior version pipelined
+    via ``UNWIND all_names AS name``. When a label had ZERO suspicious
+    matches (the expected happy-path), ``all_names`` was the empty list,
+    ``UNWIND []`` produced zero rows, and the entire downstream pipeline
+    — including ``total`` — collapsed to 0 rows. ``result.single()``
+    then returned ``None`` and the audit_label fallback reported
+    ``total=0`` even when there were thousands of clean nodes. Fix:
+    Neo4j's ``collect()`` already skips NULLs, so the explicit UNWIND +
+    ``WHERE name IS NOT NULL`` + re-collect was redundant. Single-row
+    return regardless of match count."""
     return f"""
     MATCH (n:{label})
     WITH count(n) AS total,
-         collect(CASE WHEN n.name =~ $regex THEN n.name END) AS all_names
-    UNWIND all_names AS name
-    WITH total, name
-    WHERE name IS NOT NULL
-    WITH total, collect(name) AS suspicious_names
+         collect(CASE WHEN n.name =~ $regex THEN n.name END) AS suspicious_names
     RETURN total,
            size(suspicious_names) AS suspicious,
            suspicious_names[0..$sample_limit] AS samples
@@ -179,6 +186,13 @@ def audit_label(driver: Driver, label: str, sample_limit: int) -> Dict[str, Any]
         )
         record = result.single()
         if record is None:
+            # Defensive: post-Bugbot-round-1 fix, _count_query always
+            # returns exactly one row (count + collect always produce a
+            # single-row aggregation). This branch is only reachable on
+            # a degenerate driver-level error (e.g. transaction rolled
+            # back mid-query). Keep the fallback rather than silently
+            # KeyError — but operators should treat total=0 here as
+            # "couldn't get a real count" not "label is empty".
             return {"label": label, "total": 0, "suspicious": 0, "samples": []}
         return {
             "label": label,

--- a/tests/test_pr_n32_unicode_audit.py
+++ b/tests/test_pr_n32_unicode_audit.py
@@ -42,6 +42,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import Any
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 SRC = REPO_ROOT / "src"
@@ -262,6 +263,189 @@ class TestPRN32AuditOutput:
         assert _annotate_codepoints("‮unknown") == "<U+202E>unknown"
         # Clean strings pass through unchanged.
         assert _annotate_codepoints("Conti") == "Conti"
+
+
+class TestPRN32AuditLabelBehaviouralFakeDriver:
+    """PR-N32 Bugbot round 1 (2026-04-25, MED): the prior ``_count_query``
+    used ``UNWIND all_names AS name``. When a label had ZERO suspicious
+    matches (the expected happy-path), ``UNWIND []`` produced zero rows
+    and the entire downstream pipeline collapsed — including ``total``.
+    ``result.single()`` returned ``None`` and the audit_label fallback
+    reported ``total=0`` even when there were thousands of clean nodes.
+
+    The pre-Bugbot tests passed because they hand-crafted the
+    ``per_label`` dict and called ``render_human`` directly — they
+    NEVER exercised the real ``audit_label`` → ``_count_query`` path.
+
+    This class fills that gap: a fake driver / session / result that
+    exercises ``audit_label`` end-to-end with two scenarios:
+      * ZERO matches (the Bugbot-flagged case)
+      * N matches (sanity)
+
+    If a future maintainer reverts the Cypher fix, these tests fire
+    BEFORE Bugbot has to catch it again.
+    """
+
+    @staticmethod
+    def _build_fake_driver(rows: list[dict]) -> Any:
+        """Build a context-manager-shaped fake driver that returns
+        the supplied rows from session.run().single(). Mirrors the
+        neo4j Python driver's contract closely enough for audit_label
+        to consume it as if it were a real driver."""
+
+        class _FakeRecord:
+            def __init__(self, row: dict) -> None:
+                self._row = row
+
+            def __getitem__(self, key: str) -> Any:
+                return self._row[key]
+
+        class _FakeResult:
+            def __init__(self, rows: list[dict]) -> None:
+                self._rows = rows
+
+            def single(self) -> Any:
+                return _FakeRecord(self._rows[0]) if self._rows else None
+
+        class _FakeSession:
+            def __init__(self, rows: list[dict]) -> None:
+                self._rows = rows
+                self.last_query: str | None = None
+                self.last_params: dict | None = None
+                self.access_mode: str | None = None
+
+            def __enter__(self) -> "_FakeSession":
+                return self
+
+            def __exit__(self, *args: Any) -> None:
+                pass
+
+            def run(self, query: str, **params: Any) -> _FakeResult:
+                self.last_query = query
+                self.last_params = params
+                return _FakeResult(self._rows)
+
+        class _FakeDriver:
+            def __init__(self, rows: list[dict]) -> None:
+                self._rows = rows
+                self.last_session: _FakeSession | None = None
+
+            def session(self, default_access_mode: str | None = None) -> _FakeSession:
+                self.last_session = _FakeSession(self._rows)
+                self.last_session.access_mode = default_access_mode
+                return self.last_session
+
+            def close(self) -> None:
+                pass
+
+        return _FakeDriver(rows)
+
+    def test_audit_label_preserves_total_when_zero_suspicious(self):
+        """PR-N32 Bugbot round 1: ZERO suspicious matches must NOT
+        collapse the ``total`` count to 0. Pre-fix, ``UNWIND []`` killed
+        the whole pipeline and the audit reported every clean label as
+        ``total=0`` — which an operator would read as "the query found
+        nothing" rather than "12,000 clean nodes."""
+        from audit_legacy_unicode_bypass_nodes import audit_label
+
+        # Simulate: 12,000 Malware nodes, 0 of them suspicious.
+        # Post-fix ``_count_query`` always returns one row even with
+        # an empty suspicious_names list.
+        fake = self._build_fake_driver([{"total": 12000, "suspicious": 0, "samples": []}])
+        result = audit_label(fake, "Malware", sample_limit=5)
+        assert result == {
+            "label": "Malware",
+            "total": 12000,
+            "suspicious": 0,
+            "samples": [],
+        }, (
+            "PR-N32 Bugbot round 1: total must survive even when the "
+            "suspicious list is empty. Pre-fix UNWIND [] dropped the "
+            "whole pipeline."
+        )
+
+    def test_audit_label_returns_full_result_when_n_suspicious(self):
+        """Sanity: when there ARE matches, all three fields propagate."""
+        from audit_legacy_unicode_bypass_nodes import audit_label
+
+        fake = self._build_fake_driver([{"total": 12000, "suspicious": 3, "samples": ["unknown​", "n/a‎", "tbd‪"]}])
+        result = audit_label(fake, "Malware", sample_limit=5)
+        assert result["label"] == "Malware"
+        assert result["total"] == 12000
+        assert result["suspicious"] == 3
+        assert len(result["samples"]) == 3
+
+    def test_audit_label_uses_read_access_session(self):
+        """Behavioural: the session MUST be opened with READ_ACCESS.
+        Defense-in-depth pin — if a future maintainer changes the
+        access mode, this test fires loudly."""
+        from audit_legacy_unicode_bypass_nodes import audit_label
+
+        from neo4j import READ_ACCESS
+
+        fake = self._build_fake_driver([{"total": 0, "suspicious": 0, "samples": []}])
+        audit_label(fake, "Malware", sample_limit=5)
+        assert fake.last_session is not None
+        assert fake.last_session.access_mode == READ_ACCESS, (
+            "PR-N32: audit_label MUST open sessions with READ_ACCESS so "
+            "any future-maintainer drift adding a write hits a server-side "
+            "rejection rather than silently mutating production."
+        )
+
+    def test_audit_label_passes_regex_and_sample_limit_params(self):
+        """Behavioural: the canonical regex + sample_limit param land
+        on the query. Without this, the audit could silently use a stale
+        regex (missing recently-added chars from
+        _ZERO_WIDTH_AND_BIDI_CHARS)."""
+        from audit_legacy_unicode_bypass_nodes import _SUSPICIOUS_REGEX, audit_label
+
+        fake = self._build_fake_driver([{"total": 0, "suspicious": 0, "samples": []}])
+        audit_label(fake, "Malware", sample_limit=42)
+        assert fake.last_session is not None
+        params = fake.last_session.last_params or {}
+        assert params.get("regex") == _SUSPICIOUS_REGEX, (
+            "PR-N32: audit_label MUST pass the canonical _SUSPICIOUS_REGEX "
+            "to the Cypher query — otherwise the audit silently uses "
+            "whatever regex the future maintainer hard-codes."
+        )
+        assert params.get("sample_limit") == 42, "PR-N32: audit_label MUST forward the operator-supplied sample_limit"
+
+
+class TestPRN32CountQueryShape:
+    """PR-N32 Bugbot round 1 follow-up: the negative shape pin —
+    the new query must not contain the failed UNWIND pattern. If a
+    future maintainer reverts to the UNWIND approach, this test fires
+    BEFORE the bug surfaces in production."""
+
+    def test_count_query_does_not_use_unwind(self):
+        """Pre-fix _count_query used ``UNWIND all_names AS name`` —
+        which produced 0 rows when all_names was empty, dropping the
+        entire pipeline. The fix removes the UNWIND. Pin so a future
+        revert can't silently re-introduce the bug."""
+        from audit_legacy_unicode_bypass_nodes import _AUDITED_LABELS, _count_query
+
+        for label in _AUDITED_LABELS:
+            cypher = _count_query(label)
+            assert "UNWIND" not in cypher.upper(), (
+                f"PR-N32 Bugbot round 1: _count_query({label!r}) must not use "
+                f"UNWIND — when the suspicious list is empty, ``UNWIND []`` "
+                f"produces zero rows and drops the entire pipeline (including "
+                f"total). Use a single-row aggregation instead."
+            )
+
+    def test_count_query_returns_total_outside_any_loop(self):
+        """Belt-and-braces: the RETURN clause must include ``total``
+        as a top-level binding (not nested inside a list comprehension
+        or sub-query that could collapse on empty input)."""
+        from audit_legacy_unicode_bypass_nodes import _AUDITED_LABELS, _count_query
+
+        for label in _AUDITED_LABELS:
+            cypher = _count_query(label)
+            assert "RETURN total" in cypher, (
+                f"PR-N32: _count_query({label!r}) must RETURN total directly "
+                f"(not as part of a sub-query / list comprehension that could "
+                f"yield zero rows on the empty case)."
+            )
 
 
 # ===========================================================================

--- a/tests/test_pr_n32_unicode_audit.py
+++ b/tests/test_pr_n32_unicode_audit.py
@@ -1,0 +1,373 @@
+"""
+PR-N32 — read-only unicode-bypass audit + launch-day checklist.
+
+PR-N29 L1 + PR-N31 closed 35 zero-width / bidi-control / variation-
+selector chars in `is_placeholder_name` so an attacker (or buggy feed)
+can no longer create Malware/ThreatActor/Tool nodes whose names are
+placeholders padded with invisible chars. PR-N32 ships:
+
+* `scripts/audit_legacy_unicode_bypass_nodes.py` — read-only audit
+  that answers "do legacy unicode-bypass nodes still exist in
+  production Neo4j?" so the operator can decide whether a destructive
+  cleanup migration is needed at all.
+* `docs/BASELINE_LAUNCH_CHECKLIST.md` — the single doc the operator
+  walks through immediately before triggering a 730-day baseline.
+
+Both are deliberately small surfaces:
+
+* The script uses READ_ACCESS at the session level (loud-fail on any
+  future-maintainer drift that adds a stray write); the canonical
+  char list is imported from `node_identity._ZERO_WIDTH_AND_BIDI_CHARS`
+  (single source of truth — adds to that list propagate automatically).
+* The checklist references existing docs (RUNBOOK, BACKUP,
+  BASELINE_SMOKE_TEST) rather than duplicating them — so a future
+  edit to RUNBOOK doesn't drift away from the checklist.
+
+Tests pin both deliverables' contracts:
+
+* The script is importable + structured-output stable
+* The audit-regex matches every char in the canonical list
+  (cross-source-of-truth pin: if a future PR adds a char to
+  `_ZERO_WIDTH_AND_BIDI_CHARS`, the audit picks it up)
+* The script is read-only (no MERGE / SET / DELETE / CREATE /
+  REMOVE in any of its Cypher templates)
+* The checklist references the right scripts / docs / alerts and
+  the cross-references actually resolve
+"""
+
+from __future__ import annotations
+
+import importlib
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SRC = REPO_ROOT / "src"
+SCRIPTS = REPO_ROOT / "scripts"
+DOCS = REPO_ROOT / "docs"
+
+if str(SRC) not in sys.path:
+    sys.path.insert(0, str(SRC))
+if str(SCRIPTS) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS))
+
+os.environ.setdefault("NEO4J_PASSWORD", "test-pw-pr-n32")
+
+
+# ===========================================================================
+# scripts/audit_legacy_unicode_bypass_nodes.py — read-only audit
+# ===========================================================================
+
+
+class TestPRN32AuditScriptShape:
+    """Source-pin the audit script's shape so a future-maintainer drift
+    can't silently turn a read-only audit into a destructive write."""
+
+    SCRIPT_FILE = SCRIPTS / "audit_legacy_unicode_bypass_nodes.py"
+
+    def test_script_exists_and_executable(self):
+        """The script must be present + have the executable bit set so
+        operators can invoke it via `./scripts/audit_legacy_unicode_bypass_nodes.py`."""
+        assert self.SCRIPT_FILE.exists(), "PR-N32 audit script must exist"
+        assert os.access(self.SCRIPT_FILE, os.X_OK), (
+            "PR-N32: audit script must have executable bit set so operators can "
+            "invoke it directly via ./scripts/audit_legacy_unicode_bypass_nodes.py"
+        )
+
+    def test_script_is_importable(self):
+        """The script must import cleanly without a live Neo4j (the
+        connection only happens inside main(), not at import time)."""
+        mod = importlib.import_module("audit_legacy_unicode_bypass_nodes")
+        # Smoke: module-level objects we depend on
+        assert hasattr(mod, "_AUDITED_LABELS")
+        assert hasattr(mod, "_SUSPICIOUS_REGEX")
+        assert hasattr(mod, "audit_label")
+        assert hasattr(mod, "render_human")
+        assert hasattr(mod, "main")
+
+    def test_audited_labels_match_placeholder_filtered_labels(self):
+        """The audited labels must exactly match the labels that use
+        ``is_placeholder_name`` filtering. Currently: Malware, ThreatActor,
+        Tool. (Sector is excluded — operator-controlled config, not
+        feed-derived.) If a future PR adds placeholder filtering to a new
+        label, the audit MUST be expanded to cover it; this test surfaces
+        the drift loudly rather than silently leaving a label uncovered."""
+        from audit_legacy_unicode_bypass_nodes import _AUDITED_LABELS
+
+        assert set(_AUDITED_LABELS) == {"Malware", "ThreatActor", "Tool"}, (
+            "PR-N32: _AUDITED_LABELS must match the labels that use "
+            "is_placeholder_name filtering (Malware, ThreatActor, Tool). "
+            "If a new label gets placeholder filtering, expand both."
+        )
+
+    def test_uses_read_access_session_mode(self):
+        """Defense-in-depth: the audit script MUST open Neo4j sessions
+        in READ_ACCESS mode so any future drift (e.g. a maintainer
+        adding a stray MERGE while extending the script) loud-fails on
+        the server side rather than silently mutating production."""
+        text = self.SCRIPT_FILE.read_text()
+        assert "READ_ACCESS" in text, "PR-N32: script must import + use READ_ACCESS"
+        assert "default_access_mode=READ_ACCESS" in text, (
+            "PR-N32: session must be opened with default_access_mode=READ_ACCESS — "
+            "without this, a future maintainer's accidental MERGE would silently "
+            "mutate production rather than loud-failing on the server."
+        )
+
+    def test_no_write_cypher_in_script(self):
+        """Negative pin: every Cypher template used by the script must be
+        write-free. Belt-and-braces with the READ_ACCESS session mode.
+
+        Scope: scans only the actual Cypher templates (functions whose
+        body returns a Cypher string + the literal string passed to
+        ``session.run``). Excludes the operator-facing recommendation
+        narrative strings in ``render_human`` which legitimately contain
+        the keywords MERGE / SET / DELETE as English text in the
+        triage tree.
+        """
+        import ast
+
+        # The only Cypher in the script is generated by _count_query —
+        # exercise it for each audited label and scan the resulting strings.
+        from audit_legacy_unicode_bypass_nodes import _AUDITED_LABELS, _count_query
+
+        for label in _AUDITED_LABELS:
+            cypher = _count_query(label)
+            for forbidden in ("MERGE", "SET ", "DELETE", "CREATE", "REMOVE"):
+                assert forbidden not in cypher.upper(), (
+                    f"PR-N32: _count_query({label!r}) contains write-Cypher "
+                    f"keyword ``{forbidden}``. The audit MUST be read-only — "
+                    f"if you need a write path, put it in a separate cleanup "
+                    f"script that explicitly opts INTO write mode."
+                )
+
+        # Also AST-scan any other string literal passed to ``session.run(...)``
+        # so a future maintainer adding a second query gets the same check.
+        tree = ast.parse(self.SCRIPT_FILE.read_text())
+        run_args: list[str] = []
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "run"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)
+                and isinstance(node.args[0].value, str)
+            ):
+                run_args.append(node.args[0].value)
+        for arg in run_args:
+            for forbidden in ("MERGE", "SET ", "DELETE", "CREATE", "REMOVE"):
+                assert forbidden not in arg.upper(), (
+                    f"PR-N32: literal Cypher string passed to session.run() "
+                    f"contains write-keyword ``{forbidden}``. Audit must be "
+                    f"strictly read-only."
+                )
+
+
+class TestPRN32AuditRegexCanonicalParity:
+    """Single-source-of-truth pin: the audit's regex must cover every
+    char in `node_identity._ZERO_WIDTH_AND_BIDI_CHARS`. If a future PR
+    adds a char to that list (e.g. a new bidi attack vector), the audit
+    must pick it up automatically — that's the contract this test pins."""
+
+    def test_regex_matches_every_canonical_char(self):
+        from audit_legacy_unicode_bypass_nodes import _SUSPICIOUS_REGEX
+
+        from node_identity import _ZERO_WIDTH_AND_BIDI_CHARS
+
+        # The Cypher regex uses ``\\uXXXX`` syntax — reformat to Python
+        # regex (which uses the same Unicode escapes inside character
+        # classes). Both engines are PCRE-compatible enough for this
+        # equivalence to hold for character-class membership tests.
+        py_pattern = re.compile(_SUSPICIOUS_REGEX, re.DOTALL)
+        for c in _ZERO_WIDTH_AND_BIDI_CHARS:
+            test_str = f"unknown{c}foo"
+            assert py_pattern.fullmatch(test_str), (
+                f"PR-N32: audit regex must match canonical char U+{ord(c):04X}. "
+                f"If the regex doesn't pick up a char that the placeholder "
+                f"filter strips, legacy nodes with that char in their name "
+                f"will be silently invisible to the audit."
+            )
+
+    def test_regex_does_not_match_clean_strings(self):
+        """Negative pin: the regex must NOT match strings that contain
+        only ASCII + standard whitespace. Otherwise the audit would
+        produce false positives on every node and lose its signal."""
+        from audit_legacy_unicode_bypass_nodes import _SUSPICIOUS_REGEX
+
+        py_pattern = re.compile(_SUSPICIOUS_REGEX, re.DOTALL)
+        for clean in ("Conti", "LockBit 3.0", "Cobalt Strike", "unknown"):
+            assert not py_pattern.fullmatch(clean), (
+                f"PR-N32: audit regex must not match clean string {clean!r} — "
+                f"otherwise the audit reports false positives on every node."
+            )
+
+
+class TestPRN32AuditOutput:
+    """Pin the human + JSON output shapes. The JSON schema is the
+    machine-readable contract for downstream piping (e.g., ``--json |
+    jq '.total_suspicious'`` in CI)."""
+
+    def test_render_human_zero_finds_recommends_no_op(self):
+        """Behavioural: with 0 suspicious nodes across all labels, the
+        human-readable summary must explicitly recommend closing the PR
+        as a no-op. Operators reading the output should not have to
+        guess — the recommendation must be unambiguous."""
+        from audit_legacy_unicode_bypass_nodes import render_human
+
+        per_label = [
+            {"label": "Malware", "total": 100, "suspicious": 0, "samples": []},
+            {"label": "ThreatActor", "total": 50, "suspicious": 0, "samples": []},
+            {"label": "Tool", "total": 25, "suspicious": 0, "samples": []},
+        ]
+        out = render_human(per_label)
+        assert "Total suspicious: 0" in out
+        assert "PR-N32 cleanup is NOT needed" in out
+
+    def test_render_human_small_count_recommends_one_shot(self):
+        """1–10 suspicious nodes → "manual one-shot Cypher"."""
+        from audit_legacy_unicode_bypass_nodes import render_human
+
+        per_label = [
+            {"label": "Malware", "total": 100, "suspicious": 3, "samples": ["unknown​", "n/a‎", "tbd‪"]},
+            {"label": "ThreatActor", "total": 50, "suspicious": 0, "samples": []},
+            {"label": "Tool", "total": 25, "suspicious": 0, "samples": []},
+        ]
+        out = render_human(per_label)
+        assert "Total suspicious: 3" in out
+        assert "manual one-shot Cypher" in out
+
+    def test_render_human_large_count_recommends_full_migration(self):
+        """> 10 suspicious → "full PR-N32 migration warranted"."""
+        from audit_legacy_unicode_bypass_nodes import render_human
+
+        per_label = [
+            {"label": "Malware", "total": 100, "suspicious": 50, "samples": []},
+            {"label": "ThreatActor", "total": 50, "suspicious": 0, "samples": []},
+            {"label": "Tool", "total": 25, "suspicious": 0, "samples": []},
+        ]
+        out = render_human(per_label)
+        assert "Total suspicious: 50" in out
+        assert "full PR-N32 migration warranted" in out
+
+    def test_render_human_codepoint_annotation_makes_invisible_visible(self):
+        """The whole point of codepoint annotation: a raw ``"unknown\\u200b"``
+        printed to terminal looks identical to ``"unknown"``. The audit
+        must render the codepoint so the operator can see WHICH char is
+        the bypass."""
+        from audit_legacy_unicode_bypass_nodes import _annotate_codepoints
+
+        assert _annotate_codepoints("unknown​") == "unknown<U+200B>"
+        assert _annotate_codepoints("‮unknown") == "<U+202E>unknown"
+        # Clean strings pass through unchanged.
+        assert _annotate_codepoints("Conti") == "Conti"
+
+
+# ===========================================================================
+# docs/BASELINE_LAUNCH_CHECKLIST.md — pre-launch operator pass
+# ===========================================================================
+
+
+class TestPRN32LaunchChecklistDoc:
+    """Pin the checklist's structure + cross-references. If a future PR
+    moves or renames a referenced doc / script / alert, this test fires
+    immediately rather than the operator discovering broken links at
+    launch time."""
+
+    CHECKLIST = DOCS / "BASELINE_LAUNCH_CHECKLIST.md"
+
+    def test_checklist_exists(self):
+        assert self.CHECKLIST.exists(), "PR-N32 launch checklist must exist"
+
+    def test_has_six_numbered_sections(self):
+        """The checklist's 6 items must all be present + numbered. If a
+        future PR adds or removes an item, bump the count + update this
+        test deliberately — no silent drift."""
+        text = self.CHECKLIST.read_text()
+        for n in range(1, 7):
+            assert f"### [{n}]" in text, f"PR-N32 checklist must contain section ### [{n}]"
+
+    def test_references_preflight_script(self):
+        """Item [1] uses the preflight script — must reference it correctly."""
+        text = self.CHECKLIST.read_text()
+        assert "scripts/preflight_baseline.sh" in text
+        assert "EDGEGUARD_PREFLIGHT_STRICT=1" in text
+        # The actual file must exist
+        assert (REPO_ROOT / "scripts" / "preflight_baseline.sh").exists()
+
+    def test_references_smoke_test_doc(self):
+        """Item [2] points to BASELINE_SMOKE_TEST.md — must exist."""
+        text = self.CHECKLIST.read_text()
+        assert "BASELINE_SMOKE_TEST.md" in text
+        assert (DOCS / "BASELINE_SMOKE_TEST.md").exists()
+
+    def test_references_audit_script(self):
+        """Item [6] uses the new audit script — must point to it correctly."""
+        text = self.CHECKLIST.read_text()
+        assert "scripts/audit_legacy_unicode_bypass_nodes.py" in text
+        assert (REPO_ROOT / "scripts" / "audit_legacy_unicode_bypass_nodes.py").exists()
+
+    def test_references_pr_n31_alert_names(self):
+        """Items [3] + 'During the run' reference the PR-N31 alert names —
+        must match what's actually in alerts.yml."""
+        text = self.CHECKLIST.read_text()
+        alerts_text = (REPO_ROOT / "prometheus" / "alerts.yml").read_text()
+        for alert_name in ("EdgeGuardMispFetchFallbackActive", "EdgeGuardMispFetchFallbackHardError"):
+            assert alert_name in text, f"checklist must reference {alert_name}"
+            assert alert_name in alerts_text, f"alerts.yml must define {alert_name} — checklist references it"
+
+    def test_references_runbook_sections_that_exist(self):
+        """The checklist sends operators to RUNBOOK § 'Top 8 failure
+        modes' and § 'Baseline launch path' — both must exist in the
+        actual RUNBOOK."""
+        text = self.CHECKLIST.read_text()
+        runbook = (DOCS / "RUNBOOK.md").read_text()
+        assert "Top 8 failure modes" in text
+        assert "Top 8 failure modes" in runbook, (
+            "RUNBOOK must have a 'Top 8 failure modes' section that the checklist points to"
+        )
+        assert "Baseline launch path" in text
+        assert "Baseline launch path" in runbook
+
+    def test_references_pr_n32_audit_count_buckets(self):
+        """Item [6]'s decision tree must match the audit script's
+        recommendation buckets (0 / 1–10 / >10). If the script changes
+        bucket boundaries, this test surfaces the drift."""
+        text = self.CHECKLIST.read_text()
+        # Three buckets in the table
+        assert "1–10" in text, "checklist must use the en-dash 1–10 bucket label (matches audit script wording)"
+        # The cutoff must be exactly 10 for the manual-one-shot vs full-migration boundary
+        assert "> 10" in text
+
+
+class TestPRN32ChecklistSourceOfTruthInvariants:
+    """Cross-file pins so the checklist + the rest of the repo can't
+    drift apart silently. Each test answers: "if X changes, does the
+    checklist need an update?" and fails when the answer is yes."""
+
+    def test_alert_count_floor_consistent_with_alerts_yml(self):
+        """The checklist's `[1]` says preflight requires "≥ 11 rules".
+        That number must match what's actually in preflight + the actual
+        alert count in alerts.yml."""
+        checklist = (DOCS / "BASELINE_LAUNCH_CHECKLIST.md").read_text()
+        preflight = (REPO_ROOT / "scripts" / "preflight_baseline.sh").read_text()
+
+        assert "≥ 11" in checklist, "checklist must mention the ≥ 11 alert floor"
+        assert "-ge 11" in preflight, "preflight must enforce ≥ 11 alert floor"
+
+    def test_fallback_max_pages_value_consistent_with_source(self):
+        """The checklist's `[4]` quotes ``_FALLBACK_MAX_PAGES = 200``
+        and ``200 × 500 = 100,000`` — must match the actual constant
+        in run_misp_to_neo4j.py. If the cap is bumped without updating
+        the checklist, operators get the wrong number when sizing
+        their MISP."""
+        checklist = (DOCS / "BASELINE_LAUNCH_CHECKLIST.md").read_text()
+        sync = (SRC / "run_misp_to_neo4j.py").read_text()
+
+        assert "_FALLBACK_MAX_PAGES = 200" in checklist
+        assert "_FALLBACK_MAX_PAGES = 200" in sync, (
+            "run_misp_to_neo4j.py must define _FALLBACK_MAX_PAGES = 200 "
+            "OR the checklist's [4] must be updated to match."
+        )
+        assert "100,000" in checklist


### PR DESCRIPTION
## Summary

Closes the last deferred item from PR #110 (PR-N29) merge body. Two bounded operator-facing deliverables, no new runtime behaviour.

### `scripts/audit_legacy_unicode_bypass_nodes.py`

Read-only audit answering one question: **do legacy `Malware`/`ThreatActor`/`Tool` nodes exist in production with zero-width / bidi-control / variation-selector chars in their names** — created BEFORE the PR-N29 L1 placeholder filter landed?

The answer determines whether a destructive cleanup PR is needed at all:

| Audit returns | Recommendation |
|---|---|
| 0 suspicious | Close PR-N32 cleanup as a no-op |
| 1–10 suspicious | One-shot Cypher per node (rename / re-merge / delete) |
| > 10 suspicious | Build a proper PR-N32 migration BEFORE the baseline |

Defense-in-depth design:

- `READ_ACCESS` at session level — server REJECTS any write attempt with `neo4j.exceptions.ClientError`, so future-maintainer drift loud-fails rather than silently mutating production.
- 35-char "suspicious" list imported from `node_identity._ZERO_WIDTH_AND_BIDI_CHARS` (single source of truth — adds to that list propagate automatically).
- Codepoint annotation in human output (`"unknown<U+200B>"`) — raw printing is identical to `"unknown"` and useless for triage.
- `--json` mode for CI piping; `--sample-limit` for triage scope.

### `docs/BASELINE_LAUNCH_CHECKLIST.md`

The single doc the operator walks through immediately before triggering a 730d baseline. 6 numbered sections, each mapping to a concrete failure mode that has either bitten us in a prior run or that the audit cycle (PR-N26 / N29 / N30 / N31) explicitly built defenses against:

| # | Check | Failure mode it catches |
|---|---|---|
| [1] | `EDGEGUARD_PREFLIGHT_STRICT=1 ./scripts/preflight_baseline.sh` | Missing creds, broken APOC, stale baseline_lock, PR-N29 invariants reverted |
| [2] | 7-day smoke baseline | New `_MispFallbackHardError` + counter wiring untested against live MISP |
| [3] | Alertmanager receiver wired for `severity=critical, component=sync` | Critical alert fires into the void if no receiver matches |
| [4] | MISP event count vs `_FALLBACK_MAX_PAGES = 200` (=100k events safety cap) | Cap-hit at hour 18 of a 32h dagrun |
| [5] | Disk + RAM headroom for projected 350k nodes / 700k rels | OOM at hour 26 → 6+ hours of restore |
| [6] | `./scripts/audit_legacy_unicode_bypass_nodes.py` | Legacy invisible-char nodes from before PR-N29 L1 |

References existing docs (`RUNBOOK`, `BACKUP`, `BASELINE_SMOKE_TEST`) rather than duplicating them. Pin tests enforce the cross-references actually resolve.

## Test plan

- [x] 21 new PR-N32 tests pass:
  - 5 audit-script-shape (exists, executable, importable, READ_ACCESS, no write-Cypher via AST scan)
  - 2 regex canonical parity (every char in `_ZERO_WIDTH_AND_BIDI_CHARS` matched + clean strings rejected)
  - 4 audit output (zero-recommendation, small-recommendation, large-recommendation, codepoint annotation)
  - 7 checklist doc structure (6 sections present, all referenced files exist, alert names match)
  - 3 source-of-truth invariants (alert-count floor, `_FALLBACK_MAX_PAGES` value, audit-bucket consistency)
- [x] Full suite: 1814 passed, 3 skipped, 3 xfailed (3m41s)
- [x] `ruff format` / `ruff check` / `mypy`: green
- [x] Audit script smoke: `--help` works; runs without `NEO4J_URI` exits with operator-actionable error

## What this PR does NOT do

* No CalVer bump — docs + audit don't change runtime behaviour. Per `docs/VERSIONING.md`, bump only on releases worth tagging.
* No cleanup of legacy nodes — the audit ONLY counts and samples. The operator runs it against production Neo4j to decide whether a follow-up cleanup PR is needed.
* No new alert rules — the operator surface is the audit script's exit summary.

## After this merges

The 730d baseline launch surface is **fully ready code-side**. The remaining items live in operator-side runtime (the 6 checklist items above), not in the codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are operator tooling/docs plus tests, with no production pipeline logic changes; primary risk is minor false positives/negatives in the Neo4j audit query/output.
> 
> **Overview**
> Adds `docs/BASELINE_LAUNCH_CHECKLIST.md`, a **six-step preflight checklist** operators run immediately before starting a 730-day MISP→Neo4j baseline (preflight script, smoke run, Alertmanager routing, MISP size vs `_FALLBACK_MAX_PAGES`, resource headroom, and the new unicode audit).
> 
> Introduces `scripts/audit_legacy_unicode_bypass_nodes.py`, a **read-only Neo4j audit** that counts/samples `Malware`/`ThreatActor`/`Tool` nodes whose `name` contains the canonical zero-width/bidi char set (imported from `node_identity`), with both human and `--json` output.
> 
> Adds `tests/test_pr_n32_unicode_audit.py` to lock in the audit’s read-only guarantees (READ_ACCESS + no write-Cypher), regex parity with the canonical character list, stable output/recommendation buckets, and checklist cross-reference integrity.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60bd805eec37d94f7da901367cbd37ae803824b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->