### PR TITLE
feat(graphrag): alias round-trip + KEV marker + IOC normalization + 19 catalog shapes (Stage-2 readiness)

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -243,7 +243,7 @@ When data is pushed to MISP, it gets tagged with:
 | `EMPLOYS_TECHNIQUE` | ThreatActor / Campaign → Technique | Attribution — MITRE STIX **`uses`** → `uses_techniques` on actor → `build_relationships.py`. *(Split from a generic `USES` in 2026-04.)* |
 | `IMPLEMENTS_TECHNIQUE` | Malware / Tool → Technique | Capability — MITRE STIX **`uses`** → `uses_techniques` on malware/tool (MISP **`MITRE_USES_TECHNIQUES:`** round-trip for malware) → `build_relationships.py`. *(Split from a generic `USES` in 2026-04.)* |
 | `USES_TECHNIQUE` | Indicator → Technique | Observation — OTX `attack_ids` on indicator → `build_relationships.py` (confidence 0.85). |
-| `ATTRIBUTED_TO` | Malware → ThreatActor | MITRE / MISP event data |
+| `ATTRIBUTED_TO` | Malware → ThreatActor | `build_relationships.py` exact match on the malware's own `attributed_to` claim against the actor's `name` OR the actor's `aliases` (the "Cozy Bear → APT29" path). Actor/malware `aliases` survive the MISP round-trip via `alias:` tags (2026-06). The inverse path (actor name ∈ malware aliases) was **removed** 2026-06 as an attribution-forgery vector — see `build_relationships.py` Q2. |
 | `INDICATES` | Indicator → Malware | MISP event co-occurrence (`misp_event_ids[]` array IN-membership match) |
 | `EXPLOITS` | Indicator → CVE/Vulnerability | Indicator tagged with matching `cve_id` |
 | `IN_TACTIC` | Technique → Tactic | MITRE ATT&CK tactic phases |
@@ -480,4 +480,4 @@ See [`RESILMESH_INTEROPERABILITY.md` §8.4](RESILMESH_INTEROPERABILITY.md) for t
 
 ---
 
-_Last updated: 2026-04-28 — PR-N36 Tier-2 deep verification: re-verified — no factual drift. The 13-source inventory matches `src/collectors/` (incl. healthcare/energy placeholders). `EDGEGUARD_REL_BATCH_SIZE` default 500 matches `_RELATIONSHIP_BATCH_DEFAULT` in `src/run_misp_to_neo4j.py:484`; `EDGEGUARD_DEBUG_GC` exists at line 3723. `create_misp_relationships_batch` and the per-edge-type provenance scoping all match code. Prior: 2026-04-26 PR-N33 docs audit (corrected PR-N26 edge scope); 2026-04-18 chip 5a + PR #41 cleanup._
+_Last updated: 2026-06-11 — PR #126: ATTRIBUTED_TO row now documents the alias round-trip (actor/malware aliases survive the MISP round-trip via `alias:` tags) and the removal of the alias attribution-forgery branch (Q2 Branch 3). Prior: 2026-04-28 — PR-N36 Tier-2 deep verification: re-verified — no factual drift. The 13-source inventory matches `src/collectors/` (incl. healthcare/energy placeholders). `EDGEGUARD_REL_BATCH_SIZE` default 500 matches `_RELATIONSHIP_BATCH_DEFAULT` in `src/run_misp_to_neo4j.py:484`; `EDGEGUARD_DEBUG_GC` exists at line 3723. `create_misp_relationships_batch` and the per-edge-type provenance scoping all match code. Prior: 2026-04-26 PR-N33 docs audit (corrected PR-N26 edge scope); 2026-04-18 chip 5a + PR #41 cleanup._

--- a/docs/DOCUMENTATION_AUDIT.md
+++ b/docs/DOCUMENTATION_AUDIT.md
@@ -209,6 +209,17 @@ Per-PR narrative for the train (cross-doc summary):
   Tier-3 sweep itself — confirms PR-J1's CI-side defense + PR-N33's
   6-agent batch already addressed the bulk of drift.
 
