### PR TITLE
docs(audit): PR-N34 — ARCHITECTURE_DIAGRAMS verification + 6 drift fixes

### DIFF
--- a/docs/ARCHITECTURE_DIAGRAMS.md
+++ b/docs/ARCHITECTURE_DIAGRAMS.md
@@ -31,16 +31,16 @@ graph TB
     subgraph EdgeGuard Pipeline
         COLL[Collectors<br/>11 sources]
         MISP[(MISP 2.4.x<br/>Single Source of Truth<br/>port 8443)]
-        SYNC[MISP-to-Neo4j Sync<br/>Paged streaming<br/>OOM-safe chunking]
+        SYNC[MISP-to-Neo4j Sync<br/>Paged streaming + OOM-safe chunking<br/>+ PR-N29 _MispFallbackHardError sentinel<br/>+ PR-N31 MISP_FETCH_FALLBACK_ACTIVE Counter]
         NEO4J[(Neo4j 2026.03<br/>Knowledge Graph<br/>ports 7474 / 7687)]
-        BREL[build_relationships<br/>11 relationship types]
-        ENRICH[Enrichment Jobs<br/>Decay / Campaigns /<br/>Calibration / CVE Bridge]
+        BREL["build_relationships<br/>12 link queries → many edge types<br/>incl. INDICATES, EXPLOITS, TARGETS, AFFECTS<br/>+ PR-N26 r.misp_event_ids array on edges"]
+        ENRICH[Enrichment Jobs<br/>Bridge / Campaigns /<br/>Calibration / Decay]
     end
 
     subgraph APIs
         REST[FastAPI REST<br/>port 8000]
         GQL[Strawberry GraphQL<br/>port 4001]
-        METRICS[Prometheus Metrics<br/>port 8001]
+        METRICS[Prometheus Metrics<br/>port 8001<br/>+ 2 PR-N31 fallback alerts:<br/>EdgeGuardMispFetchFallbackActive warning<br/>EdgeGuardMispFetchFallbackHardError critical]
     end
 
     subgraph Orchestration
@@ -127,7 +127,7 @@ graph TB
     V -->|AFFECTS| S
     V -->|REFERS_TO| CVE
     CVE -->|REFERS_TO| V
-    CVE -->|HAS_CVSS| CVSS[CVSSv2 / v3.0 / v3.1 / v4.0]
+    CVE -->|HAS_CVSS_v*| CVSS[CVSSv2 / v3.0 / v3.1 / v4.0]
     T -->|IN_TACTIC| TAC[Tactic]
     TOOL[Tool] -->|IMPLEMENTS_TECHNIQUE| T
 
@@ -136,6 +136,18 @@ graph TB
     %%   IMPLEMENTS_TECHNIQUE = capability   (what the code/tool can do)
     %%   USES_TECHNIQUE       = observation  (indicator observed tied to a TTP)
     %% Split from a generic USES edge in the 2026-04 refactor.
