### PR TITLE
Cypher query-catalog harness + fix batch-ingest enrichment drop

### DIFF
--- a/docs/KNOWLEDGE_GRAPH.md
+++ b/docs/KNOWLEDGE_GRAPH.md
@@ -349,13 +349,17 @@ EdgeGuard uses a **weighted scoring system** to detect sectors from threat data,
 
 > **Scope:** The first queries use labels and properties written by **EdgeGuard’s default MISP→Neo4j pipeline** (`neo4j_client`, `build_relationships`). Patterns involving `Host`, `SoftwareVersion`, `IP`, `DomainName`, or sector **secondary labels** are **ResilMesh-shaped illustrations** — they are valid Cypher for a full CRUSOE graph but may not return rows until those node types are populated by your deployment.
 
-### Healthcare-related CVEs / vulnerabilities (zone property)
+### Healthcare-related CVEs (zone property)
+
+The sync writes CVEs under the **`:CVE`** label (`:Vulnerability` is legacy and empty on
+current baselines — see NEO4J_SAMPLE_QUERIES.md). Use the portable form if a graph may
+still hold legacy nodes: `MATCH (v) WHERE v:CVE OR v:Vulnerability`.
 
 ```cypher
-MATCH (v:Vulnerability)
-WHERE 'healthcare' IN coalesce(v.zone, []) AND coalesce(v.cvss_score, 0) >= 7.0
-RETURN v.cve_id, v.description, v.cvss_score
-ORDER BY v.cvss_score DESC
+MATCH (c:CVE)
+WHERE 'healthcare' IN coalesce(c.zone, []) AND coalesce(c.cvss_score, 0) >= 7.0
+RETURN c.cve_id, c.description, c.cvss_score
+ORDER BY c.cvss_score DESC
 ```
 
 ### Alert enrichment: trace indicator to actor
@@ -368,13 +372,13 @@ OPTIONAL MATCH (tech)-[:IN_TACTIC]->(tactic:Tactic)
 RETURN ind.value, m.name, ta.name, collect(DISTINCT tech.name) AS techniques, collect(DISTINCT tactic.name) AS tactics
 ```
 
-### Cross-zone: critical vulnerabilities (`zone` list contains `global`)
+### Cross-zone: critical CVEs (`zone` list contains `global`)
 
 ```cypher
-MATCH (v:Vulnerability)
-WHERE 'global' IN coalesce(v.zone, []) AND coalesce(v.cvss_score, 0) >= 9.0
-RETURN v.cve_id, v.description, v.first_seen
-ORDER BY v.first_seen DESC
+MATCH (c:CVE)
+WHERE 'global' IN coalesce(c.zone, []) AND coalesce(c.cvss_score, 0) >= 9.0
+RETURN c.cve_id, c.description, c.cvss_score
+ORDER BY c.cvss_score DESC
 ```
 
 ### Query all indicators in a Campaign

--- a/docs/NEO4J_SAMPLE_QUERIES.md
+++ b/docs/NEO4J_SAMPLE_QUERIES.md
@@ -25,22 +25,24 @@ ORDER BY count DESC
 
 ## Vulnerabilities
 
-### Find critical vulnerabilities
+> **Label note (verified 2026-05-25 against the live graph):** the MISP→Neo4j sync routes every CVE through `merge_cve()` → the **`:CVE`** label (`src/run_misp_to_neo4j.py:3415`). The older **`:Vulnerability`** label is legacy and is **empty** on current baselines (the production snapshot held 99,757 `:CVE` and 0 `:Vulnerability`), so query `:CVE`. If a graph may still hold legacy nodes, use the portable form `MATCH (v) WHERE v:CVE OR v:Vulnerability`.
+
+### Find critical CVEs
 ```cypher
-MATCH (v:Vulnerability)
-WHERE v.cvss_score >= 9.0
-RETURN v.cve_id, v.cvss_score, v.severity, v.zone
-ORDER BY v.cvss_score DESC
+MATCH (c:CVE)
+WHERE c.cvss_score >= 9.0
+RETURN c.cve_id, c.cvss_score, c.severity, c.zone
+ORDER BY c.cvss_score DESC
 LIMIT 20
 ```
 
-### Find healthcare-tagged vulnerabilities
-Sectors are stored on the **`zone`** property (list of strings) at MERGE time. After the post-sync `apply_sector_labels()` call (see `src/neo4j_client.py:1580`), nodes ALSO get secondary labels (e.g. `:Vulnerability :Healthcare`). For portable queries — pre or post `apply_sector_labels` — use the `zone` property:
+### Find healthcare-tagged CVEs
+Sectors are stored on the **`zone`** property (list of strings) at MERGE time. After the post-sync `apply_sector_labels()` call (see `src/neo4j_client.py:1580`), nodes ALSO get secondary labels (e.g. `:CVE :Healthcare`). For portable queries — pre or post `apply_sector_labels` — use the `zone` property:
 
 ```cypher
