### PR TITLE
fix(ioc): remove crypto raw-vocab from fold set + unify alert-path type resolution (post-#126 hardening)

### DIFF
--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -6267,6 +6267,14 @@ class Neo4jClient:
                 f"(type={indicator_type!r}) — skipping Indicator MERGE"
             )
             return False
+        # Bugbot (PR #130): a blank/"unknown" type whose value is NOT
+        # shape-inferable resolves to None — and a null MERGE-key property
+        # raises in Neo4j, silently dropping the indicator. Coalesce to the
+        # graph's "unknown" sentinel: the exact key the sync stores for
+        # un-typeable values (TYPE_MAPPING "text" → "unknown") and the same
+        # coalesce alert_processor applies (`resolved_type or "unknown"`),
+        # so the alert path keys the node sync data already uses.
+        normalized_type = normalized_type or "unknown"
 
         # zone is now an array
         zone_array = zones if zones else (zone if isinstance(zone, list) else [zone])

--- a/src/neo4j_client.py
+++ b/src/neo4j_client.py
@@ -34,6 +34,9 @@ except ImportError:
 # src/node_identity.py for the namespace, canonicalization rules, and the
 # per-label natural-key map.
 import source_registry  # noqa: E402  — single-source-of-truth for SOURCES dict (chip 5a refactor)