+    %%
+    %% HAS_CVSS_v* expands to four concrete edge types written by
+    %% _merge_cvss_node inside merge_cve(): HAS_CVSS_v2, HAS_CVSS_v30,
+    %% HAS_CVSS_v31, HAS_CVSS_v40 (per neo4j_client.py — note the
+    %% underscore + lowercase v + version).
+    %%
+    %% PR-N26 (2026-04-23): the four edge types created by
+    %% build_relationships.py — INDICATES, EXPLOITS, TARGETS, AFFECTS —
+    %% additionally carry r.misp_event_ids[] for per-edge MISP-event
+    %% provenance (intersection of the endpoint nodes' arrays). Backfill
+    %% via scripts/backfill_edge_misp_event_ids.py for graphs that
+    %% pre-date PR-N26.
 
     classDef core fill:#2563eb,stroke:#1d4ed8,color:#fff
     classDef vuln fill:#dc2626,stroke:#b91c1c,color:#fff
@@ -209,17 +221,29 @@ flowchart TD
     FN -->|transient error<br/>ServiceUnavailable<br/>TransientError<br/>ConnectionError<br/>TimeoutError| DEC
     FN -->|non-transient error<br/>DatabaseError<br/>CypherSyntaxError| ERR[Log + return default]
 
-    DEC -->|retries exhausted<br/>neo4j: 5 retries, 2s base<br/>misp: 4 retries, 10s base| RAISE[Re-raise exception]
+    DEC -->|retries exhausted<br/>neo4j: 3 retries, 2s base<br/>misp: 4 retries, 10s base| RAISE[Re-raise exception]
     RAISE --> CALLER{Caller handles}
     CALLER -->|run_pipeline| RECONNECT[Reconnect loop<br/>3 attempts]
     CALLER -->|run_misp_to_neo4j| CIRCUIT[Circuit breaker<br/>record_failure]
-    CALLER -->|Airflow DAG| AIRFLOW[AirflowException<br/>task marked FAILED]
+    CALLER -->|Airflow DAG<br/>incremental tasks: retries=2| AIRFLOW[AirflowException<br/>task marked FAILED]
+    CALLER -->|Airflow DAG<br/>baseline critical chain<br/>PR-N29 H1: retries=0| BASELINE_FAIL[AirflowException<br/>FAILS IMMEDIATELY<br/>no retry — operator pages<br/>via EdgeGuardMispFetchFallbackHardError]
 
     style DEC fill:#7c3aed,stroke:#6d28d9,color:#fff
     style RAISE fill:#dc2626,stroke:#b91c1c,color:#fff
     style RECONNECT fill:#f59e0b,stroke:#d97706,color:#fff
     style CIRCUIT fill:#f59e0b,stroke:#d97706,color:#fff
+    style BASELINE_FAIL fill:#dc2626,stroke:#b91c1c,color:#fff
 ```
+
+**PR-N29 H1 carve-out (operator-relevant):** the four baseline critical-chain
+tasks — `baseline_clean`, `baseline_full_neo4j_sync`, `baseline_build_relationships`,
+`baseline_run_enrichment_jobs` — override `retries=0` (`dags/edgeguard_pipeline.py:2772,
+2927, 2953, 2971`). A single failure on any of these tasks immediately marks
+the DAG run FAILED rather than auto-retrying. This is intentional: a 5–6h
+critical-chain task that retries once would burn 12h of the 32h `dagrun_timeout`
+cap and could leave the graph mid-mutated. Combined with the
+`EdgeGuardMispFetchFallbackHardError` Prometheus alert (PR-N31), the operator
+gets paged immediately when the `_MispFallbackHardError` sentinel raises.
 
 ---
 
@@ -303,4 +327,13 @@ flowchart LR
 
 ---
 
-*Last updated: 2026-04-26 — PR-N33 docs audit: corrected MISP fetch flow to show the primary index path (500/page × 100 pages) vs the PR-N29 paginated fallback (500/page × 200 pages) + `_MispFallbackHardError` sentinel on cap-hit. Refined "11 edge types" → "12 link queries → many edge types" since `build_relationships.py` numbers its operations 1–12 (with sub-steps like 7a/7b). Prior: 2026-04-06.*
+*Last updated: 2026-04-28 — PR-N34 verification pass against code at HEAD. Fixed 6 drift findings:*
+
+- *§6 (HIGH): `neo4j: 5 retries, 2s base` → `3 retries, 2s base` (matches `_run_with_retries` and `_retry_db_op` in `src/neo4j_client.py`).*
+- *§6 (MED): added new branch + explanatory note for the PR-N29 H1 `retries=0` carve-out on the 4 baseline critical-chain tasks (`baseline_clean`, `baseline_full_neo4j_sync`, `baseline_build_relationships`, `baseline_run_enrichment_jobs`); operator now sees the immediate-fail path that pages via `EdgeGuardMispFetchFallbackHardError`.*
+- *§1 (MED): aligned BREL block with §5's wording — "11 relationship types" → "12 link queries → many edge types incl. INDICATES, EXPLOITS, TARGETS, AFFECTS + PR-N26 r.misp_event_ids array on edges". Reordered ENRICH job list to match actual execution order in `run_all_enrichment_jobs` (Bridge → Campaigns → Calibration → Decay).*
+- *§1 (LOW): added PR-N31 observability annotations on the SYNC node (`MISP_FETCH_FALLBACK_ACTIVE` Counter + `_MispFallbackHardError` sentinel) and METRICS node (the 2 fallback alerts).*
+- *§3 (LOW): added comment block at the bottom of the schema explaining (a) `HAS_CVSS_v*` expands to four concrete edge types and (b) PR-N26 wired `r.misp_event_ids[]` onto the 4 build_relationships edges.*
+- *§3 (LOW): edge label `HAS_CVSS` → `HAS_CVSS_v*` (matches `neo4j_client.py:_merge_cvss_node` which writes `HAS_CVSS_v2 / v30 / v31 / v40` with underscore + lowercase v + version).*
+
+*Prior: 2026-04-26 PR-N33 docs audit; 2026-04-06.*

--- a/docs/RESILMESH_INTEGRATION_GUIDE.md
+++ b/docs/RESILMESH_INTEGRATION_GUIDE.md
@@ -155,7 +155,7 @@ client.merge_resilmesh_cve({
 | Component is App | `create_component_has_identity_application()` | `(:Component)-[:HAS_IDENTITY]->(:Application)` | Component identity |
 | Vuln refers to CVE | `create_vulnerability_refers_to_cve()` | `(:Vulnerability)-[:REFERS_TO]->(:CVE)` | Vuln mapping |
 | CVE refers to Vuln | `create_cve_refers_to_vulnerability()` | `(:CVE)-[:REFERS_TO]->(:Vulnerability)` | CVE mapping |
-| CVE has CVSS | *(internal: `_merge_cvss_node` inside `merge_cve()`)* | `(:CVE)-[:HAS_CVSSv*]->(:CVSSv*)` | Scoring link — created automatically by `Neo4jClient.merge_cve()` when CVSS data is present in the input. There is **no** standalone `create_cve_has_cvss()` helper today (the four `create_cve_has_cvss_v*` helpers were removed in PR #33 round 12 because the relationship is fully derived from CVSS sub-node creation in `_merge_cvss_node`). |
+| CVE has CVSS | *(internal: `_merge_cvss_node` inside `merge_cve()`)* | `(:CVE)-[:HAS_CVSS_v*]->(:CVSSv*)` | Scoring link — created automatically by `Neo4jClient.merge_cve()` when CVSS data is present in the input. There is **no** standalone `create_cve_has_cvss()` helper today (the four `create_cve_has_cvss_v*` helpers were removed in PR #33 round 12 because the relationship is fully derived from CVSS sub-node creation in `_merge_cvss_node`). |
 | Indicator → IP (planned) | *(no method yet — see INTEROP § cross-layer bridges)* | `INDICATOR_RESOLVES_TO` planned | Use **`IP.address`** for future matching. Note: the planned edge name is **`INDICATOR_RESOLVES_TO`** (NOT `RESOLVES_TO`) to avoid collision with ISIM's `(IP)-[:RESOLVES_TO]->(DomainName)`. |
 | Vuln ↔ CVE bridge | `create_vulnerability_refers_to_cve()` / `create_cve_refers_to_vulnerability()` | `(:Vulnerability)-[:REFERS_TO]->(:CVE)` (+ reverse) | Also created by **`enrichment_jobs.bridge_vulnerability_cve()`** |
 | Malware → Host | *(not implemented)* | `(:Malware)-[:TARGETS]->(:Host)` | Listed in INTEROP as **not** in scheduled pipeline |
@@ -194,7 +194,7 @@ client.create_networkservice_on_host(
 #### CVE to CVSS
 
 CVSS sub-nodes (`CVSSv2`, `CVSSv30`, `CVSSv31`, `CVSSv40`) and the
-matching `(:CVE)-[:HAS_CVSSv*]->(:CVSSv*)` edges are created
+matching `(:CVE)-[:HAS_CVSS_v*]->(:CVSSv*)` edges are created
 **automatically** by `Neo4jClient.merge_cve()` when the input dict
 contains CVSS data. There is no standalone helper to call:
 
@@ -209,7 +209,7 @@ client.merge_cve(
     },
     source_id="nvd",
 )
-# → MERGE the CVSSv31 node + the (:CVE)-[:HAS_CVSSv31]->(:CVSSv31) edge
+# → MERGE the CVSSv31 node + the (:CVE)-[:HAS_CVSS_v31]->(:CVSSv31) edge
 #   inside _merge_cvss_node, in the same transaction as the CVE itself.
 ```
 
@@ -543,7 +543,7 @@ MATCH ()-[r]->()
 WHERE type(r) IN ['ON', 'TO', 'ASSIGNED_TO', 'HAS_IDENTITY', 'IS_A',
                   'HAS_ASSIGNED', 'PART_OF', 'FOR', 'SUPPORTS',
                   'PROVIDED_BY', 'FROM', 'IS_CONNECTED_TO', 'REFERS_TO',
-                  'HAS_CVSSv2', 'HAS_CVSSv30', 'HAS_CVSSv31', 'HAS_CVSSv40']
+                  'HAS_CVSS_v2', 'HAS_CVSS_v30', 'HAS_CVSS_v31', 'HAS_CVSS_v40']
 RETURN type(r) as relationship_type, count(r) as count
 ORDER BY count DESC;
 
