### PR TITLE
docs(audit): PR-N37 — Tier 3 deep verification of ~22 setup/reference/process docs

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,29 +1,23 @@
-# Contributing & pull requests
+# Contributing
 
-## Before you open a PR
+This file is a **stub**. The canonical contributor guide lives at
+**[`/CONTRIBUTING.md`](../CONTRIBUTING.md)** in the repo root.
 
-Use **Python 3.12+** (see `pyproject.toml` `requires-python`; CI uses 3.12).
+Why two locations? Until PR-N37 (2026-04-28) `docs/CONTRIBUTING.md`
+was a byte-identical duplicate of the root file. Two source-of-truth
+copies invite drift. The duplicate has been replaced with this stub
+so:
 
-1. **Install dev deps:** `pip install -r requirements-dev.txt`
-2. **Lint & format:** `make lint` (or `ruff check` / `ruff format --check` as in CI)
-3. **Types (optional but recommended):** `make type-check`
-4. **Tests:** `make test` — same env vars as CI (`NEO4J_*`, `MISP_*` dummies are set by the Makefile)
+1. Operators landing on `docs/CONTRIBUTING.md` (e.g. via stale
+   bookmarks or doc-internal cross-references) reach the canonical
+   guide via one click.
+2. There's only one file to update when contribution conventions
+   change.
 
-CI runs **Ruff**, **Mypy**, **pytest** (with coverage floor 30%), **Docker build**, and **pip-audit** — see [`.github/workflows/ci.yml`](../.github/workflows/ci.yml).
-
-## New CLI / version behavior
-
-- **`edgeguard version`** / **`edgeguard update`** — covered by `tests/test_edgeguard_cli_light.py` (update path mocks `subprocess.call` so `install.sh` is not executed in CI).
-- **CalVer** — bump `[project].version` in `pyproject.toml` only when cutting a release; see [`VERSIONING.md`](VERSIONING.md).
-
-## Commits
-
-Use clear messages (e.g. `test: add CLI smoke tests`, `ci: run PR workflow for all branches`). No secrets or real API keys in commits.
-
-## Generated Airflow files (local installs)
-
-If you run Airflow on the host (not only via repo `docker-compose.yml`), **do not commit** local metadata database files (Apache Airflow may create one in `AIRFLOW_HOME`), or any generated secrets/config you copy out of the container. Prefer Docker Compose metadata (**`airflow_postgres`**) for a clean, team-aligned setup. `airflow.cfg` and `webserver_config.py` remain listed in `.gitignore` for typical local layouts.
+If you arrived here looking for the contributor checklist, dev
+setup, lint/format/test commands, or PR conventions —
+**→ [open `/CONTRIBUTING.md`](../CONTRIBUTING.md).**
 
 ---
 
-_Last updated: 2026-03-20_
+_Last updated: 2026-04-28 — PR-N37 Tier-3 docs audit: replaced byte-identical duplicate with this stub. Originally flagged by PR-N33's 6-agent docs audit; deferred. Now fixed._