+from ioc_normalize import (
+    canonicalize_lookup,  # noqa: E402  — alert-path (type, value) parity with the sync vocabulary (post-#126 hardening)
+)
 from node_identity import (  # noqa: E402
     canonicalize_merge_key,
     compute_node_uuid,
@@ -6243,24 +6246,34 @@ class Neo4jClient:
         """Create an Indicator node from a ResilMesh alert."""
         now = datetime.now(timezone.utc).isoformat()
 
-        type_mapping = {
-            "ip": "ipv4",
-            "ipv4": "ipv4",
-            "ipv6": "ipv6",
-            "domain": "domain",
-            "file_hash": "hash",
-            "hash": "hash",
-            "sha256": "sha256",
-            "md5": "md5",
-        }
-        normalized_type = type_mapping.get(indicator_type, indicator_type)
+        # Post-#126 hardening: resolve (type, value) through the SAME
+        # canonicalization layer every other entrypoint uses
+        # (ioc_normalize wraps the sync's TYPE_MAPPING vocabulary) instead
+        # of a private local map. The old map here was the last unguarded
+        # copy of the type vocabulary and had ALREADY drifted: it kept
+        # sha256/md5 as distinct graph types (the sync collapses both to
+        # "hash") and blanket-mapped ip→ipv4 (IPv6 alerts got the wrong
+        # type) — since the Indicator MERGE key is (indicator_type, value),
+        # any caller bypassing alert_processor's pre-resolution MERGEd a
+        # duplicate node beside the sync-written one. alert_processor
+        # already pre-canonicalizes, so this is idempotent on that path.
+        normalized_type, normalized_value = canonicalize_lookup(indicator_type, indicator_value)
+        if not normalized_value:
+            # Same contract as the read paths: "" means no usable merge key
+            # (empty / whitespace / zero-width / bare defang token). Never
+            # MERGE an empty-key Indicator node.
+            logger.warning(
+                f"create_indicator_from_alert: no usable merge key after canonicalization "
+                f"(type={indicator_type!r}) — skipping Indicator MERGE"
+            )
+            return False
 
         # zone is now an array
         zone_array = zones if zones else (zone if isinstance(zone, list) else [zone])
 
         data = {
             "indicator_type": normalized_type,
-            "value": indicator_value,
+            "value": normalized_value,
             "tag": f"{zone_array[0]}_{normalized_type}",
             "zone": zone_array,
             # PR (S5) (bugbot 6543da4 LOW): dropped the stale

--- a/src/node_identity.py
+++ b/src/node_identity.py
@@ -436,9 +436,14 @@ _CASE_INSENSITIVE_INDICATOR_TYPES = frozenset(
         # NOTE: btc → "bitcoin" is also collapsed by TYPE_MAPPING but is
         # DELIBERATELY excluded — legacy Base58 BTC addresses are
         # case-sensitive (lowercasing breaks the Base58 checksum and the
-        # value no longer identifies any on-chain address). The pre-existing
-        # "btc"/"xmr"/"eth" entries below predate this fix and are left
-        # untouched (out of scope), but no NEW crypto-address type folding.
+        # value no longer identifies any on-chain address). The legacy
+        # raw-vocab entries "btc"/"xmr"/"eth" were REMOVED (2026-06,
+        # post-#126 hardening): dormant in every current path (callers
+        # collapse btc→bitcoin via TYPE_MAPPING / _GRAPH_TYPE_MAP first),
+        # but a future direct caller passing the raw type would have
+        # lowercase-corrupted the address on write. Cryptocurrency
+        # addresses are case-sensitive across the board (Base58 BTC/XMR,
+        # EIP-55 checksummed ETH) — no crypto-address type belongs here.
         "hash",
         "ssdeep",
         "imphash",
@@ -446,9 +451,6 @@ _CASE_INSENSITIVE_INDICATOR_TYPES = frozenset(
         "ja3s",
         "jarm",
         "mutex",
-        "btc",
-        "xmr",
-        "eth",
     }
 )
 

--- a/tests/test_ioc_vocab_hardening.py
+++ b/tests/test_ioc_vocab_hardening.py
@@ -137,6 +137,31 @@ class TestCreateIndicatorFromAlertVocabParity:
         client.create_indicator_from_alert("EvIl[.]CoM", None, "global")
         assert _merged_params(session) == ("domain", "evil.com")
 
+    def test_uninferable_unknown_type_keys_unknown_not_null(self, mock_neo4j_client):
+        # Bugbot (PR #130): "unknown" type + a value no shape claims resolves
+        # to None — a null MERGE-key property raises in Neo4j and the
+        # indicator would be silently dropped. Must coalesce to the graph's
+        # "unknown" sentinel (the same key TYPE_MAPPING stores for MISP
+        # text attributes, and the same coalesce alert_processor applies).
+        client, session = mock_neo4j_client
+        assert client.create_indicator_from_alert("randomstring123", "unknown", "global") is True
+        itype, value = _merged_params(session)
+        assert itype == "unknown"
+        assert value == "randomstring123"
+
+    def test_uninferable_none_type_keys_unknown_not_null(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        client.create_indicator_from_alert("randomstring123", None, "global")
+        itype, _ = _merged_params(session)
+        assert itype == "unknown"
+
+    def test_inferable_unknown_type_still_infers(self, mock_neo4j_client):
+        # The coalesce must NOT defeat inference: "unknown" + an IP-shaped
+        # value still keys ipv4 (the PR #126 domain-parity behavior).
+        client, session = mock_neo4j_client
+        client.create_indicator_from_alert("192.168.1.100", "unknown", "global")
+        assert _merged_params(session) == ("ipv4", "192.168.1.100")
+
     def test_empty_value_never_merges(self, mock_neo4j_client):
         client, session = mock_neo4j_client
         assert client.create_indicator_from_alert("   ", "domain", "global") is False

--- a/tests/test_ioc_vocab_hardening.py
+++ b/tests/test_ioc_vocab_hardening.py
@@ -1,0 +1,166 @@
+"""Post-#126 IOC type-vocabulary hardening (2026-06).
+
+Two residual risks from the robustness audit of PR #126:
+
+1. ``node_identity._CASE_INSENSITIVE_INDICATOR_TYPES`` still carried the
+   legacy raw-vocab entries ``btc``/``xmr``/``eth``. Dormant (every caller
+   collapses btc→bitcoin via TYPE_MAPPING / _GRAPH_TYPE_MAP before reaching
+   ``canonicalize_merge_key``), but a future direct caller passing the raw
+   type would have lowercase-corrupted a Base58/EIP-55 address on write —
+   contradicting the rationale documented in the same set ("lowercasing
+   breaks the Base58 checksum"). Entries REMOVED; pinned here.
+
+2. ``Neo4jClient.create_indicator_from_alert`` had a private local type map
+   — the last unguarded copy of the type vocabulary — which had ALREADY
+   drifted from the sync's TYPE_MAPPING: sha256/md5 stayed granular (sync
+   collapses both to "hash") and "ip" blanket-mapped to ipv4 (IPv6 alerts
+   mistyped). Since the Indicator MERGE key is (indicator_type, value), a
+   caller bypassing alert_processor's pre-resolution MERGEd duplicate nodes.
+   The map is replaced by ``ioc_normalize.canonicalize_lookup`` (the same
+   layer every read entrypoint uses); end-to-end parity pinned here.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "src"))
+
+from node_identity import _CASE_INSENSITIVE_INDICATOR_TYPES, canonicalize_merge_key  # noqa: E402
+
+# A real (well-known genesis-era) Base58 address shape — mixed case is the point.
+_BASE58_BTC = "1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa"
+_EIP55_ETH = "0x5aAeb6053F3E94C9b9A09f33669435E7Ef1BeAed"
+
+
+class TestCryptoRawVocabRemoved:
+    """Pin the REMOVAL of btc/xmr/eth from the case-folding set."""
+
+    def test_raw_crypto_types_not_in_fold_set(self):
+        for raw in ("btc", "xmr", "eth"):
+            assert raw not in _CASE_INSENSITIVE_INDICATOR_TYPES, (
+                f"'{raw}' must stay OUT of _CASE_INSENSITIVE_INDICATOR_TYPES — "
+                "cryptocurrency addresses are case-sensitive (Base58 / EIP-55); "
+                "folding corrupts the address"
+            )
+
+    def test_collapsed_bitcoin_type_not_in_fold_set(self):
+        # The collapsed graph type must stay excluded too (PR #126 decision).
+        assert "bitcoin" not in _CASE_INSENSITIVE_INDICATOR_TYPES
+
+    def test_merge_key_preserves_base58_case_for_raw_btc_type(self):
+        # THE failure mode the removal closes: a direct caller passing the
+        # raw "btc" vocab no longer gets its address lowercased.
+        out = canonicalize_merge_key("indicator", {"indicator_type": "btc", "value": _BASE58_BTC})
+        assert out["value"] == _BASE58_BTC
+
+    def test_merge_key_preserves_eip55_case_for_raw_eth_type(self):
+        out = canonicalize_merge_key("indicator", {"indicator_type": "eth", "value": _EIP55_ETH})
+        assert out["value"] == _EIP55_ETH
+
+    def test_hash_still_folds(self):
+        # Guard against over-removal: hex digests stay case-insensitive.
+        digest = "DEADBEEF" * 8
+        out = canonicalize_merge_key("indicator", {"indicator_type": "hash", "value": digest})
+        assert out["value"] == digest.lower()
+
+
+@pytest.fixture
+def mock_neo4j_client():
+    """Real Neo4jClient with a mocked driver/session (same pattern as
+    tests/test_node_property_promotion.py)."""
+    with patch.dict(os.environ, {"NEO4J_PASSWORD": "test", "MISP_API_KEY": "test"}):
+        from neo4j_client import Neo4jClient
+
+        client = Neo4jClient.__new__(Neo4jClient)
+        client.driver = MagicMock()
+        client._uri = "bolt://localhost:7687"
+        mock_session = MagicMock()
+        mock_run = MagicMock()
+        mock_run.single.return_value = None
+        mock_session.run.return_value = mock_run
+        client.driver.session.return_value.__enter__ = MagicMock(return_value=mock_session)
+        client.driver.session.return_value.__exit__ = MagicMock(return_value=False)
+        return client, mock_session
+
+
+def _merged_params(session):
+    """(indicator_type, value) bound into the MERGE by the last run call."""
+    kwargs = session.run.call_args.kwargs
+    return kwargs["indicator_type"], kwargs["value"]
+
+
+class TestCreateIndicatorFromAlertVocabParity:
+    """create_indicator_from_alert must key the same (indicator_type, value)
+    the MISP sync MERGEd — no more private drifted map."""
+
+    def test_hostname_resolves_to_domain_and_folds(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        assert client.create_indicator_from_alert("EvIl.CoM", "hostname", "global") is True
+        assert _merged_params(session) == ("domain", "evil.com")
+
+    def test_sha256_collapses_to_hash(self, mock_neo4j_client):
+        # The OLD local map kept sha256 granular — the sync stores "hash".
+        client, session = mock_neo4j_client
+        digest = "A" * 64
+        client.create_indicator_from_alert(digest, "sha256", "global")
+        assert _merged_params(session) == ("hash", digest.lower())
+
+    def test_md5_collapses_to_hash(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        digest = "B" * 32
+        client.create_indicator_from_alert(digest, "md5", "global")
+        assert _merged_params(session) == ("hash", digest.lower())
+
+    def test_btc_collapses_to_bitcoin_without_folding(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        client.create_indicator_from_alert(_BASE58_BTC, "btc", "global")
+        assert _merged_params(session) == ("bitcoin", _BASE58_BTC)
+
+    def test_ip_type_resolves_ipv6_by_value_shape(self, mock_neo4j_client):
+        # The OLD local map blanket-mapped ip→ipv4.
+        client, session = mock_neo4j_client
+        client.create_indicator_from_alert("2001:db8::1", "ip", "global")
+        itype, _ = _merged_params(session)
+        assert itype == "ipv6"
+
+    def test_misp_text_type_keys_unknown(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        client.create_indicator_from_alert("free form note", "text", "global")
+        itype, _ = _merged_params(session)
+        assert itype == "unknown"
+
+    def test_defanged_typeless_value_refangs_and_infers(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        client.create_indicator_from_alert("EvIl[.]CoM", None, "global")
+        assert _merged_params(session) == ("domain", "evil.com")
+
+    def test_empty_value_never_merges(self, mock_neo4j_client):
+        client, session = mock_neo4j_client
+        assert client.create_indicator_from_alert("   ", "domain", "global") is False
+        session.run.assert_not_called()
+
+    def test_bare_defang_token_never_merges(self, mock_neo4j_client):
+        # "[.]" refangs to "." — no alphanumeric content, no merge key.
+        client, session = mock_neo4j_client
+        assert client.create_indicator_from_alert("[.]", None, "global") is False
+        session.run.assert_not_called()
+
+    def test_every_sync_type_mapping_entry_agrees_end_to_end(self, mock_neo4j_client):
+        """Drift guard at the WRITE path: for every entry in the sync's
+        TYPE_MAPPING, the type bound into the alert-path MERGE equals the
+        graph type the sync would store. This replaces the old unguarded
+        local map with an executable invariant."""
+        from run_misp_to_neo4j import MISPToNeo4jSync
+
+        client, session = mock_neo4j_client
+        for misp_type, graph_type in MISPToNeo4jSync.TYPE_MAPPING.items():
+            session.run.reset_mock()
+            client.create_indicator_from_alert("samplevalue123", misp_type, "global")
+            itype, _ = _merged_params(session)
+            assert itype == graph_type, (
+                f"alert path stores '{misp_type}' as '{itype}' but the sync "
+                f"stores '{graph_type}' — duplicate-node drift reintroduced"
+            )


### PR DESCRIPTION
Closes out the two residual risks flagged by the post-#126 multi-agent robustness audit.

## 1. `btc`/`xmr`/`eth` removed from `_CASE_INSENSITIVE_INDICATOR_TYPES`
Dormant foot-gun: every current caller collapses `btc`→`bitcoin` (sync `TYPE_MAPPING` / read-side `_GRAPH_TYPE_MAP`) before reaching `canonicalize_merge_key`, but a future direct caller passing the raw vocab would have **lowercase-corrupted a Base58/EIP-55 address on write** — directly contradicting the rationale PR #126 documented three lines above when it deliberately excluded `bitcoin`. Cryptocurrency addresses are case-sensitive across the board (Base58 BTC/XMR, EIP-55 checksummed ETH).

## 2. `create_indicator_from_alert` now resolves via `ioc_normalize.canonicalize_lookup`
The private local type map was the **last unguarded copy of the type vocabulary** — and it had *already drifted*, beyond what the audit flagged:
- `sha256`/`md5` stayed granular while the sync collapses both to `hash`
- `ip` blanket-mapped to `ipv4` (IPv6 alerts mistyped)
- `hostname`/`btc`/`regkey`/`email-src`/`text` missing entirely

Since the Indicator MERGE key is `(indicator_type, value)`, any caller bypassing `alert_processor`'s pre-resolution MERGEd a duplicate node beside the sync-written one. Now both halves go through the single shared layer (idempotent on the normal alert_processor path), plus the read paths' empty-key contract: whitespace / zero-width / bare-defang values never MERGE an empty-key node. Import direction verified cycle-free (`ioc_normalize` → `node_identity` → stdlib only); ruff isort applied.

## Tests
New `tests/test_ioc_vocab_hardening.py` (15 tests): Base58/EIP-55 case preserved for raw vocab, `hash` still folds (no over-removal), write-path parity (`hostname`→`domain`, `sha256`/`md5`→`hash`, `btc`→`bitcoin` unfolded, `ip`→`ipv6` by value shape, `text`→`unknown`, defang refang on typeless input, empty-key guard short-circuits before any Cypher), and an **executable drift guard** iterating every real `TYPE_MAPPING` entry end-to-end through the alert write path — the unguarded-copy bug class can't silently return.

Full local suite: **1,995 passed / 0 failed** (203 skipped integration, 3 xfailed); ruff + mypy green. Cypher unchanged — existing source-inspection pins (PR-S5 first_seen / original_source) unaffected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how alert-path Indicator nodes are keyed in Neo4j (type/value canonicalization), which affects graph deduplication but fixes known drift and adds guards rather than widening behavior on the main alert_processor path.
> 
> **Overview**
> Post-#126 hardening aligns **Indicator** write keys with the MISP sync and read paths so alert-created nodes do not duplicate sync-written ones.
> 
> **`node_identity`:** Removes legacy raw crypto types (`btc`, `xmr`, `eth`) from `_CASE_INSENSITIVE_INDICATOR_TYPES` so a direct caller cannot lowercase-corrupt Base58 or EIP-55 addresses on merge; hex `hash` folding is unchanged.
> 
> **`Neo4jClient.create_indicator_from_alert`:** Drops the private type map in favor of `ioc_normalize.canonicalize_lookup` (same vocabulary as sync `TYPE_MAPPING`), uses the canonicalized **value** in the MERGE, skips empty/unusable keys, and coalesces uninferable types to `"unknown"` instead of null MERGE keys. Also removes an unused `first_seen` parameter from the payload.
> 
> **Tests:** Adds `tests/test_ioc_vocab_hardening.py` to pin crypto case preservation, alert-path parity (e.g. `sha256`/`md5`→`hash`, IPv6 under `ip`), empty-key guards, and an end-to-end check over every `TYPE_MAPPING` entry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8e51baa0d92f6425218aef69bc93260caeaa169d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->