-MATCH (v:Vulnerability)
-WHERE 'healthcare' IN coalesce(v.zone, [])
-RETURN v.cve_id, v.cvss_score, v.description
+MATCH (c:CVE)
+WHERE 'healthcare' IN coalesce(c.zone, [])
+RETURN c.cve_id, c.cvss_score, c.description
 LIMIT 20
 ```
 
@@ -169,6 +171,6 @@ RETURN type(r) AS edge_type, count(r) AS gap
 
 ---
 
-_Last updated: 2026-04-28 — PR-N36 Tier-2 deep verification: corrected the "stored on `zone` property, not as extra labels" claim — sectors are stored on BOTH (`zone` property at MERGE time, plus secondary labels like `:Healthcare` after `apply_sector_labels()` runs post-sync). Recommend `zone` property for portable queries that work pre or post the label-apply step. Prior: 2026-04-26 PR-N33 docs audit (replaced broken `t.platforms` query with `t.tactic_phases`; added Edge provenance section)._
+_Last updated: 2026-05-25 — Cypher-catalog verification against the live graph: switched the Vulnerabilities sample queries from the legacy `:Vulnerability` label (empty on current baselines) to `:CVE` (the label the sync actually writes) and added the label note in the Vulnerabilities section. Prior: 2026-04-28 — PR-N36 Tier-2 deep verification: corrected the "stored on `zone` property, not as extra labels" claim — sectors are stored on BOTH (`zone` property at MERGE time, plus secondary labels like `:Healthcare` after `apply_sector_labels()` runs post-sync). Recommend `zone` property for portable queries that work pre or post the label-apply step. Prior: 2026-04-26 PR-N33 docs audit (replaced broken `t.platforms` query with `t.tactic_phases`; added Edge provenance section)._
 
 *Save queries to test the prototype*

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,3 +10,4 @@ pytest-asyncio~=0.24
 httpx~=0.28        # async test client for FastAPI
 ruff~=0.9          # linter / formatter
 mypy~=1.14         # static type checker
+websocket-client~=1.9  # Bolt-over-WSS bridge for Cloudflare-fronted Neo4j (scripts/neo4j_wss_bridge.py)

--- a/scripts/neo4j_wss_bridge.py
+++ b/scripts/neo4j_wss_bridge.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Local TCP→WSS bridge so the official Neo4j **Bolt driver** can reach a
+Cloudflare-fronted Neo4j that only exposes Bolt-over-WebSocket (the same
+transport the Neo4j Browser uses). Direct `bolt+s://...:443` fails with
+"looks like HTTP" because Cloudflare proxies HTTP/WebSocket, not raw Bolt TCP.
+
+This opens a localhost TCP server, hands its address to a normal
+`GraphDatabase.driver("bolt://127.0.0.1:<port>", encrypted=False)`, and pumps
+bytes between that socket and `wss://<hostname>` as binary WebSocket frames.
+
+Requires: websocket-client  (pip install websocket-client)
+
+Standalone connectivity test:
+  set -a; source .env.edgeguard; set +a; python scripts/neo4j_wss_bridge.py
+(reads NEO4J_USER / NEO4J_PASSWORD; host defaults to neo4j-bolt.edgeguard.org,
+override with NEO4J_WSS_HOST)
+"""
+
+import os
+import socket
+import threading
+
+import websocket
+
+from neo4j import GraphDatabase
+
+
+class Neo4jWssBridge:
+    """Local TCP-to-WSS tunnel for the neo4j driver through Cloudflare."""
+
+    def __init__(self, hostname, auth):
+        self.hostname, self.auth = hostname, auth
+        self.driver, self._srv, self._stop = None, None, threading.Event()
+
+    def connect(self):
+        self._srv = socket.create_server(("127.0.0.1", 0))
+        self._srv.settimeout(1)
+        port = self._srv.getsockname()[1]
+        threading.Thread(target=self._accept, daemon=True).start()
+        self.driver = GraphDatabase.driver(f"bolt://127.0.0.1:{port}", auth=self.auth, encrypted=False)
+        return self.driver
+
+    def close(self):
+        self._stop.set()
+        if self.driver:
+            self.driver.close()
+        if self._srv:
+            try:
+                self._srv.close()
+            except OSError:
+                pass
+
+    def __enter__(self):
+        self.connect()
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+
+    def _accept(self):
+        while not self._stop.is_set():
+            try:
+                client, _ = self._srv.accept()
+                client.settimeout(1)
+                threading.Thread(target=self._bridge, args=(client,), daemon=True).start()
+            except socket.timeout:
+                continue
+            except OSError:
+                break
+
+    def _bridge(self, client):
+        ws = websocket.create_connection(f"wss://{self.hostname}", timeout=20, enable_multithread=True)
+
+        def pump(src, dst):
+            try:
+                while not self._stop.is_set():
+                    try:
+                        data = src()
+                    except socket.timeout:
+                        continue
+                    if not data:
+                        return
+                    dst(data)
+            except Exception:
+                pass
+
+        threading.Thread(
+            target=pump,
+            daemon=True,
+            args=(lambda: client.recv(65536), lambda d: ws.send(d, opcode=websocket.ABNF.OPCODE_BINARY)),
+        ).start()
+        threading.Thread(
+            target=pump,
+            daemon=True,
+            args=(ws.recv, lambda d: client.sendall(d if isinstance(d, bytes) else d.encode())),
+        ).start()
+
+
+if __name__ == "__main__":
+    host = os.getenv("NEO4J_WSS_HOST", "neo4j-bolt.edgeguard.org")
+    auth = (os.getenv("NEO4J_USER", "neo4j"), os.getenv("NEO4J_PASSWORD", ""))
+    db = os.getenv("NEO4J_DATABASE", "neo4j")
+    print(f"Bridging Bolt driver -> wss://{host}  (user={auth[0]}, db={db})")
+    with Neo4jWssBridge(host, auth) as b:
+        b.driver.verify_connectivity()
+        print("Connected successfully!")
+        records, _, _ = b.driver.execute_query(
+            "MATCH (n) RETURN labels(n)[0] AS l, count(n) AS c ORDER BY c DESC", database_=db
+        )
+        for r in records:
+            print(f"  {r['l']:16} {r['c']:>9,}")

--- a/scripts/run_cypher_catalog_http.py
+++ b/scripts/run_cypher_catalog_http.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""
+Run the Cypher catalog over the Neo4j **HTTP Query API v2** and optionally
+collect the results to disk.
+
+Companion to tests/test_cypher_query_catalog.py. Use this when the Neo4j Bolt
+port isn't reachable from where you are — e.g. a Cloudflare-proxied endpoint
+that only speaks Bolt-over-WebSocket (the Neo4j Browser works, but the Python
+Bolt driver, which needs raw Bolt-over-TCP, gets "looks like HTTP"). The HTTP
+Query API is plain HTTPS, so it passes straight through Cloudflare.
+
+It imports the SAME ``QUERY_CATALOG`` as the pytest harness (no duplication) and,
+per query, (1) sends ``EXPLAIN <q>`` to check validity and (2) executes ``<q>``
+and captures the returned rows.
+
+With ``--out <dir>`` (or env ``CATALOG_OUTPUT_DIR``) it writes two artifacts to
+that directory — meant for a deliverables folder like ``Sprint 2/``:
+  * cypher_catalog_results.json — full machine-readable results (every row)
+  * cypher_catalog_results.md   — readable report (summary + sample rows)
+The runtime stays in the repo; only the collected DATA lands in <dir>.
+
+Env:
+  NEO4J_HTTP_URL   base URL (default: https://neo4j.edgeguard.org)
+  NEO4J_DATABASE   database name (default: neo4j)
+  NEO4J_USER       basic-auth user
+  NEO4J_PASSWORD   basic-auth password
+  CATALOG_OUTPUT_DIR  default output dir (overridden by --out)
+
+Usage:
+  set -a; source .env.edgeguard; set +a
+  python scripts/run_cypher_catalog_http.py                       # print only
+  python scripts/run_cypher_catalog_http.py --out "../Sprint 2"   # + write files
+"""
+
+import base64
+import json
+import os
+import sys
+import urllib.error
+import urllib.request
+from datetime import datetime, timezone
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.join(HERE, "..", "tests"))
+
+from test_cypher_query_catalog import QUERY_CATALOG  # noqa: E402
+
+BASE = os.getenv("NEO4J_HTTP_URL", "https://neo4j.edgeguard.org").rstrip("/")
+DB = os.getenv("NEO4J_DATABASE", "neo4j")
+USER = os.getenv("NEO4J_USER", "neo4j")
+PWD = os.getenv("NEO4J_PASSWORD", "")
+URL = f"{BASE}/db/{DB}/query/v2"
+_AUTH = "Basic " + base64.b64encode(f"{USER}:{PWD}".encode()).decode()
+# Cloudflare fronts this endpoint and its bot rule 403s the default
+# "Python-urllib/x.y" User-Agent (Error 1010). A normal browser UA passes.
+_UA = os.getenv(
+    "NEO4J_HTTP_USER_AGENT",
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36",
+)
+_MD_SAMPLE_ROWS = 5  # rows shown per query in the .md report (full set is in the .json)
+
+
+def _post(statement, params):
+    """POST one Cypher statement to the Query API v2.
+
+    Returns (fields, values, error_message). On success error_message is None.
+    """
+    body = json.dumps({"statement": statement, "parameters": params or {}}).encode()
+    req = urllib.request.Request(URL, data=body, method="POST")
+    req.add_header("Authorization", _AUTH)
+    req.add_header("Content-Type", "application/json")
+    req.add_header("Accept", "application/json")
+    req.add_header("User-Agent", _UA)
+    try:
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            payload = json.loads(resp.read().decode())
+        errs = payload.get("errors") or []
+        if errs:
+            return None, None, errs[0].get("message") or str(errs[0])
+        data = payload.get("data", {})
+        return data.get("fields", []), data.get("values", []), None
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        try:
+            msg = (json.loads(detail).get("errors") or [{}])[0].get("message") or detail
+        except Exception:
+            msg = detail
+        return None, None, f"HTTP {e.code}: {msg[:200]}"
+    except Exception as e:  # noqa: BLE001 — report mode, surface everything
+        return None, None, f"{type(e).__name__}: {e}"
+
+
+def _md_cell(v):
+    s = json.dumps(v, default=str) if isinstance(v, (list, dict)) else str(v)
+    s = s.replace("|", "\\|").replace("\n", " ")
+    return s if len(s) <= 60 else s[:57] + "..."
+
+
+def _write_outputs(out_dir, results, summary):
+    os.makedirs(out_dir, exist_ok=True)
+    meta = {
+        "endpoint": URL,
+        "user": USER,
+        "database": DB,
+        "generated_utc": datetime.now(timezone.utc).isoformat(timespec="seconds"),
+        **summary,
+    }
+    json_path = os.path.join(out_dir, "cypher_catalog_results.json")
+    with open(json_path, "w") as f:
+        json.dump({"meta": meta, "results": results}, f, indent=2, default=str)
+
+    lines = [
+        "# EdgeGuard — Cypher catalog results",
+        "",
+        f"- Endpoint: `{URL}` (db `{DB}`, user `{USER}`)",
+        f"- Generated: {meta['generated_utc']}",
+        f"- {summary['query_count']} queries — **{summary['valid']} valid**, "
+        f"{summary['invalid']} invalid, {summary['empty']} valid-but-empty",
+        "",
+        "## Summary",
+        "",
+        "| id | layer | valid | rows | title |",
+        "|----|-------|:-----:|-----:|-------|",
+    ]
+    for r in results:
+        valid = "yes" if r["valid"] else "**NO**"
+        rows = "" if r["row_count"] is None else r["row_count"]
+        lines.append(f"| `{r['id']}` | {r['layer']} | {valid} | {rows} | {r['title']} |")
+
+    lines += ["", "## Results with data", ""]
+    for r in results:
+        if not r["valid"] or not r["rows"]:
+            continue
+        lines += [f"### `{r['id']}` — {r['title']}", "", f"```cypher\n{r['cypher']}\n```", ""]
+        fields = r["fields"]
+        lines.append("| " + " | ".join(fields) + " |")
+        lines.append("|" + "|".join(["---"] * len(fields)) + "|")
+        for row in r["rows"][:_MD_SAMPLE_ROWS]:
+            lines.append("| " + " | ".join(_md_cell(c) for c in row) + " |")
+        if r["row_count"] > _MD_SAMPLE_ROWS:
+            lines.append(f"\n_… {r['row_count'] - _MD_SAMPLE_ROWS} more rows in the JSON_")
+        lines.append("")
+
+    empty_ids = [r["id"] for r in results if r["valid"] and r["row_count"] == 0]
+    invalid_ids = [r["id"] for r in results if not r["valid"]]
+    lines += [
+        "## Valid but empty (graph slice not populated)",
+        "",
+        ", ".join(f"`{i}`" for i in empty_ids) or "_none_",
+        "",
+    ]
+    if invalid_ids:
+        lines += ["## Invalid", "", ", ".join(f"`{i}`" for i in invalid_ids), ""]
+
+    md_path = os.path.join(out_dir, "cypher_catalog_results.md")
+    with open(md_path, "w") as f:
+        f.write("\n".join(lines))
+    return json_path, md_path
+
+
+def main():
+    args = sys.argv[1:]
+    out_dir = args[args.index("--out") + 1] if "--out" in args else os.getenv("CATALOG_OUTPUT_DIR")
+
+    print(f"HTTP Query API : {URL}")
+    print(f"User           : {USER}")
+    print(f"Queries        : {len(QUERY_CATALOG)}\n")
+    print(f"{'id':34} {'layer':12} {'valid':5} {'rows':>6}  title")
+    print("-" * 108)
+
+    results = []
+    n_valid = n_invalid = 0
+    empties = []
+    for q in QUERY_CATALOG:
+        _, _, verr = _post("EXPLAIN " + q.cypher, q.params)
+        rec = {
+            "id": q.id,
+            "layer": q.layer,
+            "title": q.title,
+            "cypher": q.cypher,
+            "params": q.params,
+            "valid": verr is None,
+            "explain_error": verr,
+            "fields": [],
+            "row_count": None,
+            "rows": [],
+            "run_error": None,
+        }
+        if verr:
+            n_invalid += 1
+            results.append(rec)
+            print(f"{q.id:34} {q.layer:12} {'FAIL':5} {'-':>6}  {q.title}\n{'':54}<<< {verr}")
+            continue
+        n_valid += 1
+        fields, vals, rerr = _post(q.cypher, q.params)
+        if rerr:
+            rec["run_error"] = rerr
+            nrows = -1
+        else:
+            rec["fields"], rec["rows"], rec["row_count"] = fields or [], vals or [], len(vals or [])
+            nrows = rec["row_count"]
+            if nrows == 0:
+                empties.append(q.id)
+        results.append(rec)
+        print(f"{q.id:34} {q.layer:12} {('ERR' if nrows < 0 else 'OK'):5} {nrows:>6}  {q.title}")
+
+    print("-" * 108)
+    print(f"{len(QUERY_CATALOG)} queries — {n_valid} valid (EXPLAIN ok), {n_invalid} invalid")
+    if empties:
+        print(f"{len(empties)} valid-but-empty: {', '.join(empties)}")
+
+    if out_dir:
+        summary = {"query_count": len(results), "valid": n_valid, "invalid": n_invalid, "empty": len(empties)}
+        jp, mp = _write_outputs(out_dir, results, summary)
+        print(f"\nWrote results to:\n  {jp}\n  {mp}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -3029,6 +3029,31 @@ class Neo4jClient:
                     if item.get("threat_label"):
                         batch_item["threat_label"] = item["threat_label"]
 
+                    # Parity with the single-item ``merge_indicator`` (neo4j_client.py
+                    # ~L2329): promote the OTX / ThreatFox enrichment fields it promotes.
+                    # Pre-fix the batch path (the baseline + scheduled-sync path) dropped
+                    # these — they survived only inside the SOURCED_FROM edge's raw_data
+                    # JSON, never as queryable node properties. That silently zeroed
+                    # ``Indicator.attack_ids`` (so build_relationships step 8 USES_TECHNIQUE
+                    # built 0 edges) and ``Indicator.malware_family`` (so step 9 INDICATES
+                    # family-match matched nothing) for every batch-ingested Indicator.
+                    # Confirmed against the 2026-05 baseline: attack_ids / malware_family /
+                    # targeted_countries = 0/146,185, while indicator_role (which IS in the
+                    # SET clause below) = 41. ``coalesce(item.x, n.x)`` keeps any existing
+                    # value when a later (e.g. non-OTX) source omits the field.
+                    for _enrich_field in (
+                        "attack_ids",
+                        "targeted_countries",
+                        "malware_family",
+                        "malware_malpedia",
+                        "reference",
+                        "reporter",
+                        "domain",
+                        "hostnames",
+                    ):
+                        if item.get(_enrich_field):
+                            batch_item[_enrich_field] = item[_enrich_field]
+
                     batch_data.append(batch_item)
 
                 # PR #34 round 24: zone-accumulation now applies the
@@ -3068,7 +3093,15 @@ class Neo4jClient:
                     n.abuse_categories = {_dedup_concat_clause("n.abuse_categories", "coalesce(item.abuse_categories, [])")},
                     n.yara_rules = {_dedup_concat_clause("n.yara_rules", "coalesce(item.yara_rules, [])")},
                     n.sigma_rules = {_dedup_concat_clause("n.sigma_rules", "coalesce(item.sigma_rules, [])")},
-                    n.threat_label = coalesce(item.threat_label, n.threat_label)
+                    n.threat_label = coalesce(item.threat_label, n.threat_label),
+                    n.attack_ids = coalesce(item.attack_ids, n.attack_ids),
+                    n.targeted_countries = coalesce(item.targeted_countries, n.targeted_countries),
+                    n.malware_family = coalesce(item.malware_family, n.malware_family),
+                    n.malware_malpedia = coalesce(item.malware_malpedia, n.malware_malpedia),
+                    n.reference = coalesce(item.reference, n.reference),
+                    n.reporter = coalesce(item.reporter, n.reporter),
+                    n.domain = coalesce(item.domain, n.domain),
+                    n.hostnames = coalesce(item.hostnames, n.hostnames)
                 WITH n, item
                 MATCH (s:Source {{source_id: item.source_id}})
                 MERGE (n)-[r:SOURCED_FROM]->(s)

--- a/tests/test_cypher_query_catalog.py
+++ b/tests/test_cypher_query_catalog.py
@@ -1,0 +1,906 @@
+#!/usr/bin/env python3
+"""
+EdgeGuard — Cypher query catalog & validation harness.
+
+A data-driven catalog of read-only Cypher queries spanning BOTH graph layers:
+
+  * threat_intel — Indicator / CVE / Vulnerability / CVSSv* / Malware /
+    ThreatActor / Technique / Tactic / Tool / Sector / Campaign / Alert / Source
+  * asset        — ResilMesh / ISIM topology: Host / Device / IP / Subnet /
+    NetworkService / SoftwareVersion / Application / Role / User / Component /
+    Mission / OrganizationUnit / MissionDependency / Node
+
+Each query is verified two independent ways against a live Neo4j:
+
+  1. VALIDITY (``test_query_is_valid``) — always runs, even on an EMPTY db. The
+     query is sent with an ``EXPLAIN`` prefix straight to a raw driver session so
+     Neo4j parses + plans it. Any CypherSyntaxError / ClientError (bad syntax,
+     unknown procedure, …) raises and FAILS the test. This proves the query is a
+     *valid combination* against the real schema.
+
+     NB: we deliberately bypass ``Neo4jClient.run()`` here — it swallows
+     ``CypherSyntaxError`` and returns ``[]`` (src/neo4j_client.py:1160), which
+     would hide an invalid query behind an empty result set.
+
+  2. ROW PRESENCE (``test_query_returns_rows``) — data-aware. The query is
+     executed; if it returns >=1 row the projected column aliases are asserted;
+     if it returns 0 rows the test SKIPS (that slice of the graph isn't populated
+     in this db — e.g. the asset layer before any topology ingest, or a fresh
+     baseline that writes :CVE rather than the legacy :Vulnerability label).
+
+If Neo4j is unreachable the whole module skips (mirrors
+tests/test_resilmesh_integration.py), so this is CI-safe.
+
+Schema is the source of truth, verified 2026-05-25 against
+``src/neo4j_client.py`` (``create_constraints`` + every ``merge_*``) and the 12
+link steps in ``src/build_relationships.py``. See also docs/KNOWLEDGE_GRAPH.md
+and docs/NEO4J_SAMPLE_QUERIES.md.
+
+Run as a suite:        pytest tests/test_cypher_query_catalog.py -v
+Run as a live report:  python tests/test_cypher_query_catalog.py
+
+Against the Cloudflare-fronted edgeguard.org DB (Bolt-over-TCP blocked), tunnel
+the driver through Bolt-over-WebSocket by setting NEO4J_WSS_HOST:
+  set -a; source .env; source .env.edgeguard; set +a
+  MISP_API_KEY=unused NEO4J_WSS_HOST=neo4j-bolt.edgeguard.org \
+    pytest tests/test_cypher_query_catalog.py -q
+"""
+
+import os
+import sys
+from dataclasses import dataclass, field
+from typing import Dict, Tuple
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+
+# --------------------------------------------------------------------------- #
+# Connectivity (mirrors tests/test_resilmesh_integration.py's skip-if-absent
+# contract, but connects only ONCE — the module-scoped fixture below caches it)
+# --------------------------------------------------------------------------- #
+_SKIP_MSG = "Neo4j not available (integration test)"
+
+
+# --------------------------------------------------------------------------- #
+# Catalog model
+# --------------------------------------------------------------------------- #
+@dataclass(frozen=True)
+class CatalogQuery:
+    """One read-only Cypher query plus how to test it.
+
+    id          stable kebab-case identifier (used as the pytest parametrize id)
+    layer       "schema" | "threat_intel" | "asset"
+    title       human-readable one-liner
+    cypher      the query (every projection aliased with AS so result keys are stable)
+    params      query parameters (always passed to EXPLAIN + run)
+    expect_rows when True, test_query_returns_rows runs (and skips on 0 rows)
+    expect_keys result column aliases asserted present when rows are returned
+    """
+
+    id: str
+    layer: str
+    title: str
+    cypher: str
+    params: Dict = field(default_factory=dict)
+    expect_rows: bool = True
+    expect_keys: Tuple[str, ...] = ()
+
+
+# --------------------------------------------------------------------------- #
+# 0. Schema / overview
+# --------------------------------------------------------------------------- #
+_SCHEMA = [
+    CatalogQuery(
+        "schema-node-counts",
+        "schema",
+        "Count nodes by primary label",
+        "MATCH (n) RETURN labels(n)[0] AS label, count(n) AS count ORDER BY count DESC",
+        expect_keys=("label", "count"),
+    ),
+    CatalogQuery(
+        "schema-rel-counts",
+        "schema",
+        "Count relationships by type",
+        "MATCH ()-[r]->() RETURN type(r) AS rel_type, count(r) AS count ORDER BY count DESC",
+        expect_keys=("rel_type", "count"),
+    ),
+    CatalogQuery(
+        "schema-zone-counts",
+        "schema",
+        "Count zoned nodes by sector",
+        "MATCH (n) WHERE n.zone IS NOT NULL UNWIND n.zone AS zone RETURN zone, count(n) AS count ORDER BY count DESC",
+        expect_keys=("zone", "count"),
+    ),
+    CatalogQuery(
+        "schema-labels",
+        "schema",
+        "List label tokens present in the db",
+        "CALL db.labels() YIELD label RETURN label ORDER BY label",
+        expect_keys=("label",),
+    ),
+    CatalogQuery(
+        "schema-rel-types",
+        "schema",
+        "List relationship-type tokens present in the db",
+        "CALL db.relationshipTypes() YIELD relationshipType RETURN relationshipType ORDER BY relationshipType",
+        expect_keys=("relationshipType",),
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# 1. Threat-intel — single node (label + real properties)
+# --------------------------------------------------------------------------- #
+_TI_NODES = [
+    CatalogQuery(
+        "ti-indicator",
+        "threat_intel",
+        "Indicators with type/confidence/zone",
+        "MATCH (i:Indicator) "
+        "RETURN i.value AS value, i.indicator_type AS type, "
+        "i.confidence_score AS confidence, i.zone AS zone LIMIT 10",
+        expect_keys=("value", "type"),
+    ),
+    CatalogQuery(
+        "ti-indicator-by-type",
+        "threat_intel",
+        "Indicators of a given type (parameterized)",
+        "MATCH (i:Indicator {indicator_type: $indicator_type}) "
+        "RETURN i.value AS value, i.confidence_score AS confidence LIMIT 10",
+        params={"indicator_type": "domain"},
+        expect_keys=("value",),
+    ),
+    CatalogQuery(
+        "ti-indicator-suspicious-ip",
+        "threat_intel",
+        "IPv4 indicators above a confidence floor",
+        "MATCH (i:Indicator {indicator_type: 'ipv4'}) WHERE i.confidence_score > 0.5 "
+        "RETURN i.value AS value, i.confidence_score AS confidence "
+        "ORDER BY i.confidence_score DESC LIMIT 10",
+        expect_keys=("value",),
+    ),
+    CatalogQuery(
+        "ti-indicator-zone",
+        "threat_intel",
+        "Healthcare-zoned indicators (portable zone filter)",
+        "MATCH (i:Indicator) WHERE 'healthcare' IN coalesce(i.zone, []) "
+        "RETURN i.value AS value, i.indicator_type AS type LIMIT 10",
+        expect_keys=("value",),
+    ),
+    CatalogQuery(
+        "ti-cve",
+        "threat_intel",
+        "CVE nodes (production-primary vuln label)",
+        "MATCH (c:CVE) RETURN c.cve_id AS cve, c.cvss_score AS cvss, c.severity AS severity LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cve-critical",
+        "threat_intel",
+        "Critical CVEs (cvss_score >= 9.0)",
+        "MATCH (c:CVE) WHERE c.cvss_score >= 9.0 "
+        "RETURN c.cve_id AS cve, c.cvss_score AS cvss ORDER BY c.cvss_score DESC LIMIT 20",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cve-kev",
+        "threat_intel",
+        "CVEs on the CISA KEV list",
+        "MATCH (c:CVE) WHERE c.cisa_exploit_add IS NOT NULL "
+        "RETURN c.cve_id AS cve, c.cisa_vulnerability_name AS name LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-vulnerability-legacy",
+        "threat_intel",
+        "Legacy :Vulnerability nodes (skips on CVE-only baselines)",
+        "MATCH (v:Vulnerability) RETURN v.cve_id AS cve, v.cvss_score AS cvss LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cve-or-vulnerability",
+        "threat_intel",
+        "Both vuln labels in one match (portable)",
+        "MATCH (v) WHERE v:CVE OR v:Vulnerability RETURN labels(v) AS labels, v.cve_id AS cve LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cvss31",
+        "threat_intel",
+        "CVSS v3.1 sub-nodes (base_score/base_severity)",
+        "MATCH (n:CVSSv31) RETURN n.cve_id AS cve, n.base_score AS base_score, n.base_severity AS severity LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cvss40",
+        "threat_intel",
+        "CVSS v4.0 sub-nodes",
+        "MATCH (n:CVSSv40) RETURN n.cve_id AS cve, n.base_score AS base_score, n.base_severity AS severity LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cvss30",
+        "threat_intel",
+        "CVSS v3.0 sub-nodes",
+        "MATCH (n:CVSSv30) RETURN n.cve_id AS cve, n.base_score AS base_score, n.base_severity AS severity LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-cvss2",
+        "threat_intel",
+        "CVSS v2 sub-nodes (skips when NVD supplied no v2 metrics)",
+        "MATCH (n:CVSSv2) RETURN n.cve_id AS cve, n.base_score AS base_score LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-malware",
+        "threat_intel",
+        "Malware families with aliases",
+        "MATCH (m:Malware) RETURN m.name AS name, m.aliases AS aliases LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "ti-actor",
+        "threat_intel",
+        "Threat actors with aliases",
+        "MATCH (a:ThreatActor) RETURN a.name AS name, a.aliases AS aliases LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "ti-actor-multisource",
+        "threat_intel",
+        "Actors merged from >1 source (provenance array)",
+        "MATCH (a:ThreatActor) WHERE size(coalesce(a.source, [])) > 1 "
+        "RETURN a.name AS name, a.source AS sources ORDER BY size(a.source) DESC LIMIT 20",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "ti-technique",
+        "threat_intel",
+        "MITRE techniques (tactic_phases, NOT platforms)",
+        "MATCH (t:Technique) RETURN t.mitre_id AS mitre_id, t.name AS name, t.tactic_phases AS phases LIMIT 10",
+        expect_keys=("mitre_id",),
+    ),
+    CatalogQuery(
+        "ti-technique-by-phase",
+        "threat_intel",
+        "Techniques in a kill-chain phase (parameterized)",
+        "MATCH (t:Technique) WHERE $phase IN coalesce(t.tactic_phases, []) "
+        "RETURN t.mitre_id AS mitre_id, t.name AS name LIMIT 20",
+        params={"phase": "lateral-movement"},
+        expect_keys=("mitre_id",),
+    ),
+    CatalogQuery(
+        "ti-tactic",
+        "threat_intel",
+        "MITRE tactics (14 fixed nodes)",
+        "MATCH (t:Tactic) RETURN t.mitre_id AS mitre_id, t.shortname AS shortname, "
+        "t.name AS name ORDER BY t.mitre_id LIMIT 20",
+        expect_keys=("mitre_id",),
+    ),
+    CatalogQuery(
+        "ti-tool",
+        "threat_intel",
+        "MITRE tools",
+        "MATCH (t:Tool) RETURN t.mitre_id AS mitre_id, t.name AS name LIMIT 10",
+        expect_keys=("mitre_id",),
+    ),
+    CatalogQuery(
+        "ti-sector",
+        "threat_intel",
+        "Sector nodes",
+        "MATCH (s:Sector) RETURN s.name AS name ORDER BY s.name",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "ti-source",
+        "threat_intel",
+        "Source provenance nodes",
+        "MATCH (s:Source) RETURN s.source_id AS source_id, s.name AS name, "
+        "s.reliability AS reliability ORDER BY s.source_id LIMIT 50",
+        expect_keys=("source_id",),
+    ),
+    CatalogQuery(
+        "ti-campaign",
+        "threat_intel",
+        "Campaign nodes (enrichment-derived)",
+        "MATCH (c:Campaign) RETURN c.name AS name, c.zone AS zone LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "ti-alert",
+        "threat_intel",
+        "Alert nodes",
+        "MATCH (a:Alert) RETURN a.alert_id AS alert_id LIMIT 10",
+        expect_keys=("alert_id",),
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# 2. Threat-intel — 1-hop edges (directed; direction matters here)
+# --------------------------------------------------------------------------- #
+_TI_HOPS = [
+    CatalogQuery(
+        "ti-sourced-from",
+        "threat_intel",
+        "(n)-[:SOURCED_FROM]->(Source) provenance fan-in",
+        "MATCH (n)-[:SOURCED_FROM]->(s:Source) RETURN s.name AS source, count(n) AS nodes ORDER BY nodes DESC LIMIT 20",
+        expect_keys=("source", "nodes"),
+    ),
+    CatalogQuery(
+        "ti-exploits-cve",
+        "threat_intel",
+        "(Indicator)-[:EXPLOITS]->(CVE)",
+        "MATCH (i:Indicator)-[:EXPLOITS]->(c:CVE) RETURN i.value AS indicator, c.cve_id AS cve LIMIT 10",
+        expect_keys=("indicator", "cve"),
+    ),
+    CatalogQuery(
+        "ti-exploits-vuln",
+        "threat_intel",
+        "(Indicator)-[:EXPLOITS]->(Vulnerability) [legacy]",
+        "MATCH (i:Indicator)-[:EXPLOITS]->(v:Vulnerability) RETURN i.value AS indicator, v.cve_id AS cve LIMIT 10",
+        expect_keys=("indicator", "cve"),
+    ),
+    CatalogQuery(
+        "ti-indicates",
+        "threat_intel",
+        "(Indicator)-[:INDICATES]->(Malware)",
+        "MATCH (i:Indicator)-[r:INDICATES]->(m:Malware) "
+        "RETURN i.value AS indicator, m.name AS malware, r.confidence_score AS confidence LIMIT 10",
+        expect_keys=("indicator", "malware"),
+    ),
+    CatalogQuery(
+        "ti-attributed",
+        "threat_intel",
+        "(Malware)-[:ATTRIBUTED_TO]->(ThreatActor)",
+        "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(a:ThreatActor) RETURN m.name AS malware, a.name AS actor LIMIT 10",
+        expect_keys=("malware", "actor"),
+    ),
+    CatalogQuery(
+        "ti-employs",
+        "threat_intel",
+        "(ThreatActor)-[:EMPLOYS_TECHNIQUE]->(Technique) [attribution]",
+        "MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t:Technique) "
+        "RETURN a.name AS actor, t.mitre_id AS mitre_id, t.name AS technique LIMIT 10",
+        expect_keys=("actor", "mitre_id"),
+    ),
+    CatalogQuery(
+        "ti-implements",
+        "threat_intel",
+        "(Malware)-[:IMPLEMENTS_TECHNIQUE]->(Technique) [capability]",
+        "MATCH (m:Malware)-[r:IMPLEMENTS_TECHNIQUE]->(t:Technique) "
+        "RETURN m.name AS malware, t.mitre_id AS mitre_id, r.confidence_score AS confidence LIMIT 10",
+        expect_keys=("malware", "mitre_id"),
+    ),
+    CatalogQuery(
+        "ti-tool-implements",
+        "threat_intel",
+        "(Tool)-[:IMPLEMENTS_TECHNIQUE]->(Technique)",
+        "MATCH (tool:Tool)-[:IMPLEMENTS_TECHNIQUE]->(t:Technique) "
+        "RETURN tool.name AS tool, t.mitre_id AS mitre_id LIMIT 10",
+        expect_keys=("tool", "mitre_id"),
+    ),
+    CatalogQuery(
+        "ti-uses-technique",
+        "threat_intel",
+        "(Indicator)-[:USES_TECHNIQUE]->(Technique) [OTX attack_ids]",
+        "MATCH (i:Indicator)-[:USES_TECHNIQUE]->(t:Technique) "
+        "RETURN i.value AS indicator, t.mitre_id AS mitre_id LIMIT 10",
+        expect_keys=("indicator", "mitre_id"),
+    ),
+    CatalogQuery(
+        "ti-in-tactic",
+        "threat_intel",
+        "(Technique)-[:IN_TACTIC]->(Tactic)",
+        "MATCH (t:Technique)-[:IN_TACTIC]->(tc:Tactic) RETURN t.mitre_id AS technique, tc.shortname AS tactic LIMIT 10",
+        expect_keys=("technique", "tactic"),
+    ),
+    CatalogQuery(
+        "ti-targets",
+        "threat_intel",
+        "(Indicator)-[:TARGETS]->(Sector) breakdown",
+        "MATCH (i:Indicator)-[:TARGETS]->(s:Sector) "
+        "RETURN s.name AS sector, count(i) AS indicators ORDER BY indicators DESC",
+        expect_keys=("sector", "indicators"),
+    ),
+    CatalogQuery(
+        "ti-affects",
+        "threat_intel",
+        "(CVE|Vulnerability)-[:AFFECTS]->(Sector) breakdown",
+        "MATCH (v)-[:AFFECTS]->(s:Sector) WHERE v:CVE OR v:Vulnerability "
+        "RETURN s.name AS sector, count(v) AS vulns ORDER BY vulns DESC",
+        expect_keys=("sector", "vulns"),
+    ),
+    CatalogQuery(
+        "ti-has-cvss",
+        "threat_intel",
+        "(CVE)-[:HAS_CVSS_v31]-(CVSSv31) [edge is bidirectional → undirected]",
+        "MATCH (c:CVE)-[:HAS_CVSS_v31]-(n:CVSSv31) RETURN c.cve_id AS cve, n.base_score AS base_score LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-has-cvss-v40",
+        "threat_intel",
+        "(CVE)-[:HAS_CVSS_v40]-(CVSSv40) [bidirectional → undirected]",
+        "MATCH (c:CVE)-[:HAS_CVSS_v40]-(n:CVSSv40) RETURN c.cve_id AS cve, n.base_score AS base_score LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-has-cvss-v30",
+        "threat_intel",
+        "(CVE)-[:HAS_CVSS_v30]-(CVSSv30) [bidirectional → undirected]",
+        "MATCH (c:CVE)-[:HAS_CVSS_v30]-(n:CVSSv30) RETURN c.cve_id AS cve, n.base_score AS base_score LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-has-cvss-v2",
+        "threat_intel",
+        "(CVE)-[:HAS_CVSS_v2]-(CVSSv2) [bidirectional → undirected]",
+        "MATCH (c:CVE)-[:HAS_CVSS_v2]-(n:CVSSv2) RETURN c.cve_id AS cve LIMIT 10",
+        expect_keys=("cve",),
+    ),
+    CatalogQuery(
+        "ti-alert-involves",
+        "threat_intel",
+        "(Alert)-[:INVOLVES]->(Indicator)",
+        "MATCH (a:Alert)-[:INVOLVES]->(i:Indicator) RETURN a.alert_id AS alert, i.value AS indicator LIMIT 10",
+        expect_keys=("alert", "indicator"),
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# 3. Threat-intel — multi-hop traversals
+# --------------------------------------------------------------------------- #
+_TI_PATHS = [
+    CatalogQuery(
+        "ti-chain-attribution",
+        "threat_intel",
+        "Indicator → Malware → ThreatActor",
+        "MATCH (i:Indicator)-[:INDICATES]->(m:Malware)-[:ATTRIBUTED_TO]->(a:ThreatActor) "
+        "RETURN i.value AS indicator, m.name AS malware, a.name AS actor LIMIT 10",
+        expect_keys=("indicator", "malware", "actor"),
+    ),
+    CatalogQuery(
+        "ti-chain-4hop",
+        "threat_intel",
+        "Indicator → Malware → ThreatActor → Technique",
+        "MATCH (i:Indicator)-[:INDICATES]->(m:Malware)-[:ATTRIBUTED_TO]->(a:ThreatActor)"
+        "-[:EMPLOYS_TECHNIQUE]->(t:Technique) "
+        "RETURN i.value AS indicator, m.name AS malware, a.name AS actor, "
+        "t.mitre_id AS technique LIMIT 10",
+        expect_keys=("indicator", "actor", "technique"),
+    ),
+    CatalogQuery(
+        "ti-cve-cvss-exploit",
+        "threat_intel",
+        "Indicator → CVE with optional CVSS v3.1 score",
+        "MATCH (i:Indicator)-[:EXPLOITS]->(c:CVE) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v31]-(cvss:CVSSv31) "
+        "RETURN i.value AS indicator, c.cve_id AS cve, cvss.base_score AS cvss_score "
+        "ORDER BY cvss.base_score DESC LIMIT 15",
+        expect_keys=("indicator", "cve"),
+    ),
+    CatalogQuery(
+        "ti-actor-deepdive",
+        "threat_intel",
+        "All edges around one actor (parameterized)",
+        "MATCH (a:ThreatActor {name: $name})-[r]-(x) "
+        "RETURN type(r) AS rel, labels(x)[0] AS label, count(*) AS count ORDER BY count DESC",
+        params={"name": "apt41"},
+        expect_keys=("rel", "label", "count"),
+    ),
+    CatalogQuery(
+        "ti-actor-tech-coverage",
+        "threat_intel",
+        "Actors ranked by technique count",
+        "MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t:Technique) "
+        "RETURN a.name AS actor, count(t) AS techniques ORDER BY techniques DESC LIMIT 10",
+        expect_keys=("actor", "techniques"),
+    ),
+    CatalogQuery(
+        "ti-cross-sector",
+        "threat_intel",
+        "Actors operating in BOTH healthcare and energy",
+        "MATCH (a:ThreatActor) WHERE 'healthcare' IN coalesce(a.zone, []) "
+        "AND 'energy' IN coalesce(a.zone, []) "
+        "RETURN a.name AS actor, a.zone AS zones LIMIT 20",
+        expect_keys=("actor", "zones"),
+    ),
+    CatalogQuery(
+        "ti-malware-tech-via-actor",
+        "threat_intel",
+        "Malware → (actor) → techniques",
+        "MATCH (m:Malware)-[:ATTRIBUTED_TO]->(a:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t:Technique) "
+        "RETURN m.name AS malware, a.name AS actor, collect(DISTINCT t.name)[..5] AS techniques LIMIT 15",
+        expect_keys=("malware", "actor"),
+    ),
+    CatalogQuery(
+        "ti-provenance",
+        "threat_intel",
+        "INDICATES edges carrying MISP-event provenance",
+        "MATCH (i:Indicator)-[r:INDICATES]->(m:Malware) "
+        "WHERE size(coalesce(r.misp_event_ids, [])) > 0 "
+        "RETURN i.value AS indicator, m.name AS malware, size(r.misp_event_ids) AS misp_events "
+        "ORDER BY misp_events DESC LIMIT 10",
+        expect_keys=("indicator", "misp_events"),
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# 4. Asset / ISIM topology — single node
+# --------------------------------------------------------------------------- #
+_ASSET_NODES = [
+    CatalogQuery(
+        "as-host",
+        "asset",
+        "Host nodes",
+        "MATCH (h:Host) RETURN h.hostname AS hostname LIMIT 10",
+        expect_keys=("hostname",),
+    ),
+    CatalogQuery(
+        "as-device",
+        "asset",
+        "Device nodes",
+        "MATCH (d:Device) RETURN d.device_id AS device_id LIMIT 10",
+        expect_keys=("device_id",),
+    ),
+    CatalogQuery(
+        "as-ip", "asset", "IP nodes", "MATCH (i:IP) RETURN i.address AS address LIMIT 10", expect_keys=("address",)
+    ),
+    CatalogQuery(
+        "as-subnet",
+        "asset",
+        "Subnet nodes",
+        "MATCH (s:Subnet) RETURN s.range AS range LIMIT 10",
+        expect_keys=("range",),
+    ),
+    CatalogQuery(
+        "as-networkservice",
+        "asset",
+        "NetworkService nodes (port, protocol)",
+        "MATCH (n:NetworkService) RETURN n.port AS port, n.protocol AS protocol LIMIT 10",
+        expect_keys=("port", "protocol"),
+    ),
+    CatalogQuery(
+        "as-softwareversion",
+        "asset",
+        "SoftwareVersion nodes",
+        "MATCH (sv:SoftwareVersion) RETURN sv.version AS version LIMIT 10",
+        expect_keys=("version",),
+    ),
+    CatalogQuery(
+        "as-application",
+        "asset",
+        "Application nodes",
+        "MATCH (a:Application) RETURN a.name AS name LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "as-role",
+        "asset",
+        "Role nodes (keyed by permission)",
+        "MATCH (r:Role) RETURN r.permission AS permission LIMIT 10",
+        expect_keys=("permission",),
+    ),
+    CatalogQuery(
+        "as-user",
+        "asset",
+        "User nodes (username, domain)",
+        "MATCH (u:User) RETURN u.username AS username, u.domain AS domain LIMIT 10",
+        expect_keys=("username", "domain"),
+    ),
+    CatalogQuery(
+        "as-component",
+        "asset",
+        "Component nodes",
+        "MATCH (c:Component) RETURN c.name AS name LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "as-mission",
+        "asset",
+        "Mission nodes",
+        "MATCH (m:Mission) RETURN m.name AS name LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "as-orgunit",
+        "asset",
+        "OrganizationUnit nodes",
+        "MATCH (o:OrganizationUnit) RETURN o.name AS name LIMIT 10",
+        expect_keys=("name",),
+    ),
+    CatalogQuery(
+        "as-missiondependency",
+        "asset",
+        "MissionDependency nodes",
+        "MATCH (md:MissionDependency) RETURN md.dependency_id AS dependency_id LIMIT 10",
+        expect_keys=("dependency_id",),
+    ),
+    CatalogQuery(
+        "as-node",
+        "asset",
+        "Node (ISIM topology) nodes",
+        "MATCH (n:Node) RETURN n.node_id AS node_id LIMIT 10",
+        expect_keys=("node_id",),
+    ),
+]
+
+# --------------------------------------------------------------------------- #
+# 5. Asset / ISIM topology — 1-hop edges
+# (the asset graph writes most edges in BOTH directions, so match undirected)
+# --------------------------------------------------------------------------- #
+_ASSET_HOPS = [
+    CatalogQuery(
+        "as-sv-on-host",
+        "asset",
+        "(SoftwareVersion)-[:ON]-(Host)",
+        "MATCH (sv:SoftwareVersion)-[:ON]-(h:Host) RETURN sv.version AS version, h.hostname AS hostname LIMIT 10",
+        expect_keys=("version", "hostname"),
+    ),
+    CatalogQuery(
+        "as-netservice-on-host",
+        "asset",
+        "(NetworkService)-[:ON]-(Host)",
+        "MATCH (ns:NetworkService)-[:ON]-(h:Host) "
+        "RETURN ns.port AS port, ns.protocol AS protocol, h.hostname AS hostname LIMIT 10",
+        expect_keys=("hostname",),
+    ),
+    CatalogQuery(
+        "as-device-host-identity",
+        "asset",
+        "(Device)-[:HAS_IDENTITY]-(Host)",
+        "MATCH (d:Device)-[:HAS_IDENTITY]-(h:Host) RETURN d.device_id AS device_id, h.hostname AS hostname LIMIT 10",
+        expect_keys=("device_id", "hostname"),
+    ),
+    CatalogQuery(
+        "as-app-component-identity",
+        "asset",
+        "(Application)-[:HAS_IDENTITY]-(Component)",
+        "MATCH (a:Application)-[:HAS_IDENTITY]-(c:Component) "
+        "RETURN a.name AS application, c.name AS component LIMIT 10",
+        expect_keys=("application", "component"),
+    ),
+    CatalogQuery(
+        "as-ip-part-of-subnet",
+        "asset",
+        "(IP)-[:PART_OF]-(Subnet)",
+        "MATCH (i:IP)-[:PART_OF]-(s:Subnet) RETURN i.address AS address, s.range AS subnet LIMIT 10",
+        expect_keys=("address", "subnet"),
+    ),
+    CatalogQuery(
+        "as-node-is-a-host",
+        "asset",
+        "(Node)-[:IS_A]-(Host)",
+        "MATCH (n:Node)-[:IS_A]-(h:Host) RETURN n.node_id AS node_id, h.hostname AS hostname LIMIT 10",
+        expect_keys=("node_id", "hostname"),
+    ),
+    CatalogQuery(
+        "as-ip-has-assigned-node",
+        "asset",
+        "(IP)-[:HAS_ASSIGNED]-(Node)",
+        "MATCH (i:IP)-[:HAS_ASSIGNED]-(n:Node) RETURN i.address AS address, n.node_id AS node_id LIMIT 10",
+        expect_keys=("address", "node_id"),
+    ),
+    CatalogQuery(
+        "as-node-connected",
+        "asset",
+        "(Node)-[:IS_CONNECTED_TO]-(Node)",
+        "MATCH (n1:Node)-[:IS_CONNECTED_TO]-(n2:Node) RETURN n1.node_id AS node_a, n2.node_id AS node_b LIMIT 10",
+        expect_keys=("node_a", "node_b"),
+    ),
+    CatalogQuery(
+        "as-vuln-in-sv",
+        "asset",
+        "(CVE|Vulnerability)-[:IN]-(SoftwareVersion)",
+        "MATCH (v)-[:IN]-(sv:SoftwareVersion) WHERE v:Vulnerability OR v:CVE "
+        "RETURN v.cve_id AS cve, sv.version AS version LIMIT 10",
+        expect_keys=("cve", "version"),
+    ),
+    CatalogQuery(
+        "as-vuln-refers-cve",
+        "asset",
+        "(Vulnerability)-[:REFERS_TO]-(CVE)",
+        "MATCH (v:Vulnerability)-[:REFERS_TO]-(c:CVE) RETURN v.cve_id AS vuln, c.cve_id AS cve LIMIT 10",
+        expect_keys=("vuln", "cve"),
+    ),
+    CatalogQuery(
+        "as-component-supports-mission",
+        "asset",
+        "(Component)-[:SUPPORTS]-(Mission)",
+        "MATCH (c:Component)-[:SUPPORTS]-(m:Mission) RETURN c.name AS component, m.name AS mission LIMIT 10",
+        expect_keys=("component", "mission"),
+    ),
+    CatalogQuery(
+        "as-host-provided-by-component",
+        "asset",
+        "(Host)-[:PROVIDED_BY]-(Component)",
+        "MATCH (h:Host)-[:PROVIDED_BY]-(c:Component) RETURN h.hostname AS hostname, c.name AS component LIMIT 10",
+        expect_keys=("hostname", "component"),
+    ),
+    CatalogQuery(
+        "as-mission-for-orgunit",
+        "asset",
+        "(Mission)-[:FOR]-(OrganizationUnit)",
+        "MATCH (m:Mission)-[:FOR]-(o:OrganizationUnit) RETURN m.name AS mission, o.name AS org_unit LIMIT 10",
+        expect_keys=("mission", "org_unit"),
+    ),
+    CatalogQuery(
+        "as-component-missiondependency",
+        "asset",
+        "(Component)-[:TO|FROM]-(MissionDependency)",
+        "MATCH (c:Component)-[:TO|FROM]-(md:MissionDependency) "
+        "RETURN c.name AS component, md.dependency_id AS dependency LIMIT 10",
+        expect_keys=("component", "dependency"),
+    ),
+    CatalogQuery(
+        "as-role-assigned-user",
+        "asset",
+        "(Role)-[:ASSIGNED_TO]-(User)",
+        "MATCH (r:Role)-[:ASSIGNED_TO]-(u:User) RETURN r.permission AS permission, u.username AS username LIMIT 10",
+        expect_keys=("permission", "username"),
+    ),
+    CatalogQuery(
+        "as-device-to-role",
+        "asset",
+        "(Device)-[:TO]-(Role)",
+        "MATCH (d:Device)-[:TO]-(r:Role) RETURN d.device_id AS device_id, r.permission AS permission LIMIT 10",
+        expect_keys=("device_id", "permission"),
+    ),
+]
+
+QUERY_CATALOG = _SCHEMA + _TI_NODES + _TI_HOPS + _TI_PATHS + _ASSET_NODES + _ASSET_HOPS
+
+
+# --------------------------------------------------------------------------- #
+# Fixtures + helpers
+# --------------------------------------------------------------------------- #
+@pytest.fixture(scope="module")
+def neo4j_client():
+    try:
+        import config
+
+        # Guard against MagicMock pollution from other test modules' stubs.
+        if not hasattr(config, "NEO4J_URI") or not isinstance(config.NEO4J_URI, str):
+            pytest.skip(_SKIP_MSG)
+        from neo4j_client import Neo4jClient
+    except ImportError:
+        pytest.skip(_SKIP_MSG)
+
+    # Bridge mode: when NEO4J_WSS_HOST is set, tunnel the Bolt driver through
+    # Cloudflare's WebSocket (see scripts/neo4j_wss_bridge.py). Needed for the
+    # edgeguard.org deployment, where raw Bolt-over-TCP is blocked but
+    # Bolt-over-WebSocket (the Neo4j Browser transport) works. Auth comes from
+    # NEO4J_USER / NEO4J_PASSWORD. Zero effect when the env var is unset.
+    wss_host = os.getenv("NEO4J_WSS_HOST")
+    if wss_host:
+        try:
+            sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "scripts"))
+            from neo4j_wss_bridge import Neo4jWssBridge
+        except ImportError:
+            pytest.skip("NEO4J_WSS_HOST set but websocket-client/bridge unavailable")
+        auth = (os.getenv("NEO4J_USER", "neo4j"), os.getenv("NEO4J_PASSWORD", ""))
+        bridge = Neo4jWssBridge(wss_host, auth)
+        try:
+            driver = bridge.connect()
+            driver.verify_connectivity()
+        except Exception:
+            bridge.close()
+            pytest.skip(_SKIP_MSG)
+        c = Neo4jClient()
+        c.driver = driver  # inject the bridged driver; skip c.connect()'s direct dial
+        yield c
+        bridge.close()
+        return
+
+    c = Neo4jClient()
+    try:
+        connected = c.connect()
+    except Exception:
+        # connect() may raise (e.g. ServiceUnavailable after exhausting
+        # retries) rather than return False when no server is reachable.
+        connected = False
+    if not connected:
+        pytest.skip(_SKIP_MSG)
+    yield c
+    c.close()
+
+
+def _explain(client, q: "CatalogQuery"):
+    """Plan ``EXPLAIN <query>`` on a raw driver session so any
+    CypherSyntaxError / ClientError propagates (unlike Neo4jClient.run, which
+    swallows syntax errors). Returns the result summary."""
+    with client.driver.session() as session:
+        result = session.run("EXPLAIN " + q.cypher, q.params)
+        return result.consume()
+
+
+# --------------------------------------------------------------------------- #
+# Catalog self-checks (run without a db)
+# --------------------------------------------------------------------------- #
+def test_catalog_ids_unique():
+    ids = [q.id for q in QUERY_CATALOG]
+    assert len(ids) == len(set(ids)), "duplicate catalog ids: " + str(sorted({i for i in ids if ids.count(i) > 1}))
+
+
+def test_catalog_covers_both_layers():
+    layers = {q.layer for q in QUERY_CATALOG}
+    assert {"threat_intel", "asset"}.issubset(layers)
+
+
+# --------------------------------------------------------------------------- #
+# Tier 1 — VALIDITY (runs even on an empty db)
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("q", QUERY_CATALOG, ids=[q.id for q in QUERY_CATALOG])
+def test_query_is_valid(neo4j_client, q):
+    """EXPLAIN must not raise — proves the query is a valid combination."""
+    _explain(neo4j_client, q)
+
+
+# --------------------------------------------------------------------------- #
+# Tier 2 — ROW PRESENCE (skips when a graph slice isn't populated)
+# --------------------------------------------------------------------------- #
+_ROW_QUERIES = [q for q in QUERY_CATALOG if q.expect_rows]
+
+
+@pytest.mark.parametrize("q", _ROW_QUERIES, ids=[q.id for q in _ROW_QUERIES])
+def test_query_returns_rows(neo4j_client, q):
+    rows = neo4j_client.run(q.cypher, q.params)
+    if not rows:
+        pytest.skip(f"{q.id}: 0 rows — graph slice not populated in this db")
+    if q.expect_keys:
+        missing = set(q.expect_keys) - set(rows[0].keys())
+        assert not missing, f"{q.id}: missing result keys {missing}; got {list(rows[0].keys())}"
+
+
+# --------------------------------------------------------------------------- #
+# Schema-token sanity (skips on empty db)
+# --------------------------------------------------------------------------- #
+def test_core_threat_intel_tokens_present(neo4j_client):
+    counts = neo4j_client.run("MATCH (n) RETURN count(n) AS c")
+    if not counts or counts[0]["c"] == 0:
+        pytest.skip("empty db — no tokens to assert")
+    labels = {r["label"] for r in neo4j_client.run("CALL db.labels() YIELD label RETURN label")}
+    assert "Indicator" in labels, "no :Indicator label — threat-intel ingest may have never run"
+    # CVE is production-primary; Vulnerability is the legacy label. Either is acceptable.
+    assert "CVE" in labels or "Vulnerability" in labels, (
+        "neither :CVE nor :Vulnerability present — the CVE ingest path may be broken"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Live report:  python tests/test_cypher_query_catalog.py
+# --------------------------------------------------------------------------- #
+def _print_report():
+    from neo4j_client import Neo4jClient
+
+    c = Neo4jClient()
+    if not c.connect():
+        print("Neo4j not reachable — set NEO4J_URI / NEO4J_USER / NEO4J_PASSWORD and retry.")
+        return
+    try:
+        print(f"{'id':36} {'layer':12} {'valid':5} {'rows':>6}  title")
+        print("-" * 100)
+        n_valid = n_fail = 0
+        for q in QUERY_CATALOG:
+            try:
+                _explain(c, q)
+                valid, n_valid = "OK", n_valid + 1
+            except Exception as e:  # noqa: BLE001 — report mode, show everything
+                valid, n_fail = "FAIL", n_fail + 1
+                print(f"{q.id:36} {q.layer:12} {valid:5} {'-':>6}  {q.title}  <<< {type(e).__name__}: {e}")
+                continue
+            try:
+                nrows = len(c.run(q.cypher, q.params))
+            except Exception:  # noqa: BLE001
+                nrows = -1
+            print(f"{q.id:36} {q.layer:12} {valid:5} {nrows:>6}  {q.title}")
+        print("-" * 100)
+        print(f"{len(QUERY_CATALOG)} queries — {n_valid} valid, {n_fail} invalid")
+    finally:
+        c.close()
+
+
+if __name__ == "__main__":
+    _print_report()

--- a/tests/test_indicator_enrichment_parity.py
+++ b/tests/test_indicator_enrichment_parity.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Regression test: ``merge_indicators_batch`` must promote the SAME enrichment
+fields as the single-item ``merge_indicator``, so they land as queryable node
+properties — not only inside the SOURCED_FROM edge's ``raw_data`` JSON.
+
+Bug this guards against (found 2026-05 against the edgeguard.org baseline):
+the bulk/batch path (used by the baseline + scheduled MISP→Neo4j sync) wrote
+only a subset of enrichment fields and silently dropped the rest. As a result:
+
+  * ``Indicator.attack_ids`` was 0/146,185  → build_relationships step 8
+    (USES_TECHNIQUE, matches ``i.attack_ids`` → Technique.mitre_id) could never
+    create an edge.
+  * ``Indicator.malware_family`` was 0      → build_relationships step 9
+    (INDICATES via malware-family name match) could never fire for
+    batch-ingested indicators.
+
+The single-item ``merge_indicator`` (neo4j_client.py ~L2329) promoted these all
+along, so the two ingest paths had drifted. This test pins parity WITHOUT a live
+Neo4j: it captures the Cypher ``merge_indicators_batch`` generates (by
+monkeypatching the batch executor) and asserts every promoted field is SET on
+the node.
+"""
+
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(os.path.abspath(__file__)), "..", "src"))
+
+import neo4j_client as nc  # noqa: E402
+from neo4j_client import Neo4jClient  # noqa: E402
+
+# Enrichment fields the single-item merge_indicator promotes (neo4j_client.py
+# ~L2329). The batch path must keep parity with this list.
+_PROMOTED_FIELDS = [
+    "attack_ids",
+    "targeted_countries",
+    "malware_family",
+    "malware_malpedia",
+    "reference",
+    "reporter",
+    "domain",
+    "hostnames",
+]
+
+
+def test_merge_indicators_batch_promotes_enrichment_fields(monkeypatch):
+    """The generated batch Cypher must SET every promoted enrichment field."""
+    import config
+
+    # Guard against MagicMock pollution from other test modules (e.g. the
+    # test_graphql_api stubs that replace config / neo4j_client in sys.modules).
+    if not hasattr(config, "NEO4J_URI") or not isinstance(config.NEO4J_URI, str):
+        pytest.skip("config stubbed by another test module — run this test in isolation")
+
+    captured = {}
+
+    def _fake_exec(driver, query, **kwargs):
+        captured["query"] = query
+        return True, len(kwargs.get("query_kwargs", {}).get("batch", []))
+
+    monkeypatch.setattr(nc, "_execute_batch_with_retry", _fake_exec)
+
+    client = Neo4jClient()
+    client.driver = object()  # truthy sentinel so the method does real work
+
+    item = {
+        "indicator_type": "domain",
+        "value": "enrichment-parity.test",
+        "zone": ["global"],
+        "source": ["alienvault_otx"],
+        "attack_ids": ["T1059", "T1071"],
+        "targeted_countries": ["US"],
+        "malware_family": "emotet",
+        "malware_malpedia": "win.emotet",
+        "reference": "https://example.test/ref",
+        "reporter": "tester",
+        "domain": "enrichment-parity.test",
+        "hostnames": ["host.enrichment-parity.test"],
+    }
+    client.merge_indicators_batch([item], source_id="alienvault_otx")
+
+    query = captured.get("query", "")
+    if not isinstance(query, str) or not query:
+        pytest.skip("neo4j_client appears stubbed (MagicMock pollution) — run in isolation")
+    # Sanity: we captured the Indicator MERGE (not some other query).
+    assert "MERGE (n:Indicator" in query
+
+    missing = [f for f in _PROMOTED_FIELDS if f"n.{f} =" not in query]
+    assert not missing, (
+        "merge_indicators_batch Cypher does not promote these enrichment fields "
+        f"to node properties: {missing}. The batch path has drifted from "
+        "single-item merge_indicator parity (see this module's docstring)."
+    )


### PR DESCRIPTION
## Summary

Adds a verified, data-driven **Cypher query catalog + validation harness** (the original ask — "valid combinations of Cypher we can test"), and fixes two real errors it surfaced when run against the live `edgeguard.org` graph (359k nodes / 605k rels).

The catalog (`tests/test_cypher_query_catalog.py`) holds **84 read-only queries** across both graph layers (threat-intel + ResilMesh/ISIM), each validated two independent ways:
1. **VALIDITY** — `EXPLAIN <q>` sent to a raw driver session (so `CypherSyntaxError` propagates; `Neo4jClient.run()` swallows it). Works on an empty DB.
2. **ROW PRESENCE** — executes and asserts result keys; **skips** when a graph slice isn't populated (CI-safe).

## Bugs fixed

### 1. `merge_indicators_batch` dropped enrichment fields (real ingest bug)
The bulk/baseline sync path built its `batch_item` + Cypher SET clause with only a *subset* of enrichment fields (`indicator_role`, `url_status`, `threat_label`, …). It silently dropped the rest — `attack_ids`, `malware_family`, `targeted_countries`, `malware_malpedia`, `reference`, `reporter`, `domain`, `hostnames` — which the **single-item** `merge_indicator` (neo4j_client.py ~L2329) *does* promote. They survived only inside the `SOURCED_FROM` edge's `raw_data` JSON, never as queryable node properties.

Consequences (both confirmed against the live graph):
- `Indicator.attack_ids` = **0/146,185** → `build_relationships.py` step 8 (`USES_TECHNIQUE`, matches `i.attack_ids`) could never build an edge.
- `Indicator.malware_family` = **0** → step 9 (`INDICATES` family-name match) could never fire for batch-ingested indicators.
- Control: `indicator_role` (which *is* in the SET clause) = **41**, proving the batch path only persists fields it explicitly SETs.

**Fix:** promote the same fields in the batch path at parity, using the existing `coalesce(item.x, n.x)` pattern (keeps existing values when a later/non-OTX source omits the field). Pinned by a new DB-free regression test (`tests/test_indicator_enrichment_parity.py`) that captures the generated Cypher and asserts each field is SET.

### 2. Doc drift: `:Vulnerability` → `:CVE`
The sync routes every CVE through `merge_cve()` → the `:CVE` label (`run_misp_to_neo4j.py:3415`); `:Vulnerability` is legacy and **empty** on current baselines (live: 99,757 `:CVE`, 0 `:Vulnerability`). The sample/example queries in `docs/NEO4J_SAMPLE_QUERIES.md` and `docs/KNOWLEDGE_GRAPH.md` matched `(v:Vulnerability)` and returned 0 rows. Switched them to `:CVE` (the fixed healthcare query now returns 645 rows live) and added a label note. Also fixed a stale `v.first_seen` (removed from nodes in PR S5).

## New tooling (for the Cloudflare-fronted deployment)
- `scripts/neo4j_wss_bridge.py` — tunnels the Bolt driver through Bolt-over-WebSocket. Direct `bolt+s://…:443` fails ("looks like HTTP") because Cloudflare proxies HTTP/WebSocket, not raw Bolt TCP.
- `scripts/run_cypher_catalog_http.py` — runs the same catalog over the HTTP Query API and optionally collects results (`--out <dir>`).
- `requirements-dev`: `websocket-client`.

## Not fixed here (operational, not code) — for awareness
The live snapshot is missing `IN_TACTIC` / `IMPLEMENTS_TECHNIQUE` edges **even though the source data is present** (`tactic_phases` 831/831, `Malware.uses_techniques` 3,144/3,409, `Tool` 90/90). Root cause: every edge carries a *sync* signature (`match_type='cve_tag'` / `source_id='misp_cooccurrence'`) and **none** of `build_relationships.py`'s signatures — i.e. that post-sync linking step never ran on this DB. The sync's `_build_cross_item_relationships` only emits `EMPLOYS_TECHNIQUE`/`ATTRIBUTED_TO`/`INDICATES`/`EXPLOITS`/`TARGETS`/`AFFECTS`; `IMPLEMENTS_TECHNIQUE` is deliberately deferred to `build_relationships.py` (comment at run_misp_to_neo4j.py:2430). Running `build_relationships.py` would create those edges immediately. Left as an operational action (a DB write, not a code change).

## Test plan
- [x] `ruff check` + `ruff format --check` on `src/ dags/ tests/ scripts/`
- [x] `mypy src/ scripts/` (clean)
- [x] `pytest` affected units (parity + neo4j_client guards + sync chunking + build_relationships) — 35 passed
- [x] Full catalog harness over the WSS bridge against the live DB — **129 passed, 42 skipped, 0 failed** (all 84 queries valid)
- [x] New CVSS queries return rows live (v40/v30); `:CVE` doc query returns 645
- [ ] CI (ruff/mypy/pytest + coverage gate) on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> The `merge_indicators_batch` change alters production MISP→Neo4j writes for all bulk indicators; behavior is intended parity with the single-item path but affects graph linking inputs until re-sync.
> 
> **Overview**
> Adds a **84-query Cypher catalog** with pytest validation (`EXPLAIN` for syntax on any DB; optional row checks that skip empty slices) plus HTTP and WSS tooling to run it against Cloudflare-fronted Neo4j.
> 
> **Ingest fix:** `merge_indicators_batch` now SETs the same OTX/ThreatFox enrichment fields as single-item `merge_indicator` (`attack_ids`, `malware_family`, etc.), so batch sync can populate properties needed for `USES_TECHNIQUE` and family-based `INDICATES` instead of leaving them only in `SOURCED_FROM.raw_data`. Regression test captures generated Cypher without a live DB.
> 
> **Docs:** Sample queries in `KNOWLEDGE_GRAPH.md` and `NEO4J_SAMPLE_QUERIES.md` use `:CVE` instead of empty legacy `:Vulnerability`, with notes on portable `CVE OR Vulnerability` matching.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 194ffee4648da1470707c44132e9f9e3b002fa70. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->