### PR TITLE
fix(types): restore green mypy CI — covariant _SessionLike + typed MISP params

### DIFF
--- a/src/baseline_clean.py
+++ b/src/baseline_clean.py
@@ -254,9 +254,10 @@ def _probe_misp(misp_url: str, misp_api_key: str, ssl_verify: bool) -> tuple[int
             with warnings.catch_warnings():
                 if not ssl_verify:
                     warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+                params: dict[str, str | int] = {"searchall": "EdgeGuard", "limit": 500, "page": page}
                 resp = sess.get(
                     f"{misp_url}/events/index",
-                    params={"searchall": "EdgeGuard", "limit": 500, "page": page},
+                    params=params,
                     verify=ssl_verify,
                     timeout=(10, 30),
                     allow_redirects=False,  # Red Team H1 — defense-in-depth
@@ -463,9 +464,10 @@ def _wipe_misp_events(misp_url: str, misp_api_key: str, ssl_verify: bool, max_pa
         with warnings.catch_warnings():
             if not ssl_verify:
                 warnings.filterwarnings("ignore", category=urllib3.exceptions.InsecureRequestWarning)
+            params: dict[str, str | int] = {"searchall": "EdgeGuard", "limit": 500, "page": page}
             resp = sess.get(
                 f"{misp_url}/events/index",
-                params={"searchall": "EdgeGuard", "limit": 500, "page": page},
+                params=params,
                 verify=ssl_verify,
                 timeout=(15, 60),
                 allow_redirects=False,  # Red Team H1

--- a/src/config.py
+++ b/src/config.py
@@ -390,7 +390,15 @@ if MISP_API_KEY in _MISP_KEY_PLACEHOLDERS:
 
 
 class _SessionLike(Protocol):
-    headers: MutableMapping[str, str]
+    # Read-only property → the attribute is COVARIANT. requests 2.34.2 ships
+    # py.typed and types ``Session.headers`` as ``CaseInsensitiveDict[str]`` (a
+    # ``MutableMapping[str, str]`` *subtype*); an invariant *mutable attribute*
+    # would reject it (the type-check drift that broke CI's mypy job).
+    # ``apply_misp_http_host_header`` only mutates the mapping
+    # (``session.headers["Host"] = ...``) and never reassigns it, so a read-only
+    # property is sufficient and keeps ``requests.Session`` structurally matching.
+    @property
+    def headers(self) -> MutableMapping[str, str]: ...
 
 
 def get_edgeguard_misp_http_host() -> str:


### PR DESCRIPTION
## Summary
Restores the **Lint & type-check** CI job, which began failing on PRs with *unrelated* diffs. Root cause is dependency-stub drift, not any specific PR: `requests` (pinned `~=2.32`) floats to **2.34.2**, which now ships `py.typed` with stricter inline stubs that flag **pre-existing** code in files no recent PR touched.

## The 6 errors (all in untouched files)
- `apply_misp_http_host_header(requests.Session)` at `scripts/clear_misp.py:53`, `src/health_check.py:73`, `src/baseline_clean.py:240,457` — `requests.Session` no longer matches the `_SessionLike` Protocol.
- `Session.get(params=…)` at `src/baseline_clean.py:259,468` — the inline dict literal infers `dict[str, object]`.

## Fixes (correct under the new stubs — no version pin, no behavior change)
1. **`_SessionLike.headers` → read-only `@property`** (`src/config.py`). requests 2.34.2 types `Session.headers` as `CaseInsensitiveDict[str]` (a `MutableMapping[str, str]` *subtype*); the Protocol's **invariant mutable attribute** rejected it. The helper only mutates the mapping (`session.headers["Host"]=…`), never reassigns it, so a covariant read-only property is sufficient and correct.
2. **Type the MISP params dicts** as `dict[str, str | int]` locals (`src/baseline_clean.py`) so they match `requests`' `params` union instead of inferring `dict[str, object]`.

## Verification
`mypy src/ scripts/ --ignore-missing-imports --no-error-summary` → **exit 0** with `requests==2.34.2` + `mypy==1.20.2` (the exact versions CI installs; reproduced the failures first, then confirmed the fix). `ruff check` + `ruff format --check` clean.

## Cross-PR note
This is one of three focused PRs clearing pre-existing CI drift discovered while landing #120:
- **this PR** → Lint & type-check (mypy)
- **#122** → Dependency security scan (fastapi 0.136.3 malware pin + starlette CVE ignore)
- Docker build (Trivy base-image CRITICALs) → triaged separately (needs a base-image decision)

Each PR is off `main`, so sibling reds will still show here until all merge.

## Test plan
- [x] Reproduced all 6 errors locally with CI's `requests`/`mypy` versions
- [x] `mypy src/ scripts/` exit 0 after fix; `ruff` clean
- [ ] CI **Lint & type-check** goes green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only and annotation changes; no behavioral changes to MISP or baseline wipe logic.
> 
> **Overview**
> Unblocks **Lint & type-check** after `requests` 2.34.2 began shipping stricter `py.typed` stubs (no runtime or pin changes).
> 
> **`src/config.py`:** `_SessionLike` now declares `headers` as a read-only `@property` returning `MutableMapping[str, str]` instead of a mutable attribute, so `requests.Session` (with `CaseInsensitiveDict` headers) structurally matches while `apply_misp_http_host_header` still only sets `session.headers["Host"]`.
> 
> **`src/baseline_clean.py`:** MISP `/events/index` query dicts are assigned to `params: dict[str, str | int]` before `Session.get`, fixing inference as `dict[str, object]` in the probe and wipe loops.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fc8a4946263fa7e482b0166164fc384832161251. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->