@@ -716,4 +716,4 @@ The integration enables **context-aware threat detection** that combines:
 
 ---
 
-_Last updated: 2026-04-26 — PR-N33 docs audit: removed calls to deleted `create_cve_has_cvss()` helper (now internal to `merge_cve()` via `_merge_cvss_node`); fixed `RESOLVES_TO` → `INDICATOR_RESOLVES_TO` (planned name avoids ISIM `(IP)-[:RESOLVES_TO]->(DomainName)` collision); updated `HAS_CVSS_v*` → `HAS_CVSSv*` (matches actual edge type names). Prior: 2026-04-18 PR #41 cleanup pass._
+_Last updated: 2026-04-28 — PR-N34 fixup of PR-N33 slip: corrected edge name `HAS_CVSSv*` → `HAS_CVSS_v*` (actual edges in `neo4j_client.py:_merge_cvss_node` use underscore + lowercase v + version: `HAS_CVSS_v2 / HAS_CVSS_v30 / HAS_CVSS_v31 / HAS_CVSS_v40`). Per-version mentions in code blocks + verification Cypher all corrected. Prior: 2026-04-26 PR-N33 docs audit (removed calls to deleted `create_cve_has_cvss()` helper, now internal to `merge_cve()` via `_merge_cvss_node`; fixed `RESOLVES_TO` → `INDICATOR_RESOLVES_TO` to avoid ISIM collision). 2026-04-18 PR #41 cleanup pass._

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "edgeguard"
 # CalVer: release date YYYY.M.D (PEP 440). Bump when you tag/publish a release — not on every commit.
