### PR TITLE
fix(ops): MISP push success-rate gate + preflight APOC probe (pre-baseline safety)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -281,6 +281,15 @@ AIRFLOW_CONN_NEO4J_DEFAULT=
 # Opt-in: run gc.collect() after each Neo4j sync chunk (not recommended in small workers).
 # EDGEGUARD_DEBUG_GC=1
 
+# Issue #62 silent-loss gate: minimum fraction of ATTEMPTED MISP pushes
+# (success / (success + failed); deduplicated items are not attempts) that must
+# succeed for a collector run to count as success. Below the threshold the
+# Airflow task fails RED with the rate in the error (the 2026-04-19 baseline
+# lost 14.7% of NVD attributes under a green DAG). Default 0.95. Set to 0 to
+# disable (legacy any-success-is-success). Every run also logs a grep-able
+# COLLECTOR_SUMMARY line with pushed/failed/rate.
+# EDGEGUARD_MISP_MIN_SUCCESS_RATE=0.95
+
 # MISP write throttling — pause between batch POSTs to prevent MISP memory exhaustion
 # on large events (e.g. 95K NVD attributes). Increase on memory-constrained MISP hosts.
 # EDGEGUARD_MISP_BATCH_THROTTLE_SEC=5.0

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,9 @@ x-common-env: &common-env
   EDGEGUARD_DEBUG_GC: ${EDGEGUARD_DEBUG_GC:-}
   # restSearch substring for EdgeGuard event discovery (default EdgeGuard in code if unset).
   EDGEGUARD_MISP_EVENT_SEARCH: ${EDGEGUARD_MISP_EVENT_SEARCH:-}
+  # Issue #62: min fraction of ATTEMPTED MISP pushes that must succeed or the
+  # collector task fails RED (default 0.95 in code; 0 disables the gate).
+  EDGEGUARD_MISP_MIN_SUCCESS_RATE: ${EDGEGUARD_MISP_MIN_SUCCESS_RATE:-}
 
 services:
   # ─────────────────────────────────────────────────────────────────────────────

--- a/docs/RUNBOOK.md
+++ b/docs/RUNBOOK.md
@@ -408,6 +408,24 @@ docker logs edgeguard_airflow 2>&1 | grep -E '\[BUILD_RELATIONSHIPS SUMMARY\]'
 Absence of this line = silent subprocess death (the exact scenario the
 `EdgeGuardBuildRelationshipsSilentDeath` alert guards against).
 
+Every collector run also emits one grep-able push summary (Issue #62,
+2026-06):
+
+```bash
+docker logs edgeguard_airflow 2>&1 | grep "COLLECTOR_SUMMARY"
+# expected per source: COLLECTOR_SUMMARY source=nvd items=N pushed=S failed=F \
+#                      attempted=A success_rate=R min_success_rate=T
+```
+
+A `success_rate` below `EDGEGUARD_MISP_MIN_SUCCESS_RATE` (default **0.95**,
+`0` disables) now marks the collector run **failed** — the Airflow task goes
+RED with the rate in the error instead of the pre-2026-06 behavior where one
+successful attribute out of 92k made the run green (how the 2026-04-19
+baseline silently lost 14.7% of NVD attributes). Rate is computed over
+**attempted** pushes only — deduplicated re-runs are unaffected. Remediation
+for a tripped gate = failure mode 1 above (MISP batch permanent failure);
+the re-trigger is dedup-safe.
+
 ---
 
 ## Baseline-day protocol
@@ -746,7 +764,7 @@ means re-runs are safe:
 
 ---
 