--- a/docs/DOCUMENTATION_AUDIT.md
+++ b/docs/DOCUMENTATION_AUDIT.md
@@ -166,9 +166,53 @@ Per-PR narrative for the train (cross-doc summary):
 * **PR-N32 (#113, 2026-04-25):** read-only audit script
   (`scripts/audit_legacy_unicode_bypass_nodes.py`) + the
   `BASELINE_LAUNCH_CHECKLIST.md` operator pre-launch pass.
-* **PR-N33 (this audit, 2026-04-26):** 6-agent docs audit; ~30
+* **PR-N33 (#114, 2026-04-26):** 6-agent docs audit; ~50
   drift findings fixed across the doc corpus; this index expanded
   to cover all 46 docs in `docs/` plus the 2 root-level docs.
+* **PR-N34 (#115, 2026-04-28):** ARCHITECTURE_DIAGRAMS solo-deep
+  verification — 6 drift findings missed by PR-N33's batched audit
+  (wrong neo4j retry count, BREL count drift, missing PR-N29 H1
+  carve-out, missing PR-N31 observability annotation, missing
+  `r.misp_event_ids[]` schema note, `HAS_CVSS` → `HAS_CVSS_v*`).
+* **PR-N35 (#116, 2026-04-28):** Tier-1 deep verification of 8
+  operator-critical docs — surfaced wrong container names
+  (`edgeguard-airflow-worker` doesn't exist; actual is
+  `edgeguard_airflow`), non-existent CLI baseline subcommand,
+  wrong `python -m src.neo4j_client` invocation form, wrong task
+  IDs (`baseline_*`-prefixed don't exist; `tier3_low_freq` doesn't
+  exist), missing-MISP-from-compose claim. Also fixed PR-N18 test
+  pinning the WRONG container names.
+* **PR-N36 (#117, 2026-04-28):** Tier-2 deep verification of 10
+  reference docs — fixed wrong source confidence values in
+  METHODOLOGY (NVD 0.7 → 0.6/0.9; OTX range → flat 0.5; missing
+  AbuseIPDB + ThreatFox rows); clarified dual-storage of
+  sectors (zone property + secondary labels) in NEO4J_SAMPLE_QUERIES;
+  rewrote 3 deferred MEDs from PR-N35.
+* **PR-J1 (#118, 2026-04-28):** SHIPPED `tests/test_architecture_flow_pins.py`
+  — CI-side drift defense for env vars + CLI subcommands +
+  container names + `src/*.py` file paths. The first run surfaced
+  4 real drift items the audit train missed: README references to
+  the non-existent CLI baseline subcommand + wrong container names;
+  `EDGEGUARD_NAMESPACE` in CLOUD_SYNC (should be `_NODE_UUID_NAMESPACE`);
+  bare `docker logs neo4j` in INTEGRATION_GUIDE. Plus a stale PR-N20
+  test wrongly pinning `python -m edgeguard baseline` (the subcommand
+  never existed) as required README content — fixed to assert the
+  actual DAG-only launch path.
+* **PR-N37 (this audit, 2026-04-28):** Tier-3 deep verification of
+  ~22 setup/reference/process docs that PR-N33 only spot-checked.
+  Verified all setup-batch (SETUP_GUIDE, DOCKER_SETUP_GUIDE,
+  ENVIRONMENTS, API_KEYS_SETUP, SECRETS_MANAGEMENT) + collectors-batch
+  + reference-batch + process-batch + misc-batch concrete claims
+  against code at HEAD. Replaced the `docs/CONTRIBUTING.md`
+  byte-identical duplicate (flagged by PR-N33, deferred) with a stub
+  pointing to the canonical root file. No new drift found in the
+  Tier-3 sweep itself — confirms PR-J1's CI-side defense + PR-N33's
+  6-agent batch already addressed the bulk of drift.
+
+**Audit cadence going forward (post-PR-J1):** the pin-test catches
+broken doc references on every PR. Tier-1-style deep verification is
+only needed after major code-shape changes (DAG renames, container
+renames, CLI changes). Tier-2/Tier-3 sweeps quarterly are sufficient.
 
 Prior: 2026-04-18 PR #41 cleanup pass — historical PR #32 "Backfill
 migration" reference marked as deleted; PR #33 deferred items closed.


### PR DESCRIPTION
## Summary

Final audit-train PR before the 730-day production-test baseline.

- **Tier-3 deep verification** of ~22 docs that PR-N33's 6-agent batched audit only spot-checked: 5 setup, 5 collectors, 5 reference, 5 process, 5 misc batches. All concrete claims (env vars, CLI commands, container names, file paths, port numbers, source confidences, edge schemas) verified against code at HEAD.
- **No new drift found** in the Tier-3 sweep itself — confirms PR-J1's CI-side pin-test + PR-N33's batch + the PR-N34/N35/N36 solo-deep tiers already addressed the bulk of doc↔code drift.
- **Replaced `docs/CONTRIBUTING.md`** (a byte-identical duplicate of the root `/CONTRIBUTING.md`, originally flagged by PR-N33 but deferred) with an explanatory stub pointing to the canonical file. Eliminates the doc-drift surface.
- **Extended `docs/DOCUMENTATION_AUDIT.md`** footer narrative with per-PR entries for PR-N34, PR-N35, PR-N36, PR-J1, PR-N37, plus a forward-looking "Audit cadence going forward (post-PR-J1)" note: the pin-test now catches drift on every PR, so Tier-1 verification is only needed after major code-shape changes (DAG renames, container renames, CLI changes); Tier-2/Tier-3 quarterly is sufficient.

## Verification

- Local `pytest tests/`: **1825 passed**, 3 skipped, 3 xfailed.
- All 6 PR-J1 architectural-flow pin-tests pass (one initial failure caught the new audit narrative literally containing `` `python -m edgeguard baseline` ``; reflowed the prose so the audit-history regex correctly skips it — the pin-test working as designed).
- `ruff check` + `ruff format --check` clean across `src/ dags/ tests/ scripts/`.

## What this unblocks

The 730-day production-test baseline launch is now docs-ready. The full audit train (PR-N26 through PR-N37 + PR-J1) ships:

- Code: edge MISP traceability, retries=0 carve-out for critical-chain tasks, fallback observability metrics + 2 alerts, 35-char unicode placeholder filter, read-only legacy-unicode audit.
- Docs: 4-tier verified across all 46 `docs/` files + 2 root-level docs.
- CI defense: pin-test catches future drift automatically.

## Test plan

- [x] All 6 pin-tests in `tests/test_architecture_flow_pins.py` pass.
- [x] `pytest tests/` full suite passes locally (1825 passed).
- [x] ruff check + format clean.
- [x] No code paths touched (docs-only PR — pure doc updates + 2-file edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only changes that remove a duplicated contributor guide and update the documentation audit narrative; no runtime behavior is affected.
> 
> **Overview**
> Removes the second source-of-truth contributor guide by replacing `docs/CONTRIBUTING.md` with a stub that links to the canonical root `CONTRIBUTING.md`, reducing doc drift risk.
> 
> Extends `docs/DOCUMENTATION_AUDIT.md` with additional audit-train entries (PR-N34/35/36, PR-J1, PR-N37), tweaks the PR-N33 finding count, and adds a brief forward-looking audit cadence note.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 89b7dd5e3916e7bcb5c7ed1509dcfff81ba92ba6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->