### PR TITLE
docs: post-baseline GraphRAG verification checklist + KEV/alias query samples

### DIFF
--- a/docs/BASELINE_LAUNCH_CHECKLIST.md
+++ b/docs/BASELINE_LAUNCH_CHECKLIST.md
@@ -288,6 +288,41 @@ replace the manual-pause step.
 Follow [`docs/RUNBOOK.md`](RUNBOOK.md) § "After the run" — postcheck
 queries, sector-stats reconciliation, alert mute window cleanup.
 
+### GraphRAG readiness verification (post-#126)
+
+Several PR #126 fixes change what is *written*, so they only materialize
+on a fresh baseline — and several analyst-facing query shapes depend on
+`build_relationships.py` having run after the sync. Verify in this order
+(all read-only; Neo4j Browser or the HTTP runner):
+
+1. **Aliases populated** — the alias round-trip fix. The pre-June
+   snapshot had **0/917** actors with aliases, which silently disabled
+   alias-based attribution and lookups ("Cozy Bear" → APT29):
+   ```cypher
+   MATCH (a:ThreatActor) WHERE size(coalesce(a.aliases, [])) > 0
+   RETURN count(a)  // expect hundreds, not 0
+   ```
+2. **KEV markers populated** — CISA-only CVEs (~480 on the old
+   snapshot) previously got no `cisa_exploit_add` property:
+   ```cypher
+   MATCH (c:CVE) WHERE c.cisa_exploit_add IS NOT NULL RETURN count(c)
+   ```
+3. **`build_relationships.py` ran** — `IMPLEMENTS_TECHNIQUE`,
+   `USES_TECHNIQUE`, and `IN_TACTIC` edges come ONLY from this job
+   (deliberately deferred out of the sync). All three edge types were
+   entirely absent from the pre-June snapshot because the job never ran:
+   ```cypher
+   MATCH ()-[r:IMPLEMENTS_TECHNIQUE|USES_TECHNIQUE|IN_TACTIC]->()
+   RETURN type(r) AS rel, count(r)  // all three must be non-zero
+   ```
+4. **Expected-empty is not a bug** — `Campaign` nodes are materialized
+   by `enrichment_jobs.py`, not the sync; campaign queries return 0 rows
+   until that job runs.
+
+The full analyst-question catalog (19 test-pinned shapes) lives in
+`tests/test_cypher_query_catalog.py::_TI_GRAPHRAG`, runnable against the
+live graph via [`scripts/run_cypher_catalog_http.py`](../scripts/run_cypher_catalog_http.py).
+
 ---
 
 ## Cross-references
@@ -301,7 +336,7 @@ queries, sector-stats reconciliation, alert mute window cleanup.
 
 ---
 
-_Last updated: 2026-06-11 — PR #125 docs correction: the lock sentinel is NOT written by the baseline DAG (PR-F2 de-scope, Issue #57) — manual pausing is the ONLY mutex on the DAG path, and the pause list now covers all 5 scheduled DAGs (added edgeguard_neo4j_sync); CLI wrappers exist (PR-C) but trigger the same DAG. Prior: 2026-04-28 — PR-N35 Tier-1 + PR-N36 follow-up:_
+_Last updated: 2026-06-12 — added "GraphRAG readiness verification" to § After the run: post-baseline checks for the PR #126 write-side fixes (aliases, KEV markers) + the build_relationships edge types absent from the pre-June snapshot. Prior: 2026-06-11 — PR #125 docs correction: the lock sentinel is NOT written by the baseline DAG (PR-F2 de-scope, Issue #57) — manual pausing is the ONLY mutex on the DAG path, and the pause list now covers all 5 scheduled DAGs (added edgeguard_neo4j_sync); CLI wrappers exist (PR-C) but trigger the same DAG. Prior: 2026-04-28 — PR-N35 Tier-1 + PR-N36 follow-up:_
 - _Item `[4]` description (PR-N35): "CLI vs DAG+pause" → "DAG-only at HEAD" (the
   CLI baseline subcommand referenced in older RUNBOOK versions doesn't
   exist in `src/edgeguard.py` — verified by `grep "add_parser"`)._

--- a/docs/NEO4J_SAMPLE_QUERIES.md
+++ b/docs/NEO4J_SAMPLE_QUERIES.md
@@ -2,6 +2,12 @@
 
 Run these in Neo4j Browser (e.g. `http://localhost:7474`).
 
+> This is an illustrative operator cookbook. The full **test-pinned analyst
+> query catalog** (19 GraphRAG shapes: IOC triage, sector relevance, CVE/KEV
+> prioritization, ATT&CK hunting, actor investigation) lives in
+> `tests/test_cypher_query_catalog.py::_TI_GRAPHRAG` and runs against the
+> live graph via `scripts/run_cypher_catalog_http.py`.
+
 ---
 
 ## Basic Stats