-_Last updated: 2026-06-11 — PR #125 docs correction (supersedes the PR-N35 note in § Baseline launch path): edgeguard baseline/fresh-baseline DO exist (PR-C wrappers, no mutex); the lock sentinel is written only by the legacy in-process CLI path, not the DAG; pause procedure extended to all 5 scheduled DAGs incl. edgeguard_neo4j_sync. Prior: 2026-04-28 — PR-N35 Tier-1 + PR-N36 follow-up:_
+_Last updated: 2026-06-12 — Issue #62 silent-loss gate: documented the COLLECTOR_SUMMARY grep + EDGEGUARD_MISP_MIN_SUCCESS_RATE fail policy in § Post-run summary grep (partial MISP push loss below 0.95 now fails the task RED). Prior: 2026-06-11 — PR #125 docs correction (supersedes the PR-N35 note in § Baseline launch path): edgeguard baseline/fresh-baseline DO exist (PR-C wrappers, no mutex); the lock sentinel is written only by the legacy in-process CLI path, not the DAG; pause procedure extended to all 5 scheduled DAGs incl. edgeguard_neo4j_sync. Prior: 2026-04-28 — PR-N35 Tier-1 + PR-N36 follow-up:_
 - _**Container/service names** (BLOCK, PR-N35):_ replaced `edgeguard-airflow-worker` (doesn't exist) with `edgeguard_airflow` (single Airflow standalone container, per `docker-compose.yml:204`) across 15+ command examples; `edgeguard-neo4j` → `edgeguard_neo4j`; `edgeguard-misp` → `<your-misp-container>` (MISP is NOT in the compose stack); `docker compose exec airflow-worker` → `docker compose exec airflow`. Added an explicit container-name table to the deployment-assumption block at the top.
 - _**Baseline launch path** (BLOCK, PR-N35):_ removed the entire Option A "CLI baseline" path (`python -m edgeguard baseline --days 730` / `fresh-baseline`) — those subcommands do NOT exist in `src/edgeguard.py` (verified via `grep "add_parser"`). Promoted the DAG+pause path to Option A. Added a callout explaining the historical CLI path was never shipped at HEAD.
 - _**`--bootstrap-sources` invocation form** (BLOCK, PR-N35):_ flag DOES exist (PR-N18) but `python -m src.neo4j_client …` doesn't work (no `src/__init__.py`). Fixed to `python src/neo4j_client.py --bootstrap-sources`._

--- a/scripts/preflight_baseline.sh
+++ b/scripts/preflight_baseline.sh
@@ -126,11 +126,17 @@ else
   fail "Neo4j not reachable at $NEO4J_URL with current credentials"
 fi
 
-APOC_OK=$("${NEO4J_CMD[@]}" "CALL dbms.procedures() YIELD name WHERE name STARTS WITH 'apoc.coll' RETURN count(*) AS n;" 2>/dev/null | tail -1 || true)
-if [[ "$APOC_OK" =~ ^[1-9] ]]; then
-  pass "APOC coll procedures present ($APOC_OK procs)"
+# apoc.coll.sort is an APOC *function* (not a procedure), and dbms.procedures()
+# was REMOVED in Neo4j 5.x (the pinned server is neo4j:2026.03.1-community) —
+# the old `CALL dbms.procedures()` probe errored on a healthy stack, came back
+# empty (stderr discarded), and hard-failed preflight with a phantom "APOC
+# missing". Probe by actually CALLING the function this pipeline depends on;
+# still fail-closed when APOC is genuinely absent.
+APOC_OK=$("${NEO4J_CMD[@]}" "RETURN apoc.coll.sort([2,1])[0] AS n;" 2>/dev/null | tail -1 || true)
+if [[ "$APOC_OK" == "1" ]]; then
+  pass "APOC functions present (apoc.coll.sort smoke test passed)"
 else
-  fail "APOC procedures missing (apoc.coll.sort is required for PR-N19 Fix #2 canonical zone ordering)"
+  fail "APOC missing or broken (apoc.coll.sort is required for PR-N19 Fix #2 canonical zone ordering)"
 fi
 
 # Critical uniqueness constraints + the n.uuid index (PR #33 when merged)

--- a/src/collectors/collector_utils.py
+++ b/src/collectors/collector_utils.py
@@ -10,6 +10,7 @@ across every collector:
 """
 
 import logging
+import os
 import time
 from collections import deque
 from datetime import datetime, timedelta, timezone
@@ -441,6 +442,42 @@ def is_auth_or_access_denied(exc: BaseException) -> bool:
     return False
 
 
+# Issue #62 (silent MISP push loss): minimum fraction of ATTEMPTED pushes
+# (success / (success + failed); dedup-skipped items are not attempts) that
+# must succeed for a collector run to count as success. Below the threshold
+# the run is marked failed so the Airflow task goes RED instead of the
+# 2026-04-19 failure mode (14.7% NVD loss under a green DAG — the old rule
+# was "1 success out of 92k attempts = success"). Set to 0 to disable.
+_DEFAULT_MISP_MIN_SUCCESS_RATE = 0.95
+
+
+def _misp_min_success_rate() -> float:
+    """Parse ``EDGEGUARD_MISP_MIN_SUCCESS_RATE`` (float in [0, 1]).
+
+    Empty/unset → default. Junk or out-of-range → default with a WARNING
+    (fail-safe: a typo must not silently disable the loss gate). ``0``
+    explicitly disables the gate (legacy any-success-is-success behavior).
+    Read per call, not at import — Airflow tasks inherit env at fork time
+    and tests monkeypatch it.
+    """
+    raw = os.environ.get("EDGEGUARD_MISP_MIN_SUCCESS_RATE", "").strip()
+    if not raw:
+        return _DEFAULT_MISP_MIN_SUCCESS_RATE
+    try:
+        val = float(raw)
+    except ValueError:
+        logger.warning(
+            f"EDGEGUARD_MISP_MIN_SUCCESS_RATE={raw!r} is not a float — using default {_DEFAULT_MISP_MIN_SUCCESS_RATE}"
+        )
+        return _DEFAULT_MISP_MIN_SUCCESS_RATE
+    if not 0.0 <= val <= 1.0:
+        logger.warning(
+            f"EDGEGUARD_MISP_MIN_SUCCESS_RATE={val} outside [0, 1] — using default {_DEFAULT_MISP_MIN_SUCCESS_RATE}"
+        )
+        return _DEFAULT_MISP_MIN_SUCCESS_RATE
+    return val
+
+
 def status_after_misp_push(
     source: str,
     num_items: int,
@@ -449,15 +486,42 @@ def status_after_misp_push(
 ) -> Dict[str, Any]:
     """Build a standard ``make_status`` dict after ``push_items`` / ``push_indicators``.
 
-    Mirrors MITRE collector semantics: empty batch is success; at least one successful
-    MISP write counts as success; all writes failed yields ``success=False`` and an error.
+    Mirrors MITRE collector semantics: empty batch is success; all items
+    deduplicated (0 pushed, 0 failed) is success. A run with failures must
+    additionally clear the Issue-#62 success-rate gate (see
+    ``_misp_min_success_rate``): partial loss below the threshold marks the
+    run FAILED so the DAG task goes red (dags/edgeguard_pipeline.py gates on
+    ``success=False``) instead of silently passing.
+
+    Always emits one grep-able ``COLLECTOR_SUMMARY`` log line per run —
+    the at-a-glance operator surface Issue #62 asked for.
     """
     if num_items == 0:
         return make_status(source, True, count=0, failed=0)
+    attempted = push_success_count + push_failed_count
     # All items deduplicated (0 pushed, 0 failed) = success, not failure.
     # This is the normal case on re-runs where MISP already has all items.
+    # Rate over ATTEMPTED pushes only — a mostly-deduplicated re-run with a
+    # handful of new items is judged on those items alone.
+    rate = (push_success_count / attempted) if attempted else 1.0
+    min_rate = _misp_min_success_rate()
+    logger.info(
+        f"COLLECTOR_SUMMARY source={source} items={num_items} pushed={push_success_count} "
+        f"failed={push_failed_count} attempted={attempted} success_rate={rate:.3f} "
+        f"min_success_rate={min_rate:.2f}"
+    )
     ok = push_success_count > 0 or (push_success_count == 0 and push_failed_count == 0)
     err: Optional[str] = None
     if not ok and push_failed_count:
         err = f"MISP push failed for all or part of batch ({push_failed_count} failures, 0 successes)"
+    elif ok and attempted > 0 and min_rate > 0.0 and rate < min_rate:
+        # Issue #62 gate: partial silent loss. rate == min_rate passes.
+        ok = False
+        err = (
+            f"MISP push success rate {rate:.3f} below EDGEGUARD_MISP_MIN_SUCCESS_RATE="
+            f"{min_rate:.2f} ({push_success_count} pushed, {push_failed_count} failed, "
+            f"{attempted} attempted) — partial silent loss; see the COLLECTOR_SUMMARY "
+            f"line above and Issue #62"
+        )
+        logger.error(f"{source}: {err}")
     return make_status(source, ok, count=num_items, failed=push_failed_count, error=err)

--- a/tests/test_status_after_misp_push.py
+++ b/tests/test_status_after_misp_push.py
@@ -1,6 +1,20 @@
-"""Tests for collector_utils.status_after_misp_push."""
+"""Tests for collector_utils.status_after_misp_push.
 