-version = "2026.4.26"
+version = "2026.4.28"
 description = "Threat Intelligence Pipeline - Sources to MISP to Neo4j"
 authors = [
     {name = "EdgeGuard Team"}


### PR DESCRIPTION
## Summary

Targeted re-verification of `docs/ARCHITECTURE_DIAGRAMS.md` against the codebase at HEAD surfaced 6 drift findings the PR-N33 audit missed. Bumps CalVer **2026.4.26 → 2026.4.28**.

| # | Severity | Section | Issue | Fix |
|---|---|---|---|---|
| 1 | **HIGH** | §6 | `neo4j: 5 retries, 2s base` — actual is 3 retries (`_run_with_retries:248` + `_retry_db_op:4314`) | `5 retries` → `3 retries` |
| 2 | MED | §1 | BREL "11 relationship types" inconsistent with §5's "12 link queries" (PR-N33 fixed §5 only) | Aligned §1 to §5; reordered ENRICH job list to match `run_all_enrichment_jobs` execution order |
| 3 | MED | §6 | Missing PR-N29 H1 `retries=0` carve-out for the 4 baseline critical-chain tasks | Added BASELINE_FAIL branch + explanatory note linking to `EdgeGuardMispFetchFallbackHardError` alert |
| 4 | LOW | §1 | Missing PR-N31 observability surface | SYNC node now annotates `_MispFallbackHardError` + `MISP_FETCH_FALLBACK_ACTIVE` Counter; METRICS node annotates the 2 fallback alerts |
| 5 | LOW | §3 | Missing PR-N26 `r.misp_event_ids[]` edge-property note | Added schema-comment block explaining the 4 wired edge types + backfill-script pointer |
| 6 | LOW | §3 | Edge label `HAS_CVSS` was a simplification | `HAS_CVSS` → `HAS_CVSS_v*` (matches `neo4j_client.py:_merge_cvss_node`). Bonus: corrected my PR-N33 slip in `RESILMESH_INTEGRATION_GUIDE.md` (was `HAS_CVSSv*` without underscore — fixed in 4 places) |

## Verification

- [x] 3 files changed, 47 insertions, 14 deletions
- [x] ruff format / ruff check / mypy: green
- [x] Full pytest suite: **1820 passed**, 3 skipped, 3 xfailed (3m41s)
- [x] All 6 findings traced to specific source-of-truth code paths

## What this PR does NOT do

- No code changes — pure docs.
- The PR-J1-aspirational `tests/test_architecture_flow_pins.py` pin-test (which would catch this kind of drift in CI) is still the right long-term answer but not in scope for this small fixup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk because changes are documentation-only plus a version string bump, with no runtime logic modifications.
> 
> **Overview**
> Docs were re-verified against HEAD and updated to fix drift in the Mermaid diagrams and narrative: Neo4j retry counts, Airflow baseline critical-chain `retries=0` immediate-fail path, and updated `build_relationships`/enrichment labeling plus PR-N26/PR-N31 observability annotations.
> 
> Also corrects CVSS relationship naming in both `ARCHITECTURE_DIAGRAMS.md` and `RESILMESH_INTEGRATION_GUIDE.md` to `HAS_CVSS_v*`/`HAS_CVSS_v2|v30|v31|v40`, and bumps the project CalVer in `pyproject.toml` from `2026.4.26` to `2026.4.28`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63bc73d0cb6126c90ed579142b71459911ec6a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->