@@ -46,6 +52,19 @@ RETURN c.cve_id, c.cvss_score, c.description
 LIMIT 20
 ```
 
+### Find actively exploited CVEs (CISA KEV)
+`cisa_exploit_add` (date added to the CISA Known Exploited Vulnerabilities
+list) is range-indexed (PR #126). On pre-June-2026 baselines only
+NVD-enriched CVEs carry it; after a fresh baseline CISA-only CVEs do too.
+
+```cypher
+MATCH (c:CVE)
+WHERE c.cisa_exploit_add IS NOT NULL
+RETURN c.cve_id, c.cisa_exploit_add, c.cisa_vulnerability_name, c.cvss_score
+ORDER BY c.cisa_exploit_add DESC
+LIMIT 20
+```
+
 ---
 
 ## Indicators
@@ -74,6 +93,21 @@ LIMIT 20
 MATCH (a:ThreatActor)
 RETURN a.name, a.aliases, a.confidence_score
 LIMIT 20
+```
+
+### Resolve an actor by name OR alias ("Cozy Bear" → APT29)
+`aliases` is populated by the PR #126 alias round-trip — on baselines from
+before June 2026 the property is empty (0/917 actors), so this query only
+resolves canonical names there. `a.name` is stored lowercase; aliases keep
+display case.
+
+```cypher
+WITH 'Cozy Bear' AS name
+MATCH (a:ThreatActor)
+WHERE a.name = toLower(trim(name))
+   OR any(x IN coalesce(a.aliases, []) WHERE toLower(trim(x)) = toLower(trim(name)))
+RETURN a.name, a.aliases, a.zone
+LIMIT 5
 ```
 
 ---
@@ -171,6 +205,6 @@ RETURN type(r) AS edge_type, count(r) AS gap
 
 ---
 
-_Last updated: 2026-05-25 — Cypher-catalog verification against the live graph: switched the Vulnerabilities sample queries from the legacy `:Vulnerability` label (empty on current baselines) to `:CVE` (the label the sync actually writes) and added the label note in the Vulnerabilities section. Prior: 2026-04-28 — PR-N36 Tier-2 deep verification: corrected the "stored on `zone` property, not as extra labels" claim — sectors are stored on BOTH (`zone` property at MERGE time, plus secondary labels like `:Healthcare` after `apply_sector_labels()` runs post-sync). Recommend `zone` property for portable queries that work pre or post the label-apply step. Prior: 2026-04-26 PR-N33 docs audit (replaced broken `t.platforms` query with `t.tactic_phases`; added Edge provenance section)._
+_Last updated: 2026-06-12 — added the CISA-KEV sample (`cisa_exploit_add`, range-indexed since PR #126), the alias-aware actor-resolve sample, and the header pointer to the test-pinned `_TI_GRAPHRAG` catalog (19 analyst-question shapes). Prior: 2026-05-25 — Cypher-catalog verification against the live graph: switched the Vulnerabilities sample queries from the legacy `:Vulnerability` label (empty on current baselines) to `:CVE` (the label the sync actually writes) and added the label note in the Vulnerabilities section. Prior: 2026-04-28 — PR-N36 Tier-2 deep verification: corrected the "stored on `zone` property, not as extra labels" claim — sectors are stored on BOTH (`zone` property at MERGE time, plus secondary labels like `:Healthcare` after `apply_sector_labels()` runs post-sync). Recommend `zone` property for portable queries that work pre or post the label-apply step. Prior: 2026-04-26 PR-N33 docs audit (replaced broken `t.platforms` query with `t.tactic_phases`; added Edge provenance section)._
 
 *Save queries to test the prototype*


### PR DESCRIPTION
Distills the Sprint-2 GraphRAG-readiness insights into the docs — **only the durable operator knowledge**, deliberately NOT duplicating the 19-query catalog (the test harness is its source of truth; a verbatim docs copy would drift).

## BASELINE_LAUNCH_CHECKLIST.md — § After the run
New **GraphRAG readiness verification** subsection: the PR #126 write-side fixes (actor aliases, KEV markers for CISA-only CVEs) only materialize on a fresh baseline, and `IMPLEMENTS_TECHNIQUE`/`USES_TECHNIQUE`/`IN_TACTIC` edges exist **only** after `build_relationships.py` runs — all three were entirely absent from the pre-June snapshot because the job never ran. Four ordered, read-only checks with expected outcomes, plus the "Campaign queries empty is correct until enrichment_jobs" note, and a pointer to the `_TI_GRAPHRAG` catalog + HTTP runner.

## NEO4J_SAMPLE_QUERIES.md
- **CISA-KEV sample** (`cisa_exploit_add IS NOT NULL`, range-indexed since #126) — the audit's flagged nice-to-have.
- **Alias-aware actor-resolve sample** ("Cozy Bear" → APT29), Browser-runnable via `WITH ... AS name`, with the pre-June 0/917-aliases caveat so operators don't misread empty results as a bug.
- **Header pointer** to `tests/test_cypher_query_catalog.py::_TI_GRAPHRAG` (19 test-pinned analyst shapes) — fixes catalog discoverability with one line instead of a duplicating doc.

Both footers bumped to 2026-06-12; CalVer untouched at 2026.6.11 (no release cut). Docs-only — no code paths affected.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes; no application code, pipelines, or runtime behavior are modified.
> 
> **Overview**
> **Docs-only:** captures post-baseline GraphRAG operator checks and sample Cypher without duplicating the test catalog.
> 
> `docs/BASELINE_LAUNCH_CHECKLIST.md` gains a **GraphRAG readiness verification** block under § After the run: four ordered read-only Cypher checks (actor `aliases` after PR #126, `cisa_exploit_add` on CVEs, `IMPLEMENTS_TECHNIQUE`/`USES_TECHNIQUE`/`IN_TACTIC` edges after `build_relationships.py`, and the note that empty `Campaign` results are expected until `enrichment_jobs.py`). It points operators to `tests/test_cypher_query_catalog.py::_TI_GRAPHRAG` and `scripts/run_cypher_catalog_http.py`.
> 
> `docs/NEO4J_SAMPLE_QUERIES.md` adds a header callout to that same catalog, plus runnable samples for **CISA KEV** (`cisa_exploit_add`) and **alias-aware actor resolution**, including pre-June baseline caveats. Footers in both files are updated to 2026-06-12.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1e470ce9ac4b3657e70a4406eebe094d783a970d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->