-from collectors.collector_utils import status_after_misp_push
+Extended 2026-06 with the Issue-#62 silent-loss gate: a partial MISP push
+loss below EDGEGUARD_MISP_MIN_SUCCESS_RATE (default 0.95) now FAILS the
+run instead of silently passing (the 2026-04-19 baseline lost 14.7% of NVD
+attributes under a green DAG because "1 success out of 92k = success").
+"""
+
+import logging
+
+import pytest
+
+from collectors.collector_utils import (
+    _DEFAULT_MISP_MIN_SUCCESS_RATE,
+    _misp_min_success_rate,
+    status_after_misp_push,
+)
 
 
 def test_empty_batch_success():
@@ -18,8 +32,114 @@ def test_all_failed():
     assert "failures" in st["error"]
 
 
-def test_partial_success():
-    st = status_after_misp_push("otx", 10, 3, 2)
+def test_all_deduplicated_is_success():
+    # 0 pushed, 0 failed = everything already in MISP — zero attempts, no
+    # divide-by-zero, and the gate must not fire on a no-op re-run.
+    st = status_after_misp_push("otx", 50, 0, 0)
     assert st["success"] is True
-    assert st["count"] == 10
-    assert st["failed"] == 2
+    assert st["failed"] == 0
+
+
+class TestIssue62SuccessRateGate:
+    """Partial loss below the threshold fails; at/above passes."""
+
+    def test_partial_loss_below_threshold_now_fails(self):
+        # Pre-#62 behavior: 3 pushed / 2 failed (rate 0.6) was a green run —
+        # the exact silent-loss class behind the 2026-04-19 incident. The
+        # gate (default 0.95) must now mark it failed, loudly.
+        st = status_after_misp_push("otx", 10, 3, 2)
+        assert st["success"] is False
+        assert st["count"] == 10
+        assert st["failed"] == 2
+        assert "success rate" in st["error"]
+        assert "0.600" in st["error"]
+        assert "EDGEGUARD_MISP_MIN_SUCCESS_RATE" in st["error"]
+
+    def test_rate_above_threshold_preserves_legacy_success(self):
+        # 97 pushed / 3 failed = 0.97 >= 0.95 — small losses still pass.
+        st = status_after_misp_push("nvd", 100, 97, 3)
+        assert st["success"] is True
+        assert st["failed"] == 3
+        # make_status only includes "error" when one is provided.
+        assert "error" not in st
+
+    def test_rate_exactly_at_threshold_passes(self):
+        # Boundary: 95/100 attempted = exactly 0.95 — gate fires only BELOW.
+        st = status_after_misp_push("nvd", 100, 95, 5)
+        assert st["success"] is True
+
+    def test_rate_just_below_threshold_fails(self):
+        # 94/100 = 0.94 < 0.95.
+        st = status_after_misp_push("nvd", 100, 94, 6)
+        assert st["success"] is False
+
+    def test_rate_computed_over_attempted_not_batch_size(self):
+        # Mostly-deduplicated re-run: 1000-item batch, only 20 attempted
+        # (19 pushed / 1 failed = 0.95). Rate must use attempted, not
+        # num_items — judged on the new items alone.
+        st = status_after_misp_push("nvd", 1000, 19, 1)
+        assert st["success"] is True
+
+    def test_april_incident_scenario_is_now_red(self):
+        # The 2026-04-19 numbers: 78,999 pushed / 13,621 failed = 0.853.
+        st = status_after_misp_push("nvd", 92620, 78999, 13621)
+        assert st["success"] is False
+        assert "0.853" in st["error"]
+
+    def test_zero_disables_gate(self, monkeypatch):
+        monkeypatch.setenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", "0")
+        st = status_after_misp_push("otx", 10, 3, 2)
+        assert st["success"] is True  # legacy any-success-is-success
+
+    def test_threshold_one_fails_any_loss(self, monkeypatch):
+        monkeypatch.setenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", "1.0")
+        st = status_after_misp_push("otx", 100, 99, 1)
+        assert st["success"] is False
+
+    def test_all_failed_keeps_legacy_error_not_gate_error(self):
+        # The 0-successes path keeps its original, clearer message.
+        st = status_after_misp_push("otx", 10, 0, 10)
+        assert st["success"] is False
+        assert "0 successes" in st["error"]
+
+    def test_collector_summary_line_emitted(self, caplog):
+        with caplog.at_level(logging.INFO, logger="collectors.collector_utils"):
+            status_after_misp_push("nvd", 100, 97, 3)
+        summary = [r.message for r in caplog.records if r.message.startswith("COLLECTOR_SUMMARY")]
+        assert len(summary) == 1
+        line = summary[0]
+        assert "source=nvd" in line
+        assert "pushed=97" in line
+        assert "failed=3" in line
+        assert "success_rate=0.970" in line
+
+
+class TestMinSuccessRateEnvParsing:
+    """Fail-safe parsing: a typo must not silently disable the loss gate."""
+
+    def test_unset_returns_default(self, monkeypatch):
+        monkeypatch.delenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", raising=False)
+        assert _misp_min_success_rate() == _DEFAULT_MISP_MIN_SUCCESS_RATE
+
+    def test_empty_string_returns_default(self, monkeypatch):
+        # docker-compose ${VAR:-} passthrough yields "" when unset in .env.
+        monkeypatch.setenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", "")
+        assert _misp_min_success_rate() == _DEFAULT_MISP_MIN_SUCCESS_RATE
+
+    def test_junk_returns_default_with_warning(self, monkeypatch, caplog):
+        monkeypatch.setenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", "ninety-five")
+        with caplog.at_level(logging.WARNING, logger="collectors.collector_utils"):
+            assert _misp_min_success_rate() == _DEFAULT_MISP_MIN_SUCCESS_RATE
+        assert any("not a float" in r.message for r in caplog.records)
+
+    @pytest.mark.parametrize("bad", ["-0.1", "1.5", "95"])
+    def test_out_of_range_returns_default_with_warning(self, monkeypatch, caplog, bad):
+        # "95" guards the percent-vs-fraction typo (95 instead of 0.95).
+        monkeypatch.setenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", bad)
+        with caplog.at_level(logging.WARNING, logger="collectors.collector_utils"):
+            assert _misp_min_success_rate() == _DEFAULT_MISP_MIN_SUCCESS_RATE
+        assert any("outside [0, 1]" in r.message for r in caplog.records)
+
+    def test_valid_value_parsed(self, monkeypatch):
+        monkeypatch.setenv("EDGEGUARD_MISP_MIN_SUCCESS_RATE", "0.8")
+        assert _misp_min_success_rate() == 0.8


### PR DESCRIPTION
Two fixes that must land before the fresh 730-day baseline run. Refs #62.

## 1. MISP push silent-loss gate (Refs #62)

`status_after_misp_push` marked a collector run successful if even **one** attribute pushed — `ok = push_success_count > 0`. This is exactly how the 2026-04-19 baseline lost **14.7% of NVD attributes (13,620 of 92,620) under a green DAG** (Issue #62's headline finding: silent data loss looks identical to success).

Now:
- **Success rate** = `pushed / (pushed + failed)` over **attempted** pushes only — dedup-skipped items are not attempts, so no-op/mostly-deduplicated re-runs are unaffected (judged on their new items alone).
- Below **`EDGEGUARD_MISP_MIN_SUCCESS_RATE`** (default **0.95**; `0` disables; `rate == threshold` passes) the run is marked `success=False` → the existing DAG gate turns the task **RED** with the rate in the error. No DAG change needed; the single choke point covers all **11 collector call sites** (nvd, otx, cisa_kev, virustotal×2, abuseipdb, threatfox, urlhaus, cybercure, feodo, sslbl).
- **Fail-safe env parsing**: junk / out-of-range values (incl. the `95` percent-vs-fraction typo) fall back to the default **with a WARNING** — a typo must not silently disable the loss gate.
- Every run emits one grep-able **`COLLECTOR_SUMMARY`** line (`source/items/pushed/failed/attempted/success_rate/min_success_rate`) — the at-a-glance operator surface the issue asked for.
- Wired through docker-compose `x-common-env`; documented in `.env.example` + **RUNBOOK § Post-run summary grep** (footer bumped).

**Why "Refs" not "Closes":** the issue's Prometheus gauge + Grafana panel acceptance items remain open — the metrics transport is a separately-tracked inert item. The structured log line + threshold fail policy (the two items that would have made 2026-04-19 visible) land here. Note: the issue suggested shipping the threshold default-off; this PR ships **0.95 default-on** deliberately — the whole point is protection during the imminent baseline, and `0` is the documented opt-out.

## 2. Preflight APOC probe false-fail

`preflight_baseline.sh` check [2] used `CALL dbms.procedures()` — **removed in Neo4j 5.x** (the pinned server is `neo4j:2026.03.1-community`) — and `apoc.coll.sort` is an APOC **function**, not a procedure, so even on pre-5.x servers the procedures listing matched nothing. The probe errored (stderr discarded), `APOC_OK` came back empty, and preflight **hard-failed a healthy stack** with a phantom "APOC procedures missing" — i.e. the operator would be falsely blocked on baseline day. Now a direct smoke test (`RETURN apoc.coll.sort([2,1])[0]` → `1`), same cypher-shell invocation pattern as the surrounding checks, still fail-closed when APOC is genuinely absent. `bash -n` clean.

## Tests
20 tests in `test_status_after_misp_push.py`: the exact 2026-04-19 incident numbers now produce a red run (`0.853 < 0.95`), threshold boundary (95/100 passes, 94/100 fails), rate over attempted-not-batch-size, dedup zero-attempt no-divide, gate-off via `0`, threshold `1.0`, legacy all-failed error preserved, COLLECTOR_SUMMARY emission, and the full env-parsing matrix. The old `test_partial_success` (3 pushed / 2 failed → green) pinned exactly the silent-loss behavior this PR kills — deliberately replaced.

Related-tests sweep: 456 passed. Full suite running locally; CI will confirm.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes default collector success semantics (partial MISP loss now fails tasks across all collectors using status_after_misp_push); intended for baseline safety but may surface RED runs where operators previously saw green.
> 
> **Overview**
> Adds **Issue #62** protection so collector runs no longer pass Airflow when most MISP pushes fail. **`status_after_misp_push`** now computes success rate as `pushed / (pushed + failed)` over **attempted** pushes only (dedup skips do not count), logs a **`COLLECTOR_SUMMARY`** line every run, and sets **`success=False`** when rate is below **`EDGEGUARD_MISP_MIN_SUCCESS_RATE`** (default **0.95**, **`0`** disables). Env parsing is fail-safe on junk/out-of-range values. The variable is documented in **`.env.example`**, passed through **`docker-compose.yml`**, and described in **`RUNBOOK.md`**.
> 
> **`preflight_baseline.sh`** replaces the Neo4j 5.x–broken **`dbms.procedures()`** APOC check with a direct **`apoc.coll.sort`** smoke test so healthy stacks are not blocked before baseline.
> 
> Tests in **`test_status_after_misp_push.py`** cover the gate, boundaries, and env parsing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d746e9a6ad08d2499427697868f5f206c2095028. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->