### PR TITLE
ci: Node 24 action pins (June 16 deadline) + fix pip-audit artifact never written

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       # PR-A audit fix (Dependency HIGH-5): pin to commit SHA, not floating
-      # @v4. The tj-actions/changed-files attack (March 2025) exploited the
-      # mutability of major-version tags. Renovate/Dependabot can update.
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      # major tag. The tj-actions/changed-files attack (March 2025) exploited
+      # the mutability of major-version tags. Renovate/Dependabot can update.
+      # 2026-06: all pins bumped to Node 24 releases — GitHub forces JS
+      # actions onto Node 24 from 2026-06-16 and removes Node 20 from runners
+      # 2026-09-16 (upload-artifact v6+ needs runner >= 2.327.1;
+      # GitHub-hosted ubuntu-latest always satisfies that).
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3 (node24)
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0 (node24)
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -45,10 +49,10 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3 (node24)
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0 (node24)
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -72,7 +76,7 @@ jobs:
             --cov-fail-under=30
 
       - name: Upload coverage report
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1 (node24)
         with:
           name: coverage-report
           path: coverage.xml
@@ -82,7 +86,7 @@ jobs:
     name: Docker build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3 (node24)
 
       - name: Build Docker image
         run: docker build -t edgeguard-kg:ci .
@@ -165,10 +169,10 @@ jobs:
     name: Dependency security scan
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4.3.1
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3 (node24)
 
       - name: Set up Python
-        uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065  # v5.6.0
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0 (node24)
         with:
           python-version: ${{ env.PYTHON_VERSION }}
           cache: pip
@@ -220,10 +224,17 @@ jobs:
           #   unauthenticated on a non-loopback host). REMOVE this ignore once
           #   Airflow permits starlette>=1.0.1.
           #   Tracking: https://github.com/Kopanov/EdgeGuard-Knowledge-Graph/issues/121
-          pip-audit -r requirements.txt --ignore-vuln PYSEC-2026-161 --output json -o pip-audit.json
+          # NOTE: ``--format json --output <file>`` (NOT ``--output json -o
+          # <file>`` — ``-o`` IS ``--output``, so that form set the output
+          # FILE twice and left the format as ``columns``, and pip-audit
+          # skips writing the columns file entirely when no vulnerabilities
+          # are found — the artifact upload below then warned "No files were
+          # found"). The json format always writes the file, including the
+          # full dependency listing on a clean run.
+          pip-audit -r requirements.txt --ignore-vuln PYSEC-2026-161 --format json --output pip-audit.json
 
       - name: Upload audit results
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1 (node24)
         with:
           name: pip-audit
           path: pip-audit.json


### PR DESCRIPTION
## Why now
GitHub forces all JavaScript actions onto **Node 24 starting 2026-06-16** (and removes Node 20 from runners 2026-09-16) — [changelog](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Every CI run currently emits the deprecation annotation; all three pinned actions are Node 20 builds.

## Pin bumps (SHA-pinned per repo convention, each SHA verified against its tag via the GitHub API, `runs.using: node24` confirmed in each tag's action.yml)
| Action | Before | After |
|---|---|---|
| actions/checkout | v4.3.1 `34e11487` | **v6.0.3** `df4cb1c0` |
| actions/setup-python | v5.6.0 `a26af69b` | **v6.2.0** `a309ff8b` |
| actions/upload-artifact | v4.6.2 `ea165f8d` | **v7.0.1** `043fb46d` |

Usage audit against the breaking changes: we use bare `checkout`, `setup-python` with `{python-version, cache: pip}`, and `upload-artifact` with `{name, path}` — none affected by upload-artifact v7's opt-in direct uploads / ESM internals. upload-artifact v6+ requires runner ≥ 2.327.1, always satisfied on GitHub-hosted `ubuntu-latest`.

## pip-audit artifact fix
The Dependency security scan job has warned **"No files were found with the provided path: pip-audit.json"** on every run. Root cause (verified empirically with both flag forms): the command passed `--output json -o pip-audit.json` — `-o` IS `--output`, so the output file was set twice and the format stayed `columns`, and pip-audit **skips writing the columns file entirely when no vulnerabilities are found**. Now `--format json --output pip-audit.json`, which always writes the file (full dependency listing on a clean run), so the artifact uploads.

## Expected CI
All four jobs should stay green (this PR exercises all three bumped actions across all four jobs). Known/expected reds unrelated to this PR: none on the GitHub Actions board (starlette PYSEC-2026-161 remains ignored per #121; Trivy airflow-base CRITICALs tracked in #52/#124).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only changes (pinned action SHAs and a pip-audit CLI flag fix); no application runtime or deployment logic is modified.
> 
> **Overview**
> Updates **CI** ahead of GitHub’s **Node 24** mandate for JavaScript actions (June 2026): all SHA-pinned uses of `actions/checkout`, `actions/setup-python`, and `actions/upload-artifact` across the **lint**, **test**, **docker**, and **security** jobs move to **Node 24** builds (checkout **v6.0.3**, setup-python **v6.2.0**, upload-artifact **v7.0.1**), with comments noting runner compatibility for upload-artifact v6+.
> 
> Fixes the **dependency security** job so `pip-audit.json` is always produced and uploaded: the command now uses `--format json --output pip-audit.json` instead of `--output json -o pip-audit.json`, which had left the default **columns** format and skipped writing a file on clean runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c303702d2d0cab2ac31257c65c8a8eaecc5bc544. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->