+* **PR #126 (2026-06-11):** Stage-2 GraphRAG readiness (alias round-trip,
+  KEV marker, `ioc_normalize` read-side layer, `/actors/{name}/summary`,
+  19 catalog queries). Per BUGBOT.md §11, updated the core graph docs for
+  the touched code paths: METHODOLOGY.md (real three-layer confidence
+  model — the aspirational `data_quality_factor` formula removed),
+  KNOWLEDGE_GRAPH.md (ATTRIBUTED_TO alias note + the two new CVE range
+  indexes), RESILMESH_INTEROPERABILITY.md (new REST endpoint + read-side
+  normalization), ARCHITECTURE.md (ATTRIBUTED_TO row: alias round-trip +
+  Q2 Branch-3 removal). Driven by an 8-agent proactive audit, not a
+  reactive sweep.
+
 **Audit cadence going forward (post-PR-J1):** the pin-test catches
 broken doc references on every PR. Tier-1-style deep verification is
 only needed after major code-shape changes (DAG renames, container

--- a/docs/KNOWLEDGE_GRAPH.md
+++ b/docs/KNOWLEDGE_GRAPH.md
@@ -53,7 +53,7 @@ EdgeGuard partitions the knowledge graph by **three sectors** plus a **central O
 | `EMPLOYS_TECHNIQUE` | ThreatActor → Technique | **Attribution.** MITRE STIX explicit `uses` relationship (confidence 0.95) *(split from a generic `USES` in 2026-04)* |
 | `IMPLEMENTS_TECHNIQUE` | Malware → Technique | **Capability.** MITRE STIX explicit `uses` relationship via `uses_techniques` (confidence 0.95) *(split from a generic `USES` in 2026-04)* |
 | `IMPLEMENTS_TECHNIQUE` | Tool → Technique | **Capability.** MITRE STIX explicit `uses` relationship (confidence 0.95) *(split from a generic `USES` in 2026-04)* |
-| `ATTRIBUTED_TO` | Malware → ThreatActor | `build_relationships.py` name matching |
+| `ATTRIBUTED_TO` | Malware → ThreatActor | `build_relationships.py` name matching — `m.attributed_to` exact match, OR alias match against `a.aliases` / `m.aliases`. ThreatActor and Malware `aliases` survive the MISP round-trip via `alias:` tags (2026-06 fix); ATT&CK malware aliases come from `x_mitre_aliases`. |
 | `INDICATES` | Indicator → Malware | MISP event co-occurrence (confidence 0.5) **and** malware_family name match from ThreatFox/VT (confidence 0.8) |
 | `EXPLOITS` | Indicator → Vulnerability/CVE | CVE tag exact match (confidence 1.0) |
 | `REFERS_TO` | Vulnerability ↔ CVE | `bridge_vulnerability_cve()` |
@@ -191,6 +191,11 @@ CREATE INDEX indicator_zone IF NOT EXISTS FOR (i:Indicator) ON (i.zone);
 CREATE INDEX malware_name IF NOT EXISTS FOR (m:Malware) ON (m.name);
 CREATE INDEX actor_name IF NOT EXISTS FOR (a:ThreatActor) ON (a.name);
 CREATE INDEX technique_mitre IF NOT EXISTS FOR (t:Technique) ON (t.mitre_id);
+
+// CVE prioritization range scans (2026-06, GraphRAG): CVSS-threshold
+// filters and the CISA-KEV (cisa_exploit_add IS NOT NULL) query family.
+CREATE INDEX cve_cvss_score IF NOT EXISTS FOR (c:CVE) ON (c.cvss_score);
+CREATE INDEX cve_cisa_exploit_add IF NOT EXISTS FOR (c:CVE) ON (c.cisa_exploit_add);
 
 // Original source tracking
 CREATE INDEX indicator_original_source IF NOT EXISTS FOR (i:Indicator) ON (i.original_source);
@@ -403,8 +408,7 @@ ORDER BY i.last_updated DESC
 
 ---
 
-_Last updated: 2026-04-28 — PR-N36 Tier-2 deep verification:_
-
+_Last updated: 2026-06-11 — PR #126: documented the alias round-trip (ThreatActor/Malware `aliases` survive the MISP round-trip via `alias:` tags; ATT&CK malware aliases from `x_mitre_aliases`) on the ATTRIBUTED_TO matching note, and added the cve_cvss_score + cve_cisa_exploit_add range indexes. Prior: 2026-04-28 — PR-N36 Tier-2 deep verification:_
 - _Verified all confidence values match `src/build_relationships.py`:
   EMPLOYS_TECHNIQUE = 0.95 (line 5/12), IMPLEMENTS_TECHNIQUE = 0.95
   (lines 6/12 and 10/12), USES_TECHNIQUE = 0.85 (8/12 — OTX

--- a/docs/KNOWLEDGE_GRAPH.md
+++ b/docs/KNOWLEDGE_GRAPH.md
@@ -53,7 +53,7 @@ EdgeGuard partitions the knowledge graph by **three sectors** plus a **central O
 | `EMPLOYS_TECHNIQUE` | ThreatActor → Technique | **Attribution.** MITRE STIX explicit `uses` relationship (confidence 0.95) *(split from a generic `USES` in 2026-04)* |
 | `IMPLEMENTS_TECHNIQUE` | Malware → Technique | **Capability.** MITRE STIX explicit `uses` relationship via `uses_techniques` (confidence 0.95) *(split from a generic `USES` in 2026-04)* |
 | `IMPLEMENTS_TECHNIQUE` | Tool → Technique | **Capability.** MITRE STIX explicit `uses` relationship (confidence 0.95) *(split from a generic `USES` in 2026-04)* |
-| `ATTRIBUTED_TO` | Malware → ThreatActor | `build_relationships.py` name matching — `m.attributed_to` exact match, OR alias match against `a.aliases` / `m.aliases`. ThreatActor and Malware `aliases` survive the MISP round-trip via `alias:` tags (2026-06 fix); ATT&CK malware aliases come from `x_mitre_aliases`. |
+| `ATTRIBUTED_TO` | Malware → ThreatActor | `build_relationships.py` name matching — the malware's own `m.attributed_to` claim, matched exactly against the actor's `a.name` OR the actor's `a.aliases` (the "Cozy Bear → APT29" path). Actor/Malware `aliases` survive the MISP round-trip via `alias:` tags (2026-06 fix; ATT&CK malware aliases from `x_mitre_aliases`). The inverse path (actor name ∈ malware `aliases`) was **removed** 2026-06 as an attribution-forgery vector — see `build_relationships.py` Q2. |
 | `INDICATES` | Indicator → Malware | MISP event co-occurrence (confidence 0.5) **and** malware_family name match from ThreatFox/VT (confidence 0.8) |
 | `EXPLOITS` | Indicator → Vulnerability/CVE | CVE tag exact match (confidence 1.0) |
 | `REFERS_TO` | Vulnerability ↔ CVE | `bridge_vulnerability_cve()` |

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -281,18 +281,21 @@ def merge_node(existing, new):
 1. **Source prior at ingest** — the per-source values in the table above,
    set by each collector when the item is created.
 2. **Co-occurrence calibration** (post-sync, `enrichment_jobs.py`
-   `calibrate_cooccurrence`): co-occurrence-derived `INDICATES` edges from
-   large bulk-feed MISP events are down-weighted (event-size based) into
-   the 0.30-0.50 band; calibrated edges carry `r.calibrated_at`.
+   `calibrate_cooccurrence_confidence`): co-occurrence-derived `INDICATES`
+   **and** `EXPLOITS` edges from large bulk-feed MISP events are
+   down-weighted by event size into the 0.30–0.50 band (≤10 → 0.50,
+   ≤20 → 0.45, ≤100 → 0.40, ≤500 → 0.35, >500 → 0.30); only edges marked
+   `misp_cooccurrence` / `misp_correlation` are touched.
 3. **Time decay** (post-sync, `enrichment_jobs.py` `decay_ioc_confidence`):
-   Indicator/Vulnerability confidence x0.85 at 90-180 days, x0.70 at
-   180-365 days (floor 0.10), `active=false` retirement past 365 days;
-   decayed nodes carry `last_decayed_tier`.
+   tiered by label — **Indicator** ×0.85 at 90–180 days, ×0.70 at
+   180–365 days; **Vulnerability** ×0.90 at 90–180 days, ×0.80 at
+   180–365 days; both retire (`active=false`) past 365 days. Decayed
+   nodes carry `last_decayed_tier`.
 
-When explaining a score, cite the layer that produced it (source prior vs
-`r.calibrated_at` vs `last_decayed_tier`) — multi-source corroboration is
-visible through per-source `SOURCED_FROM` edges, not folded into a single
-multiplier.
+When explaining a score, cite the layer that produced it (source prior, the
+co-occurrence calibration band, or the `last_decayed_tier`) — multi-source
+corroboration is visible through per-source `SOURCED_FROM` edges, not
+folded into a single multiplier.
 
 ---
 

--- a/docs/METHODOLOGY.md
+++ b/docs/METHODOLOGY.md
@@ -269,15 +269,30 @@ def merge_node(existing, new):
 | AbuseIPDB | `abuseConfidenceScore / 100.0` | Vendor-supplied 0-100 score divided to 0-1 range |
 | ThreatFox / global feeds | 0.5 / 0.6 / vendor-supplied | `global_feed_collector.py`; vendor-supplied takes precedence |
 
-**Confidence Calculation:**
-```
-final_confidence = source_confidence * data_quality_factor
+**Confidence Calculation (as actually implemented):**
 
-# data_quality_factor accounts for:
-# - Completeness of attributes (0.8-1.0)
-# - Age of data (newer = higher)
-# - Number of sources confirming (more = higher)
-```
+> **Docs correction (2026-06):** earlier versions described a
+> `final_confidence = source_confidence * data_quality_factor` formula.
+> No `data_quality_factor` exists anywhere in the code — that formula was
+> aspirational and is removed so downstream consumers (including the
+> Stage-2 fine-tuning dataset) don't learn semantics the system doesn't
+> have. The real model is three independent layers:
+
+1. **Source prior at ingest** — the per-source values in the table above,
+   set by each collector when the item is created.
+2. **Co-occurrence calibration** (post-sync, `enrichment_jobs.py`
+   `calibrate_cooccurrence`): co-occurrence-derived `INDICATES` edges from
+   large bulk-feed MISP events are down-weighted (event-size based) into
+   the 0.30-0.50 band; calibrated edges carry `r.calibrated_at`.
+3. **Time decay** (post-sync, `enrichment_jobs.py` `decay_ioc_confidence`):
+   Indicator/Vulnerability confidence x0.85 at 90-180 days, x0.70 at
+   180-365 days (floor 0.10), `active=false` retirement past 365 days;
+   decayed nodes carry `last_decayed_tier`.
+
+When explaining a score, cite the layer that produced it (source prior vs
+`r.calibrated_at` vs `last_decayed_tier`) — multi-source corroboration is
+visible through per-source `SOURCED_FROM` edges, not folded into a single
+multiplier.
 
 ---
 
@@ -448,4 +463,4 @@ Future enhancements include embedding-based classification for better context un
 
 ---
 
-_Last updated: 2026-04-28 — PR-N36 Tier-2 deep verification: corrected the per-source confidence table to match `src/collectors/`. Findings: NVD says 0.7 in doc but actual is 0.6 (default) / 0.9 (when CISA-listed); OTX says 0.5-0.7 range but actual is flat 0.5 across all 4 emit sites; added missing rows for AbuseIPDB (vendor score / 100), ThreatFox/global feeds (0.5/0.6/vendor), and split MISP into push-side (0.8) vs collector-side (0.5–0.8). Prior: 2026-04-26 PR-N33 docs audit (removed contradictory "tag scopes the dedup key"; fixed `vulnerability_key` Cypher); 2026-03-28._
+_Last updated: 2026-06-11 — removed the aspirational data_quality_factor confidence formula (no such factor exists in code); documented the real three-layer model (source prior → co-occurrence calibration → time decay). Prior: 2026-04-28 — PR-N36 Tier-2 deep verification: corrected the per-source confidence table to match `src/collectors/`. Findings: NVD says 0.7 in doc but actual is 0.6 (default) / 0.9 (when CISA-listed); OTX says 0.5-0.7 range but actual is flat 0.5 across all 4 emit sites; added missing rows for AbuseIPDB (vendor score / 100), ThreatFox/global feeds (0.5/0.6/vendor), and split MISP into push-side (0.8) vs collector-side (0.5–0.8). Prior: 2026-04-26 PR-N33 docs audit (removed contradictory "tag scopes the dedup key"; fixed `vulnerability_key` Cypher); 2026-03-28._

--- a/docs/RESILMESH_INTEROPERABILITY.md
+++ b/docs/RESILMESH_INTEROPERABILITY.md
@@ -1,6 +1,6 @@
 # EdgeGuard ↔ ResilMesh Interoperability Guide
 
-**Last updated: 2026-04-26** — PR-N33 docs audit: explicitly noted that the 4 PR-N26 edge types (`INDICATES`, `EXPLOITS`, `TARGETS`, `AFFECTS`) carry `r.misp_event_ids[]` for edge-level provenance (not just node-level). Cross-link to [`BASELINE_LAUNCH_CHECKLIST.md`](BASELINE_LAUNCH_CHECKLIST.md) for the operator pre-launch pass and to [`scripts/audit_legacy_unicode_bypass_nodes.py`](../scripts/audit_legacy_unicode_bypass_nodes.py) (PR-N32) for the unicode-bypass audit. Prior: 2026-04-18 PR #41 cleanup pass.
+**Last updated: 2026-06-11** — PR #126: documented the SOC-analyst REST endpoint `GET /actors/{name}/summary` (alias-aware actor resolution) and the read-side IOC/CVE input normalization layer (`src/ioc_normalize.py`). Prior: 2026-04-26 PR-N33 docs audit: explicitly noted that the 4 PR-N26 edge types (`INDICATES`, `EXPLOITS`, `TARGETS`, `AFFECTS`) carry `r.misp_event_ids[]` for edge-level provenance (not just node-level). Prior: 2026-04-18 PR #41 cleanup pass.
 **Document type:** Integration contract — shared reference between EdgeGuard (IICT-BAS + Ratio1) and ResilMesh  
 **Purpose:** Defines exactly what EdgeGuard produces, what it relies on ResilMesh to provide, and what neither system covers today.
 
@@ -500,6 +500,8 @@ ResilMesh exposes two query interfaces:
 
 **EdgeGuard GraphQL** (`src/graphql_api.py`, Strawberry + FastAPI) also listens on **4001** by default (`EDGEGUARD_GRAPHQL_PORT`). **Auth:** when `EDGEGUARD_API_KEY` is set in the environment, requests must include header **`X-Api-Key`**. **GraphiQL** is off unless `EDGEGUARD_GRAPHQL_PLAYGROUND=true`. **Rate limiting:** default **120 requests/minute** per IP (`slowapi`). **Health:** `GET /health` — **HTTP 200** only when Neo4j is healthy (ping + APOC); **503** otherwise. (REST API on port 8000 always returns **200** with `neo4j_connected` in JSON — see [README.md](../README.md) § *HTTP APIs*.)
 
+**SOC-analyst REST endpoints (port 8000):** `GET /actors/{name}/summary` (2026-06) resolves a threat actor by canonical name **or alias** (case-insensitive; `resolved_by` reports which) and returns an aggregated profile — attributed malware, employed techniques, campaigns, with counts — backing analyst "tell me about this actor" queries. Analyst-supplied IOC/CVE/technique inputs at the REST and GraphQL boundaries are refanged + canonicalized to graph form via `src/ioc_normalize.py` (write-side parity), so defanged paste (`1.2.3[.]4`, `hxxp://`), uppercase hashes, and en-dash CVE ids resolve to the stored nodes.
+
 **Real example from ISIM README** — query an IP address and trace to its missions:
 ```graphql
 query IPaddresses {
@@ -704,3 +706,4 @@ RETURN
 | [`docs/BASELINE_LAUNCH_CHECKLIST.md`](BASELINE_LAUNCH_CHECKLIST.md) | **PR-N32:** the 6-section pre-launch operator pass that must be walked through before triggering a 730d baseline (preflight, smoke, Alertmanager wiring, MISP scale, RAM/disk, unicode-bypass audit) |
 | [`docs/RUNBOOK.md`](RUNBOOK.md) § 8 | **PR-N31:** operator triage tree for `_MispFallbackHardError` (4 hard-failure modes: errors-payload, unexpected-shape, non-200, cap-hit) |
 | [`scripts/audit_legacy_unicode_bypass_nodes.py`](../scripts/audit_legacy_unicode_bypass_nodes.py) | **PR-N32:** read-only audit of legacy `Malware`/`ThreatActor`/`Tool` nodes with zero-width / bidi-control / variation-selector chars in their `name` (created BEFORE the PR-N29 L1 placeholder filter landed) |
+

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -9,6 +9,7 @@ This module aligns EdgeGuard's Neo4j schema with ResilMesh alert format:
 - Returns enriched responses on: resilmesh.enriched.alerts
 """
 
+import copy
 import json
 import logging
 import os
@@ -20,7 +21,7 @@ from typing import Any, Dict, List, Optional
 # Add src to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from ioc_normalize import infer_indicator_type, normalize_indicator_value
+from ioc_normalize import canonicalize_lookup
 from neo4j_client import Neo4jClient
 from package_meta import package_version
 
@@ -214,6 +215,12 @@ class AlertProcessor:
         """
         start_time = datetime.now(timezone.utc)
 
+        # Snapshot the RAW alert before any normalization mutates it — the
+        # response's original_alert must be the verbatim incoming payload
+        # (e.g. the defanged "hxxp://evil[.]com" the sensor sent), not the
+        # canonicalized form this method writes back into alert_data below.
+        original_alert_snapshot = copy.deepcopy(alert_data)
+
         # Parse alert
         alert = ResilMeshAlert.from_dict(alert_data)
         logger.info(f"🚨 Processing alert: {alert.alert_id} (zone: {alert.zone})")
@@ -237,35 +244,38 @@ class AlertProcessor:
         # Without inference, a typeless domain alert persists as
         # (indicator_type="unknown", value="EvIl.CoM") while MISP sync stores
         # the same host as (domain, "evil.com") — two nodes, and a
-        # type=domain search misses the alert one. Inferring "domain" gives
-        # both the right MERGE-key type AND case-folding parity.
-        _raw_indicator = alert.threat.get("indicator")
-        indicator_type = alert.threat.get("type") or "unknown"
-        if indicator_type == "unknown" and isinstance(_raw_indicator, str):
-            inferred = infer_indicator_type(_raw_indicator)
-            if inferred:
-                indicator_type = inferred
-
-        # Canonicalize ONCE, BEFORE the write — refang + NFC + case-fold
-        # (src/ioc_normalize.py, write-side parity) so the WRITE path
-        # (create_indicator_from_alert) and the READ path (enrichment MATCH)
-        # share one canonical value. Validate AFTER normalization: a
-        # whitespace/zero-width-only value passes a raw-truthiness check but
-        # normalizes to "" (would skip node creation yet still report
-        # enriched=True against an empty key). Propagate the canonical value
-        # AND the resolved type into alert_data["threat"] (consumed by the
-        # write) and alert.threat (consumed below).
-        indicator = normalize_indicator_value(indicator_type, _raw_indicator)
-        if not isinstance(indicator, str) or not indicator.strip():
-            return self._create_error_response(alert, "No indicator in alert")
+        # type=domain search misses the alert one. canonicalize_lookup (the
+        # SAME shared read-side path used by /search/indicator and STIX
+        # export) infers "domain" and folds the value, giving both the right
+        # MERGE-key type AND case-folding parity. An empty/whitespace result
+        # is coerced to "" so the indicator MERGE no-ops (guarded by
+        # ``if indicator:`` in create_indicator_from_alert) while the Alert
+        # node is STILL written. Propagate value + resolved type into
+        # alert_data["threat"] (consumed by the write) and alert.threat
+        # (consumed by enrichment).
+        resolved_type, indicator = canonicalize_lookup(alert.threat.get("type"), alert.threat.get("indicator"))
+        indicator_type = resolved_type or "unknown"
         alert.threat["indicator"] = indicator
         alert.threat["type"] = indicator_type
         if isinstance(alert_data.get("threat"), dict):
             alert_data["threat"]["indicator"] = indicator
             alert_data["threat"]["type"] = indicator_type
 
-        # Step 1-7: Process complete ResilMesh alert (create all nodes and relationships)
+        # Step 1-7: Process complete ResilMesh alert (create all nodes and
+        # relationships). This ALWAYS runs — even for a host-only / CVE-only
+        # alert with no IOC indicator — so the Alert node, zone link, and
+        # forensic context are recorded (create_alert_node is unconditional;
+        # the indicator MERGE inside no-ops on the empty value). Moving the
+        # empty-indicator guard ahead of this write (an earlier 2026-06
+        # draft) silently dropped legitimate indicatorless alerts.
         self.neo4j.process_complete_resilmesh_alert(alert_data)
+
+        # Enrichment requires a concrete indicator — a whitespace/zero-width
+        # or absent value normalizes to "" and has no graph key to look up.
+        # The Alert node is already persisted above, so this is a degraded
+        # (un-enriched) response, not a lost alert.
+        if not indicator:
+            return self._create_error_response(alert, "No indicator in alert")
 
         # Step 8: Query Neo4j for enrichment
         enrichment_data = self._enrich_indicator(indicator, indicator_type, alert)
@@ -286,7 +296,7 @@ class AlertProcessor:
             latency_ms=round(latency_ms, 2),
             query_metadata=enrichment_data["metadata"],
             enrichment=enrichment_data["enrichment"],
-            original_alert=alert_data,
+            original_alert=original_alert_snapshot,
         )
 
     def _enrich_indicator(self, indicator: str, indicator_type: str, alert: ResilMeshAlert) -> Dict:

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -233,12 +233,16 @@ class AlertProcessor:
         # uppercase alert value was persisted raw, then looked up canonical,
         # so the enrichment never found the node it had just written.
         # Propagate into both alert_data["threat"] (consumed by the write)
-        # and alert.threat (consumed below).
-        _raw_indicator = alert.threat.get("indicator")
-        if not _raw_indicator:
-            return self._create_error_response(alert, "No indicator in alert")
+        # and alert.threat (consumed below). Validate AFTER normalization:
+        # a whitespace/zero-width-only value passes a raw-truthiness check
+        # but normalizes to "" — which would skip node creation yet still
+        # report enriched=True against an empty lookup key. The same resolved
+        # type feeds normalization and enrichment so "unknown" vs missing
+        # type can't diverge.
         indicator_type = alert.threat.get("type", "unknown")
-        indicator = normalize_indicator_value(alert.threat.get("type"), _raw_indicator)
+        indicator = normalize_indicator_value(indicator_type, alert.threat.get("indicator"))
+        if not isinstance(indicator, str) or not indicator.strip():
+            return self._create_error_response(alert, "No indicator in alert")
         alert.threat["indicator"] = indicator
         if isinstance(alert_data.get("threat"), dict):
             alert_data["threat"]["indicator"] = indicator

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional
 # Add src to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from ioc_normalize import normalize_indicator_value
 from neo4j_client import Neo4jClient
 from package_meta import package_version
 
@@ -231,6 +232,12 @@ class AlertProcessor:
 
         if not indicator:
             return self._create_error_response(alert, "No indicator in alert")
+
+        # READ-side canonicalization (src/ioc_normalize.py): refang + NFC +
+        # case-fold so every $indicator bound into the enrichment Cypher
+        # below matches the write-side MERGE keys. The enrichment payload
+        # echoes the normalized form (it is the graph-canonical identity).
+        indicator = normalize_indicator_value(alert.threat.get("type"), indicator)
 
         # Step 8: Query Neo4j for enrichment
         enrichment_data = self._enrich_indicator(indicator, indicator_type, alert)

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -223,21 +223,28 @@ class AlertProcessor:
             logger.error("[ERR] Cannot process alert - Neo4j not connected")
             return self._create_error_response(alert, "Neo4j connection failed")
 
+        # Canonicalize the indicator ONCE, BEFORE the write — refang + NFC +
+        # case-fold (src/ioc_normalize.py, write-side parity). This must run
+        # before process_complete_resilmesh_alert so the WRITE path
+        # (create_indicator_from_alert MERGEs (:Indicator {value:$value}))
+        # and the READ path (enrichment MATCH below) agree on the same
+        # canonical value. Normalizing only the read key (the earlier
+        # 2026-06 version) created a read-after-write split: a defanged or
+        # uppercase alert value was persisted raw, then looked up canonical,
+        # so the enrichment never found the node it had just written.
+        # Propagate into both alert_data["threat"] (consumed by the write)
+        # and alert.threat (consumed below).
+        _raw_indicator = alert.threat.get("indicator")
+        if not _raw_indicator:
+            return self._create_error_response(alert, "No indicator in alert")
+        indicator_type = alert.threat.get("type", "unknown")
+        indicator = normalize_indicator_value(alert.threat.get("type"), _raw_indicator)
+        alert.threat["indicator"] = indicator
+        if isinstance(alert_data.get("threat"), dict):
+            alert_data["threat"]["indicator"] = indicator
+
         # Step 1-7: Process complete ResilMesh alert (create all nodes and relationships)
         self.neo4j.process_complete_resilmesh_alert(alert_data)
-
-        # Extract indicator from threat
-        indicator = alert.threat.get("indicator")
-        indicator_type = alert.threat.get("type", "unknown")
-
-        if not indicator:
-            return self._create_error_response(alert, "No indicator in alert")
-
-        # READ-side canonicalization (src/ioc_normalize.py): refang + NFC +
-        # case-fold so every $indicator bound into the enrichment Cypher
-        # below matches the write-side MERGE keys. The enrichment payload
-        # echoes the normalized form (it is the graph-canonical identity).
-        indicator = normalize_indicator_value(alert.threat.get("type"), indicator)
 
         # Step 8: Query Neo4j for enrichment
         enrichment_data = self._enrich_indicator(indicator, indicator_type, alert)

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -228,7 +228,7 @@ class AlertProcessor:
         # Ensure connection
         if not self.connect():
             logger.error("[ERR] Cannot process alert - Neo4j not connected")
-            return self._create_error_response(alert, "Neo4j connection failed")
+            return self._create_error_response(alert, "Neo4j connection failed", original_alert_snapshot)
 
         # Canonicalize the indicator ONCE, BEFORE the write — refang + NFC +
         # case-fold (src/ioc_normalize.py, write-side parity). This must run
@@ -275,7 +275,7 @@ class AlertProcessor:
         # The Alert node is already persisted above, so this is a degraded
         # (un-enriched) response, not a lost alert.
         if not indicator:
-            return self._create_error_response(alert, "No indicator in alert")
+            return self._create_error_response(alert, "No indicator in alert", original_alert_snapshot)
 
         # Step 8: Query Neo4j for enrichment
         enrichment_data = self._enrich_indicator(indicator, indicator_type, alert)
@@ -644,8 +644,16 @@ class AlertProcessor:
 
         return recommendations
 
-    def _create_error_response(self, alert: ResilMeshAlert, error_message: str) -> EnrichedAlert:
-        """Create an error response when enrichment fails"""
+    def _create_error_response(
+        self, alert: ResilMeshAlert, error_message: str, original_alert: Optional[Dict] = None
+    ) -> EnrichedAlert:
+        """Create an error/degraded response when enrichment fails.
+
+        ``original_alert`` should be the RAW pre-normalization snapshot when
+        the caller has one — degraded responses (e.g. an indicatorless alert
+        whose Alert node WAS persisted) carry the same verbatim payload the
+        success path returns, not an empty dict.
+        """
         return EnrichedAlert(
             alert_id=alert.alert_id,
             enriched=False,
@@ -653,7 +661,7 @@ class AlertProcessor:
             latency_ms=0.0,
             query_metadata={"error": error_message},
             enrichment={},
-            original_alert={},
+            original_alert=original_alert if original_alert is not None else {},
         )
 
     def close(self):

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -582,13 +582,20 @@ class AlertProcessor:
         """Generate security recommendations based on enrichment"""
         recommendations = []
 
-        # Base recommendation: block the indicator
-        if indicator_type == "ip":
+        # Base recommendation: block the indicator. Accept BOTH the legacy
+        # ResilMesh alert labels (ip / file_hash) AND the canonical
+        # write-side / inferred type names (ipv4 / ipv6 / hash) — since
+        # typeless alerts now resolve their type via infer_indicator_type
+        # (e.g. "ipv4", "hash"), this block must recognize those or an
+        # inferred IP/hash alert would silently lose its primary guidance.
+        if indicator_type in ("ip", "ipv4", "ipv6"):
             recommendations.append(f"Block IP {indicator} at perimeter firewall")
-        elif indicator_type == "domain":
+        elif indicator_type in ("domain", "hostname"):
             recommendations.append(f"Block domain {indicator} via DNS sinkhole")
-        elif indicator_type == "file_hash":
+        elif indicator_type in ("file_hash", "hash"):
             recommendations.append(f"Block file hash {indicator} on endpoints")
+        elif indicator_type == "url":
+            recommendations.append(f"Block URL {indicator} at web proxy / gateway")
 
         # Host-based recommendations
         hostname = alert.threat.get("hostname")

--- a/src/alert_processor.py
+++ b/src/alert_processor.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Optional
 # Add src to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from ioc_normalize import normalize_indicator_value
+from ioc_normalize import infer_indicator_type, normalize_indicator_value
 from neo4j_client import Neo4jClient
 from package_meta import package_version
 
@@ -232,20 +232,37 @@ class AlertProcessor:
         # 2026-06 version) created a read-after-write split: a defanged or
         # uppercase alert value was persisted raw, then looked up canonical,
         # so the enrichment never found the node it had just written.
-        # Propagate into both alert_data["threat"] (consumed by the write)
-        # and alert.threat (consumed below). Validate AFTER normalization:
-        # a whitespace/zero-width-only value passes a raw-truthiness check
-        # but normalizes to "" — which would skip node creation yet still
-        # report enriched=True against an empty lookup key. The same resolved
-        # type feeds normalization and enrichment so "unknown" vs missing
-        # type can't diverge.
-        indicator_type = alert.threat.get("type", "unknown")
-        indicator = normalize_indicator_value(indicator_type, alert.threat.get("indicator"))
+        # Resolve the indicator type, INFERRING it from the value shape when
+        # the alert gives none ("unknown"/missing — the ResilMesh default).
+        # Without inference, a typeless domain alert persists as
+        # (indicator_type="unknown", value="EvIl.CoM") while MISP sync stores
+        # the same host as (domain, "evil.com") — two nodes, and a
+        # type=domain search misses the alert one. Inferring "domain" gives
+        # both the right MERGE-key type AND case-folding parity.
+        _raw_indicator = alert.threat.get("indicator")
+        indicator_type = alert.threat.get("type") or "unknown"
+        if indicator_type == "unknown" and isinstance(_raw_indicator, str):
+            inferred = infer_indicator_type(_raw_indicator)
+            if inferred:
+                indicator_type = inferred
+
+        # Canonicalize ONCE, BEFORE the write — refang + NFC + case-fold
+        # (src/ioc_normalize.py, write-side parity) so the WRITE path
+        # (create_indicator_from_alert) and the READ path (enrichment MATCH)
+        # share one canonical value. Validate AFTER normalization: a
+        # whitespace/zero-width-only value passes a raw-truthiness check but
+        # normalizes to "" (would skip node creation yet still report
+        # enriched=True against an empty key). Propagate the canonical value
+        # AND the resolved type into alert_data["threat"] (consumed by the
+        # write) and alert.threat (consumed below).
+        indicator = normalize_indicator_value(indicator_type, _raw_indicator)
         if not isinstance(indicator, str) or not indicator.strip():
             return self._create_error_response(alert, "No indicator in alert")
         alert.threat["indicator"] = indicator
+        alert.threat["type"] = indicator_type
         if isinstance(alert_data.get("threat"), dict):
             alert_data["threat"]["indicator"] = indicator
+            alert_data["threat"]["type"] = indicator_type
 
         # Step 1-7: Process complete ResilMesh alert (create all nodes and relationships)
         self.neo4j.process_complete_resilmesh_alert(alert_data)

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -483,12 +483,16 @@ def build_relationships():
         # the end with AND would make NULL-propagation kill those
         # legitimate rows (NULL IN […] → NULL → falsy → AND … → falsy).
         # Inner separately rejects placeholder ``a.name``.
+        # Branch 3 removal (2026-06): the outer no longer needs the
+        # alias-only ``OR size(m.aliases) > 0`` arm — every remaining inner
+        # branch (1 + 2) reads ``m.attributed_to``, so a malware with only
+        # aliases and no attributed_to can never match. Dropping that arm
+        # avoids fanning the inner over malware rows that produce zero edges.
         _outer = (
             "MATCH (m:Malware) "
-            "WHERE (m.attributed_to IS NOT NULL "
-            "       AND size(trim(m.attributed_to)) > 0 "
-            f"       AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST}) "
-            "   OR size(coalesce(m.aliases, [])) > 0 "
+            "WHERE m.attributed_to IS NOT NULL "
+            "  AND size(trim(m.attributed_to)) > 0 "
+            f"  AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
             "RETURN m"
         )
         # PR-N10 follow-up (cursor-bugbot 2026-04-21, Medium): placeholder
@@ -513,49 +517,34 @@ def build_relationships():
             f"       AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
             "       AND toLower(trim(m.attributed_to)) = toLower(trim(a.name))) "
             # Branch 2: m.attributed_to ∈ actor.aliases — same gate,
-            # plus aliases comprehension drops placeholder entries.
+            # plus aliases comprehension drops placeholder entries. This is
+            # the load-bearing alias path (e.g. malware attributed_to
+            # "Cozy Bear" matches ThreatActor APT29 whose aliases include
+            # "Cozy Bear"): it keys on the MALWARE's OWN attributed_to claim
+            # against the ACTOR's OWN aliases — both authored by the same
+            # MISP attribute as the malware, so it carries no cross-entity
+            # spoofing surface.
             "   OR (m.attributed_to IS NOT NULL AND size(trim(m.attributed_to)) > 0 "
             f"       AND NOT toLower(trim(m.attributed_to)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} "
             f"       AND toLower(trim(m.attributed_to)) IN [x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 AND NOT toLower(trim(x)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} | toLower(trim(x))]) "
-            # Branch 3: a.name ∈ malware.aliases — doesn't read
-            # attributed_to, reachable when attributed_to is NULL.
-            #
-            # TODO (PR-N16+): Red-Team attribution-hijack vector left open.
-            # A compromised MISP peer can ship ``Malware{name:"benign",
-            # aliases:["APT29","Cozy Bear"]}``. Branch 3 then matches
-            # real APT29 (a.name) against the forged aliases entry,
-            # creating a false ATTRIBUTED_TO edge. PR-N14 Fix #3
-            # capped aliases cardinality + dropped placeholder entries,
-            # but DOES NOT block real-actor-name injection. The full
-            # fix needs either (a) source-allowlist (only trusted
-            # sources can write aliases), (b) multi-source
-            # corroboration (require 2+ sources agreeing on the
-            # alias before it attributes), or (c) disabling branch 3
-            # entirely (current mitigation: branch 3's aliases
-            # comprehension drops placeholder entries, but not
-            # real-actor names). Deferred pending design discussion.
-            # See: 7-agent pre-baseline audit Red-Team BLOCK #19
-            # (2026-04-21), PR-N14 body.
-            #
-            # TODO (2026-06 UPDATE to Red-Team BLOCK #19) — surface change,
-            # NOT yet fixed: before the alias round-trip fix, MISP-sourced
-            # Malware reached Neo4j with ``aliases=[]`` (parse_attribute
-            # hardcoded it), so branch 3 could never fire on the EdgeGuard
-            # MISP round-trip path — the vector was dormant there and only
-            # reachable via direct Neo4j writes. Now that
-            # ``_extract_alias_tags`` rehydrates ``alias:`` tags, a malware
-            # attribute carrying ``alias:APT29`` WILL forge attribution.
-            # This is the SAME trust model the rest of the pipeline already
-            # lives under (an untrusted MISP writer can already forge zones /
-            # source-truthful timestamps), governed by the staged MISP trust
-            # boundary ``EDGEGUARD_TRUSTED_MISP_ORG_UUIDS`` / ``_NAMES``
-            # (src/source_trust.py; Tier-3 fail-closed boot refusal is the
-            # roadmapped close — docs/SECURITY_ROADMAP.md). Operators
-            # federating an untrusted MISP MUST set that allowlist. Closing
-            # branch 3 (option c) or gating alias-derived attribution on the
-            # trusted-org check (option a) is now higher priority given the
-            # path is live; tracked for the post-baseline hardening pass.
-            f"   OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 AND NOT toLower(trim(x)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} | toLower(trim(x))]"
+            # Branch 3 (a.name ∈ malware.aliases) was REMOVED 2026-06
+            # (Red-Team BLOCK #19, proactive PR #126 audit). It attributed a
+            # malware to an actor whenever the actor's name appeared in the
+            # MALWARE's aliases — a cross-entity match with no legitimate
+            # signal (ATT&CK malware aliases are alternate malware NAMES,
+            # never actor names, so it created ~0 real edges) but a live
+            # forgery vector once the alias round-trip began rehydrating
+            # MISP ``alias:`` tags into m.aliases: an untrusted/federated
+            # MISP writer could ship ``Malware{name:"benign", alias:"APT29"}``
+            # and forge ``(benign)-[:ATTRIBUTED_TO {confidence 1.0,
+            # match_type:"exact"}]->(APT29)`` into the GraphRAG dataset. The
+            # PR-N14 sanitizer drops placeholders but NOT real actor names,
+            # and the EDGEGUARD_TRUSTED_MISP_ORG_UUIDS allowlist is fail-open
+            # and never gated this path. Removal closes the vector outright
+            # while preserving every legitimate attribution path (Branches
+            # 1+2 above, which key on the malware's OWN attributed_to claim).
+            # Malware-alias signal is still used — safely — by Q9 INDICATES
+            # (indicator.malware_family ∈ m.aliases) at calibrated confidence.
             ") "
             "MERGE (m)-[r:ATTRIBUTED_TO]->(a) "
             'ON CREATE SET r.confidence_score = 1.0, r.match_type = "exact", r.created_at = datetime() '

--- a/src/build_relationships.py
+++ b/src/build_relationships.py
@@ -536,6 +536,25 @@ def build_relationships():
             # real-actor names). Deferred pending design discussion.
             # See: 7-agent pre-baseline audit Red-Team BLOCK #19
             # (2026-04-21), PR-N14 body.
+            #
+            # TODO (2026-06 UPDATE to Red-Team BLOCK #19) — surface change,
+            # NOT yet fixed: before the alias round-trip fix, MISP-sourced
+            # Malware reached Neo4j with ``aliases=[]`` (parse_attribute
+            # hardcoded it), so branch 3 could never fire on the EdgeGuard
+            # MISP round-trip path — the vector was dormant there and only
+            # reachable via direct Neo4j writes. Now that
+            # ``_extract_alias_tags`` rehydrates ``alias:`` tags, a malware
+            # attribute carrying ``alias:APT29`` WILL forge attribution.
+            # This is the SAME trust model the rest of the pipeline already
+            # lives under (an untrusted MISP writer can already forge zones /
+            # source-truthful timestamps), governed by the staged MISP trust
+            # boundary ``EDGEGUARD_TRUSTED_MISP_ORG_UUIDS`` / ``_NAMES``
+            # (src/source_trust.py; Tier-3 fail-closed boot refusal is the
+            # roadmapped close — docs/SECURITY_ROADMAP.md). Operators
+            # federating an untrusted MISP MUST set that allowlist. Closing
+            # branch 3 (option c) or gating alias-derived attribution on the
+            # trusted-org check (option a) is now higher priority given the
+            # path is live; tracked for the post-baseline hardening pass.
             f"   OR toLower(trim(a.name)) IN [x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0 AND NOT toLower(trim(x)) IN {_PLACEHOLDER_NAMES_CYPHER_LIST} | toLower(trim(x))]"
             ") "
             "MERGE (m)-[r:ATTRIBUTED_TO]->(a) "

--- a/src/collectors/cisa_collector.py
+++ b/src/collectors/cisa_collector.py
@@ -286,6 +286,20 @@ class CISACollector:
                         "known_ransomware_use": known_ransomware,
                         "cisa_cwes": vuln.get("cwes", []),
                         "cisa_notes": vuln.get("notes", ""),
+                        # KEV marker round-trip (2026-06): every CVE in this
+                        # feed IS the KEV list, but only NVD-sourced CVEs used
+                        # to get a queryable ``cisa_exploit_add`` property (via
+                        # NVD's cisaExploitAdd enrichment). CVEs known ONLY
+                        # from this collector reached Neo4j with no KEV marker
+                        # — 480 such CVEs on the 2026-04 baseline were
+                        # invisible to the ``ti-cve-kev`` query family. Emit
+                        # the same four cisa_* fields the NVD path emits;
+                        # misp_writer embeds them in the META comment and
+                        # run_misp_to_neo4j rehydrates them onto the CVE node.
+                        "cisa_exploit_add": date_added or "",
+                        "cisa_action_due": due_date or "",
+                        "cisa_required_action": required_action or "",
+                        "cisa_vulnerability_name": vuln.get("vulnerabilityName", "") or "",
                     }
                 )
 

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1183,6 +1183,13 @@ class MISPWriter:
                 nvd_fields["cvss_v31_data"],
                 nvd_fields["cvss_v30_data"],
                 nvd_fields["cvss_v2_data"],
+                # KEV marker round-trip (2026-06): CISA-collector CVEs carry
+                # cisa_exploit_add but none of the NVD enrichment fields above,
+                # so the META comment was skipped and the KEV marker silently
+                # dropped between MISP and Neo4j (480 KEV-only CVEs on the
+                # 2026-04 baseline had no queryable KEV property). The KEV date
+                # alone now qualifies the attribute for the META carrier.
+                nvd_fields["cisa_exploit_add"],
             ]
         )
 
@@ -1259,6 +1266,17 @@ class MISPWriter:
         if family and family != name:
             tags.append(f"malware-family:{family}")
 
+        # Add alias tags (2026-06, alias round-trip): same carrier as actors.
+        # ATT&CK malware aliases (x_mitre_aliases) are load-bearing for
+        # build_relationships Q2 branch 3 (actor name ∈ m.aliases) and Q9
+        # (i.malware_family ∈ m.aliases) — without this tag the aliases
+        # never survived the MISP round-trip. Cap matches the actor path.
+        aliases = malware.get("aliases", [])
+        for alias in aliases[:20]:
+            alias_s = sanitize_value(str(alias), max_length=100)
+            if alias_s:
+                tags.append(f"alias:{alias_s}")
+
         # Add MITRE ATT&CK galaxy tag for malware - CRITICAL for STIX conversion
         tags.append(f'misp-galaxy:malware="{name}"')
 
@@ -1327,9 +1345,16 @@ class MISPWriter:
         else:
             tags.append(f"source:{source}")
 
-        # Add alias tags
+        # Add alias tags — the MISP-side carrier for the alias round-trip:
+        # run_misp_to_neo4j.parse_attribute rehydrates ``alias:`` tags into
+        # item["aliases"], which merge_actor persists (PR-N14 sanitizer
+        # downstream: 50-item cap + placeholder filter + 200-char truncation).
+        # Cap raised 5 → 20 (2026-06): MITRE intrusion-sets commonly carry
+        # 5-10 aliases and the old cap could drop the very alias an analyst
+        # searches by ("Cozy Bear" vs "APT29"); 20 covers the ATT&CK p99
+        # while still bounding MISP tag growth from a hostile feed.
         aliases = actor.get("aliases", [])
-        for alias in aliases[:5]:  # Limit to 5 aliases
+        for alias in aliases[:20]:
             alias_s = sanitize_value(str(alias), max_length=100)
             if alias_s:
                 tags.append(f"alias:{alias_s}")

--- a/src/collectors/misp_writer.py
+++ b/src/collectors/misp_writer.py
@@ -1267,10 +1267,12 @@ class MISPWriter:
             tags.append(f"malware-family:{family}")
 
         # Add alias tags (2026-06, alias round-trip): same carrier as actors.
-        # ATT&CK malware aliases (x_mitre_aliases) are load-bearing for
-        # build_relationships Q2 branch 3 (actor name ∈ m.aliases) and Q9
-        # (i.malware_family ∈ m.aliases) — without this tag the aliases
-        # never survived the MISP round-trip. Cap matches the actor path.
+        # ATT&CK malware aliases (x_mitre_aliases) feed build_relationships
+        # Q9 INDICATES (i.malware_family ∈ m.aliases) — without this tag the
+        # aliases never survived the MISP round-trip. (They do NOT feed actor
+        # attribution: the old Q2 Branch-3 path that read m.aliases was
+        # removed 2026-06 as a forgery vector — see build_relationships.py.)
+        # Cap matches the actor path.
         aliases = malware.get("aliases", [])
         for alias in aliases[:20]:
             alias_s = sanitize_value(str(alias), max_length=100)

--- a/src/collectors/mitre_collector.py
+++ b/src/collectors/mitre_collector.py
@@ -425,6 +425,14 @@ class MITRECollector:
                         {
                             "type": "malware",
                             "name": obj.get("name", ""),
+                            # ATT&CK malware SDOs carry aliases in the MITRE
+                            # extension field ``x_mitre_aliases`` (the plain
+                            # ``aliases`` key only exists on intrusion-sets).
+                            # Load-bearing for build_relationships Q2 branch 3
+                            # (actor name ∈ malware.aliases) and Q9
+                            # (i.malware_family ∈ m.aliases) — added 2026-06
+                            # with the alias round-trip fix.
+                            "aliases": obj.get("x_mitre_aliases", []) or obj.get("aliases", []),
                             # STIX 2 uses ``labels``; some bundles also use ``malware_types``.
                             "malware_types": obj.get("malware_types", []) or obj.get("labels", []),
                             "family": obj.get("name", ""),

--- a/src/collectors/mitre_collector.py
+++ b/src/collectors/mitre_collector.py
@@ -428,10 +428,11 @@ class MITRECollector:
                             # ATT&CK malware SDOs carry aliases in the MITRE
                             # extension field ``x_mitre_aliases`` (the plain
                             # ``aliases`` key only exists on intrusion-sets).
-                            # Load-bearing for build_relationships Q2 branch 3
-                            # (actor name ∈ malware.aliases) and Q9
+                            # Feeds build_relationships Q9 INDICATES
                             # (i.malware_family ∈ m.aliases) — added 2026-06
-                            # with the alias round-trip fix.
+                            # with the alias round-trip fix. (Malware aliases
+                            # do NOT feed actor attribution: the old Q2
+                            # Branch-3 path was removed as a forgery vector.)
                             "aliases": obj.get("x_mitre_aliases", []) or obj.get("aliases", []),
                             # STIX 2 uses ``labels``; some bundles also use ``malware_types``.
                             "malware_types": obj.get("malware_types", []) or obj.get("labels", []),

--- a/src/graphql_api.py
+++ b/src/graphql_api.py
@@ -54,6 +54,7 @@ from graphql_schema import (
     Vulnerability,
     VulnerabilityFilter,
 )
+from ioc_normalize import normalize_cve_id
 from neo4j_client import NEO4J_READ_TIMEOUT, Neo4jClient
 from package_meta import package_version
 
@@ -475,7 +476,10 @@ def _get_client() -> Neo4jClient:
 class Query:
     @strawberry.field(description="Fetch a single CVE by ID, including nested CVSS scores.")
     def cve(self, cve_id: str) -> Optional[CVE]:
-        return _resolve_cve(_get_client(), cve_id)
+        # READ-side canonicalization (src/ioc_normalize.py): analyst paste
+        # variants ('cve 2021 44228', en-dash) → 'CVE-2021-44228'; fall back
+        # to the raw input when no CVE id is recognized.
+        return _resolve_cve(_get_client(), normalize_cve_id(cve_id) or cve_id)
 
     @strawberry.field(description="List vulnerabilities with optional zone / status / CVSS filters.")
     def vulnerabilities(

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -128,6 +128,22 @@ _HEX_HASH_LENGTHS = frozenset({32, 40, 64, 128})
 _HEX_VALUE_RE = re.compile(r"[0-9a-fA-F]+")
 
 
+def _blank_type_to_none(indicator_type: Optional[str]) -> Optional[str]:
+    """Collapse every "no type given" form to ``None``: actual ``None``,
+    an empty / whitespace-only string, and EdgeGuard's ``"unknown"``
+    sentinel. Returns the stripped-lowercased type otherwise.
+
+    Single source of truth so inference + refang fire identically whether
+    the caller passes ``None``, ``""``, ``"  "``, or ``"unknown"`` — without
+    this, a ``type: ""`` alert was treated as a distinct real type and
+    skipped both inference and refang.
+    """
+    if not isinstance(indicator_type, str):
+        return None
+    stripped = indicator_type.strip().lower()
+    return None if stripped in ("", "unknown") else stripped
+
+
 def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
     """Normalize an analyst-supplied indicator value for graph lookup.
 
@@ -153,14 +169,7 @@ def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
     """
     if not isinstance(value, str):
         return value
-    itype = indicator_type.strip().lower() if isinstance(indicator_type, str) else None
-    # "unknown" is EdgeGuard's sentinel for "no type given" (the default the
-    # alert path fills in), so treat it identically to a missing type — both
-    # get refang + the hex-hash heuristic. Without this, a missing-type alert
-    # (itype=None → refang) and an explicit type="unknown" alert (refang
-    # skipped) normalized the SAME value differently.
-    if itype == "unknown":
-        itype = None
+    itype = _blank_type_to_none(indicator_type)
     base = refang(value) if (itype is None or itype in _REFANGABLE_INDICATOR_TYPES) else value
     out = unicodedata.normalize("NFC", base).strip()
     # Alert-vocab → write-vocab: 'ip' covers ipv4+ipv6 (both case-insensitive);
@@ -296,9 +305,10 @@ def canonicalize_lookup(indicator_type: Optional[str], value: str) -> tuple[Opti
     /search/indicator, STIX indicator export, alert enrichment).
 
     Returns ``(resolved_type, normalized_value)``:
-      - ``resolved_type`` is the given type, or — when it is missing /
-        ``"unknown"`` — the type inferred from the value's shape
-        (:func:`infer_indicator_type`), or ``None`` if uninferable.
+      - ``resolved_type`` is the given type, or — when it is "blank"
+        (``None`` / empty / whitespace / the ``"unknown"`` sentinel) — the
+        type inferred from the value's shape (:func:`infer_indicator_type`),
+        or ``None`` if uninferable.
       - ``normalized_value`` is :func:`normalize_indicator_value` applied
         with the resolved type (refang + NFC + case-fold to the write-side
         MERGE key), stripped. May be ``""`` when the input is empty /
@@ -309,8 +319,8 @@ def canonicalize_lookup(indicator_type: Optional[str], value: str) -> tuple[Opti
     inferred + folded while another bound the raw value, so identical paste
     enriched on ingest yet returned not-found on search.
     """
-    itype = indicator_type
-    if (itype is None or (isinstance(itype, str) and itype.strip().lower() == "unknown")) and isinstance(value, str):
+    itype = _blank_type_to_none(indicator_type)
+    if itype is None and isinstance(value, str):
         inferred = infer_indicator_type(value)
         if inferred:
             itype = inferred

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -162,6 +162,13 @@ _GRAPH_TYPE_MAP = {
     "snort": "snort",
     "btc": "bitcoin",
     "bitcoin": "bitcoin",
+    # MISP free-text attributes (``text``) are stored by the write side as
+    # graph type ``unknown`` (TYPE_MAPPING["text"]="unknown"), NOT shape-
+    # inferred — so a read-side lookup must key the literal ``unknown`` to hit
+    # that node. Distinct from a BLANK/``"unknown"`` *input*, which
+    # ``_blank_type_to_none`` collapses to None → shape inference; only the
+    # explicit MISP ``text`` vocab maps here.
+    "text": "unknown",
 }
 
 # md5 / sha1 / sha256 / sha512 hex-digest lengths.

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -1,0 +1,184 @@
+"""READ-side input normalization for analyst-supplied IOC values.
+
+Why this module exists
+----------------------
+The WRITE side canonicalizes natural keys before any Neo4j MERGE
+(``node_identity.canonicalize_merge_key``: NFC-normalize + strip, and
+lowercase for the case-insensitive labels/indicator-types). Analyst input
+arriving at the query APIs (REST ``/search/indicator``, STIX export,
+GraphQL ``cve`` resolver, NATS alert enrichment) is raw paste material:
+defanged URLs (``hxxp://evil[.]com``), mixed-case hashes, en-dash CVE ids
+copied from PDFs. Without a matching READ-side normalization, an exact-key
+``MATCH`` silently misses nodes the graph actually contains.
+
+Write-side parity guarantee
+---------------------------
+Every rule here either *reuses* the write-side helper data directly or is a
+strict superset of it that converges to the same canonical form:
+
+* Zero-width/bidi stripping reuses
+  ``node_identity._ZERO_WIDTH_AND_BIDI_TRANSLATE`` (the exact translate
+  table the write-side placeholder filter uses).
+* Case-folding for indicator values reuses
+  ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES`` — the same set
+  ``canonicalize_merge_key`` consults before lowercasing a MERGE key.
+* NFC-normalize + strip mirrors ``canonicalize_merge_key`` /
+  ``canonicalize_field_value`` exactly.
+
+Refanging is READ-side only by design: the write side ingests
+machine-generated feeds that are not defanged, so there is nothing to
+mirror — refanging can only *add* matches, never diverge from a stored key.
+
+Do NOT import ``query_api`` / ``graphql_api`` / ``alert_processor`` here —
+those modules import this one (cycle guard).
+"""
+
+from __future__ import annotations
+
+import re
+import unicodedata
+from typing import Optional
+
+from node_identity import (
+    _CASE_INSENSITIVE_INDICATOR_TYPES,
+    _ZERO_WIDTH_AND_BIDI_TRANSLATE,
+)
+
+# Conservative defang vocabulary only — exotic schemes (``meow://`` etc.)
+# are deliberately NOT rewritten. Patterns are applied in order; bracket
+# forms first so ``hxxp[:]//`` resolves to ``hxxp://`` before the scheme
+# rewrite sees it.
+_DEFANG_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
+    # Bracketed dots: evil[.]com / evil(.)com / evil{.}com → evil.com
+    (re.compile(r"\[\.\]|\(\.\)|\{\.\}"), "."),
+    # Bracketed colon: hxxp[:]// → hxxp://
+    (re.compile(r"\[:\]"), ":"),
+    # Bracketed at-sign: user[@]example.com → user@example.com
+    (re.compile(r"\[@\]"), "@"),
+    # Spelled-out at-sign (optional surrounding spaces): user [at] example → user@example
+    (re.compile(r"\s*[\[(]at[\])]\s*", re.IGNORECASE), "@"),
+    # Defanged schemes — only with an explicit ``://`` following, so plain
+    # words containing "hxxp" are never rewritten.
+    (re.compile(r"hxxps(?=://)", re.IGNORECASE), "https"),
+    (re.compile(r"hxxp(?=://)", re.IGNORECASE), "http"),
+)
+
+# Fixpoint bound: nested defanging (``[[.]]``) needs >1 pass to become
+# idempotent; the bound keeps adversarial deeply-nested input O(1).
+_REFANG_MAX_PASSES = 8
+
+
+def refang(value: str) -> str:
+    """Conservatively refang a defanged IOC string.
+
+    Rewrites only the common defang vocabulary (``hxxp(s)://``, ``[.]``,
+    ``(.)``, ``{.}``, ``[:]``, ``[at]``/``(at)``/``[@]``), strips the
+    zero-width/bidi control characters via the write-side translate table
+    (``node_identity._ZERO_WIDTH_AND_BIDI_TRANSLATE`` — parity guarantee),
+    and strips surrounding whitespace.
+
+    Idempotent (substitutions run to a bounded fixpoint) and never raises:
+    non-``str`` input is returned unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    out = value.translate(_ZERO_WIDTH_AND_BIDI_TRANSLATE)
+    for _ in range(_REFANG_MAX_PASSES):
+        prev = out
+        for pattern, replacement in _DEFANG_REPLACEMENTS:
+            out = pattern.sub(replacement, out)
+        if out == prev:
+            break
+    return out.strip()
+
+
+# Indicator types where case IS meaningful — mirror of the exclusion list
+# documented above ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES``
+# (URL paths, file/registry paths, RFC email local-parts). Anything in
+# neither set is treated as *unknown* and falls through to the hex-hash
+# heuristic below.
+_KNOWN_CASE_SENSITIVE_INDICATOR_TYPES = frozenset({"url", "email", "filename", "filepath", "regkey", "cmdline"})
+
+# md5 / sha1 / sha256 / sha512 hex-digest lengths.
+_HEX_HASH_LENGTHS = frozenset({32, 40, 64, 128})
+_HEX_VALUE_RE = re.compile(r"[0-9a-fA-F]+")
+
+
+def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
+    """Normalize an analyst-supplied indicator value for graph lookup.
+
+    Pipeline: :func:`refang` → NFC-normalize + strip → lowercase IFF the
+    type is in ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES`` (the
+    exact set the write side consults in ``canonicalize_merge_key`` — this
+    is the write-side parity guarantee: the value bound into a read-side
+    ``MATCH`` equals the value the write side used as its MERGE key).
+
+    When ``indicator_type`` is None or not a recognized type (neither
+    case-insensitive nor known case-sensitive — e.g. ``hash``,
+    ``file_hash``), a hex-hash heuristic applies: a pure-hex value of
+    length 32/40/64/128 (md5/sha1/sha256/sha512) is lowercased, matching
+    how the write side stores those digests under their concrete types.
+    The generic ``hash`` type is intentionally routed through the
+    heuristic rather than the set membership (a parallel change may add
+    ``hash`` to the write-side set; both routes converge on lowercase).
+
+    Never raises: non-``str`` ``value`` is returned unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    out = unicodedata.normalize("NFC", refang(value)).strip()
+    itype = indicator_type.strip().lower() if isinstance(indicator_type, str) else None
+    if itype in _CASE_INSENSITIVE_INDICATOR_TYPES:
+        return out.lower()
+    if itype is None or itype not in _KNOWN_CASE_SENSITIVE_INDICATOR_TYPES:
+        if len(out) in _HEX_HASH_LENGTHS and _HEX_VALUE_RE.fullmatch(out):
+            return out.lower()
+    return out
+
+
+# Accepts analyst paste variants: 'CVE-2021-44228', 'cve 2021 44228',
+# 'cve_2021_44228', en-dash/em-dash separators (PDF copy artifacts).
+_CVE_RE = re.compile(r"cve[\s_–—-]*(\d{4})[\s_–—-]+(\d{4,})", re.IGNORECASE)
+
+
+def normalize_cve_id(value: str) -> Optional[str]:
+    """Extract and canonicalize a CVE id from an analyst-supplied string.
+
+    Returns the canonical ``CVE-YYYY-NNNN…`` form (uppercase, hyphen
+    separators) or ``None`` when no CVE id is present. The canonical form
+    matches the write side: ``neo4j_client.normalize_cve_id_for_graph``
+    uppercases CVE ids before every MERGE, so the output here is exactly
+    the graph key (write-side parity; see also ``node_identity`` which
+    hashes CVE natural keys case-insensitively).
+
+    Never raises: non-``str`` input returns ``None``.
+    """
+    if not isinstance(value, str):
+        return None
+    match = _CVE_RE.search(refang(value))
+    if not match:
+        return None
+    return f"CVE-{match.group(1)}-{match.group(2)}"
+
+
+_MITRE_TECHNIQUE_RE = re.compile(r"t\s*(\d{4})(\.(\d{3}))?", re.IGNORECASE)
+
+
+def normalize_mitre_technique_id(value: str) -> Optional[str]:
+    """Extract and canonicalize a MITRE ATT&CK technique id.
+
+    Returns ``T1059`` / ``T1059.001`` (uppercase ``T``, dotted
+    sub-technique) or ``None`` when no technique id is present. Matches the
+    write-side storage form: MITRE collectors store ``Technique.mitre_id``
+    in the canonical uppercase ``Tnnnn(.nnn)`` form (``node_identity``
+    keys Technique nodes on ``mitre_id``).
+
+    Never raises: non-``str`` input returns ``None``.
+    """
+    if not isinstance(value, str):
+        return None
+    match = _MITRE_TECHNIQUE_RE.search(refang(value))
+    if not match:
+        return None
+    sub = match.group(3)
+    return f"T{match.group(1)}.{sub}" if sub else f"T{match.group(1)}"

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -149,6 +149,13 @@ def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
     if not isinstance(value, str):
         return value
     itype = indicator_type.strip().lower() if isinstance(indicator_type, str) else None
+    # "unknown" is EdgeGuard's sentinel for "no type given" (the default the
+    # alert path fills in), so treat it identically to a missing type — both
+    # get refang + the hex-hash heuristic. Without this, a missing-type alert
+    # (itype=None → refang) and an explicit type="unknown" alert (refang
+    # skipped) normalized the SAME value differently.
+    if itype == "unknown":
+        itype = None
     base = refang(value) if (itype is None or itype in _REFANGABLE_INDICATOR_TYPES) else value
     out = unicodedata.normalize("NFC", base).strip()
     # Alert-vocab → write-vocab: 'ip' covers ipv4+ipv6 (both case-insensitive);

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -172,6 +172,67 @@ def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
     return out
 
 
+# Value-shape detectors for inferring an indicator type when the source
+# gives none (ResilMesh/Wazuh alerts default threat type to "unknown").
+# Conservative on purpose — only UNAMBIGUOUS shapes are claimed; anything
+# else returns None so the caller leaves the value untyped rather than
+# guessing wrong.
+_IPV4_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
+_IPV6_RE = re.compile(r"(?=.*:)[0-9A-Fa-f:]+(?:%[0-9A-Za-z]+)?")
+_EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
+_DOMAIN_RE = re.compile(r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}")
+
+
+def _is_ipv4(value: str) -> bool:
+    if not _IPV4_RE.fullmatch(value):
+        return False
+    return all(0 <= int(o) <= 255 for o in value.split("."))
+
+
+def infer_indicator_type(value: str) -> Optional[str]:
+    """Best-effort indicator-type inference from a value's shape.
+
+    For typeless inputs (an alert whose ``type`` is missing or the
+    ``"unknown"`` sentinel) this lets the caller store the indicator under
+    the SAME ``(indicator_type, value)`` MERGE key — and apply the same
+    case-folding — that the MISP sync would use, so the two don't become
+    duplicate nodes for the same host.
+
+    Only unambiguous shapes are claimed: ``url`` (has ``://``), ``email``
+    (``local@domain``), ``ipv4``/``ipv6``, ``hash`` (hex of 32/40/64/128),
+    and ``domain`` (dotted hostname with an alpha TLD, no path/space/@).
+    Returns ``None`` for anything ambiguous (e.g. a bare word, a file path)
+    so the caller keeps it untyped rather than mislabeling it.
+
+    Never raises: non-``str`` input returns ``None``. Input is refanged
+    first so defanged alerts (``1.2.3[.]4``, ``hxxp://``) classify.
+    """
+    if not isinstance(value, str):
+        return None
+    v = refang(value).strip()
+    if not v:
+        return None
+    low = v.lower()
+    if low.startswith(("http://", "https://", "ftp://")):
+        return "url"
+    if _EMAIL_RE.fullmatch(v):
+        return "email"
+    if _is_ipv4(v):
+        return "ipv4"
+    # IPv6 must contain a colon and be all hex/colon (avoid matching a bare
+    # hex hash, which has no colon).
+    if ":" in v and _IPV6_RE.fullmatch(v):
+        return "ipv6"
+    if len(v) in _HEX_HASH_LENGTHS and _HEX_VALUE_RE.fullmatch(v):
+        return "hash"
+    # Domain/hostname: dotted labels, alpha TLD, and none of the characters
+    # that would make it a URL / email / path (so "data.txt" with no path is
+    # the only realistic false positive — and folding its case is harmless).
+    if not any(c in v for c in "/\\@ \t") and _DOMAIN_RE.fullmatch(v):
+        return "domain"
+    return None
+
+
 # Accepts analyst paste variants: 'CVE-2021-44228', 'cve 2021 44228',
 # 'cve_2021_44228', en-dash/em-dash separators (PDF copy artifacts).
 _CVE_RE = re.compile(r"cve[\s_–—-]*(\d{4})[\s_–—-]+(\d{4,})", re.IGNORECASE)

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -55,8 +55,14 @@ _DEFANG_REPLACEMENTS: tuple[tuple[re.Pattern[str], str], ...] = (
     (re.compile(r"\[:\]"), ":"),
     # Bracketed at-sign: user[@]example.com → user@example.com
     (re.compile(r"\[@\]"), "@"),
-    # Spelled-out at-sign (optional surrounding spaces): user [at] example → user@example
-    (re.compile(r"\s*[\[(]at[\])]\s*", re.IGNORECASE), "@"),
+    # Spelled-out at-sign — BALANCED bracket pairs only ([at] or (at), not
+    # the mismatched [at) / (at]). Surrounding whitespace IS consumed
+    # because the email defang convention is "user [at] example [dot] com";
+    # the filename-corruption risk the review flagged ("data [at] rest.txt"
+    # → "data@rest.txt") is handled upstream by type-scoping in
+    # normalize_indicator_value (refang only runs for network/email types,
+    # never filename/regkey/cmdline).
+    (re.compile(r"\s*(?:\[at\]|\(at\))\s*", re.IGNORECASE), "@"),
     # Defanged schemes — only with an explicit ``://`` following, so plain
     # words containing "hxxp" are never rewritten.
     (re.compile(r"hxxps(?=://)", re.IGNORECASE), "https"),
@@ -77,8 +83,13 @@ def refang(value: str) -> str:
     (``node_identity._ZERO_WIDTH_AND_BIDI_TRANSLATE`` — parity guarantee),
     and strips surrounding whitespace.
 
-    Idempotent (substitutions run to a bounded fixpoint) and never raises:
-    non-``str`` input is returned unchanged.
+    Idempotent for realistic inputs: substitutions run to a fixpoint
+    bounded at ``_REFANG_MAX_PASSES`` passes, which resolves any practical
+    nesting depth (each pass peels one bracket level). Pathologically deep
+    adversarial nesting (>8 levels) may stop one pass short of the fixpoint
+    — acceptable because the only consequence is a lookup miss, never a
+    crash (all patterns are linear-time; no ReDoS). Never raises: non-``str``
+    input is returned unchanged.
     """
     if not isinstance(value, str):
         return value
@@ -90,6 +101,14 @@ def refang(value: str) -> str:
         if out == prev:
             break
     return out.strip()
+
+
+# Indicator types where defanging is a real analyst convention, so refang
+# is safe to apply. Brackets/`(at)` in any OTHER type (filename, regkey,
+# cmdline, …) may be literal content, so refang is NOT applied there.
+_REFANGABLE_INDICATOR_TYPES = frozenset(
+    {"ipv4", "ipv6", "ip", "domain", "hostname", "url", "email", "email-src", "email-dst"}
+)
 
 
 # Indicator types where case IS meaningful — mirror of the exclusion list
@@ -107,27 +126,37 @@ _HEX_VALUE_RE = re.compile(r"[0-9a-fA-F]+")
 def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
     """Normalize an analyst-supplied indicator value for graph lookup.
 
-    Pipeline: :func:`refang` → NFC-normalize + strip → lowercase IFF the
-    type is in ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES`` (the
-    exact set the write side consults in ``canonicalize_merge_key`` — this
-    is the write-side parity guarantee: the value bound into a read-side
-    ``MATCH`` equals the value the write side used as its MERGE key).
+    Pipeline: :func:`refang` (only for network types where defanging is a
+    convention — see ``_REFANGABLE_INDICATOR_TYPES``) → NFC-normalize +
+    strip → lowercase IFF the type is in
+    ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES`` (the exact set the
+    write side consults in ``canonicalize_merge_key`` — the write-side
+    parity guarantee: the value bound into a read-side ``MATCH`` equals the
+    value the write side used as its MERGE key). ``hash`` is in that set
+    today, so file hashes fold via set membership.
 
-    When ``indicator_type`` is None or not a recognized type (neither
-    case-insensitive nor known case-sensitive — e.g. ``hash``,
-    ``file_hash``), a hex-hash heuristic applies: a pure-hex value of
-    length 32/40/64/128 (md5/sha1/sha256/sha512) is lowercased, matching
-    how the write side stores those digests under their concrete types.
-    The generic ``hash`` type is intentionally routed through the
-    heuristic rather than the set membership (a parallel change may add
-    ``hash`` to the write-side set; both routes converge on lowercase).
+    Type-name reconciliation: the ResilMesh/Wazuh alert vocab uses ``ip``
+    and ``file_hash``; these are mapped to the write-side equivalents
+    (``ipv4``/``ipv6`` are both case-insensitive so ``ip`` folds; ``hash``
+    folds) so an uppercase IPv6 or hash from an alert still matches the
+    lowercased stored node.
+
+    For an unknown/None type a hex-hash heuristic is the last resort: a
+    pure-hex value of length 32/40/64/128 is lowercased.
 
     Never raises: non-``str`` ``value`` is returned unchanged.
     """
     if not isinstance(value, str):
         return value
-    out = unicodedata.normalize("NFC", refang(value)).strip()
     itype = indicator_type.strip().lower() if isinstance(indicator_type, str) else None
+    base = refang(value) if (itype is None or itype in _REFANGABLE_INDICATOR_TYPES) else value
+    out = unicodedata.normalize("NFC", base).strip()
+    # Alert-vocab → write-vocab: 'ip' covers ipv4+ipv6 (both case-insensitive);
+    # 'file_hash'/'filehash' → 'hash' (in the case-insensitive set).
+    if itype == "ip":
+        return out.lower()
+    if itype in ("file_hash", "filehash"):
+        itype = "hash"
     if itype in _CASE_INSENSITIVE_INDICATOR_TYPES:
         return out.lower()
     if itype is None or itype not in _KNOWN_CASE_SENSITIVE_INDICATOR_TYPES:

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -35,6 +35,7 @@ those modules import this one (cycle guard).
 
 from __future__ import annotations
 
+import ipaddress
 import re
 import unicodedata
 from typing import Optional
@@ -108,12 +109,11 @@ def refang(value: str) -> str:
     return out.strip()
 
 
-# Indicator types where defanging is a real analyst convention, so refang
-# is safe to apply. Brackets/`(at)` in any OTHER type (filename, regkey,
-# cmdline, …) may be literal content, so refang is NOT applied there.
-_REFANGABLE_INDICATOR_TYPES = frozenset(
-    {"ipv4", "ipv6", "ip", "domain", "hostname", "url", "email", "email-src", "email-dst"}
-)
+# Graph (EdgeGuard) indicator types where defanging is a real analyst
+# convention, so refang is safe. Brackets/`(at)` in any OTHER type
+# (filename, registry, cmdline, …) may be literal content. These are the
+# POST-mapping (graph) names — type reconciliation runs first.
+_REFANGABLE_INDICATOR_TYPES = frozenset({"ipv4", "ipv6", "domain", "url", "email"})
 
 
 # Indicator types where case IS meaningful — mirror of the exclusion list
@@ -121,7 +121,48 @@ _REFANGABLE_INDICATOR_TYPES = frozenset(
 # (URL paths, file/registry paths, RFC email local-parts). Anything in
 # neither set is treated as *unknown* and falls through to the hex-hash
 # heuristic below.
-_KNOWN_CASE_SENSITIVE_INDICATOR_TYPES = frozenset({"url", "email", "filename", "filepath", "regkey", "cmdline"})
+_KNOWN_CASE_SENSITIVE_INDICATOR_TYPES = frozenset(
+    {"url", "email", "filename", "filepath", "registry", "regkey", "cmdline", "bitcoin", "monero", "ethereum"}
+)
+
+# Alert/MISP-attribute type vocab → EdgeGuard graph type. MUST mirror
+# ``run_misp_to_neo4j.MISPToNeo4jSync.TYPE_MAPPING`` so a read-side
+# (indicator_type, value) lookup keys the SAME node the write side MERGEd —
+# without this, an alert typed "hostname" / "btc" / "regkey" / "email-src"
+# created DUPLICATE nodes (the write side stored domain / bitcoin / registry
+# / email). ``ip`` is resolved by VALUE shape (ipv4 vs ipv6) since one
+# label can't cover both. ``file_hash``/``filehash`` are ResilMesh aliases
+# for "hash". A parity test (tests/test_ioc_normalize_*) pins this against
+# the real TYPE_MAPPING so the two can't silently drift.
+_GRAPH_TYPE_MAP = {
+    "ip-dst": "ipv4",
+    "ip-src": "ipv4",
+    "ipv4": "ipv4",
+    "ipv6": "ipv6",
+    "domain": "domain",
+    "hostname": "domain",
+    "url": "url",
+    "md5": "hash",
+    "sha1": "hash",
+    "sha256": "hash",
+    "sha512": "hash",
+    "hash": "hash",
+    "file_hash": "hash",
+    "filehash": "hash",
+    "email-src": "email",
+    "email-dst": "email",
+    "email": "email",
+    "vulnerability": "cve",
+    "filename": "filename",
+    "regkey": "registry",
+    "registry": "registry",
+    "mutex": "mutex",
+    "yara": "yara",
+    "sigma": "sigma",
+    "snort": "snort",
+    "btc": "bitcoin",
+    "bitcoin": "bitcoin",
+}
 
 # md5 / sha1 / sha256 / sha512 hex-digest lengths.
 _HEX_HASH_LENGTHS = frozenset({32, 40, 64, 128})
@@ -144,43 +185,51 @@ def _blank_type_to_none(indicator_type: Optional[str]) -> Optional[str]:
     return None if stripped in ("", "unknown") else stripped
 
 
+def _resolve_graph_type(indicator_type: Optional[str], value: str) -> Optional[str]:
+    """Resolve an analyst/sensor/MISP type to the EdgeGuard GRAPH type the
+    write side actually stores (via ``_GRAPH_TYPE_MAP``), so read-side
+    lookups key the same node. A blank type is inferred from the value
+    shape; the special ResilMesh ``"ip"`` is resolved to ipv4/ipv6 by shape;
+    an unmapped type passes through unchanged. Returns ``None`` when nothing
+    can be resolved.
+    """
+    itype = _blank_type_to_none(indicator_type)
+    if itype is None:
+        return infer_indicator_type(value) if isinstance(value, str) else None
+    if itype == "ip":
+        return _classify_ip(refang(value).strip()) if isinstance(value, str) else None
+    return _GRAPH_TYPE_MAP.get(itype, itype)
+
+
 def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
     """Normalize an analyst-supplied indicator value for graph lookup.
 
-    Pipeline: :func:`refang` (only for network types where defanging is a
-    convention — see ``_REFANGABLE_INDICATOR_TYPES``) → NFC-normalize +
-    strip → lowercase IFF the type is in
-    ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES`` (the exact set the
-    write side consults in ``canonicalize_merge_key`` — the write-side
+    Pipeline: resolve the GRAPH type (:func:`_resolve_graph_type` — maps the
+    alert/MISP vocab to what the write side stores) → :func:`refang` (only
+    for network/email graph types) → NFC-normalize + strip → lowercase IFF
+    the graph type is in ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES``
+    (the exact set ``canonicalize_merge_key`` consults — the write-side
     parity guarantee: the value bound into a read-side ``MATCH`` equals the
-    value the write side used as its MERGE key). ``hash`` is in that set
-    today, so file hashes fold via set membership.
+    value the write side used as its MERGE key).
 
-    Type-name reconciliation: the ResilMesh/Wazuh alert vocab uses ``ip``
-    and ``file_hash``; these are mapped to the write-side equivalents
-    (``ipv4``/``ipv6`` are both case-insensitive so ``ip`` folds; ``hash``
-    folds) so an uppercase IPv6 or hash from an alert still matches the
-    lowercased stored node.
+    Resolving the graph type FIRST is what keeps e.g. a ``btc`` alert
+    (write side stores ``bitcoin``, case-SENSITIVE Base58) from being
+    wrongly lowercased, and a ``hostname`` alert (→ ``domain``) folding the
+    same way the write side did.
 
-    For an unknown/None type a hex-hash heuristic is the last resort: a
-    pure-hex value of length 32/40/64/128 is lowercased.
+    For an unknown/uninferable type a hex-hash heuristic is the last resort:
+    a pure-hex value of length 32/40/64/128 is lowercased.
 
     Never raises: non-``str`` ``value`` is returned unchanged.
     """
     if not isinstance(value, str):
         return value
-    itype = _blank_type_to_none(indicator_type)
-    base = refang(value) if (itype is None or itype in _REFANGABLE_INDICATOR_TYPES) else value
+    gtype = _resolve_graph_type(indicator_type, value)
+    base = refang(value) if (gtype is None or gtype in _REFANGABLE_INDICATOR_TYPES) else value
     out = unicodedata.normalize("NFC", base).strip()
-    # Alert-vocab → write-vocab: 'ip' covers ipv4+ipv6 (both case-insensitive);
-    # 'file_hash'/'filehash' → 'hash' (in the case-insensitive set).
-    if itype == "ip":
+    if gtype in _CASE_INSENSITIVE_INDICATOR_TYPES:
         return out.lower()
-    if itype in ("file_hash", "filehash"):
-        itype = "hash"
-    if itype in _CASE_INSENSITIVE_INDICATOR_TYPES:
-        return out.lower()
-    if itype is None or itype not in _KNOWN_CASE_SENSITIVE_INDICATOR_TYPES:
+    if gtype is None or gtype not in _KNOWN_CASE_SENSITIVE_INDICATOR_TYPES:
         if len(out) in _HEX_HASH_LENGTHS and _HEX_VALUE_RE.fullmatch(out):
             return out.lower()
     return out
@@ -191,10 +240,17 @@ def normalize_indicator_value(indicator_type: Optional[str], value: str) -> str:
 # Conservative on purpose — only UNAMBIGUOUS shapes are claimed; anything
 # else returns None so the caller leaves the value untyped rather than
 # guessing wrong.
-_IPV4_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
-_IPV6_RE = re.compile(r"(?=.*:)[0-9A-Fa-f:]+(?:%[0-9A-Za-z]+)?")
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
-_DOMAIN_RE = re.compile(r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}")
+# Domain shape: dotted labels + alpha TLD, with an OPTIONAL trailing root
+# dot (FQDN form "evil.com."). Label/TLD classes include Unicode letters
+# (``¡-￿``) so IDN/homograph domains ("münchen.de", "россия.рф")
+# classify the same as their punycode form — the write side stores IDN
+# domains NFC-folded, so this keeps read/write parity. (Django's URL host
+# pattern uses the same Unicode range.)
+_DOMAIN_RE = re.compile(
+    r"(?:[A-Za-z0-9¡-￿](?:[A-Za-z0-9¡-￿-]{0,61}[A-Za-z0-9¡-￿])?\.)+"
+    r"[A-Za-z¡-￿]{2,63}\.?"
+)
 # Final labels that are common file/document extensions, NOT real TLDs —
 # guards against a bare typeless filename ("pos-malware.exe", "report.pdf")
 # being mislabeled a domain (→ wrong block-recommendation + mistyped node).
@@ -247,10 +303,21 @@ _FILE_EXTENSION_FINAL_LABELS = frozenset(
 )
 
 
-def _is_ipv4(value: str) -> bool:
-    if not _IPV4_RE.fullmatch(value):
-        return False
-    return all(0 <= int(o) <= 255 for o in value.split("."))
+def _classify_ip(value: str) -> Optional[str]:
+    """Return 'ipv4' / 'ipv6' for a STRICTLY valid IP literal, else None.
+
+    Uses the stdlib ``ipaddress`` validator instead of a loose regex — a
+    hex+colon shape check wrongly accepted non-addresses like ``dead:beef``
+    and MAC addresses (``00:1a:2b:3c:4d:5e``) as IPv6, mislabeling the node
+    type and breaking MISP-sync key parity. ``%zone`` scope-id suffixes
+    (``fe80::1%eth0``) are stripped before validation since the graph stores
+    the bare address.
+    """
+    candidate = value.split("%", 1)[0] if "%" in value else value
+    try:
+        return "ipv4" if ipaddress.ip_address(candidate).version == 4 else "ipv6"
+    except ValueError:
+        return None
 
 
 def infer_indicator_type(value: str) -> Optional[str]:
@@ -278,15 +345,21 @@ def infer_indicator_type(value: str) -> Optional[str]:
         return None
     low = v.lower()
     if low.startswith(("http://", "https://", "ftp://")):
-        return "url"
+        # Well-formedness: a real URL has a non-empty host after ``://`` and
+        # NO interior whitespace. Without this, a space-corrupted paste
+        # ("http:// evil.com") was confidently mislabeled 'url' and bound a
+        # space-containing value that can never match a stored node (and the
+        # embedded host was never recovered). A scheme-bearing-but-malformed
+        # value resolves to None here (it isn't a domain/ip/hash either).
+        after = v.split("://", 1)[1].strip()
+        return "url" if (after and not any(c.isspace() for c in v)) else None
     if _EMAIL_RE.fullmatch(v):
         return "email"
-    if _is_ipv4(v):
-        return "ipv4"
-    # IPv6 must contain a colon and be all hex/colon (avoid matching a bare
-    # hex hash, which has no colon).
-    if ":" in v and _IPV6_RE.fullmatch(v):
-        return "ipv6"
+    # Strict IP validation (ipaddress) — rejects non-addresses like
+    # "dead:beef" / MAC addresses that a loose hex+colon shape accepted.
+    ip_type = _classify_ip(v)
+    if ip_type:
+        return ip_type
     if len(v) in _HEX_HASH_LENGTHS and _HEX_VALUE_RE.fullmatch(v):
         return "hash"
     # Domain/hostname: dotted labels, alpha TLD, none of the URL/email/path
@@ -294,7 +367,10 @@ def infer_indicator_type(value: str) -> Optional[str]:
     # bare typeless filename "pos-malware.exe" stays unknown rather than
     # being mislabeled a domain and given a bogus DNS-sinkhole recommendation).
     if not any(c in v for c in "/\\@ \t") and _DOMAIN_RE.fullmatch(v):
-        if v.rsplit(".", 1)[-1].lower() not in _FILE_EXTENSION_FINAL_LABELS:
+        # Final label ignoring an optional trailing root dot ("report.pdf."
+        # is still a filename, not a domain).
+        final_label = v.rstrip(".").rsplit(".", 1)[-1].lower()
+        if final_label not in _FILE_EXTENSION_FINAL_LABELS:
             return "domain"
     return None
 
@@ -319,14 +395,15 @@ def canonicalize_lookup(indicator_type: Optional[str], value: str) -> tuple[Opti
     inferred + folded while another bound the raw value, so identical paste
     enriched on ingest yet returned not-found on search.
     """
-    itype = _blank_type_to_none(indicator_type)
-    if itype is None and isinstance(value, str):
-        inferred = infer_indicator_type(value)
-        if inferred:
-            itype = inferred
-    normalized = normalize_indicator_value(itype, value)
+    resolved_type = _resolve_graph_type(indicator_type, value)
+    normalized = normalize_indicator_value(indicator_type, value)
     normalized = normalized.strip() if isinstance(normalized, str) else ""
-    return itype, normalized
+    # A value that refangs/normalizes to pure punctuation (e.g. a bare
+    # defang token "[.]" → ".") has no usable lookup key — treat as empty so
+    # callers short-circuit instead of MATCHing a junk single-char value.
+    if not any(ch.isalnum() for ch in normalized):
+        normalized = ""
+    return resolved_type, normalized
 
 
 # Accepts analyst paste variants: 'CVE-2021-44228', 'cve 2021 44228',

--- a/src/ioc_normalize.py
+++ b/src/ioc_normalize.py
@@ -79,9 +79,14 @@ def refang(value: str) -> str:
 
     Rewrites only the common defang vocabulary (``hxxp(s)://``, ``[.]``,
     ``(.)``, ``{.}``, ``[:]``, ``[at]``/``(at)``/``[@]``), strips the
-    zero-width/bidi control characters via the write-side translate table
-    (``node_identity._ZERO_WIDTH_AND_BIDI_TRANSLATE`` — parity guarantee),
-    and strips surrounding whitespace.
+    zero-width/bidi control characters using
+    ``node_identity._ZERO_WIDTH_AND_BIDI_TRANSLATE`` (the SAME table the
+    write side uses — but only to REJECT such values via
+    ``is_placeholder_name``, not to scrub them out of a stored value). So
+    the zero-width strip here is a READ-side defense for analyst paste; it
+    is NOT a two-way parity guarantee — a feed that managed to persist a
+    value with embedded zero-width chars would not be found by a stripped
+    lookup. Also strips surrounding whitespace.
 
     Idempotent for realistic inputs: substitutions run to a fixpoint
     bounded at ``_REFANG_MAX_PASSES`` passes, which resolves any practical
@@ -181,6 +186,56 @@ _IPV4_RE = re.compile(r"(?:\d{1,3}\.){3}\d{1,3}")
 _IPV6_RE = re.compile(r"(?=.*:)[0-9A-Fa-f:]+(?:%[0-9A-Za-z]+)?")
 _EMAIL_RE = re.compile(r"[^@\s]+@[^@\s]+\.[^@\s]+")
 _DOMAIN_RE = re.compile(r"(?:[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?\.)+[A-Za-z]{2,63}")
+# Final labels that are common file/document extensions, NOT real TLDs —
+# guards against a bare typeless filename ("pos-malware.exe", "report.pdf")
+# being mislabeled a domain (→ wrong block-recommendation + mistyped node).
+# A single-label value like "evil.exe" is rejected; a genuinely multi-label
+# host ("mail.evil.com") is unaffected. (.zip/.mov ARE real TLDs now, so
+# they are deliberately NOT here — folding their case is harmless anyway.)
+_FILE_EXTENSION_FINAL_LABELS = frozenset(
+    {
+        "exe",
+        "dll",
+        "sys",
+        "bin",
+        "dat",
+        "scr",
+        # NOTE: ".com" is deliberately EXCLUDED — it is overwhelmingly the
+        # most common domain TLD; the legacy DOS .com executable is
+        # vanishingly rare in modern CTI, and treating .com as a file
+        # extension would mislabel every .com DOMAIN as untyped.
+        "bat",
+        "cmd",
+        "ps1",
+        "vbs",
+        "js",
+        "jar",
+        "msi",
+        "tmp",
+        "log",
+        "ini",
+        "cfg",
+        "txt",
+        "csv",
+        "pdf",
+        "doc",
+        "docx",
+        "xls",
+        "xlsx",
+        "ppt",
+        "pptx",
+        "rtf",
+        "png",
+        "jpg",
+        "jpeg",
+        "gif",
+        "bmp",
+        "iso",
+        "img",
+        "lnk",
+        "hta",
+    }
+)
 
 
 def _is_ipv4(value: str) -> bool:
@@ -225,12 +280,43 @@ def infer_indicator_type(value: str) -> Optional[str]:
         return "ipv6"
     if len(v) in _HEX_HASH_LENGTHS and _HEX_VALUE_RE.fullmatch(v):
         return "hash"
-    # Domain/hostname: dotted labels, alpha TLD, and none of the characters
-    # that would make it a URL / email / path (so "data.txt" with no path is
-    # the only realistic false positive — and folding its case is harmless).
+    # Domain/hostname: dotted labels, alpha TLD, none of the URL/email/path
+    # characters — AND the final label is not a common file extension (so a
+    # bare typeless filename "pos-malware.exe" stays unknown rather than
+    # being mislabeled a domain and given a bogus DNS-sinkhole recommendation).
     if not any(c in v for c in "/\\@ \t") and _DOMAIN_RE.fullmatch(v):
-        return "domain"
+        if v.rsplit(".", 1)[-1].lower() not in _FILE_EXTENSION_FINAL_LABELS:
+            return "domain"
     return None
+
+
+def canonicalize_lookup(indicator_type: Optional[str], value: str) -> tuple[Optional[str], str]:
+    """Read-side lookup canonicalization shared by every entrypoint that
+    resolves an analyst/sensor-supplied indicator against the graph (REST
+    /search/indicator, STIX indicator export, alert enrichment).
+
+    Returns ``(resolved_type, normalized_value)``:
+      - ``resolved_type`` is the given type, or — when it is missing /
+        ``"unknown"`` — the type inferred from the value's shape
+        (:func:`infer_indicator_type`), or ``None`` if uninferable.
+      - ``normalized_value`` is :func:`normalize_indicator_value` applied
+        with the resolved type (refang + NFC + case-fold to the write-side
+        MERGE key), stripped. May be ``""`` when the input is empty /
+        whitespace / non-str — callers MUST treat ``""`` as "no usable
+        lookup key" and not run a graph query against it.
+
+    Centralizing this prevents the per-entrypoint drift where one path
+    inferred + folded while another bound the raw value, so identical paste
+    enriched on ingest yet returned not-found on search.
+    """
+    itype = indicator_type
+    if (itype is None or (isinstance(itype, str) and itype.strip().lower() == "unknown")) and isinstance(value, str):
+        inferred = infer_indicator_type(value)
+        if inferred:
+            itype = inferred
+    normalized = normalize_indicator_value(itype, value)
+    normalized = normalized.strip() if isinstance(normalized, str) else ""
+    return itype, normalized
 
 
 # Accepts analyst paste variants: 'CVE-2021-44228', 'cve 2021 44228',
@@ -258,7 +344,12 @@ def normalize_cve_id(value: str) -> Optional[str]:
     return f"CVE-{match.group(1)}-{match.group(2)}"
 
 
-_MITRE_TECHNIQUE_RE = re.compile(r"t\s*(\d{4})(\.(\d{3}))?", re.IGNORECASE)
+# Trailing ``(?![.\d])`` guard: after the (optional) sub-technique, the next
+# char must not be a digit or a dot. So an over-long run ("T10590") or a
+# malformed sub ("T1059.0012", "T1059.01") fails to match outright rather
+# than silently truncating to a DIFFERENT real technique ("T1059"). Groups:
+# 1 = 4-digit base, 2 = 3-digit sub (or None).
+_MITRE_TECHNIQUE_RE = re.compile(r"t\s*(\d{4})(?:\.(\d{3}))?(?![.\d])", re.IGNORECASE)
 
 
 def normalize_mitre_technique_id(value: str) -> Optional[str]:
@@ -277,5 +368,5 @@ def normalize_mitre_technique_id(value: str) -> Optional[str]:
     match = _MITRE_TECHNIQUE_RE.search(refang(value))
     if not match:
         return None
-    sub = match.group(3)
+    sub = match.group(2)
     return f"T{match.group(1)}.{sub}" if sub else f"T{match.group(1)}"

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -1459,6 +1459,11 @@ class Neo4jClient:
             "CREATE INDEX campaign_last_seen IF NOT EXISTS FOR (c:Campaign) ON (c.last_seen)",
             # build_relationships performance: CVE.cve_id needed for EXPLOITS query
             "CREATE INDEX cve_cve_id IF NOT EXISTS FOR (c:CVE) ON (c.cve_id)",
+            # GraphRAG retrieval shapes (2026-06, Stage-2 dataset): CVSS range scans
+            # (cvss_score >= $min_cvss) + KEV filters (cisa_exploit_add IS NOT NULL /
+            # >= $since) — see tests/test_cypher_query_catalog.py _TI_GRAPHRAG.
+            "CREATE INDEX cve_cvss_score IF NOT EXISTS FOR (c:CVE) ON (c.cvss_score)",
+            "CREATE INDEX cve_cisa_exploit_add IF NOT EXISTS FOR (c:CVE) ON (c.cisa_exploit_add)",
             # Deterministic per-node UUID indexes — added 2026-04 for delta-sync
             # local→cloud (cloud MERGEs by uuid) and self-describing edge serialization
             # (xAI / RAG consumers resolve r.src_uuid / r.trg_uuid back to nodes by uuid).

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -426,6 +426,15 @@ _CASE_INSENSITIVE_INDICATOR_TYPES = frozenset(
         "sha1",
         "sha256",
         "sha512",
+        # The sync pipeline's TYPE_MAPPING (run_misp_to_neo4j.py) collapses
+        # md5/sha1/sha256/sha512 → "hash" and btc → "bitcoin" BEFORE merge,
+        # so the granular names above never reach the graph as
+        # indicator_type — only these collapsed names do. Without them here
+        # (2026-06 fix), file hashes were stored with whatever case the
+        # source emitted and an uppercase-pasted SHA256 lookup missed.
+        # Granular names are kept for callers that canonicalize pre-mapping.
+        "hash",
+        "bitcoin",
         "ssdeep",
         "imphash",
         "ja3",

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -427,14 +427,19 @@ _CASE_INSENSITIVE_INDICATOR_TYPES = frozenset(
         "sha256",
         "sha512",
         # The sync pipeline's TYPE_MAPPING (run_misp_to_neo4j.py) collapses
-        # md5/sha1/sha256/sha512 → "hash" and btc → "bitcoin" BEFORE merge,
-        # so the granular names above never reach the graph as
-        # indicator_type — only these collapsed names do. Without them here
-        # (2026-06 fix), file hashes were stored with whatever case the
-        # source emitted and an uppercase-pasted SHA256 lookup missed.
-        # Granular names are kept for callers that canonicalize pre-mapping.
+        # md5/sha1/sha256/sha512 → "hash" BEFORE merge, so the granular
+        # names above never reach the graph as indicator_type — only the
+        # collapsed "hash" does. Without it here (2026-06 fix), file hashes
+        # were stored with whatever case the source emitted and an
+        # uppercase-pasted SHA256 lookup missed. Hex digests are genuinely
+        # case-insensitive, so folding is safe.
+        # NOTE: btc → "bitcoin" is also collapsed by TYPE_MAPPING but is
+        # DELIBERATELY excluded — legacy Base58 BTC addresses are
+        # case-sensitive (lowercasing breaks the Base58 checksum and the
+        # value no longer identifies any on-chain address). The pre-existing
+        # "btc"/"xmr"/"eth" entries below predate this fix and are left
+        # untouched (out of scope), but no NEW crypto-address type folding.
         "hash",
-        "bitcoin",
         "ssdeep",
         "imphash",
         "ja3",

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -27,7 +27,7 @@ from slowapi.util import get_remote_address
 # Add src to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from ioc_normalize import normalize_cve_id, normalize_indicator_value
+from ioc_normalize import canonicalize_lookup, normalize_cve_id
 from neo4j_client import Neo4jClient
 from package_meta import package_version
 
@@ -472,13 +472,26 @@ async def search_indicator(request: Request, s: IndicatorSearch):
         raise HTTPException(status_code=503, detail="Neo4j not connected")
 
     try:
-        # READ-side canonicalization (src/ioc_normalize.py): refang + NFC +
-        # case-fold so analyst paste variants ("EvIl[.]CoM") hit the
-        # write-side MERGE keys. Raw value stays echoed in the response.
-        normalized_value = normalize_indicator_value(
+        # READ-side canonicalization (src/ioc_normalize.py): infer the type
+        # when the caller omits it, then refang + NFC + case-fold so analyst
+        # paste variants ("EvIl[.]CoM", "EVIL.COM" with no type) hit the
+        # write-side MERGE keys — the SAME shared path the alert enrichment
+        # uses, so a value that enriches on ingest also resolves on search.
+        # Raw value stays echoed in the response.
+        _resolved_type, normalized_value = canonicalize_lookup(
             s.indicator_type.value if s.indicator_type else None,
             s.value,
         )
+        # An empty/whitespace/zero-width-only input normalizes to "" — there
+        # is no graph key to look up, and MATCH {value: ""} could false-match
+        # a legacy empty-key node. Treat as not-found without querying.
+        if not normalized_value:
+            return IndicatorResponse(
+                value=s.value,
+                found=False,
+                zone=s.zone.value if s.zone else None,
+                normalized_value=normalized_value,
+            )
         with neo4j_client.driver.session() as session:
             # Find the indicator
             query = """
@@ -1072,7 +1085,13 @@ async def stix_export(
     try:
         ot = object_type.lower()
         if ot == "indicator":
-            bundle = exporter.export_indicator(identifier, depth=depth)
+            # READ-side canonicalization: infer type from the value shape and
+            # refang + NFC + case-fold so a defanged / mixed-case IOC path
+            # ("EvIl[.]CoM", "EVIL.COM") resolves to the stored node — same
+            # shared path as /search/indicator and alert enrichment. Falls
+            # back to the raw identifier when normalization yields nothing.
+            _t, _norm = canonicalize_lookup(None, identifier)
+            bundle = exporter.export_indicator(_norm or identifier, depth=depth)
         elif ot == "actor":
             bundle = exporter.export_threat_actor(identifier, depth=depth)
         elif ot == "technique":

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -1116,7 +1116,13 @@ _ACTOR_SUMMARY_CYPHER = """
     WHERE a.edgeguard_managed = true
       AND (a.name = toLower(trim($name))
            OR any(x IN coalesce(a.aliases, []) WHERE toLower(trim(x)) = toLower(trim($name))))
-    WITH a ORDER BY a.name LIMIT 1
+    // Deterministic tiebreak: a canonical-NAME hit always wins over an
+    // alias-only hit, then by name for stability — so when two managed
+    // actors share the same alias string, we never return the wrong
+    // profile nondeterministically (Bugbot 2026-06).
+    WITH a, (CASE WHEN a.name = toLower(trim($name)) THEN 0 ELSE 1 END) AS _match_rank
+    ORDER BY _match_rank, a.name
+    LIMIT 1
     OPTIONAL MATCH (m:Malware)-[:ATTRIBUTED_TO]->(a)
       WHERE m.edgeguard_managed = true
     WITH a, collect(DISTINCT m.name) AS malware_names

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -27,7 +27,7 @@ from slowapi.util import get_remote_address
 # Add src to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-from ioc_normalize import canonicalize_lookup, normalize_cve_id
+from ioc_normalize import canonicalize_lookup, normalize_cve_id, normalize_mitre_technique_id
 from neo4j_client import Neo4jClient
 from package_meta import package_version
 
@@ -1103,7 +1103,11 @@ async def stix_export(
         elif ot == "actor":
             bundle = exporter.export_threat_actor(identifier, depth=depth)
         elif ot == "technique":
-            bundle = exporter.export_technique(identifier, depth=depth)
+            # READ-side canonicalization (parity with the cve/indicator
+            # branches): 't1059' / 'T 1059' → 'T1059' (the graph stores the
+            # canonical uppercase Tnnnn(.nnn) form). Raw fallback when the
+            # paste isn't a recognizable technique id.
+            bundle = exporter.export_technique(normalize_mitre_technique_id(identifier) or identifier, depth=depth)
         elif ot == "cve":
             # READ-side canonicalization: 'cve 2021 44228' / en-dash paste
             # variants → 'CVE-2021-44228' (graph stores uppercase CVE ids).

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -27,6 +27,7 @@ from slowapi.util import get_remote_address
 # Add src to path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
+from ioc_normalize import normalize_cve_id, normalize_indicator_value
 from neo4j_client import Neo4jClient
 from package_meta import package_version
 
@@ -307,6 +308,10 @@ class IndicatorResponse(BaseModel):
     indicator: Optional[Dict[str, Any]] = None
     related: List[Dict[str, Any]] = []
     zone: Optional[str] = None
+    normalized_value: Optional[str] = Field(
+        default=None,
+        description="Canonical form of `value` bound into the graph MATCH (refanged + NFC + case-folded).",
+    )
 
 
 class ZoneThreatsResponse(BaseModel):
@@ -331,6 +336,33 @@ class GraphQueryRequest(BaseModel):
 
     cypher: str = Field(..., description="Cypher query to execute")
     parameters: Optional[Dict[str, Any]] = Field(default_factory=dict)
+
+
+class ActorTechniqueSummary(BaseModel):
+    """One employed technique in an actor summary."""
+
+    mitre_id: Optional[str] = None
+    name: Optional[str] = None
+
+
+class ActorSummaryResponse(BaseModel):
+    """Threat-actor profile + top-N related entities with total counts."""
+
+    name: str
+    aliases: List[str] = []
+    description: Optional[str] = None
+    sophistication: Optional[str] = None
+    motivation: Optional[str] = None
+    confidence_score: Optional[float] = None
+    zone: List[str] = []
+    source: List[str] = []
+    resolved_by: str = Field(description="How the actor was matched: 'name' (canonical) or 'alias'.")
+    malware: List[str] = Field(default=[], description="Attributed malware names (up to 10).")
+    malware_total: int = 0
+    techniques: List[ActorTechniqueSummary] = Field(default=[], description="Employed techniques (up to 15).")
+    technique_total: int = 0
+    campaigns: List[str] = Field(default=[], description="Campaign names run by the actor (up to 5).")
+    campaign_total: int = 0
 
 
 # ============================================================================
@@ -440,6 +472,13 @@ async def search_indicator(request: Request, s: IndicatorSearch):
         raise HTTPException(status_code=503, detail="Neo4j not connected")
 
     try:
+        # READ-side canonicalization (src/ioc_normalize.py): refang + NFC +
+        # case-fold so analyst paste variants ("EvIl[.]CoM") hit the
+        # write-side MERGE keys. Raw value stays echoed in the response.
+        normalized_value = normalize_indicator_value(
+            s.indicator_type.value if s.indicator_type else None,
+            s.value,
+        )
         with neo4j_client.driver.session() as session:
             # Find the indicator
             query = """
@@ -447,11 +486,16 @@ async def search_indicator(request: Request, s: IndicatorSearch):
                 WHERE n.edgeguard_managed = true
                 RETURN n LIMIT 1
             """
-            result = session.run(query, value=s.value, timeout=_NEO4J_QUERY_TIMEOUT)
+            result = session.run(query, value=normalized_value, timeout=_NEO4J_QUERY_TIMEOUT)
             record = result.single()
 
             if not record:
-                return IndicatorResponse(value=s.value, found=False, zone=s.zone.value if s.zone else None)
+                return IndicatorResponse(
+                    value=s.value,
+                    found=False,
+                    zone=s.zone.value if s.zone else None,
+                    normalized_value=normalized_value,
+                )
 
             indicator = dict(record["n"])
 
@@ -461,11 +505,16 @@ async def search_indicator(request: Request, s: IndicatorSearch):
                 WHERE n.edgeguard_managed = true
                 RETURN related LIMIT 10
             """
-            related_result = session.run(related_query, value=s.value, timeout=_NEO4J_QUERY_TIMEOUT)
+            related_result = session.run(related_query, value=normalized_value, timeout=_NEO4J_QUERY_TIMEOUT)
             related = [dict(r["related"]) for r in related_result]
 
             return IndicatorResponse(
-                value=s.value, found=True, indicator=indicator, related=related, zone=s.zone.value if s.zone else None
+                value=s.value,
+                found=True,
+                indicator=indicator,
+                related=related,
+                zone=s.zone.value if s.zone else None,
+                normalized_value=normalized_value,
             )
 
     except Exception:
@@ -1029,7 +1078,9 @@ async def stix_export(
         elif ot == "technique":
             bundle = exporter.export_technique(identifier, depth=depth)
         elif ot == "cve":
-            bundle = exporter.export_cve(identifier, depth=depth)
+            # READ-side canonicalization: 'cve 2021 44228' / en-dash paste
+            # variants → 'CVE-2021-44228' (graph stores uppercase CVE ids).
+            bundle = exporter.export_cve(normalize_cve_id(identifier) or identifier, depth=depth)
         else:
             # Static error string (no f-string interpolation of the URL
             # path parameter). Every other HTTPException in this file uses
@@ -1050,6 +1101,105 @@ async def stix_export(
         content=bundle,
         media_type=StixExporter.MEDIA_TYPE,
     )
+
+
+# Alias-aware actor resolution + fenced aggregation, modeled on
+# stix_exporter.export_threat_actor: a ``WITH … collect(DISTINCT …)`` step
+# between every OPTIONAL MATCH keeps the row count bounded by one
+# collection at a time instead of the Cartesian product of all four.
+# Actor names are stored LOWERCASE at write time
+# (node_identity.canonicalize_merge_key); aliases keep display case — hence
+# toLower(trim(…)) on both the input and each alias. $name is ALWAYS a
+# bound parameter (Cypher-injection rule), never interpolated.
+_ACTOR_SUMMARY_CYPHER = """
+    MATCH (a:ThreatActor)
+    WHERE a.edgeguard_managed = true
+      AND (a.name = toLower(trim($name))
+           OR any(x IN coalesce(a.aliases, []) WHERE toLower(trim(x)) = toLower(trim($name))))
+    WITH a ORDER BY a.name LIMIT 1
+    OPTIONAL MATCH (m:Malware)-[:ATTRIBUTED_TO]->(a)
+      WHERE m.edgeguard_managed = true
+    WITH a, collect(DISTINCT m.name) AS malware_names
+    OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE]->(t:Technique)
+      WHERE t.edgeguard_managed = true
+    WITH a, malware_names, collect(DISTINCT t {.mitre_id, .name}) AS technique_rows
+    OPTIONAL MATCH (a)-[:RUNS]->(c:Campaign)
+      WHERE c.edgeguard_managed = true
+    WITH a, malware_names, technique_rows, collect(DISTINCT c.name) AS campaign_names
+    RETURN a {.name, .aliases, .description, .sophistication, .motivation,
+              .primary_motivation, .confidence_score, .zone, .source} AS actor,
+           a.name = toLower(trim($name)) AS resolved_by_name,
+           malware_names[0..10] AS malware,
+           size(malware_names) AS malware_total,
+           technique_rows[0..15] AS techniques,
+           size(technique_rows) AS technique_total,
+           campaign_names[0..5] AS campaigns,
+           size(campaign_names) AS campaign_total
+"""
+
+
+def _as_str_list(val: Any) -> List[str]:
+    """Coerce a Neo4j property (scalar, list, or None) to a list of strings."""
+    if val is None:
+        return []
+    if isinstance(val, (list, tuple)):
+        return [str(v) for v in val]
+    return [str(val)]
+
+
+@app.get(
+    "/actors/{name}/summary",
+    response_model=ActorSummaryResponse,
+    dependencies=[Depends(_verify_api_key)],
+)
+@limiter.limit(_RATE_LIMIT_READ)
+async def actor_summary(request: Request, name: str):
+    """Summarize a threat actor: profile + attributed malware, employed
+    techniques, and campaigns (top-N lists with total counts).
+
+    Resolution is alias-aware and case-insensitive — ``name`` may be the
+    canonical (lowercase-stored) actor name or any alias in its observed
+    display case. Returns 404 when no actor matches.
+    """
+    if not neo4j_client or not neo4j_client.is_connected():
+        raise HTTPException(status_code=503, detail="Neo4j not connected")
+
+    try:
+        with neo4j_client.driver.session(default_access_mode="READ") as session:
+            record = session.run(_ACTOR_SUMMARY_CYPHER, name=name, timeout=_NEO4J_QUERY_TIMEOUT).single()
+
+        if not record:
+            raise HTTPException(status_code=404, detail="Threat actor not found")
+
+        actor = dict(record["actor"] or {})
+        techniques = [
+            ActorTechniqueSummary(mitre_id=t.get("mitre_id"), name=t.get("name"))
+            for t in (record["techniques"] or [])
+            if t
+        ]
+        return ActorSummaryResponse(
+            name=actor.get("name", ""),
+            aliases=_as_str_list(actor.get("aliases")),
+            description=actor.get("description"),
+            sophistication=actor.get("sophistication"),
+            motivation=actor.get("motivation") or actor.get("primary_motivation"),
+            confidence_score=actor.get("confidence_score"),
+            zone=_as_str_list(actor.get("zone")),
+            source=_as_str_list(actor.get("source")),
+            resolved_by="name" if record["resolved_by_name"] else "alias",
+            malware=[m for m in (record["malware"] or []) if m],
+            malware_total=record["malware_total"] or 0,
+            techniques=techniques,
+            technique_total=record["technique_total"] or 0,
+            campaigns=[c for c in (record["campaigns"] or []) if c],
+            campaign_total=record["campaign_total"] or 0,
+        )
+
+    except HTTPException:
+        raise
+    except Exception:
+        logger.error("Actor summary failed", exc_info=True)
+        raise HTTPException(status_code=500, detail="Internal error — see server logs")
 
 
 @app.post("/admin/query", dependencies=[Depends(_verify_api_key)])

--- a/src/query_api.py
+++ b/src/query_api.py
@@ -1088,10 +1088,18 @@ async def stix_export(
             # READ-side canonicalization: infer type from the value shape and
             # refang + NFC + case-fold so a defanged / mixed-case IOC path
             # ("EvIl[.]CoM", "EVIL.COM") resolves to the stored node — same
-            # shared path as /search/indicator and alert enrichment. Falls
-            # back to the raw identifier when normalization yields nothing.
+            # shared path as /search/indicator and alert enrichment.
+            # canonicalize_lookup yields "" only for empty / whitespace /
+            # zero-width-only input — there is no graph key to export, so
+            # reject (same empty-key guard as /search/indicator) instead of
+            # running a MATCH on a meaningless value.
             _t, _norm = canonicalize_lookup(None, identifier)
-            bundle = exporter.export_indicator(_norm or identifier, depth=depth)
+            if not _norm:
+                raise HTTPException(
+                    status_code=400,
+                    detail="Indicator identifier is empty after normalization.",
+                )
+            bundle = exporter.export_indicator(_norm, depth=depth)
         elif ot == "actor":
             bundle = exporter.export_threat_actor(identifier, depth=depth)
         elif ot == "technique":

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -2973,8 +2973,11 @@ class MISPToNeo4jSync:
 
             # Alias round-trip (2026-06): same carrier as actors — MISPWriter
             # exports ATT&CK malware aliases (x_mitre_aliases) as ``alias:``
-            # tags; rehydrate so build_relationships Q2 branch 3 and Q9
-            # alias-matching have data. merge_malware sanitizes downstream.
+            # tags; rehydrate so build_relationships Q9 INDICATES
+            # (i.malware_family ∈ m.aliases) has data. merge_malware
+            # sanitizes downstream. (Malware aliases no longer feed actor
+            # attribution — the Q2 Branch-3 path was removed as a forgery
+            # vector; only the actor's OWN aliases drive ATTRIBUTED_TO.)
             malware_aliases = _extract_alias_tags(tags)
 
             # PR (S5): source-truthful timestamps via allowlist-gated helper.

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -725,18 +725,23 @@ def _extract_alias_tags(tags: List[Dict[str, Any]]) -> List[str]:
     MISP-sourced actor/malware lost its aliases, disabling the
     alias-matching branches in build_relationships Q2/Q9.
 
-    Order-preserving dedup (case-insensitive); entries are NOT otherwise
-    filtered here — merge_actor/merge_malware apply the PR-N14 sanitizer
-    (50-item cap, placeholder filter, 200-char truncation) downstream,
-    keeping a single enforcement point.
+    Entries are NFC-normalized (parity with node_identity name handling —
+    build_relationships Q2/Q9 compare via ``toLower(trim(...))`` which does
+    NOT unicode-normalize, so a non-NFC alias like NFD "Café" would never
+    match an NFC-stored actor name without this). Order-preserving
+    case-insensitive dedup. Not otherwise filtered here — merge_actor /
+    merge_malware apply the PR-N14 sanitizer (50-item cap, placeholder
+    filter, 200-char truncation) downstream, keeping one enforcement point.
     """
+    import unicodedata
+
     aliases: List[str] = []
     seen: set = set()
     for tag in tags:
         tag_name = tag.get("name", "")
         if not isinstance(tag_name, str) or not tag_name.startswith("alias:"):
             continue
-        alias = tag_name[len("alias:") :].strip()
+        alias = unicodedata.normalize("NFC", tag_name[len("alias:") :]).strip()
         key = alias.lower()
         if alias and key not in seen:
             seen.add(key)

--- a/src/run_misp_to_neo4j.py
+++ b/src/run_misp_to_neo4j.py
@@ -715,6 +715,35 @@ def normalize_misp_tag_list(tags: Any) -> List[Dict[str, Any]]:
     return out
 
 
+def _extract_alias_tags(tags: List[Dict[str, Any]]) -> List[str]:
+    """Rehydrate ``alias:<name>`` MISP tags into an aliases list.
+
+    The MISP-side carrier is written by MISPWriter for ThreatActor and
+    Malware attributes (capped at 20 tags / 100 chars each at write time).
+    This is the read half of the alias round-trip (2026-06) — before it
+    existed, parse_attribute hardcoded ``aliases: []`` and every
+    MISP-sourced actor/malware lost its aliases, disabling the
+    alias-matching branches in build_relationships Q2/Q9.
+
+    Order-preserving dedup (case-insensitive); entries are NOT otherwise
+    filtered here — merge_actor/merge_malware apply the PR-N14 sanitizer
+    (50-item cap, placeholder filter, 200-char truncation) downstream,
+    keeping a single enforcement point.
+    """
+    aliases: List[str] = []
+    seen: set = set()
+    for tag in tags:
+        tag_name = tag.get("name", "")
+        if not isinstance(tag_name, str) or not tag_name.startswith("alias:"):
+            continue
+        alias = tag_name[len("alias:") :].strip()
+        key = alias.lower()
+        if alias and key not in seen:
+            seen.add(key)
+            aliases.append(alias)
+    return aliases
+
+
 # STIX 2.1 Cyber-observable Objects (SCOs) — the spec does not define ``labels`` on these types.
 # Manual conversion uses ``x_edgeguard_zones`` for SCOs; PyMISP ``to_stix2()`` output must be patched the same way.
 STIX_21_SCO_TYPES: FrozenSet[str] = frozenset(
@@ -2859,6 +2888,16 @@ class MISPToNeo4jSync:
                     }
                 )
 
+            # Alias round-trip (2026-06): MISPWriter exports actor aliases as
+            # ``alias:<name>`` tags, but this parser used to hardcode
+            # ``aliases: []`` — every MISP-sourced actor reached Neo4j with
+            # zero aliases (0/917 on the 2026-04 baseline), silently disabling
+            # the alias-matching branches in build_relationships Q2 and any
+            # alias-based lookup ("Cozy Bear" → APT29). Rehydrate here;
+            # merge_actor sanitizes downstream (PR-N14: 50-item cap,
+            # placeholder filter, 200-char truncation).
+            actor_aliases = _extract_alias_tags(tags)
+
             # PR (S5): source-truthful timestamps when source is on the
             # reliable allowlist (NVD/CISA/MITRE/etc.). Returns (None, None)
             # for unreliable sources so first_seen_at_source stays NULL.
@@ -2866,7 +2905,7 @@ class MISPToNeo4jSync:
             item = {
                 "type": "actor",
                 "name": actor_name,
-                "aliases": [],
+                "aliases": actor_aliases,
                 "description": actor_description,
                 "uses_techniques": uses_techniques,
                 "zone": zones,
@@ -2927,11 +2966,18 @@ class MISPToNeo4jSync:
                     }
                 )
 
+            # Alias round-trip (2026-06): same carrier as actors — MISPWriter
+            # exports ATT&CK malware aliases (x_mitre_aliases) as ``alias:``
+            # tags; rehydrate so build_relationships Q2 branch 3 and Q9
+            # alias-matching have data. merge_malware sanitizes downstream.
+            malware_aliases = _extract_alias_tags(tags)
+
             # PR (S5): source-truthful timestamps via allowlist-gated helper.
             _fs_at_source, _ls_at_source = extract_source_truthful_timestamps(attr, source_id, event_info=event_info)
             item = {
                 "type": "malware",
                 "name": malware_name,
+                "aliases": malware_aliases,
                 "malware_types": malware_types if malware_types else ["unknown"],
                 "family": value,
                 "description": description,

--- a/tests/test_alias_kev_roundtrip.py
+++ b/tests/test_alias_kev_roundtrip.py
@@ -191,8 +191,10 @@ class TestKevMarkerRoundTrip:
         "cve_id": "CVE-2026-12345",
         "description": "Known exploited vulnerability",
         "zone": ["global"],
-        "tag": "cisa",
-        "source": ["cisa"],
+        # Mirror the real collector: CISACollector emits tag/source =
+        # SOURCE_TAGS["cisa"] which resolves to the canonical "cisa_kev".
+        "tag": "cisa_kev",
+        "source": ["cisa_kev"],
         "confidence_score": 0.9,
         "severity": "CRITICAL",
         "cvss_score": 9.0,

--- a/tests/test_alias_kev_roundtrip.py
+++ b/tests/test_alias_kev_roundtrip.py
@@ -22,11 +22,13 @@ time (which is why they ship before the planned fresh baseline):
    emits the four cisa_* fields and misp_writer's META-carrier gate now
    accepts ``cisa_exploit_add`` alone as qualification.
 
-3. **Hash/bitcoin case canonicalization.** The sync pipeline's
-   TYPE_MAPPING collapses md5/sha1/sha256/sha512 → "hash" and
-   btc → "bitcoin" BEFORE merge, but _CASE_INSENSITIVE_INDICATOR_TYPES
-   only listed the granular names — file hashes were stored with
-   source-supplied case and an uppercase-pasted SHA256 lookup missed.
+3. **Hash case canonicalization.** The sync pipeline's TYPE_MAPPING
+   collapses md5/sha1/sha256/sha512 → "hash" BEFORE merge, but
+   _CASE_INSENSITIVE_INDICATOR_TYPES only listed the granular names —
+   file hashes were stored with source-supplied case and an
+   uppercase-pasted SHA256 lookup missed. Only "hash" is added; "bitcoin"
+   (also collapsed by TYPE_MAPPING) is DELIBERATELY excluded because
+   Base58 BTC addresses are case-sensitive (folding breaks the checksum).
 """
 
 from __future__ import annotations
@@ -225,10 +227,20 @@ class TestKevMarkerRoundTrip:
         assert item.get("cisa_vulnerability_name") == "Example RCE Vulnerability"
 
     def test_cisa_collector_emits_kev_fields(self, monkeypatch):
+        from datetime import datetime, timedelta, timezone
+
         from collectors.cisa_collector import CISACollector
 
         collector = CISACollector.__new__(CISACollector)
-        collector.tag = "cisa"
+        # Real __init__ resolves the tag via SOURCE_TAGS["cisa"] == "cisa_kev";
+        # mirror that canonical value so the fake doesn't drift from prod.
+        collector.tag = "cisa_kev"
+        # dateAdded must stay inside the collector's now()-relative
+        # incremental window (default 30 days) — hardcoding a fixed date
+        # would silently expire and fail CI ~30 days after merge. Use
+        # "yesterday" so it's always within any sane window.
+        recent = (datetime.now(timezone.utc) - timedelta(days=1)).strftime("%Y-%m-%d")
+        due = (datetime.now(timezone.utc) + timedelta(days=20)).strftime("%Y-%m-%d")
         monkeypatch.setattr(
             collector,
             "_fetch_kev",
@@ -240,8 +252,8 @@ class TestKevMarkerRoundTrip:
                     "vulnerabilityName": "Example RCE Vulnerability",
                     "shortDescription": "RCE in example product",
                     "requiredAction": "Apply updates per vendor instructions.",
-                    "dateAdded": "2026-05-30",
-                    "dueDate": "2026-06-20",
+                    "dateAdded": recent,
+                    "dueDate": due,
                     "knownRansomwareCampaignUse": "Known",
                     "cwes": ["CWE-94"],
                     "notes": "",
@@ -252,14 +264,14 @@ class TestKevMarkerRoundTrip:
         items = result if isinstance(result, list) else (result.get("items") or [])
         assert items, f"expected processed items from collect(), got: {type(result).__name__}"
         item = items[0]
-        assert item["cisa_exploit_add"] == "2026-05-30"
-        assert item["cisa_action_due"] == "2026-06-20"
+        assert item["cisa_exploit_add"] == recent
+        assert item["cisa_action_due"] == due
         assert item["cisa_required_action"] == "Apply updates per vendor instructions."
         assert item["cisa_vulnerability_name"] == "Example RCE Vulnerability"
 
 
 # ---------------------------------------------------------------------------
-# 3. Hash / bitcoin case canonicalization
+# 3. Hash case canonicalization (bitcoin DELIBERATELY excluded)
 # ---------------------------------------------------------------------------
 
 
@@ -271,14 +283,18 @@ class TestCollapsedTypeCaseCanonicalization:
             "TYPE_MAPPING stores file hashes as indicator_type='hash' — it must canonicalize like sha256"
         )
 
-    def test_bitcoin_type_is_case_insensitive(self):
+    def test_bitcoin_type_stays_case_sensitive(self):
+        """Base58 BTC addresses are case-sensitive — lowercasing breaks the
+        checksum and the value no longer identifies any on-chain address.
+        'bitcoin' must NOT be in the case-insensitive set (review caught an
+        earlier draft that wrongly folded it)."""
         upper = canonicalize_merge_key(
-            "Indicator", {"indicator_type": "bitcoin", "value": "1A1ZP1EP5QGEFI2DMPTFTL5SLMV7DIVFNA"}
+            "Indicator", {"indicator_type": "bitcoin", "value": "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"}
         )
         lower = canonicalize_merge_key(
             "Indicator", {"indicator_type": "bitcoin", "value": "1a1zp1ep5qgefi2dmptftl5slmv7divfna"}
         )
-        assert upper == lower
+        assert upper != lower, "bitcoin Base58 addresses must NOT be case-folded"
 
     def test_url_stays_case_sensitive(self):
         a = canonicalize_merge_key("Indicator", {"indicator_type": "url", "value": "http://x/PATH"})
@@ -292,16 +308,35 @@ class TestCollapsedTypeCaseCanonicalization:
 
 
 class TestMitreMalwareAliasExtraction:
-    def test_source_extracts_x_mitre_aliases(self):
-        """Source pin: ATT&CK malware SDOs carry aliases ONLY in
-        x_mitre_aliases (plain `aliases` exists on intrusion-sets) — the
-        malware branch must read the extension field."""
+    def test_malware_item_dict_assigns_aliases_from_x_mitre_aliases(self):
+        """Source pin (parsing is inline in collect(), no isolatable method
+        to drive — so pin the exact assignment, not just substring presence
+        which a comment could satisfy). ATT&CK malware SDOs carry aliases
+        ONLY in x_mitre_aliases (the plain `aliases` key is intrusion-set
+        only), so the malware item dict must read the extension field with
+        the documented fallback."""
+        import re as _re
+
         with open(os.path.join(_SRC, "collectors", "mitre_collector.py")) as fh:
             src = fh.read()
-        assert "x_mitre_aliases" in src
         idx = src.find("malware.append(")
         assert idx > 0
-        block = src[idx : idx + 800]
-        assert '"aliases"' in block and "x_mitre_aliases" in block, (
-            "the malware item dict must emit an aliases field (from x_mitre_aliases) for the MISP round-trip"
+        block = src[idx : idx + 1200]
+        # The actual code line: "aliases": obj.get("x_mitre_aliases", []) or obj.get("aliases", [])
+        assert _re.search(r'"aliases"\s*:\s*obj\.get\(\s*"x_mitre_aliases"', block), (
+            "malware item dict must assign aliases from obj.get('x_mitre_aliases', ...)"
+        )
+
+    def test_actor_item_dict_keeps_plain_aliases(self):
+        """Counterpart pin: intrusion-sets DO use the plain `aliases` key —
+        the actor branch must not be switched to x_mitre_aliases."""
+        import re as _re
+
+        with open(os.path.join(_SRC, "collectors", "mitre_collector.py")) as fh:
+            src = fh.read()
+        idx = src.find("actors.append(")
+        assert idx > 0
+        block = src[idx : idx + 1200]
+        assert _re.search(r'"aliases"\s*:\s*obj\.get\(\s*"aliases"', block), (
+            "actor item dict must keep obj.get('aliases', ...) (intrusion-set key)"
         )

--- a/tests/test_alias_kev_roundtrip.py
+++ b/tests/test_alias_kev_roundtrip.py
@@ -1,0 +1,307 @@
+"""Alias + KEV round-trip fixes (2026-06, Stage-2 GraphRAG readiness).
+
+Three ingest-side data losses, all of which only heal at collection/sync
+time (which is why they ship before the planned fresh baseline):
+
+1. **Alias round-trip drop.** MISPWriter exported ThreatActor aliases as
+   ``alias:`` tags (capped at 5), but ``parse_attribute`` hardcoded
+   ``aliases: []`` on rehydration and the Malware path had no alias
+   carrier at all — 0/917 actors and 0/3,409 malware on the 2026-04
+   baseline carried aliases, silently disabling the alias-matching
+   branches in build_relationships Q2/Q9 (built in c5a58ec, hardened in
+   PR-N8/N9/N10/N14) and any "Cozy Bear" → APT29 lookup. Fixed: malware
+   aliases extracted from ATT&CK ``x_mitre_aliases``, both writers emit
+   ``alias:`` tags (cap raised 5 → 20), parser rehydrates them via
+   ``_extract_alias_tags`` (PR-N14 sanitizer still enforced downstream).
+
+2. **KEV marker gap.** Only NVD-sourced CVEs got a queryable
+   ``cisa_exploit_add`` property (via NVD's cisaExploitAdd enrichment
+   riding the NVD_META comment). CVEs known ONLY from the CISA collector
+   (480 on the 2026-04 baseline) reached Neo4j with no KEV marker —
+   invisible to the ``ti-cve-kev`` query family. Fixed: cisa_collector
+   emits the four cisa_* fields and misp_writer's META-carrier gate now
+   accepts ``cisa_exploit_add`` alone as qualification.
+
+3. **Hash/bitcoin case canonicalization.** The sync pipeline's
+   TYPE_MAPPING collapses md5/sha1/sha256/sha512 → "hash" and
+   btc → "bitcoin" BEFORE merge, but _CASE_INSENSITIVE_INDICATOR_TYPES
+   only listed the granular names — file hashes were stored with
+   source-supplied case and an uppercase-pasted SHA256 lookup missed.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+_SRC = os.path.join(os.path.dirname(__file__), "..", "src")
+if _SRC not in sys.path:
+    sys.path.insert(0, _SRC)
+
+from collectors.misp_writer import MISPWriter  # noqa: E402
+from node_identity import canonicalize_merge_key  # noqa: E402
+from run_misp_to_neo4j import MISPToNeo4jSync, _extract_alias_tags  # noqa: E402
+
+
+@pytest.fixture
+def syncer() -> MISPToNeo4jSync:
+    return MISPToNeo4jSync(neo4j_client=MagicMock())
+
+
+@pytest.fixture
+def writer() -> MISPWriter:
+    w = MISPWriter.__new__(MISPWriter)  # no MISP connection needed for attribute builders
+    return w
+
+
+def _event(info: str = "EdgeGuard-MITRE-2026-06-11") -> dict:
+    return {"id": 42, "info": info, "date": "2026-06-11", "Tag": [{"name": "source:mitre_attck"}]}
+
+
+# ---------------------------------------------------------------------------
+# 1a. _extract_alias_tags unit behavior
+# ---------------------------------------------------------------------------
+
+
+class TestExtractAliasTags:
+    def test_extracts_and_strips(self):
+        tags = [
+            {"name": "alias:Cozy Bear "},
+            {"name": "alias:APT29"},
+            {"name": "zone:healthcare"},
+            {"name": "source:mitre_attck"},
+        ]
+        assert _extract_alias_tags(tags) == ["Cozy Bear", "APT29"]
+
+    def test_dedups_case_insensitively_order_preserving(self):
+        tags = [{"name": "alias:APT29"}, {"name": "alias:apt29"}, {"name": "alias:The Dukes"}]
+        assert _extract_alias_tags(tags) == ["APT29", "The Dukes"]
+
+    def test_ignores_empty_and_malformed(self):
+        tags = [{"name": "alias:"}, {"name": "alias:   "}, {}, {"name": None}, {"name": "aliases:nope"}]
+        assert _extract_alias_tags(tags) == []
+
+
+# ---------------------------------------------------------------------------
+# 1b. Writer side — alias tags emitted for actors AND malware
+# ---------------------------------------------------------------------------
+
+
+class TestWriterAliasTags:
+    def _tag_names(self, attribute: dict) -> list:
+        return [t["name"] for t in attribute["Tag"]]
+
+    def test_actor_alias_tags_emitted(self, writer):
+        attr = writer.create_actor_attribute(
+            {"name": "apt29", "aliases": ["Cozy Bear", "The Dukes"], "tag": "mitre_attck", "zone": ["global"]}
+        )
+        tags = self._tag_names(attr)
+        assert "alias:Cozy Bear" in tags and "alias:The Dukes" in tags
+
+    def test_actor_alias_cap_is_20_not_5(self, writer):
+        """The old cap of 5 could drop the very alias an analyst searches
+        by — MITRE intrusion-sets commonly carry 5-10 aliases."""
+        aliases = [f"alias-{i}" for i in range(30)]
+        attr = writer.create_actor_attribute(
+            {"name": "apt29", "aliases": aliases, "tag": "mitre_attck", "zone": ["global"]}
+        )
+        alias_tags = [t for t in self._tag_names(attr) if t.startswith("alias:")]
+        assert len(alias_tags) == 20, "cap must be 20 (was 5 pre-2026-06; >20 bounded against hostile feeds)"
+
+    def test_malware_alias_tags_emitted(self, writer):
+        """Malware had NO alias carrier at all pre-fix — Q2 branch 3 and Q9
+        alias matching had nothing to match against after a MISP round-trip."""
+        attr = writer.create_malware_attribute(
+            {"name": "wellmess", "aliases": ["WellMess", "BOTLIB"], "tag": "mitre_attck", "zone": ["global"]}
+        )
+        tags = self._tag_names(attr)
+        assert "alias:WellMess" in tags and "alias:BOTLIB" in tags
+
+
+# ---------------------------------------------------------------------------
+# 1c. Parser side — aliases rehydrate from MISP tags
+# ---------------------------------------------------------------------------
+
+
+class TestParserAliasRehydration:
+    def test_actor_aliases_rehydrate(self, syncer):
+        attr = {
+            "type": "threat-actor",
+            "value": "apt29",
+            "comment": "Russian state-sponsored group",
+            "Tag": [{"name": "alias:Cozy Bear"}, {"name": "alias:The Dukes"}, {"name": "zone:global"}],
+        }
+        item, _ = syncer.parse_attribute(attr, _event())
+        assert item is not None and item["type"] == "actor"
+        assert item["aliases"] == ["Cozy Bear", "The Dukes"], (
+            "pre-fix this was hardcoded [] — the regression this file exists to prevent"
+        )
+
+    def test_malware_aliases_rehydrate(self, syncer):
+        attr = {
+            "type": "malware-type",
+            "value": "wellmess",
+            "comment": "",
+            "Tag": [{"name": "alias:WellMess"}, {"name": "malware-type:backdoor"}],
+        }
+        item, _ = syncer.parse_attribute(attr, _event())
+        assert item is not None and item["type"] == "malware"
+        assert item["aliases"] == ["WellMess"]
+
+    def test_actor_without_alias_tags_gets_empty_list(self, syncer):
+        attr = {"type": "threat-actor", "value": "apt29", "comment": "", "Tag": [{"name": "zone:global"}]}
+        item, _ = syncer.parse_attribute(attr, _event())
+        assert item["aliases"] == []
+
+
+# ---------------------------------------------------------------------------
+# 1d. Full writer → parser round-trip (the actual contract)
+# ---------------------------------------------------------------------------
+
+
+class TestAliasFullRoundTrip:
+    def test_actor_aliases_survive_misp_round_trip(self, writer, syncer):
+        attribute = writer.create_actor_attribute(
+            {"name": "apt29", "aliases": ["Cozy Bear", "The Dukes"], "tag": "mitre_attck", "zone": ["global"]}
+        )
+        item, _ = syncer.parse_attribute(attribute, _event())
+        assert sorted(item["aliases"]) == ["Cozy Bear", "The Dukes"]
+
+    def test_malware_aliases_survive_misp_round_trip(self, writer, syncer):
+        attribute = writer.create_malware_attribute(
+            {"name": "wellmess", "aliases": ["WellMess"], "tag": "mitre_attck", "zone": ["global"]}
+        )
+        item, _ = syncer.parse_attribute(attribute, _event())
+        assert item["aliases"] == ["WellMess"]
+
+
+# ---------------------------------------------------------------------------
+# 2. KEV marker round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestKevMarkerRoundTrip:
+    CISA_VULN = {
+        "type": "vulnerability",
+        "cve_id": "CVE-2026-12345",
+        "description": "Known exploited vulnerability",
+        "zone": ["global"],
+        "tag": "cisa",
+        "source": ["cisa"],
+        "confidence_score": 0.9,
+        "severity": "CRITICAL",
+        "cvss_score": 9.0,
+        "vendor": "ExampleVendor",
+        "product": "ExampleProduct",
+        "known_ransomware_use": "Known",
+        # The four fields cisa_collector now emits (no NVD enrichment present):
+        "cisa_exploit_add": "2026-05-30",
+        "cisa_action_due": "2026-06-20",
+        "cisa_required_action": "Apply updates per vendor instructions.",
+        "cisa_vulnerability_name": "Example RCE Vulnerability",
+    }
+
+    def test_cisa_only_cve_gets_meta_carrier(self, writer):
+        """Pre-fix: has_nvd_meta ignored cisa_exploit_add, so CISA-collector
+        CVEs (no NVD fields) skipped the META comment and the KEV marker
+        was dropped between MISP and Neo4j."""
+        attr = writer.create_vulnerability_attribute(dict(self.CISA_VULN))
+        assert attr["comment"].startswith("NVD_META:"), "KEV date alone must qualify for the META carrier"
+        assert "2026-05-30" in attr["comment"]
+        tags = [t["name"] for t in attr["Tag"]]
+        assert "CISA-KEV" in tags
+
+    def test_kev_fields_rehydrate_onto_item(self, writer, syncer):
+        attribute = writer.create_vulnerability_attribute(dict(self.CISA_VULN))
+        item, _ = syncer.parse_attribute(attribute, _event("EdgeGuard-CISA-2026-06-11"))
+        assert item is not None
+        assert item.get("cisa_exploit_add") == "2026-05-30", (
+            "the ti-cve-kev query family keys on cisa_exploit_add — every KEV CVE must carry it"
+        )
+        assert item.get("cisa_action_due") == "2026-06-20"
+        assert item.get("cisa_vulnerability_name") == "Example RCE Vulnerability"
+
+    def test_cisa_collector_emits_kev_fields(self, monkeypatch):
+        from collectors.cisa_collector import CISACollector
+
+        collector = CISACollector.__new__(CISACollector)
+        collector.tag = "cisa"
+        monkeypatch.setattr(
+            collector,
+            "_fetch_kev",
+            lambda limit: [
+                {
+                    "cveID": "CVE-2026-12345",
+                    "vendorProject": "ExampleVendor",
+                    "product": "ExampleProduct",
+                    "vulnerabilityName": "Example RCE Vulnerability",
+                    "shortDescription": "RCE in example product",
+                    "requiredAction": "Apply updates per vendor instructions.",
+                    "dateAdded": "2026-05-30",
+                    "dueDate": "2026-06-20",
+                    "knownRansomwareCampaignUse": "Known",
+                    "cwes": ["CWE-94"],
+                    "notes": "",
+                }
+            ],
+        )
+        result = collector.collect(limit=10, push_to_misp=False)
+        items = result if isinstance(result, list) else (result.get("items") or [])
+        assert items, f"expected processed items from collect(), got: {type(result).__name__}"
+        item = items[0]
+        assert item["cisa_exploit_add"] == "2026-05-30"
+        assert item["cisa_action_due"] == "2026-06-20"
+        assert item["cisa_required_action"] == "Apply updates per vendor instructions."
+        assert item["cisa_vulnerability_name"] == "Example RCE Vulnerability"
+
+
+# ---------------------------------------------------------------------------
+# 3. Hash / bitcoin case canonicalization
+# ---------------------------------------------------------------------------
+
+
+class TestCollapsedTypeCaseCanonicalization:
+    def test_hash_type_is_case_insensitive(self):
+        upper = canonicalize_merge_key("Indicator", {"indicator_type": "hash", "value": "ABCDEF0123456789" * 4})
+        lower = canonicalize_merge_key("Indicator", {"indicator_type": "hash", "value": "abcdef0123456789" * 4})
+        assert upper == lower, (
+            "TYPE_MAPPING stores file hashes as indicator_type='hash' — it must canonicalize like sha256"
+        )
+
+    def test_bitcoin_type_is_case_insensitive(self):
+        upper = canonicalize_merge_key(
+            "Indicator", {"indicator_type": "bitcoin", "value": "1A1ZP1EP5QGEFI2DMPTFTL5SLMV7DIVFNA"}
+        )
+        lower = canonicalize_merge_key(
+            "Indicator", {"indicator_type": "bitcoin", "value": "1a1zp1ep5qgefi2dmptftl5slmv7divfna"}
+        )
+        assert upper == lower
+
+    def test_url_stays_case_sensitive(self):
+        a = canonicalize_merge_key("Indicator", {"indicator_type": "url", "value": "http://x/PATH"})
+        b = canonicalize_merge_key("Indicator", {"indicator_type": "url", "value": "http://x/path"})
+        assert a != b, "URL paths are case-sensitive — must NOT be folded"
+
+
+# ---------------------------------------------------------------------------
+# 4. MITRE collector — malware aliases extracted from x_mitre_aliases
+# ---------------------------------------------------------------------------
+
+
+class TestMitreMalwareAliasExtraction:
+    def test_source_extracts_x_mitre_aliases(self):
+        """Source pin: ATT&CK malware SDOs carry aliases ONLY in
+        x_mitre_aliases (plain `aliases` exists on intrusion-sets) — the
+        malware branch must read the extension field."""
+        with open(os.path.join(_SRC, "collectors", "mitre_collector.py")) as fh:
+            src = fh.read()
+        assert "x_mitre_aliases" in src
+        idx = src.find("malware.append(")
+        assert idx > 0
+        block = src[idx : idx + 800]
+        assert '"aliases"' in block and "x_mitre_aliases" in block, (
+            "the malware item dict must emit an aliases field (from x_mitre_aliases) for the MISP round-trip"
+        )

--- a/tests/test_cypher_query_catalog.py
+++ b/tests/test_cypher_query_catalog.py
@@ -619,11 +619,15 @@ _TI_GRAPHRAG = [
         "ti-cve-by-id",
         "threat_intel",
         "Point lookup: one CVE with every CVSS version's score",
+        # Directed (c)->(cvss) legs: _merge_cvss_node creates BOTH reciprocal
+        # edges per link, so an UNDIRECTED match would return up to 2^4
+        # value-identical rows for one CVE. Pin the (cve)->(cvss) direction
+        # (always created) so this point lookup yields exactly one row.
         "MATCH (c:CVE {cve_id: $cve_id}) "
-        "OPTIONAL MATCH (c)-[:HAS_CVSS_v2]-(v2:CVSSv2) "
-        "OPTIONAL MATCH (c)-[:HAS_CVSS_v30]-(v30:CVSSv30) "
-        "OPTIONAL MATCH (c)-[:HAS_CVSS_v31]-(v31:CVSSv31) "
-        "OPTIONAL MATCH (c)-[:HAS_CVSS_v40]-(v40:CVSSv40) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v2]->(v2:CVSSv2) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v30]->(v30:CVSSv30) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v31]->(v31:CVSSv31) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v40]->(v40:CVSSv40) "
         "RETURN c.cve_id AS cve, c.cvss_score AS cvss, c.severity AS severity, "
         "c.cisa_exploit_add AS kev_added, v2.base_score AS v2_score, "
         "v30.base_score AS v30_score, v30.base_severity AS v30_severity, "

--- a/tests/test_cypher_query_catalog.py
+++ b/tests/test_cypher_query_catalog.py
@@ -527,6 +527,229 @@ _TI_PATHS = [
     ),
 ]
 
+# --- GraphRAG point-lookup & analyst-question shapes (2026-06, Stage-2 dataset) ---
+# Each query is the canonical retrieval shape for one analyst question class.
+# Point lookups whose parameter value can't be known ahead of time (a specific
+# IOC value / CVE id / actor name) set expect_rows=False — EXPLAIN-only — while
+# ranked/filtered shapes keep expect_rows=True and rely on skip-on-0 semantics.
+# Property facts verified 2026-06-11 against src/neo4j_client.py:
+#   * Source.reliability is written by ensure_sources (s.reliability = $reliability)
+#   * SOURCED_FROM carries r.confidence + r.source_reported_first_at/_last_at
+#     (native DateTime via datetime($param)) + r.imported_at
+#   * CVE.cisa_exploit_add is stored as the raw NVD cisaExploitAdd STRING
+#     ("YYYY-MM-DD", only set when truthy) — so KEV recency compares as string
+#   * Indicator.last_updated is a native datetime() — duration arithmetic works
+_TI_GRAPHRAG = [
+    # -- Cat 1: IOC triage -------------------------------------------------- #
+    CatalogQuery(
+        "ti-indicator-by-value",
+        "threat_intel",
+        "Point lookup: one indicator by exact value",
+        "MATCH (i:Indicator {value: $value}) "
+        "RETURN i.value AS value, i.indicator_type AS type, i.confidence_score AS confidence, "
+        "i.zone AS zone, i.last_updated AS last_updated",
+        params={"value": "8.8.8.8"},
+        expect_rows=False,
+        expect_keys=("value", "type", "confidence", "zone", "last_updated"),
+    ),
+    CatalogQuery(
+        "ti-indicator-deepdive",
+        "threat_intel",
+        "All edges around one indicator (parameterized)",
+        "MATCH (i:Indicator {value: $value})-[r]-(x) "
+        "RETURN type(r) AS rel, labels(x)[0] AS label, count(*) AS count ORDER BY count DESC",
+        params={"value": "8.8.8.8"},
+        expect_rows=False,
+        expect_keys=("rel", "label", "count"),
+    ),
+    CatalogQuery(
+        "ti-indicator-recent",
+        "threat_intel",
+        "Indicators updated in the last $days days",
+        "MATCH (i:Indicator) WHERE i.last_updated >= datetime() - duration({days: $days}) "
+        "RETURN i.value AS value, i.indicator_type AS type, i.last_updated AS last_updated "
+        "ORDER BY i.last_updated DESC LIMIT 20",
+        params={"days": 30},
+        expect_keys=("value", "type", "last_updated"),
+    ),
+    CatalogQuery(
+        "ti-indicator-provenance",
+        "threat_intel",
+        "Who reported this indicator, when, and how reliably",
+        "MATCH (i:Indicator {value: $value})-[r:SOURCED_FROM]->(s:Source) "
+        "RETURN s.name AS source, s.reliability AS reliability, "
+        "r.source_reported_first_at AS first_reported, r.source_reported_last_at AS last_reported, "
+        "r.confidence AS confidence",
+        params={"value": "8.8.8.8"},
+        expect_rows=False,
+        expect_keys=("source", "reliability", "first_reported", "last_reported", "confidence"),
+    ),
+    # -- Cat 2: sector / zone ----------------------------------------------- #
+    CatalogQuery(
+        "ti-indicator-zone-param",
+        "threat_intel",
+        "Indicators in a given zone (parameterized ti-indicator-zone)",
+        "MATCH (i:Indicator) WHERE $zone IN coalesce(i.zone, []) "
+        "RETURN i.value AS value, i.indicator_type AS type, i.confidence_score AS confidence LIMIT 10",
+        params={"zone": "healthcare"},
+        expect_keys=("value", "type"),
+    ),
+    CatalogQuery(
+        "ti-actor-by-zone",
+        "threat_intel",
+        "Actors in a zone ranked by technique coverage",
+        "MATCH (a:ThreatActor) WHERE $zone IN coalesce(a.zone, []) "
+        "OPTIONAL MATCH (a)-[:EMPLOYS_TECHNIQUE]->(t:Technique) "
+        "RETURN a.name AS actor, count(t) AS techniques ORDER BY techniques DESC LIMIT 10",
+        params={"zone": "healthcare"},
+        expect_keys=("actor", "techniques"),
+    ),
+    CatalogQuery(
+        "ti-cve-affects-sector",
+        "threat_intel",
+        "High-CVSS CVEs affecting a sector (parameterized)",
+        "MATCH (c:CVE)-[:AFFECTS]->(s:Sector {name: $sector}) WHERE c.cvss_score >= $min_cvss "
+        "RETURN c.cve_id AS cve, c.cvss_score AS cvss, c.severity AS severity "
+        "ORDER BY c.cvss_score DESC LIMIT 15",
+        params={"sector": "healthcare", "min_cvss": 7.0},
+        expect_keys=("cve", "cvss"),
+    ),
+    # -- Cat 3: CVE prioritization ------------------------------------------ #
+    CatalogQuery(
+        "ti-cve-by-id",
+        "threat_intel",
+        "Point lookup: one CVE with every CVSS version's score",
+        "MATCH (c:CVE {cve_id: $cve_id}) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v2]-(v2:CVSSv2) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v30]-(v30:CVSSv30) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v31]-(v31:CVSSv31) "
+        "OPTIONAL MATCH (c)-[:HAS_CVSS_v40]-(v40:CVSSv40) "
+        "RETURN c.cve_id AS cve, c.cvss_score AS cvss, c.severity AS severity, "
+        "c.cisa_exploit_add AS kev_added, v2.base_score AS v2_score, "
+        "v30.base_score AS v30_score, v30.base_severity AS v30_severity, "
+        "v31.base_score AS v31_score, v31.base_severity AS v31_severity, "
+        "v40.base_score AS v40_score, v40.base_severity AS v40_severity",
+        params={"cve_id": "CVE-2021-44228"},
+        expect_rows=False,
+        expect_keys=("cve", "cvss", "severity", "kev_added", "v31_score", "v40_score"),
+    ),
+    CatalogQuery(
+        "ti-cve-most-exploited",
+        "threat_intel",
+        "CVEs ranked by exploiting-indicator fan-in",
+        "MATCH (c:CVE)<-[:EXPLOITS]-(i:Indicator) "
+        "RETURN c.cve_id AS cve, c.cvss_score AS cvss, count(i) AS indicators "
+        "ORDER BY indicators DESC LIMIT 10",
+        expect_keys=("cve", "indicators"),
+    ),
+    # -- Cat 4: exploited-in-the-wild (CISA KEV) ----------------------------- #
+    CatalogQuery(
+        "ti-cve-kev-exploited",
+        "threat_intel",
+        "KEV-listed CVEs with live exploiting indicators",
+        "MATCH (c:CVE)<-[:EXPLOITS]-(i:Indicator) WHERE c.cisa_exploit_add IS NOT NULL "
+        "RETURN c.cve_id AS cve, c.cisa_exploit_add AS kev_added, count(i) AS indicators "
+        "ORDER BY indicators DESC LIMIT 15",
+        expect_keys=("cve", "kev_added", "indicators"),
+    ),
+    CatalogQuery(
+        "ti-cve-kev-recent",
+        "threat_intel",
+        "CVEs added to the KEV list since $since (string ISO date)",
+        "MATCH (c:CVE) WHERE c.cisa_exploit_add >= $since "
+        "RETURN c.cve_id AS cve, c.cisa_exploit_add AS kev_added, c.cisa_action_due AS action_due, "
+        "c.cisa_vulnerability_name AS name ORDER BY c.cisa_exploit_add DESC LIMIT 15",
+        params={"since": "2026-01-01"},
+        expect_keys=("cve", "kev_added"),
+    ),
+    CatalogQuery(
+        "ti-cve-exploit-provenance",
+        "threat_intel",
+        "Which sources report exploitation of one CVE",
+        "MATCH (c:CVE {cve_id: $cve_id})<-[:EXPLOITS]-(i:Indicator)-[:SOURCED_FROM]->(s:Source) "
+        "RETURN s.name AS source, count(DISTINCT i) AS indicators ORDER BY indicators DESC",
+        params={"cve_id": "CVE-2021-44228"},
+        expect_rows=False,
+        expect_keys=("source", "indicators"),
+    ),
+    # -- Cat 5: MITRE ATT&CK ------------------------------------------------- #
+    CatalogQuery(
+        "ti-technique-family",
+        "threat_intel",
+        "A technique plus its sub-techniques (T1059 → T1059.*)",
+        "MATCH (t:Technique) WHERE t.mitre_id = $tid OR t.mitre_id STARTS WITH $tid + '.' "
+        "RETURN t.mitre_id AS mitre_id, t.name AS name ORDER BY t.mitre_id",
+        params={"tid": "T1059"},
+        expect_keys=("mitre_id", "name"),
+    ),
+    CatalogQuery(
+        "ti-technique-deepdive",
+        "threat_intel",
+        "Who uses one technique: actor/malware/tool/indicator counts",
+        "MATCH (t:Technique {mitre_id: $mitre_id}) "
+        "RETURN t.mitre_id AS mitre_id, t.name AS name, "
+        "COUNT { (:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t) } AS actors, "
+        "COUNT { (:Malware)-[:IMPLEMENTS_TECHNIQUE]->(t) } AS malware, "
+        "COUNT { (:Tool)-[:IMPLEMENTS_TECHNIQUE]->(t) } AS tools, "
+        "COUNT { (:Indicator)-[:USES_TECHNIQUE]->(t) } AS indicators",
+        params={"mitre_id": "T1059"},
+        expect_rows=False,
+        expect_keys=("mitre_id", "name", "actors", "malware", "tools", "indicators"),
+    ),
+    CatalogQuery(
+        "ti-phase-actors",
+        "threat_intel",
+        "Actors employing techniques in a kill-chain phase",
+        "MATCH (a:ThreatActor)-[:EMPLOYS_TECHNIQUE]->(t:Technique) "
+        "WHERE $phase IN coalesce(t.tactic_phases, []) "
+        "RETURN a.name AS actor, count(DISTINCT t) AS techniques ORDER BY techniques DESC LIMIT 10",
+        params={"phase": "defense-evasion"},
+        expect_keys=("actor", "techniques"),
+    ),
+    CatalogQuery(
+        "ti-technique-prevalence",
+        "threat_intel",
+        "Techniques ranked by total fan-in (actors+malware+tools+indicators)",
+        "MATCH (t:Technique)<-[r:EMPLOYS_TECHNIQUE|IMPLEMENTS_TECHNIQUE|USES_TECHNIQUE]-() "
+        "RETURN t.mitre_id AS mitre_id, t.name AS name, count(r) AS fan_in "
+        "ORDER BY fan_in DESC LIMIT 10",
+        expect_keys=("mitre_id", "fan_in"),
+    ),
+    # -- Cat 6: actor / campaign --------------------------------------------- #
+    CatalogQuery(
+        "ti-actor-resolve",
+        "threat_intel",
+        "Alias-aware actor lookup (name is lowercase, aliases display-case)",
+        "MATCH (a:ThreatActor) WHERE a.name = toLower(trim($name)) "
+        "OR any(x IN coalesce(a.aliases, []) WHERE toLower(trim(x)) = toLower(trim($name))) "
+        "RETURN a.name AS name, a.aliases AS aliases, a.zone AS zone LIMIT 5",
+        params={"name": "APT28"},
+        expect_rows=False,
+        expect_keys=("name", "aliases", "zone"),
+    ),
+    CatalogQuery(
+        "ti-campaign-graph",
+        "threat_intel",
+        "Campaign membership: actor RUNS campaign, members PART_OF it",
+        "MATCH (a:ThreatActor)-[:RUNS]->(c:Campaign)<-[:PART_OF]-(x) "
+        "RETURN c.name AS campaign, a.name AS actor, labels(x)[0] AS member_label, "
+        "count(*) AS members ORDER BY members DESC LIMIT 15",
+        expect_keys=("campaign", "actor", "member_label", "members"),
+    ),
+    CatalogQuery(
+        "ti-actor-iocs",
+        "threat_intel",
+        "IOCs attributable to one actor (alias-aware, via malware)",
+        "MATCH (i:Indicator)-[:INDICATES]->(:Malware)-[:ATTRIBUTED_TO]->(a:ThreatActor) "
+        "WHERE a.name = toLower(trim($name)) "
+        "OR any(x IN coalesce(a.aliases, []) WHERE toLower(trim(x)) = toLower(trim($name))) "
+        "RETURN i.value AS value, i.indicator_type AS type, i.confidence_score AS confidence LIMIT 20",
+        params={"name": "APT28"},
+        expect_rows=False,
+        expect_keys=("value", "type", "confidence"),
+    ),
+]
+
 # --------------------------------------------------------------------------- #
 # 4. Asset / ISIM topology — single node
 # --------------------------------------------------------------------------- #
@@ -750,7 +973,7 @@ _ASSET_HOPS = [
     ),
 ]
 
-QUERY_CATALOG = _SCHEMA + _TI_NODES + _TI_HOPS + _TI_PATHS + _ASSET_NODES + _ASSET_HOPS
+QUERY_CATALOG = _SCHEMA + _TI_NODES + _TI_HOPS + _TI_PATHS + _TI_GRAPHRAG + _ASSET_NODES + _ASSET_HOPS
 
 
 # --------------------------------------------------------------------------- #
@@ -827,6 +1050,13 @@ def test_catalog_ids_unique():
 def test_catalog_covers_both_layers():
     layers = {q.layer for q in QUERY_CATALOG}
     assert {"threat_intel", "asset"}.issubset(layers)
+
+
+def test_catalog_expect_keys_nonempty():
+    """Every entry must name its RETURN aliases — the row-presence test (and the
+    Stage-2 GraphRAG dataset built from this catalog) depend on stable keys."""
+    missing = [q.id for q in QUERY_CATALOG if not q.expect_keys]
+    assert not missing, f"catalog entries with empty expect_keys: {missing}"
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -414,6 +414,10 @@ class TestStixCveExportNormalization:
                 captured["cve_id"] = cve_id
                 return {"type": "bundle", "objects": []}
 
+            def export_indicator(self, value, depth=2):
+                captured["indicator_value"] = value
+                return {"type": "bundle", "objects": []}
+
         monkeypatch.setattr(stix_exporter, "StixExporter", _FakeExporter)
 
     def test_spaced_lowercase_identifier_uppercased(self, monkeypatch):
@@ -442,6 +446,30 @@ class TestStixCveExportNormalization:
         resp = client.get("/stix/export/cve/not-a-cve")
         assert resp.status_code == 200
         assert captured["cve_id"] == "not-a-cve"
+
+    def test_indicator_export_normalizes_identifier(self, monkeypatch):
+        """Bugbot: object_type=indicator must go through the same
+        canonicalize_lookup path as /search/indicator — defanged/mixed-case
+        IOC paste resolves to the stored key."""
+        captured = {}
+        self._install_fake_exporter(monkeypatch, captured)
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(_FakeSession()))
+
+        resp = client.get("/stix/export/indicator/EvIl[.]CoM")
+        assert resp.status_code == 200
+        assert captured["indicator_value"] == "evil.com"
+
+    def test_indicator_export_rejects_empty_normalized_key(self, monkeypatch):
+        """Bugbot: a whitespace-only identifier normalizes to '' — must be
+        rejected (400) without calling the exporter, mirroring the
+        /search/indicator empty-key guard."""
+        captured = {}
+        self._install_fake_exporter(monkeypatch, captured)
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(_FakeSession()))
+
+        resp = client.get("/stix/export/indicator/%20%20")
+        assert resp.status_code == 400
+        assert "indicator_value" not in captured, "exporter must not be called for an empty key"
 
 
 # ---------------------------------------------------------------------------
@@ -638,6 +666,17 @@ class TestAlertProcessorNormalization:
             "process_complete_resilmesh_alert must run so the Alert node is recorded"
         )
         assert self._last_fake.written_alert.get("indicator") in (None, "")
+
+    def test_degraded_response_carries_verbatim_original_alert(self):
+        """Bugbot: enriched=False responses (e.g. indicatorless alert whose
+        Alert node WAS persisted) must carry the RAW original_alert snapshot
+        like the success path — not an empty dict, and not the
+        normalization-mutated payload."""
+        _session, result = self._process({"hostname": "srv-01", "indicator": "  ", "type": "domain"})
+        assert result.enriched is False
+        assert result.original_alert, "degraded response must include the original alert payload"
+        # Verbatim pre-normalization value, not the mutated "" form.
+        assert result.original_alert["threat"]["indicator"] == "  "
 
     def test_inferred_ipv4_still_gets_block_recommendation(self):
         """Bugbot 'inferred types skip recommendations': a typeless IP alert

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -315,9 +315,29 @@ class TestInferIndicatorType:
         assert infer_indicator_type("/etc/passwd") is None
         assert infer_indicator_type("C:\\\\Windows\\\\System32") is None
 
+    def test_bare_filename_is_not_a_domain(self):
+        """#5: a typeless filename must NOT be mislabeled 'domain' (would
+        yield a bogus DNS-sinkhole recommendation + a mistyped node)."""
+        for fn in ("pos-malware.exe", "emotet-payload.dll", "report.pdf", "invoice.docx", "dropper.bin"):
+            assert infer_indicator_type(fn) is None, fn
+        # …but a real multi-label host is still a domain.
+        assert infer_indicator_type("mail.evil.com") == "domain"
+
     def test_non_str_returns_none(self):
         assert infer_indicator_type(None) is None
         assert infer_indicator_type(1234) is None
+
+
+class TestMitreTechniqueBoundary:
+    def test_overlong_input_does_not_truncate_to_a_different_technique(self):
+        """#8: 'T10590' must NOT silently resolve to the real technique
+        'T1059' — over-long numeric runs fail to match instead."""
+        assert normalize_mitre_technique_id("T10590") is None
+        assert normalize_mitre_technique_id("T1059.0012") is None
+
+    def test_valid_ids_still_parse(self):
+        assert normalize_mitre_technique_id("T1059") == "T1059"
+        assert normalize_mitre_technique_id("T1059.001") == "T1059.001"
 
 
 # ---------------------------------------------------------------------------
@@ -348,6 +368,31 @@ class TestSearchIndicatorNormalization:
         resp = client.post("/search/indicator", json={"value": "A" * 64})
         assert resp.status_code == 200
         assert session.calls[0][1]["value"] == "a" * 64
+
+    def test_typeless_uppercase_domain_is_inferred_and_folded(self, monkeypatch):
+        """#3 (Bugbot 'search skips type inference'): a typeless uppercase
+        domain must infer 'domain' and fold to the stored lowercase key —
+        so the same paste that enriches on ingest also resolves on search."""
+        session = _FakeSession(results=[_FakeResult(single_record=None)])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.post("/search/indicator", json={"value": "EVIL.COM"})
+        assert resp.status_code == 200
+        assert resp.json()["normalized_value"] == "evil.com"
+        assert session.calls[0][1]["value"] == "evil.com"
+
+    def test_empty_value_short_circuits_without_query(self, monkeypatch):
+        """#3 (Bugbot 'search allows empty normalized key'): a whitespace/
+        zero-width-only value normalizes to '' — must return found=false
+        WITHOUT running a MATCH {value: ''} that could false-match a legacy
+        empty-key node."""
+        session = _FakeSession(results=[_FakeResult(single_record=None)])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.post("/search/indicator", json={"value": "  ​ \t "})
+        assert resp.status_code == 200
+        assert resp.json()["found"] is False
+        assert not session.calls, "no Cypher should run for an empty normalized key"
 
 
 # ---------------------------------------------------------------------------
@@ -574,14 +619,25 @@ class TestAlertProcessorNormalization:
             "typeless domain alert must be written as (domain, folded value) to dedup with MISP"
         )
 
-    def test_whitespace_only_indicator_is_rejected_after_normalization(self):
-        """Bugbot: a whitespace/zero-width-only value passes the raw
-        truthiness check but normalizes to '' — it must be rejected, not
-        reported enriched against an empty key, and must NOT write a node."""
-        session, result = self._process({"indicator": "  ​ \t ", "type": "domain"})
+    def test_whitespace_only_indicator_is_not_enriched(self):
+        """A whitespace/zero-width-only value normalizes to '' — enrichment
+        must be skipped (no empty-key lookup), but the Alert node is still
+        written (the indicator MERGE no-ops on the empty value)."""
+        _session, result = self._process({"indicator": "  ​ \t ", "type": "domain"})
         assert result.enriched is False
-        bound = [p["indicator"] for _q, p in session.calls if "indicator" in p]
-        assert all(v.strip() for v in bound), "no Cypher should bind an empty/whitespace $indicator"
+        # Alert node still recorded; the indicator written is empty.
+        assert self._last_fake.written_alert == {"type": "domain", "indicator": ""}
+
+    def test_indicatorless_alert_still_writes_alert_node(self):
+        """#2 regression: a host-only / CVE-only alert (no IOC indicator)
+        must still persist its Alert node — moving the empty guard ahead of
+        the write silently dropped legitimate indicatorless alerts."""
+        _session, result = self._process({"hostname": "srv-01", "cve": "CVE-2021-44228", "severity": 9})
+        assert result.enriched is False  # nothing to enrich
+        assert self._last_fake.written_alert is not None, (
+            "process_complete_resilmesh_alert must run so the Alert node is recorded"
+        )
+        assert self._last_fake.written_alert.get("indicator") in (None, "")
 
     def test_inferred_ipv4_still_gets_block_recommendation(self):
         """Bugbot 'inferred types skip recommendations': a typeless IP alert

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -296,6 +296,18 @@ class TestInferIndicatorType:
 
     def test_ipv6(self):
         assert infer_indicator_type("2001:db8::1") == "ipv6"
+        assert infer_indicator_type("::1") == "ipv6"
+        assert infer_indicator_type("fe80::1%eth0") == "ipv6"  # zone-id stripped
+
+    def test_loose_hex_colon_is_not_ipv6(self):
+        """Bugbot: strict ipaddress validation — a hex+colon shape that is
+        NOT a valid IP (incl. MAC addresses) must NOT be labeled ipv6."""
+        assert infer_indicator_type("dead:beef") is None
+        assert infer_indicator_type("00:1a:2b:3c:4d:5e") is None  # MAC, not IPv6
+
+    def test_malformed_ipv4_is_not_ipv4(self):
+        assert infer_indicator_type("1.2.3.4.5") is None
+        assert infer_indicator_type("256.1.1.1") is None
 
     def test_url(self):
         assert infer_indicator_type("https://evil.com/path") == "url"
@@ -328,6 +340,76 @@ class TestInferIndicatorType:
         assert infer_indicator_type(1234) is None
 
 
+class TestTypeVocabReconciliation:
+    """Fuzz batch: the read side must map the alert/MISP type vocab to the
+    EdgeGuard graph type the write side stores, or duplicate nodes appear."""
+
+    def test_graph_type_map_mirrors_write_side_TYPE_MAPPING(self):
+        """Drift guard: every entry in the canonical write-side TYPE_MAPPING
+        (run_misp_to_neo4j) must resolve to the same graph type on the read
+        side, so a read lookup keys the node the write side MERGEd."""
+        from ioc_normalize import _GRAPH_TYPE_MAP
+        from run_misp_to_neo4j import MISPToNeo4jSync
+
+        for misp_type, graph_type in MISPToNeo4jSync.TYPE_MAPPING.items():
+            if graph_type == "unknown":
+                continue  # 'text' → 'unknown' is the no-type sentinel, handled separately
+            assert _GRAPH_TYPE_MAP.get(misp_type) == graph_type, (
+                f"read-side _GRAPH_TYPE_MAP['{misp_type}'] must equal write-side '{graph_type}'"
+            )
+
+    def test_hostname_resolves_to_domain_and_folds(self):
+        from ioc_normalize import canonicalize_lookup
+
+        # Write side maps hostname→domain (case-insensitive) → folds.
+        assert canonicalize_lookup("hostname", "Web01.Corp.LOCAL") == ("domain", "web01.corp.local")
+
+    def test_btc_resolves_to_bitcoin_and_does_NOT_fold(self):
+        from ioc_normalize import canonicalize_lookup
+
+        # Write side maps btc→bitcoin (case-SENSITIVE Base58) → value preserved.
+        addr = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+        assert canonicalize_lookup("btc", addr) == ("bitcoin", addr)
+
+    def test_regkey_and_email_aliases_reconcile(self):
+        from ioc_normalize import canonicalize_lookup
+
+        assert canonicalize_lookup("regkey", "HKLM\\Software\\Run")[0] == "registry"
+        assert canonicalize_lookup("email-src", "Abuse@Evil.COM") == ("email", "Abuse@Evil.COM")
+
+
+class TestInferUrlAndDomainEdgeCases:
+    """Fuzz batch: URL well-formedness + IDN/trailing-dot domains."""
+
+    def test_url_with_interior_space_is_not_url(self):
+        # Space-corrupted scheme paste must NOT be mislabeled 'url'.
+        assert infer_indicator_type("http:// evil.com") is None
+        assert infer_indicator_type("https:// 1.2.3.4") is None
+        assert infer_indicator_type("hxxp://evil .com/path") is None
+
+    def test_valid_url_still_inferred(self):
+        assert infer_indicator_type("http://evil.com/path") == "url"
+        assert infer_indicator_type("hxxp://evil[.]com/x") == "url"
+
+    def test_idn_unicode_domain_inferred(self):
+        assert infer_indicator_type("münchen.de") == "domain"
+        assert infer_indicator_type("café.fr") == "domain"
+        # Same host's punycode form classifies the same way.
+        assert infer_indicator_type("xn--mnchen-3ya.de") == "domain"
+
+    def test_trailing_dot_fqdn_inferred_as_domain(self):
+        assert infer_indicator_type("evil.com.") == "domain"
+        # …but a trailing-dot filename is still not a domain.
+        assert infer_indicator_type("report.pdf.") is None
+
+    def test_punctuation_only_value_has_empty_lookup_key(self):
+        from ioc_normalize import canonicalize_lookup
+
+        # A bare defang token refangs to pure punctuation → no usable key.
+        assert canonicalize_lookup(None, "[.]")[1] == ""
+        assert canonicalize_lookup(None, "[@]")[1] == ""
+
+
 class TestCanonicalizeLookupBlankType:
     """Bugbot 'blank type skips inference refang': every 'no type given'
     form — None, '', '  ', 'unknown' — must infer + refang + fold
@@ -341,10 +423,15 @@ class TestCanonicalizeLookupBlankType:
         # All collapse to the same inferred-domain + refanged + folded result.
         assert set(results.values()) == {("domain", "evil.com")}, results
 
-    def test_blank_type_normalize_still_refangs(self):
-        # An explicit empty type must not bypass refang (the bug).
-        assert normalize_indicator_value("", "EvIl[.]CoM") == "EvIl.CoM"  # refanged, not case-folded (unknown type)
+    def test_blank_type_normalize_refangs_and_infers(self):
+        # An empty type must not bypass refang OR inference: a defanged
+        # domain value resolves to the domain graph type and folds (parity
+        # with how the write side stores it), exactly like None/"unknown".
+        assert normalize_indicator_value("", "EvIl[.]CoM") == "evil.com"
         assert normalize_indicator_value("   ", "1.2.3[.]4") == "1.2.3.4"
+        # A value that refangs but ISN'T a recognizable shape stays
+        # case-preserved (no spurious fold).
+        assert normalize_indicator_value("", "Plain-Text[.]Token-No-TLD-x") == "Plain-Text.Token-No-TLD-x"
 
 
 class TestMitreTechniqueBoundary:

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -28,6 +28,7 @@ from fastapi.testclient import TestClient
 import alert_processor
 import query_api
 from ioc_normalize import (
+    infer_indicator_type,
     normalize_cve_id,
     normalize_indicator_value,
     normalize_mitre_technique_id,
@@ -92,8 +93,17 @@ class _FakeAlertNeo4jClient(_FakeNeo4jClient):
     def connect(self):
         return True
 
+    def __init__(self, session):
+        super().__init__(session)
+        self.written_alert = None
+
     def process_complete_resilmesh_alert(self, alert_data):
-        pass
+        # Capture the payload the real write path consumes — the indicator
+        # type + value that create_indicator_from_alert would MERGE.
+        self.written_alert = {
+            "type": alert_data.get("threat", {}).get("type"),
+            "indicator": alert_data.get("threat", {}).get("indicator"),
+        }
 
     def update_alert_enrichment_status(self, **kwargs):
         pass
@@ -272,6 +282,42 @@ class TestNormalizeMitreTechniqueId:
     def test_non_str_returns_none(self):
         assert normalize_mitre_technique_id(None) is None
         assert normalize_mitre_technique_id(1059) is None
+
+
+class TestInferIndicatorType:
+    def test_domain(self):
+        assert infer_indicator_type("evil.com") == "domain"
+        assert infer_indicator_type("sub.domain.co.uk") == "domain"
+        assert infer_indicator_type("EvIl[.]CoM") == "domain"  # refanged first
+
+    def test_ipv4(self):
+        assert infer_indicator_type("1.2.3.4") == "ipv4"
+        assert infer_indicator_type("1.2.3[.]4") == "ipv4"
+
+    def test_ipv6(self):
+        assert infer_indicator_type("2001:db8::1") == "ipv6"
+
+    def test_url(self):
+        assert infer_indicator_type("https://evil.com/path") == "url"
+        assert infer_indicator_type("hxxp://evil[.]com/x") == "url"
+
+    def test_email(self):
+        assert infer_indicator_type("user@evil.com") == "email"
+
+    def test_hash(self):
+        assert infer_indicator_type("D" * 64) == "hash"
+        assert infer_indicator_type("a" * 32) == "hash"
+
+    def test_ambiguous_returns_none(self):
+        # A bare word, an IP-with-bad-octet, a path — none claimed.
+        assert infer_indicator_type("justaword") is None
+        assert infer_indicator_type("999.999.999.999") is None
+        assert infer_indicator_type("/etc/passwd") is None
+        assert infer_indicator_type("C:\\\\Windows\\\\System32") is None
+
+    def test_non_str_returns_none(self):
+        assert infer_indicator_type(None) is None
+        assert infer_indicator_type(1234) is None
 
 
 # ---------------------------------------------------------------------------
@@ -464,7 +510,8 @@ class TestActorSummary:
 class TestAlertProcessorNormalization:
     def _process(self, threat):
         session = _FakeSession()
-        processor = alert_processor.AlertProcessor(neo4j_client=_FakeAlertNeo4jClient(session))
+        fake = _FakeAlertNeo4jClient(session)
+        processor = alert_processor.AlertProcessor(neo4j_client=fake)
         alert = {
             "alert_id": "test-norm-001",
             "source": "wazuh",
@@ -473,6 +520,7 @@ class TestAlertProcessorNormalization:
             "threat": threat,
         }
         result = processor.process_alert(alert)
+        self._last_fake = fake
         return session, result
 
     def test_domain_indicator_refanged_and_lowercased(self):
@@ -491,17 +539,26 @@ class TestAlertProcessorNormalization:
 
     def test_missing_type_and_unknown_type_normalize_identically(self):
         """Bugbot: a defanged value with NO type vs an explicit
-        type='unknown' must produce the same canonical indicator (both are
-        'no type given' — refang applies to both)."""
+        type='unknown' must produce the same canonical indicator — and with
+        type inference, a domain-shaped value resolves to a folded domain so
+        it dedups with MISP-synced (domain, value) nodes."""
         s_missing, _ = self._process({"indicator": "EvIl[.]CoM"})
         s_unknown, _ = self._process({"indicator": "EvIl[.]CoM", "type": "unknown"})
         miss = [p["indicator"] for _q, p in s_missing.calls if "indicator" in p]
         unk = [p["indicator"] for _q, p in s_unknown.calls if "indicator" in p]
         assert miss and unk
-        # Both refang (→ "EvIl.CoM") but neither case-folds: an unknown type
-        # isn't known case-insensitive (and this isn't a hex hash). The point
-        # is they AGREE — no missing-vs-"unknown" divergence.
-        assert miss == unk == ["EvIl.CoM"] * len(miss)
+        # Inferred as a domain → folded; both paths agree.
+        assert miss == unk == ["evil.com"] * len(miss)
+
+    def test_unknown_type_domain_inferred_and_node_typed(self):
+        """Bugbot 'unknown alert type breaks domain parity': a typeless
+        domain alert must persist under (indicator_type='domain', folded
+        value), matching MISP sync — not (unknown, mixed-case)."""
+        self._process({"indicator": "EvIl.CoM", "type": "unknown"})
+        written = self._last_fake.written_alert
+        assert written == {"type": "domain", "indicator": "evil.com"}, (
+            "typeless domain alert must be written as (domain, folded value) to dedup with MISP"
+        )
 
     def test_whitespace_only_indicator_is_rejected_after_normalization(self):
         """Bugbot: a whitespace/zero-width-only value passes the raw

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -488,3 +488,26 @@ class TestAlertProcessorNormalization:
         session, _result = self._process({"indicator": "D" * 64, "type": "file_hash"})
         bound = [params["indicator"] for _q, params in session.calls if "indicator" in params]
         assert bound and all(v == "d" * 64 for v in bound)
+
+    def test_missing_type_and_unknown_type_normalize_identically(self):
+        """Bugbot: a defanged value with NO type vs an explicit
+        type='unknown' must produce the same canonical indicator (both are
+        'no type given' — refang applies to both)."""
+        s_missing, _ = self._process({"indicator": "EvIl[.]CoM"})
+        s_unknown, _ = self._process({"indicator": "EvIl[.]CoM", "type": "unknown"})
+        miss = [p["indicator"] for _q, p in s_missing.calls if "indicator" in p]
+        unk = [p["indicator"] for _q, p in s_unknown.calls if "indicator" in p]
+        assert miss and unk
+        # Both refang (→ "EvIl.CoM") but neither case-folds: an unknown type
+        # isn't known case-insensitive (and this isn't a hex hash). The point
+        # is they AGREE — no missing-vs-"unknown" divergence.
+        assert miss == unk == ["EvIl.CoM"] * len(miss)
+
+    def test_whitespace_only_indicator_is_rejected_after_normalization(self):
+        """Bugbot: a whitespace/zero-width-only value passes the raw
+        truthiness check but normalizes to '' — it must be rejected, not
+        reported enriched against an empty key, and must NOT write a node."""
+        session, result = self._process({"indicator": "  ​ \t ", "type": "domain"})
+        assert result.enriched is False
+        bound = [p["indicator"] for _q, p in session.calls if "indicator" in p]
+        assert all(v.strip() for v in bound), "no Cypher should bind an empty/whitespace $indicator"

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -328,6 +328,25 @@ class TestInferIndicatorType:
         assert infer_indicator_type(1234) is None
 
 
+class TestCanonicalizeLookupBlankType:
+    """Bugbot 'blank type skips inference refang': every 'no type given'
+    form — None, '', '  ', 'unknown' — must infer + refang + fold
+    identically, so an alert with threat.type='' isn't persisted
+    non-canonical and missing MISP-synced nodes."""
+
+    def test_all_blank_type_forms_infer_and_fold(self):
+        from ioc_normalize import canonicalize_lookup
+
+        results = {repr(t): canonicalize_lookup(t, "EVIL[.]COM") for t in (None, "", "  ", "unknown", "UNKNOWN")}
+        # All collapse to the same inferred-domain + refanged + folded result.
+        assert set(results.values()) == {("domain", "evil.com")}, results
+
+    def test_blank_type_normalize_still_refangs(self):
+        # An explicit empty type must not bypass refang (the bug).
+        assert normalize_indicator_value("", "EvIl[.]CoM") == "EvIl.CoM"  # refanged, not case-folded (unknown type)
+        assert normalize_indicator_value("   ", "1.2.3[.]4") == "1.2.3.4"
+
+
 class TestMitreTechniqueBoundary:
     def test_overlong_input_does_not_truncate_to_a_different_technique(self):
         """#8: 'T10590' must NOT silently resolve to the real technique

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -481,6 +481,20 @@ class TestActorSummary:
         assert "APT28" not in cypher  # never interpolated (Cypher-injection rule)
         assert "toLower(trim($name))" in cypher
 
+    def test_query_prefers_canonical_name_over_alias_match(self, monkeypatch):
+        """Bugbot 'actor summary picks arbitrary match': when two actors
+        share an alias, a canonical-NAME hit must deterministically win.
+        Pin the rank-then-name ORDER BY (not the old bare ORDER BY a.name)."""
+        session = _FakeSession(results=[_FakeResult(single_record=_actor_record())])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+        client.get("/actors/apt28/summary")
+        cypher, _params = session.calls[0]
+        assert "_match_rank" in cypher and "ORDER BY _match_rank" in cypher, (
+            "actor-summary tiebreak must rank canonical-name matches before alias-only matches"
+        )
+        # The bare nondeterministic form must be gone.
+        assert "WITH a ORDER BY a.name LIMIT 1" not in cypher
+
     def test_404_when_no_actor_matches(self, monkeypatch):
         session = _FakeSession(results=[_FakeResult(single_record=None)])
         monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
@@ -568,3 +582,17 @@ class TestAlertProcessorNormalization:
         assert result.enriched is False
         bound = [p["indicator"] for _q, p in session.calls if "indicator" in p]
         assert all(v.strip() for v in bound), "no Cypher should bind an empty/whitespace $indicator"
+
+    def test_inferred_ipv4_still_gets_block_recommendation(self):
+        """Bugbot 'inferred types skip recommendations': a typeless IP alert
+        infers type 'ipv4' — _generate_recommendations must recognize the
+        canonical name, not only the legacy 'ip' label, or the primary
+        block guidance silently disappears."""
+        _session, result = self._process({"indicator": "203.0.113.7"})
+        recs = result.enrichment.get("recommendations", [])
+        assert any("Block IP 203.0.113.7" in r for r in recs), recs
+
+    def test_inferred_hash_still_gets_block_recommendation(self):
+        _session, result = self._process({"indicator": "d" * 64})
+        recs = result.enrichment.get("recommendations", [])
+        assert any("Block file hash" in r for r in recs), recs

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -1,0 +1,490 @@
+"""EdgeGuard — READ-side normalization layer + /actors/{name}/summary tests.
+
+Covers:
+  - ``src/ioc_normalize.py`` unit behavior (refang, indicator/CVE/MITRE
+    normalization, idempotency, weird-input no-throw)
+  - API wiring: /search/indicator binds the NORMALIZED $value,
+    /stix/export/cve/{id} canonicalizes the identifier, GraphQL ``cve``
+    resolver normalizes its input
+  - /actors/{name}/summary: happy path, 404, alias resolution, 503
+  - alert_processor: every Cypher $indicator binding is normalized
+"""
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+# Ensure env vars are set before importing query_api (which reads them at
+# import time). EDGEGUARD_ENV must be a non-prod allowlist value — query_api
+# fails closed (RuntimeError) when unset+no API key (PR-N24 secure defaults).
+os.environ.setdefault("NEO4J_URI", "bolt://localhost:7687")
+os.environ.setdefault("NEO4J_USER", "neo4j")
+os.environ.setdefault("NEO4J_PASSWORD", "test-password")
+os.environ.setdefault("EDGEGUARD_ENV", "dev")
+
+from fastapi.testclient import TestClient
+
+import alert_processor
+import query_api
+from ioc_normalize import (
+    normalize_cve_id,
+    normalize_indicator_value,
+    normalize_mitre_technique_id,
+    refang,
+)
+
+client = TestClient(query_api.app)
+
+
+# ---------------------------------------------------------------------------
+# Fakes — capture every (cypher, params) bound through session.run()
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self, single_record=None, rows=None):
+        self._single = single_record
+        self._rows = rows or []
+
+    def single(self):
+        return self._single
+
+    def __iter__(self):
+        return iter(self._rows)
+
+
+class _FakeSession:
+    def __init__(self, results=None):
+        self.calls = []
+        self._results = list(results or [])
+
+    def run(self, query, **params):
+        self.calls.append((query, params))
+        return self._results.pop(0) if self._results else _FakeResult()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+class _FakeDriver:
+    def __init__(self, session):
+        self._session = session
+
+    def session(self, **kwargs):
+        return self._session
+
+
+class _FakeNeo4jClient:
+    def __init__(self, session):
+        self.driver = _FakeDriver(session)
+
+    def is_connected(self):
+        return True
+
+
+class _FakeAlertNeo4jClient(_FakeNeo4jClient):
+    """Adds the AlertProcessor-facing surface on top of the query fake."""
+
+    def connect(self):
+        return True
+
+    def process_complete_resilmesh_alert(self, alert_data):
+        pass
+
+    def update_alert_enrichment_status(self, **kwargs):
+        pass
+
+    def close(self):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Unit — refang
+# ---------------------------------------------------------------------------
+
+
+class TestRefang:
+    def test_scheme_and_bracket_dot(self):
+        assert refang("hxxp://evil[.]com/path") == "http://evil.com/path"
+
+    def test_hxxps_scheme(self):
+        assert refang("hxxps://evil(.)com") == "https://evil.com"
+
+    def test_bracket_colon_then_scheme(self):
+        # [:] must resolve before the scheme rewrite sees hxxp://
+        assert refang("hxxp[:]//evil{.}com") == "http://evil.com"
+
+    def test_curly_paren_square_dots(self):
+        assert refang("1.2.3[.]4") == "1.2.3.4"
+        assert refang("a(.)b{.}c[.]d") == "a.b.c.d"
+
+    def test_at_variants(self):
+        assert refang("user [at] example[.]com") == "user@example.com"
+        assert refang("user(at)example.com") == "user@example.com"
+        assert refang("user[@]example.com") == "user@example.com"
+        assert refang("user [AT] example.com") == "user@example.com"
+
+    def test_exotic_scheme_not_rewritten(self):
+        assert refang("meow://evil.com") == "meow://evil.com"
+
+    def test_hxxp_without_scheme_separator_untouched(self):
+        assert refang("hxxp_in_a_word") == "hxxp_in_a_word"
+
+    def test_zero_width_and_bidi_stripped(self):
+        # ZERO WIDTH SPACE + RIGHT-TO-LEFT MARK — reuses node_identity's table
+        assert refang("evil\u200b.com\u200f") == "evil.com"
+
+    def test_surrounding_whitespace_stripped(self):
+        assert refang("  evil.com  ") == "evil.com"
+
+    def test_idempotent(self):
+        samples = [
+            "hxxps://evil[.]com/Path",
+            "user [at] example[.]com",
+            "[[.]]",  # nested defang — fixpoint loop keeps a single call idempotent
+            "plain.example.com",
+        ]
+        for s in samples:
+            once = refang(s)
+            assert refang(once) == once
+
+    def test_non_str_returned_unchanged(self):
+        assert refang(None) is None
+        assert refang(123) == 123
+        assert refang(["evil[.]com"]) == ["evil[.]com"]
+
+
+# ---------------------------------------------------------------------------
+# Unit — normalize_indicator_value
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeIndicatorValue:
+    def test_case_insensitive_type_lowercases(self):
+        assert normalize_indicator_value("domain", "EvIl[.]CoM") == "evil.com"
+
+    def test_md5_type_lowercases(self):
+        assert normalize_indicator_value("md5", "A" * 32) == "a" * 32
+
+    def test_url_preserves_case(self):
+        # url is case-sensitive on the write side — must not be folded
+        assert normalize_indicator_value("url", "hxxp://EVIL[.]com/Path") == "http://EVIL.com/Path"
+
+    def test_email_preserves_case(self):
+        assert normalize_indicator_value("email", "Admin[@]Example.com") == "Admin@Example.com"
+
+    def test_hex_hash_heuristic_when_type_none(self):
+        for length in (32, 40, 64, 128):
+            assert normalize_indicator_value(None, "AB" * (length // 2)) == "ab" * (length // 2)
+
+    def test_hex_heuristic_skips_wrong_length(self):
+        assert normalize_indicator_value(None, "ABCDEF") == "ABCDEF"
+
+    def test_hex_heuristic_skips_non_hex(self):
+        assert normalize_indicator_value(None, "Z" * 64) == "Z" * 64
+
+    def test_unknown_type_uses_hex_heuristic(self):
+        # 'file_hash' (ResilMesh alerts) and generic 'hash' are not write-side
+        # types — route through the heuristic, do NOT depend on 'hash' being
+        # added to node_identity's set by the parallel change.
+        assert normalize_indicator_value("file_hash", "B" * 40) == "b" * 40
+        assert normalize_indicator_value("hash", "C" * 64) == "c" * 64
+
+    def test_nfc_normalization(self):
+        # NFD 'e' + combining acute must collapse to the composed NFC form
+        assert normalize_indicator_value("domain", "Cafe\u0301.com") == "caf\u00e9.com"
+
+    def test_non_str_returned_unchanged(self):
+        assert normalize_indicator_value("domain", None) is None
+        assert normalize_indicator_value(None, 42) == 42
+
+    def test_idempotent(self):
+        once = normalize_indicator_value("domain", "EvIl[.]CoM")
+        assert normalize_indicator_value("domain", once) == once
+
+
+# ---------------------------------------------------------------------------
+# Unit — normalize_cve_id
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeCveId:
+    def test_canonical_passthrough(self):
+        assert normalize_cve_id("CVE-2021-44228") == "CVE-2021-44228"
+
+    def test_lowercase_with_spaces(self):
+        assert normalize_cve_id("cve 2021 44228") == "CVE-2021-44228"
+
+    def test_en_dash(self):
+        assert normalize_cve_id("CVE–2021–44228") == "CVE-2021-44228"
+
+    def test_em_dash(self):
+        assert normalize_cve_id("CVE—2021—44228") == "CVE-2021-44228"
+
+    def test_underscores(self):
+        assert normalize_cve_id("cve_2021_44228") == "CVE-2021-44228"
+
+    def test_embedded_in_text(self):
+        assert normalize_cve_id("Apache Log4j (CVE-2021-44228) RCE") == "CVE-2021-44228"
+
+    def test_long_sequence_number(self):
+        assert normalize_cve_id("cve-2024-123456") == "CVE-2024-123456"
+
+    def test_no_match_returns_none(self):
+        assert normalize_cve_id("no cve here") is None
+        assert normalize_cve_id("CVE-21-1234") is None  # 2-digit year is not a CVE id
+        assert normalize_cve_id("") is None
+
+    def test_non_str_returns_none(self):
+        assert normalize_cve_id(None) is None
+        assert normalize_cve_id(20211234) is None
+
+
+# ---------------------------------------------------------------------------
+# Unit — normalize_mitre_technique_id
+# ---------------------------------------------------------------------------
+
+
+class TestNormalizeMitreTechniqueId:
+    def test_technique(self):
+        assert normalize_mitre_technique_id("T1059") == "T1059"
+
+    def test_sub_technique(self):
+        assert normalize_mitre_technique_id("t1059.001") == "T1059.001"
+
+    def test_space_between_t_and_digits(self):
+        assert normalize_mitre_technique_id("T 1059") == "T1059"
+
+    def test_embedded_in_text(self):
+        assert normalize_mitre_technique_id("uses T1547.010 for persistence") == "T1547.010"
+
+    def test_tactic_id_is_not_a_technique(self):
+        assert normalize_mitre_technique_id("TA0001") is None
+
+    def test_no_match_returns_none(self):
+        assert normalize_mitre_technique_id("nothing here") is None
+        assert normalize_mitre_technique_id("") is None
+
+    def test_non_str_returns_none(self):
+        assert normalize_mitre_technique_id(None) is None
+        assert normalize_mitre_technique_id(1059) is None
+
+
+# ---------------------------------------------------------------------------
+# API — /search/indicator binds the normalized $value
+# ---------------------------------------------------------------------------
+
+
+class TestSearchIndicatorNormalization:
+    def test_refangs_and_lowercases_before_match(self, monkeypatch):
+        session = _FakeSession(results=[_FakeResult(single_record=None)])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.post("/search/indicator", json={"value": "EvIl[.]CoM", "indicator_type": "domain"})
+        assert resp.status_code == 200
+        data = resp.json()
+        # Raw value echoed for transparency; normalized form surfaced too
+        assert data["found"] is False
+        assert data["value"] == "EvIl[.]CoM"
+        assert data["normalized_value"] == "evil.com"
+        # The Cypher MATCH must have bound the NORMALIZED value
+        assert session.calls, "no Cypher executed"
+        assert session.calls[0][1]["value"] == "evil.com"
+
+    def test_hex_hash_heuristic_without_type(self, monkeypatch):
+        session = _FakeSession(results=[_FakeResult(single_record=None)])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.post("/search/indicator", json={"value": "A" * 64})
+        assert resp.status_code == 200
+        assert session.calls[0][1]["value"] == "a" * 64
+
+
+# ---------------------------------------------------------------------------
+# API — STIX cve export canonicalizes the identifier
+# ---------------------------------------------------------------------------
+
+
+class TestStixCveExportNormalization:
+    def _install_fake_exporter(self, monkeypatch, captured):
+        import stix_exporter
+
+        class _FakeExporter:
+            MEDIA_TYPE = stix_exporter.StixExporter.MEDIA_TYPE
+
+            def __init__(self, neo4j_client):
+                pass
+
+            def export_cve(self, cve_id, depth=2):
+                captured["cve_id"] = cve_id
+                return {"type": "bundle", "objects": []}
+
+        monkeypatch.setattr(stix_exporter, "StixExporter", _FakeExporter)
+
+    def test_spaced_lowercase_identifier_uppercased(self, monkeypatch):
+        captured = {}
+        self._install_fake_exporter(monkeypatch, captured)
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(_FakeSession()))
+
+        resp = client.get("/stix/export/cve/cve%202021%2044228")
+        assert resp.status_code == 200
+        assert captured["cve_id"] == "CVE-2021-44228"
+
+    def test_en_dash_identifier_canonicalized(self, monkeypatch):
+        captured = {}
+        self._install_fake_exporter(monkeypatch, captured)
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(_FakeSession()))
+
+        resp = client.get("/stix/export/cve/CVE–2021–44228")
+        assert resp.status_code == 200
+        assert captured["cve_id"] == "CVE-2021-44228"
+
+    def test_unrecognized_identifier_falls_back_to_raw(self, monkeypatch):
+        captured = {}
+        self._install_fake_exporter(monkeypatch, captured)
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(_FakeSession()))
+
+        resp = client.get("/stix/export/cve/not-a-cve")
+        assert resp.status_code == 200
+        assert captured["cve_id"] == "not-a-cve"
+
+
+# ---------------------------------------------------------------------------
+# GraphQL — cve resolver normalizes its input
+# ---------------------------------------------------------------------------
+
+
+class TestGraphqlCveNormalization:
+    def test_resolver_receives_canonical_cve_id(self, monkeypatch):
+        import graphql_api
+
+        captured = {}
+
+        def _fake_resolve(neo4j, cve_id):
+            captured["cve_id"] = cve_id
+            return None
+
+        monkeypatch.setattr(graphql_api, "_resolve_cve", _fake_resolve)
+        monkeypatch.setattr(graphql_api, "_client", object())
+
+        result = graphql_api.schema.execute_sync('{ cve(cveId: "cve 2021 44228") { cveId } }')
+        assert result.errors is None
+        assert captured["cve_id"] == "CVE-2021-44228"
+
+
+# ---------------------------------------------------------------------------
+# API — /actors/{name}/summary
+# ---------------------------------------------------------------------------
+
+
+def _actor_record(resolved_by_name=True):
+    """Shape of the single row returned by _ACTOR_SUMMARY_CYPHER."""
+    return {
+        "actor": {
+            "name": "apt28",
+            "aliases": ["APT28", "Fancy Bear"],
+            "description": "GRU-attributed espionage group",
+            "sophistication": "advanced",
+            "motivation": None,
+            "primary_motivation": "espionage",
+            "confidence_score": 0.9,
+            "zone": ["global"],
+            "source": ["otx"],
+        },
+        "resolved_by_name": resolved_by_name,
+        "malware": ["x-agent", "zebrocy"],
+        "malware_total": 12,
+        "techniques": [{"mitre_id": "T1059", "name": "Command and Scripting Interpreter"}],
+        "technique_total": 25,
+        "campaigns": ["grizzly steppe"],
+        "campaign_total": 2,
+    }
+
+
+class TestActorSummary:
+    def test_happy_path(self, monkeypatch):
+        session = _FakeSession(results=[_FakeResult(single_record=_actor_record())])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.get("/actors/APT28/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["name"] == "apt28"
+        assert data["aliases"] == ["APT28", "Fancy Bear"]
+        assert data["resolved_by"] == "name"
+        assert data["motivation"] == "espionage"  # falls back to primary_motivation
+        assert data["malware"] == ["x-agent", "zebrocy"]
+        assert data["malware_total"] == 12
+        assert data["techniques"] == [{"mitre_id": "T1059", "name": "Command and Scripting Interpreter"}]
+        assert data["technique_total"] == 25
+        assert data["campaigns"] == ["grizzly steppe"]
+        assert data["campaign_total"] == 2
+
+    def test_name_always_bound_as_parameter(self, monkeypatch):
+        session = _FakeSession(results=[_FakeResult(single_record=_actor_record())])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        client.get("/actors/APT28/summary")
+        cypher, params = session.calls[0]
+        assert params["name"] == "APT28"
+        assert "$name" in cypher
+        assert "APT28" not in cypher  # never interpolated (Cypher-injection rule)
+        assert "toLower(trim($name))" in cypher
+
+    def test_404_when_no_actor_matches(self, monkeypatch):
+        session = _FakeSession(results=[_FakeResult(single_record=None)])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.get("/actors/no-such-actor/summary")
+        assert resp.status_code == 404
+
+    def test_alias_resolution_path(self, monkeypatch):
+        session = _FakeSession(results=[_FakeResult(single_record=_actor_record(resolved_by_name=False))])
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(session))
+
+        resp = client.get("/actors/Fancy%20Bear/summary")
+        assert resp.status_code == 200
+        assert resp.json()["resolved_by"] == "alias"
+
+    def test_503_when_neo4j_disconnected(self, monkeypatch):
+        monkeypatch.setattr(query_api, "neo4j_client", None)
+        resp = client.get("/actors/apt28/summary")
+        assert resp.status_code == 503
+
+
+# ---------------------------------------------------------------------------
+# alert_processor — bound $indicator is normalized
+# ---------------------------------------------------------------------------
+
+
+class TestAlertProcessorNormalization:
+    def _process(self, threat):
+        session = _FakeSession()
+        processor = alert_processor.AlertProcessor(neo4j_client=_FakeAlertNeo4jClient(session))
+        alert = {
+            "alert_id": "test-norm-001",
+            "source": "wazuh",
+            "zone": "healthcare",
+            "timestamp": "2026-06-11T00:00:00+00:00",
+            "threat": threat,
+        }
+        result = processor.process_alert(alert)
+        return session, result
+
+    def test_domain_indicator_refanged_and_lowercased(self):
+        session, result = self._process({"indicator": "EvIl[.]CoM", "type": "domain"})
+        assert result.enriched is True
+        bound = [params["indicator"] for _q, params in session.calls if "indicator" in params]
+        assert bound, "no Cypher call bound $indicator"
+        assert all(v == "evil.com" for v in bound)
+        # Enrichment payload echoes the graph-canonical identity
+        assert result.enrichment["indicator"] == "evil.com"
+
+    def test_file_hash_indicator_lowercased_via_heuristic(self):
+        session, _result = self._process({"indicator": "D" * 64, "type": "file_hash"})
+        bound = [params["indicator"] for _q, params in session.calls if "indicator" in params]
+        assert bound and all(v == "d" * 64 for v in bound)

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -345,18 +345,38 @@ class TestTypeVocabReconciliation:
     EdgeGuard graph type the write side stores, or duplicate nodes appear."""
 
     def test_graph_type_map_mirrors_write_side_TYPE_MAPPING(self):
-        """Drift guard: every entry in the canonical write-side TYPE_MAPPING
+        """Drift guard: EVERY entry in the canonical write-side TYPE_MAPPING
         (run_misp_to_neo4j) must resolve to the same graph type on the read
-        side, so a read lookup keys the node the write side MERGEd."""
+        side, so a read lookup keys the node the write side MERGEd. This
+        includes ``text`` → ``unknown``: the write side stores free-text MISP
+        attributes under graph type ``unknown`` (not shape-inferred), so the
+        read side must key the literal ``unknown`` to hit them — earlier this
+        entry was skipped here and silently drifted (Bugbot)."""
         from ioc_normalize import _GRAPH_TYPE_MAP
         from run_misp_to_neo4j import MISPToNeo4jSync
 
         for misp_type, graph_type in MISPToNeo4jSync.TYPE_MAPPING.items():
-            if graph_type == "unknown":
-                continue  # 'text' → 'unknown' is the no-type sentinel, handled separately
             assert _GRAPH_TYPE_MAP.get(misp_type) == graph_type, (
                 f"read-side _GRAPH_TYPE_MAP['{misp_type}'] must equal write-side '{graph_type}'"
             )
+
+    def test_misp_text_type_resolves_to_unknown_without_inference(self):
+        """MISP ``text`` → graph type ``unknown`` (write-side parity), and it
+        must NOT shape-infer: a free-text value that happens to look like an
+        IP still keys ``unknown`` (the node the write side MERGEd), unlike a
+        BLANK/``"unknown"`` input which collapses to None and infers."""
+        from ioc_normalize import _resolve_graph_type, canonicalize_lookup
+
+        # Explicit MISP 'text' vocab → literal 'unknown', no inference even
+        # when the value's shape would otherwise infer (here, an IP-shaped
+        # string). Value is left untouched (text is not refanged/folded).
+        assert _resolve_graph_type("text", "192.168.0.1") == "unknown"
+        assert _resolve_graph_type("text", "free form note") == "unknown"
+        assert canonicalize_lookup("text", "192.168.0.1") == ("unknown", "192.168.0.1")
+        # Contrast: a BLANK / "unknown" *input* still infers by shape, so it
+        # does NOT collapse to the 'unknown' graph type for an IP-shaped value.
+        assert _resolve_graph_type("unknown", "192.168.0.1") == "ipv4"
+        assert _resolve_graph_type("", "192.168.0.1") == "ipv4"
 
     def test_hostname_resolves_to_domain_and_folds(self):
         from ioc_normalize import canonicalize_lookup

--- a/tests/test_ioc_normalize_and_actor_summary.py
+++ b/tests/test_ioc_normalize_and_actor_summary.py
@@ -418,6 +418,10 @@ class TestStixCveExportNormalization:
                 captured["indicator_value"] = value
                 return {"type": "bundle", "objects": []}
 
+            def export_technique(self, mid, depth=2):
+                captured["mitre_id"] = mid
+                return {"type": "bundle", "objects": []}
+
         monkeypatch.setattr(stix_exporter, "StixExporter", _FakeExporter)
 
     def test_spaced_lowercase_identifier_uppercased(self, monkeypatch):
@@ -470,6 +474,17 @@ class TestStixCveExportNormalization:
         resp = client.get("/stix/export/indicator/%20%20")
         assert resp.status_code == 400
         assert "indicator_value" not in captured, "exporter must not be called for an empty key"
+
+    def test_technique_export_canonicalizes_identifier(self, monkeypatch):
+        """Pre-merge audit: the technique branch must canonicalize like the
+        cve/indicator siblings — 't 1059' → 'T1059' (the stored form)."""
+        captured = {}
+        self._install_fake_exporter(monkeypatch, captured)
+        monkeypatch.setattr(query_api, "neo4j_client", _FakeNeo4jClient(_FakeSession()))
+
+        resp = client.get("/stix/export/technique/t%201059")
+        assert resp.status_code == 200
+        assert captured["mitre_id"] == "T1059"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_node_property_promotion.py
+++ b/tests/test_node_property_promotion.py
@@ -178,6 +178,55 @@ class TestActorPropertyPromotion:
         assert "n.resource_level = $resource_level" in cypher_text
 
 
+class TestAliasPersistence:
+    """End-to-end (merge-level) assertion that the alias round-trip's
+    rehydrated aliases actually land as a queryable ``aliases`` node
+    property — the round-trip tests in test_alias_kev_roundtrip stop at
+    parse_attribute and mock the merge, so this closes that gap (audit #10).
+    The aliases property is what build_relationships Q2/Q9 read."""
+
+    def _merge_cypher_and_params(self, session):
+        cypher_call = session.run.call_args_list[1]  # [0] pre-check, [1] merge
+        return cypher_call[0][0], (cypher_call[1] if len(cypher_call) > 1 else {})
+
+    def test_actor_aliases_persisted_via_dedup_concat(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        client.merge_actor(
+            {
+                "name": "apt29",
+                "aliases": ["Cozy Bear", "The Dukes"],
+                "source": ["mitre_attck"],
+                "zone": ["global"],
+                "confidence_score": 0.9,
+            },
+            source_id="mitre_attck",
+        )
+        cypher_text, params = self._merge_cypher_and_params(session)
+        # aliases must reach the SET clause via the dedup-concat helper
+        # (apoc.coll.toSet), and the sanitized list must be a bound param.
+        assert "n.aliases" in cypher_text and "apoc.coll.toSet" in cypher_text, (
+            "ThreatActor.aliases must be promoted via the dedup-concat SET form"
+        )
+        assert params.get("aliases") == ["Cozy Bear", "The Dukes"]
+
+    def test_malware_aliases_persisted(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        client.merge_malware(
+            {
+                "name": "wellmess",
+                "aliases": ["WellMess", "BOTLIB"],
+                "malware_types": ["backdoor"],
+                "source": ["mitre_attck"],
+                "zone": ["global"],
+                "confidence_score": 0.8,
+            },
+            source_id="mitre_attck",
+        )
+        cypher_text, params = self._merge_cypher_and_params(session)
+        assert "n.aliases" in cypher_text and "apoc.coll.toSet" in cypher_text
+        assert params.get("aliases") == ["WellMess", "BOTLIB"]
+
+
 class TestCVSSNullFiltering:
     """CVSS nodes must filter None/empty values before SET."""
 

--- a/tests/test_pr_n10_block_bundle.py
+++ b/tests/test_pr_n10_block_bundle.py
@@ -472,15 +472,19 @@ class TestBugbotFollowupQ2InnerAttributedToFilter:
             "PR-N8 R1 forbids coalesce(m.attributed_to, ...); use IS NOT NULL + per-branch gate"
         )
 
-    def test_q2_inner_alias_comprehensions_filter_placeholders(self):
-        """Both alias-side comprehensions (actor.aliases and malware.aliases)
-        drop placeholder entries before matching."""
+    def test_q2_inner_alias_comprehension_filters_placeholders(self):
+        """The remaining Q2 alias comprehension (Branch 2, actor.aliases)
+        drops placeholder entries before matching. Branch 3's malware.aliases
+        comprehension was removed 2026-06 (attribution-forgery vector), so
+        exactly one such guard is expected."""
         inner = self._q2_block()
-        # Count occurrences of the placeholder NOT IN guard in alias comprehensions
-        # Two comprehensions, each should have one guard
         comprehension_guard = "AND NOT toLower(trim(x)) IN"
         count = inner.count(comprehension_guard)
-        assert count >= 2, f"both alias comprehensions must filter placeholders; found {count} of 2 expected"
+        assert count >= 1, f"the actor.aliases comprehension must filter placeholders; found {count}"
+        # Branch 3 (malware.aliases) must stay removed.
+        assert "coalesce(m.aliases, [])" not in inner, (
+            "Q2 must NOT read m.aliases — Branch 3 was removed as an attribution-forgery vector"
+        )
 
 
 class TestBugbotFollowupCypherStringEscaping:

--- a/tests/test_pr_n18_runbook_observability.py
+++ b/tests/test_pr_n18_runbook_observability.py
@@ -300,20 +300,20 @@ class TestPartDPrometheusAlerts:
 
 
 class TestPartEDeferredItemsHaveInTreeTodos:
-    def test_aliases_hijack_todo_in_q2_branch_3(self):
-        """Red-Team BLOCK #19 (aliases attribution hijack) was deferred
-        to post-baseline. The Q2 branch-3 Cypher must have an inline
-        TODO so the deferral survives team rotation."""
+    def test_q2_branch3_aliases_hijack_vector_is_removed(self):
+        """Red-Team BLOCK #19 (aliases attribution hijack) was CLOSED in the
+        PR #126 proactive audit by removing Q2 Branch 3 entirely — the
+        malware-alias → actor-attribution path. This pins that the hijack
+        Cypher does NOT come back (it would re-open a live forgery vector
+        once aliases round-trip from MISP), and that the removal is
+        documented in-tree so the rationale survives team rotation."""
         src = (SRC / "build_relationships.py").read_text()
-        # Find Q2 branch 3 area — match the toLower(trim(a.name))
-        # IN [x IN coalesce(m.aliases ...] pattern.
-        idx = src.find("toLower(trim(a.name)) IN [x IN coalesce(m.aliases")
-        assert idx != -1, "Q2 branch 3 not found at expected location"
-        # Search upward for the TODO.
-        block = src[max(0, idx - 2000) : idx + 500]
-        assert "TODO" in block and "Red-Team" in block, (
-            "aliases attribution hijack (BLOCK #19) must have an inline "
-            "TODO marker near Q2 branch 3 so deferral survives rotation"
+        assert "toLower(trim(a.name)) IN [x IN coalesce(m.aliases" not in src, (
+            "Q2 Branch 3 (a.name ∈ m.aliases → ATTRIBUTED_TO) must stay REMOVED — "
+            "it is the alias attribution-hijack vector (Red-Team BLOCK #19)"
+        )
+        assert "Branch 3" in src and "Red-Team BLOCK #19" in src, (
+            "the Branch-3 removal rationale must remain documented near Q2"
         )
 
     def test_execute_write_migration_todo_in_retry_decorator(self):

--- a/tests/test_pr_n9_merge_robustness_bundle.py
+++ b/tests/test_pr_n9_merge_robustness_bundle.py
@@ -75,21 +75,23 @@ class TestFixANullEmptyAliasFilter:
     def _src(self) -> str:
         return (SRC / "build_relationships.py").read_text()
 
-    def test_q2_inner_list_comprehensions_filter_null_and_whitespace(self):
-        """Q2 inner has two list comprehensions (a.aliases + m.aliases).
-        Both must carry the ``WHERE x IS NOT NULL AND size(trim(x)) > 0``
-        filter."""
+    def test_q2_inner_list_comprehension_filters_null_and_whitespace(self):
+        """Q2 inner has ONE alias list comprehension since Branch 3
+        (a.name ∈ m.aliases) was removed 2026-06 as a forgery vector — only
+        Branch 2's a.aliases comprehension remains, and it must carry the
+        ``WHERE x IS NOT NULL AND size(trim(x)) > 0`` filter."""
         src = self._src()
         # Find Q2 block
         step2_idx = src.find("[LINK] 2/12 Malware → ThreatActor")
         step3_idx = src.find("[LINK] 3a/12", step2_idx)
         block = src[step2_idx:step3_idx]
 
-        # Must have filter in both a.aliases and m.aliases comprehensions
         a_alias_filter = "x IN coalesce(a.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0"
-        m_alias_filter = "x IN coalesce(m.aliases, []) WHERE x IS NOT NULL AND size(trim(x)) > 0"
         assert a_alias_filter in block, "Q2 a.aliases comprehension must filter NULL/whitespace entries"
-        assert m_alias_filter in block, "Q2 m.aliases comprehension must filter NULL/whitespace entries"
+        # Branch 3's m.aliases comprehension must stay REMOVED (forgery vector).
+        assert "coalesce(m.aliases, [])" not in block, (
+            "Q2 must NOT read m.aliases — Branch 3 was removed as an attribution-forgery vector"
+        )
 
     def test_q9_inner_list_comprehension_filters_null_and_whitespace(self):
         """Q9 inner has one list comprehension (m.aliases). Must carry


### PR DESCRIPTION
## Summary

Stage-2 GraphRAG readiness train, from the multi-agent review of Ivaylo's SOC prompt-category doc (dataset seed). Three ingest-side data losses fixed **before the planned fresh baseline** (they only heal at collection/sync time), plus the read-side normalization layer, 19 new catalog query shapes, and the analyst-summary endpoint. Built by parallel specialized agents, each gate-checked independently, then integrated and full-suite verified.

### 1. Alias round-trip — the crucial fix (`4617aab`)
The alias-**matching** machinery (build_relationships Q2/Q9 — built in c5a58ec, hardened across PR-N8/N9/N10/N14 with canonicalization parity, NULL guards, placeholder rejection, 50-item caps) was sound but **starved of data**: MISPWriter exported actor aliases as `alias:` tags, but `parse_attribute` hardcoded `aliases: []` on rehydration, and Malware had no alias carrier at all — 0/917 actors and 0/3,409 malware carried aliases on the 2026-04 baseline. Now:
- `mitre_collector` extracts malware aliases from `x_mitre_aliases` (ATT&CK malware SDOs never use the plain `aliases` key)
- `misp_writer` emits `alias:` tags for malware too; actor+malware cap raised 5 → 20 (ATT&CK p99 — the old cap could drop the very alias an analyst searches by)
- `run_misp_to_neo4j._extract_alias_tags` rehydrates both branches (order-preserving case-insensitive dedup); the PR-N14 sanitizer remains the single enforcement point downstream
- Full writer→parser round-trip regression tests pin the contract

### 2. KEV marker for CISA-only CVEs (`4617aab`)
480 KEV CVEs on the 2026-04 baseline had no queryable KEV property because the META-carrier gate keyed only on NVD enrichment. `cisa_collector` now emits the four `cisa_*` fields and the gate accepts `cisa_exploit_add` alone — every KEV CVE is visible to the `ti-cve-kev` query family regardless of source.

### 3. Hash/bitcoin case canonicalization (`4617aab`)
`TYPE_MAPPING` collapses hash types → `"hash"` and `btc` → `"bitcoin"` before merge, but the case-insensitive set listed only granular names — uppercase-pasted SHA256 lookups missed. Both collapsed names added; heals fully on the planned re-baseline.

### 4. Read-side normalization layer (`6a7b8f6`)
New `src/ioc_normalize.py` — refang (`hxxp://`, `1.2.3[.]4`, `[at]`, zero-width strip; bounded-fixpoint idempotent), `normalize_indicator_value` (write-side parity by reusing `node_identity` sets directly), `normalize_cve_id` (en-dash/space paste variants), `normalize_mitre_technique_id`. Wired at every analyst-input boundary: `/search/indicator`, STIX CVE export, GraphQL `cve()`, and `alert_processor` (single normalization point feeding all 5 Cypher bindings).

### 5. `GET /actors/{name}/summary` (`6a7b8f6`)
Alias-aware, case-insensitive actor resolution (`resolved_by: name|alias`) returning profile + attributed malware + techniques + campaigns with counts — backs Ivaylo's "short analyst summary" prompt category; house-style auth/rate-limit/error handling.

### 6. 19 GraphRAG catalog query shapes + 2 range indexes (`db572f3`)
Point lookups (`ti-indicator-by-value`, `ti-cve-by-id`), parameterized zone variants, the KEV∩EXPLOITS signature join (`ti-cve-kev-exploited`), technique family/prefix matching (`ti-technique-family` for sub-techniques), alias-aware actor resolve, campaign RUNS/PART_OF coverage, prevalence/recency rankings — catalog 84 → 103 entries, all schema-verified against the merge code (no invented properties), params confirmed working in both the Bolt and HTTP runners. Indexes: `cve_cvss_score`, `cve_cisa_exploit_add`.

### 7. METHODOLOGY §4.3 correction (`4617aab`)
Removed the aspirational `data_quality_factor` confidence formula (exists nowhere in code); documented the real three-layer model (source prior → co-occurrence calibration → time decay) so the Stage-2 dataset can't learn semantics the system doesn't have.

## Tests
- 88 new tests: 18 alias/KEV/case round-trip + 51 ioc_normalize/actor-summary + 19 catalog entries under the EXPLAIN/row harness (+ structural tests)
- Full suite: **1939 passed / 0 failed** (203 env-gated skips); ruff + format + mypy clean

## Notes
- Live-DB EXPLAIN validation of the new catalog entries was not run from this session (prod access not authorized for this task) — structural validation + schema verification stand in; `scripts/run_cypher_catalog_http.py` confirms against edgeguard.org when run by an operator.
- An adversarial multi-agent review of this combined diff runs next; confirmed findings will land as follow-up commits on this PR (same protocol as #125).
- Version not bumped: CalVer already at 2026.6.11 (same-day as #125); will bump at merge if the date rolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches attribution logic (Q2 removal), alert write/enrichment parity, and multiple API boundaries; broad test coverage but ingest fixes need a baseline re-sync to fully heal graph data.
> 
> **Overview**
> Stage-2 GraphRAG readiness: fixes **ingest** losses (aliases, KEV markers, hash folding), adds a **read-side** normalization layer, a new analyst API, catalog queries, and closes an attribution-forgery path.
> 
> **Ingest / graph integrity:** Threat actor and malware **`alias:`** tags now round-trip through MISP (`misp_writer`, `parse_attribute` / `_extract_alias_tags`, MITRE `x_mitre_aliases`); actor alias tag cap **5 → 20**. CISA-only KEV CVEs emit **`cisa_exploit_add`** (and related fields) so they are queryable like NVD-enriched CVEs. **`hash`** is added to case-insensitive merge keys (bitcoin stays case-sensitive). **`build_relationships` Q2 Branch 3** (actor name ∈ malware aliases → `ATTRIBUTED_TO`) is **removed** as a forgery vector; outer Q2 only considers malware with a real **`attributed_to`** claim.
> 
> **Read path & alerts:** New **`src/ioc_normalize.py`** refangs and canonicalizes analyst paste for REST, STIX, GraphQL CVE, and **`alert_processor`** (normalize **before** Neo4j write so read/write keys match; verbatim **`original_alert`** on errors). **`GET /actors/{name}/summary`** resolves by name or alias with aggregated malware, techniques, and campaigns. Neo4j indexes **`cve_cvss_score`** and **`cve_cisa_exploit_add`**; **19** GraphRAG catalog Cypher shapes added.
> 
> **Docs:** METHODOLOGY drops the nonexistent **`data_quality_factor`** formula in favor of the real three-layer confidence model; core graph docs updated for aliases, KEV, and `ATTRIBUTED_TO`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab12dd0da75cd36edd05644c99aa1f79e5bd3f1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->